### PR TITLE
[FEAT] Pretendard 기본 폰트 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query-devtools": "^5.96.2",
         "axios": "^1.15.0",
         "lucide-react": "^1.7.0",
+        "pretendard": "^1.3.9",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.0",
@@ -4368,6 +4369,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
+      "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==",
+      "license": "OFL-1.1"
     },
     "node_modules/prettier": {
       "version": "3.8.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query-devtools": "^5.96.2",
     "axios": "^1.15.0",
     "lucide-react": "^1.7.0",
+    "pretendard": "^1.3.9",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.0",

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,13 @@
+@import 'pretendard/dist/web/variable/pretendardvariable.css';
 @import 'tailwindcss';
 
 @theme {
+  --font-sans:
+    'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont,
+    system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo',
+    'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', sans-serif;
+
   /* 브랜드 컬러 */
   --color-point-red: #e50914;
   --color-point-hover: #b20710;
@@ -22,6 +29,17 @@
 
 /* 다크 모드 변수 매핑 */
 @layer base {
+  html {
+    font-family: var(--font-sans);
+  }
+
+  body {
+    font-family: inherit;
+    font-synthesis: none;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
   .dark {
     --color-bg-main: var(--color-bg-main-dark);
     --color-bg-surface: var(--color-bg-surface-dark);
@@ -35,51 +53,45 @@
 @layer components {
   /* 메인 포인트 버튼 */
   .btn-point {
-    @apply bg-point-red text-white px-6 py-3 rounded-md font-bold 
-          hover:bg-point-hover transition-all duration-200 
-          disabled:bg-gray-600 disabled:cursor-not-allowed;
+    @apply bg-point-red hover:bg-point-hover rounded-md px-6 py-3 font-bold text-white transition-all duration-200 disabled:cursor-not-allowed disabled:bg-gray-600;
   }
 
   /* 보조/라인 버튼 */
   .btn-outline {
-    @apply border border-border-main text-text-main px-6 py-3 rounded-md font-medium 
-          hover:bg-bg-surface transition-all;
+    @apply border-border-main text-text-main hover:bg-bg-surface rounded-md border px-6 py-3 font-medium transition-all;
   }
 
   /* 입력창 공통 */
   .input-base {
-    @apply w-full bg-bg-surface border border-border-main text-text-main px-4 py-2 rounded-md
-          focus:outline-none focus:border-point-red transition-all;
+    @apply bg-bg-surface border-border-main text-text-main focus:border-point-red w-full rounded-md border px-4 py-2 transition-all focus:outline-none;
   }
 
   /* 진행 바 */
   .progress-bar {
-    @apply h-2 w-full bg-border-main rounded-full overflow-hidden;
+    @apply bg-border-main h-2 w-full overflow-hidden rounded-full;
   }
 
   .progress-fill {
-    @apply h-full bg-point-red transition-all duration-300;
+    @apply bg-point-red h-full transition-all duration-300;
   }
 
   /* 사용자 말풍선 */
   .chat-bubble-user {
-    @apply bg-point-red text-white p-3 rounded-lg rounded-tr-none max-w-[80%];
+    @apply bg-point-red max-w-[80%] rounded-lg rounded-tr-none p-3 text-white;
   }
 
   /* 챗봇 말풍선 */
   .chat-bubble-bot {
-    @apply bg-bg-surface border border-border-main text-text-main p-3 rounded-lg rounded-tl-none max-w-[80%];
+    @apply bg-bg-surface border-border-main text-text-main max-w-[80%] rounded-lg rounded-tl-none border p-3;
   }
 
   /* 카드형 레이아웃 */
   .card-base {
-    @apply bg-bg-surface border border-border-main rounded-xl p-4 shadow-sm
-          hover:scale-[1.02] hover:border-point-red transition-all duration-300;
+    @apply bg-bg-surface border-border-main hover:border-point-red rounded-xl border p-4 shadow-sm transition-all duration-300 hover:scale-[1.02];
   }
 
   /* 설문조사 답변 항목 */
   .answer-item {
-    @apply w-full p-4 bg-bg-surface border-2 border-transparent rounded-lg text-left
-          hover:border-point-red hover:text-point-red transition-all cursor-pointer;
+    @apply bg-bg-surface hover:border-point-red hover:text-point-red w-full cursor-pointer rounded-lg border-2 border-transparent p-4 text-left transition-all;
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- close #17 

## ✨ 변경 내용

- `pretendard` 패키지를 추가했습니다.
- 전역 CSS에서 Pretendard variable font를 import했습니다.
- Tailwind v4 `@theme`에 `--font-sans` 토큰을 추가했습니다.
- `html`, `body`에 기본 폰트와 렌더링 보정 옵션을 적용했습니다.
- 전체 앱에서 Pretendard가 기본 폰트로 사용되도록 설정했습니다.

## 📸 스크린샷(선택)

- 전역 폰트 설정 변경으로 별도 화면 캡처는 생략합니다.

## 📚 참고사항

- CDN 방식 대신 npm 패키지 기반 self-host 방식을 사용했습니다.
- 검증 완료:
  - `npm run lint`
  - `npm run build`
