### PR TITLE
[Feat] 로그인 페이지 UI 구현 및 라우터 구조 정리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -585,6 +584,27 @@
         "conventional-commits-parser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1533,7 +1553,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
       "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.99.0"
       },
@@ -1592,7 +1611,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1603,7 +1621,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1663,7 +1680,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -1933,7 +1949,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2095,7 +2110,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2421,7 +2435,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -2687,7 +2700,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2748,7 +2760,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4342,7 +4353,6 @@
       "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4469,7 +4479,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4479,7 +4488,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4871,7 +4879,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4957,7 +4964,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5241,7 +5247,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "pretendard": "^1.3.9",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.14.0",
+        "react-router": "^7.14.1",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -74,6 +74,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -584,29 +585,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -4471,22 +4449,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
-      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.14.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/require-directory": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1404,6 +1404,64 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pretendard": "^1.3.9",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.14.0",
+    "react-router": "^7.14.1",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,46 +1,7 @@
-import Header from './components/common/Header';
-import { useTestStore } from './store/useTestStore';
+import { Outlet } from 'react-router';
 
 function App() {
-  const { count, increase, decrease } = useTestStore();
-
-  return (
-    <div className="min-h-screen bg-gray-100">
-      <main className="flex flex-col">
-        <Header fixed={false} />
-
-        <section className="mt-20 flex flex-col items-center bg-gray-100 px-6 py-10 shadow-md">
-          <p className="mb-4 text-xl">
-            Zustand 테스트 (Count):{' '}
-            <span className="font-mono font-bold text-red-500">{count}</span>
-          </p>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={increase}
-              className="rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600"
-            >
-              증가
-            </button>
-            <button
-              type="button"
-              onClick={decrease}
-              className="rounded bg-red-500 px-4 py-2 text-white hover:bg-red-600"
-            >
-              감소
-            </button>
-          </div>
-        </section>
-
-        <h1 className="px-6 text-center text-3xl font-bold text-blue-600">
-          PGTI 프로젝트 초기 세팅
-        </h1>
-        <p className="text-center text-sm text-gray-500">
-          이제 컴포넌트 작업할일만 남음
-        </p>
-      </main>
-    </div>
-  );
+  return <Outlet />;
 }
 
 export default App;

--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -1,0 +1,38 @@
+type AuthInputFieldProps = {
+  id: string;
+  name: string;
+  label: string;
+  type: 'text' | 'password' | 'email';
+  autoComplete?: string;
+  placeholder: string;
+};
+
+function AuthInputField({
+  id,
+  name,
+  label,
+  type,
+  autoComplete,
+  placeholder,
+}: AuthInputFieldProps) {
+  return (
+    <div className="space-y-3">
+      <label
+        htmlFor={id}
+        className="text-login-label block text-[15px] font-medium"
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        name={name}
+        type={type}
+        autoComplete={autoComplete}
+        placeholder={placeholder}
+        className="placeholder-login-muted bg-login-field border-login-field h-[56px] w-full rounded-[12px] border px-4 text-base text-white transition outline-none focus-visible:ring-2 focus-visible:ring-white/20"
+      />
+    </div>
+  );
+}
+
+export default AuthInputField;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import profileImg from '../../assets/프로필 이미지.png';
 
 type HeaderProps = {

--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import Header from '../common/Header';
+
+type AuthLayoutProps = {
+  title: string;
+  children: ReactNode;
+};
+
+function AuthLayout({ title, children }: AuthLayoutProps) {
+  return (
+    <div className="bg-login-page flex min-h-screen flex-col text-white">
+      <Header fixed={false} />
+
+      <main className="flex flex-1 items-start justify-center px-6 pt-8 pb-16 sm:px-8 sm:pt-12">
+        <section className="w-full max-w-[440px]">
+          <h1 className="text-center text-[34px] leading-none font-semibold sm:text-[46px]">
+            {title}
+          </h1>
+          {children}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default AuthLayout;

--- a/src/components/login/SocialLoginButton.tsx
+++ b/src/components/login/SocialLoginButton.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+type SocialLoginButtonProps = {
+  label: string;
+  icon: ReactNode;
+  className: string;
+  labelClassName?: string;
+};
+
+function SocialLoginButton({
+  label,
+  icon,
+  className,
+  labelClassName = '',
+}: SocialLoginButtonProps) {
+  return (
+    <button
+      type="button"
+      className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-transform duration-200 hover:-translate-y-0.5 ${className}`}
+    >
+      {icon}
+      <span className={`text-lg leading-7 font-normal ${labelClassName}`}>
+        {label}
+      </span>
+    </button>
+  );
+}
+
+export default SocialLoginButton;

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,25 @@
   --color-header-text: #ffffff;
   --color-header-shadow-glow: rgba(255, 255, 255, 0.14);
   --color-header-shadow-depth: rgba(0, 0, 0, 0.32);
+
+  --color-login-page: #000000;
+  --color-login-field: #1a1a1a;
+  --color-login-field-border: #262626;
+  --color-login-divider: #262626;
+  --color-login-divider-line: #3a3a3a;
+  --color-login-divider-text: #a3a3a3;
+  --color-login-helper: #a3a3a3;
+  --color-login-outline: rgba(255, 255, 255, 0.12);
+  --color-login-label: #8f8f8f;
+  --color-login-muted: #676767;
+  --color-login-google: #1a1a1a;
+  --color-login-google-border: #1a1a1a;
+  --color-login-kakao: #fee500;
+  --color-login-kakao-text: #000000;
+  --color-login-naver: #03c75a;
+  --color-login-primary: #f20f17;
+  --color-login-primary-hover: #dd0d14;
+  --shadow-login-primary: rgba(242, 15, 23, 0.42);
 }
 
 @layer base {
@@ -59,5 +78,87 @@
 
   .header-btn-solid:hover {
     background-color: var(--color-header-accent-hover);
+  }
+}
+
+@utility bg-login-page {
+  background-color: var(--color-login-page);
+}
+
+@utility bg-login-field {
+  background-color: var(--color-login-field);
+}
+
+@utility bg-login-divider {
+  background-color: var(--color-login-divider);
+}
+
+@utility bg-login-divider-line {
+  background-color: var(--color-login-divider-line);
+}
+
+@utility bg-login-google {
+  background-color: var(--color-login-google);
+}
+
+@utility bg-login-kakao {
+  background-color: var(--color-login-kakao);
+}
+
+@utility bg-login-naver {
+  background-color: var(--color-login-naver);
+}
+
+@utility bg-login-primary {
+  background-color: var(--color-login-primary);
+}
+
+@utility bg-login-primary-hover {
+  background-color: var(--color-login-primary-hover);
+}
+
+@utility text-login-label {
+  color: var(--color-login-label);
+}
+
+@utility text-login-muted {
+  color: var(--color-login-muted);
+}
+
+@utility text-login-helper {
+  color: var(--color-login-helper);
+}
+
+@utility text-login-divider-label {
+  color: var(--color-login-divider-text);
+}
+
+@utility text-login-kakao-label {
+  color: var(--color-login-kakao-text);
+}
+
+@utility border-login-divider {
+  border-color: var(--color-login-divider);
+}
+
+@utility border-login-field {
+  border-color: var(--color-login-field-border);
+}
+
+@utility border-login-outline {
+  border-color: var(--color-login-outline);
+}
+
+@utility border-login-google {
+  border-color: var(--color-login-google-border);
+}
+
+@utility shadow-login-primary {
+  box-shadow: 0 10px 24px -10px var(--shadow-login-primary);
+}
+
+@utility placeholder-login-muted {
+  &::placeholder {
+    color: var(--color-login-muted);
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import App from './App';
+import LoginPage from './pages/LoginPage';
 import './index.css';
 
 // QueryClient 인스턴스 생성
@@ -13,6 +14,12 @@ const router = createBrowserRouter([
   {
     path: '/',
     element: <App />,
+    children: [
+      {
+        index: true,
+        element: <LoginPage />,
+      },
+    ],
   },
 ]);
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,181 @@
+import type { ReactNode } from 'react';
+import Header from '../components/common/Header';
+
+const GoogleIcon = () => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
+    <path
+      fill="#4285F4"
+      d="M21.805 10.041H12.61v3.949h5.268c-.229 1.276-.955 2.356-2.036 3.083v2.526h3.304c1.937-1.783 3.056-4.41 3.056-7.548 0-.676-.061-1.315-.397-2.01Z"
+    />
+    <path
+      fill="#34A853"
+      d="M12.61 22.5c2.619 0 4.816-.867 6.421-2.352l-3.304-2.526c-.918.62-2.091.986-3.117.986-2.396 0-4.427-1.615-5.153-3.79H4.048v2.604A9.692 9.692 0 0 0 12.61 22.5Z"
+    />
+    <path
+      fill="#FBBC04"
+      d="M7.457 14.818a5.81 5.81 0 0 1-.291-1.818c0-.631.108-1.243.291-1.818V8.578H4.048A9.694 9.694 0 0 0 3 13c0 1.559.374 3.035 1.048 4.422l3.409-2.604Z"
+    />
+    <path
+      fill="#EA4335"
+      d="M12.61 7.392c1.422 0 2.697.489 3.703 1.447l2.777-2.777C17.421 4.509 15.229 3.5 12.61 3.5a9.692 9.692 0 0 0-8.562 5.078l3.409 2.604c.726-2.175 2.757-3.79 5.153-3.79Z"
+    />
+  </svg>
+);
+
+const KakaoIcon = () => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
+    <path
+      fill="#181600"
+      d="M12 4.2c-5.19 0-9.4 3.14-9.4 7.02 0 2.48 1.72 4.65 4.33 5.88l-1.08 3.96a.36.36 0 0 0 .55.4l4.57-3.1c.34.03.68.05 1.03.05 5.19 0 9.4-3.14 9.4-7.02S17.19 4.2 12 4.2Z"
+    />
+  </svg>
+);
+
+const NaverIcon = () => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
+    <path
+      fill="currentColor"
+      d="M6 5.5h4.57l2.94 4.19V5.5H18v13h-4.57l-2.94-4.19v4.19H6v-13Z"
+    />
+  </svg>
+);
+
+type SocialLoginButtonProps = {
+  label: string;
+  icon: ReactNode;
+  className: string;
+  labelClassName?: string;
+};
+
+const SocialLoginButton = ({
+  label,
+  icon,
+  className,
+  labelClassName = '',
+}: SocialLoginButtonProps) => (
+  <button
+    type="button"
+    className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-transform duration-200 hover:-translate-y-0.5 ${className}`}
+  >
+    {icon}
+    <span
+      className={`text-[18px] leading-[150%] font-normal ${labelClassName}`}
+    >
+      {label}
+    </span>
+  </button>
+);
+
+function LoginPage() {
+  return (
+    <div className="bg-login-page min-h-screen text-white">
+      <Header fixed={false} />
+
+      <main className="flex min-h-[calc(100vh-7rem)] items-start justify-center px-6 pt-8 pb-16 sm:px-8 sm:pt-12">
+        <section className="w-full max-w-[440px]">
+          <h1 className="text-center text-[34px] leading-none font-semibold sm:text-[46px]">
+            Log In
+          </h1>
+
+          <div className="mt-12 space-y-4">
+            <SocialLoginButton
+              label="Google로 로그인하기"
+              icon={<GoogleIcon />}
+              className="bg-login-google border-login-google h-[61px] border"
+              labelClassName="text-white"
+            />
+            <SocialLoginButton
+              label="카카오로 로그인하기"
+              icon={<KakaoIcon />}
+              className="bg-login-kakao h-[59px]"
+              labelClassName="text-login-kakao-label"
+            />
+            <SocialLoginButton
+              label="네이버로 로그인하기"
+              icon={<NaverIcon />}
+              className="bg-login-naver h-[59px]"
+              labelClassName="text-white"
+            />
+          </div>
+
+          <div className="my-8 flex h-[34px] items-center gap-4 py-2">
+            <div className="bg-login-divider-line h-px flex-1" />
+            <span className="text-login-divider-label text-[12px] leading-[150%] font-normal tracking-[0.18em]">
+              OR
+            </span>
+            <div className="bg-login-divider-line h-px flex-1" />
+          </div>
+
+          <form
+            className="space-y-5"
+            onSubmit={(event) => event.preventDefault()}
+          >
+            <div className="space-y-3">
+              <label
+                htmlFor="login-id"
+                className="text-login-label block text-[15px] font-medium"
+              >
+                아이디
+              </label>
+              <input
+                id="login-id"
+                name="id"
+                type="text"
+                autoComplete="username"
+                placeholder="ID"
+                className="placeholder-login-muted bg-login-field border-login-field h-[56px] w-full rounded-[12px] border px-4 text-base text-white transition outline-none focus-visible:ring-2 focus-visible:ring-white/20"
+              />
+            </div>
+
+            <div className="space-y-3">
+              <label
+                htmlFor="login-password"
+                className="text-login-label block text-[15px] font-medium"
+              >
+                비밀번호
+              </label>
+              <input
+                id="login-password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                placeholder="PASSWORD"
+                className="placeholder-login-muted bg-login-field border-login-field h-[56px] w-full rounded-[12px] border px-4 text-base text-white transition outline-none focus-visible:ring-2 focus-visible:ring-white/20"
+              />
+            </div>
+
+            <div className="flex justify-end">
+              <button
+                type="button"
+                className="text-login-muted text-sm font-medium transition-colors hover:text-white/80"
+              >
+                아이디/비밀번호를 잊어버리셨나요?
+              </button>
+            </div>
+
+            <button
+              type="submit"
+              className="shadow-login-primary bg-login-primary hover:bg-login-primary-hover mt-4 h-[56px] w-full rounded-full text-[18px] leading-[150%] font-semibold text-white transition-colors"
+            >
+              로그인
+            </button>
+          </form>
+
+          <div className="border-login-divider mt-8 border-t pt-8">
+            <p className="text-login-helper text-center text-[14px] leading-[150%] font-normal">
+              아직 PGTI 회원이 아니신가요?
+            </p>
+            <button
+              type="button"
+              className="border-login-outline mt-5 h-14 w-full rounded-full border bg-transparent text-[18px] leading-[150%] font-semibold text-white transition-colors hover:border-white/25 hover:bg-white/5"
+            >
+              회원가입
+            </button>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default LoginPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
-import type { ReactNode } from 'react';
-import Header from '../components/common/Header';
+import AuthInputField from '../components/auth/AuthInputField';
+import SocialLoginButton from '../components/login/SocialLoginButton';
+import AuthLayout from '../components/layout/AuthLayout';
 
 const GoogleIcon = () => (
   <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
@@ -40,141 +41,86 @@ const NaverIcon = () => (
   </svg>
 );
 
-type SocialLoginButtonProps = {
-  label: string;
-  icon: ReactNode;
-  className: string;
-  labelClassName?: string;
-};
-
-const SocialLoginButton = ({
-  label,
-  icon,
-  className,
-  labelClassName = '',
-}: SocialLoginButtonProps) => (
-  <button
-    type="button"
-    className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-transform duration-200 hover:-translate-y-0.5 ${className}`}
-  >
-    {icon}
-    <span
-      className={`text-[18px] leading-[150%] font-normal ${labelClassName}`}
-    >
-      {label}
-    </span>
-  </button>
-);
-
 function LoginPage() {
   return (
-    <div className="bg-login-page min-h-screen text-white">
-      <Header fixed={false} />
+    <AuthLayout title="Log In">
+      <div className="mt-12 space-y-4">
+        <SocialLoginButton
+          label="Google로 로그인하기"
+          icon={<GoogleIcon />}
+          className="bg-login-google border-login-google h-[61px] border"
+          labelClassName="text-white"
+        />
+        <SocialLoginButton
+          label="카카오로 로그인하기"
+          icon={<KakaoIcon />}
+          className="bg-login-kakao h-[59px]"
+          labelClassName="text-login-kakao-label"
+        />
+        <SocialLoginButton
+          label="네이버로 로그인하기"
+          icon={<NaverIcon />}
+          className="bg-login-naver h-[59px]"
+          labelClassName="text-white"
+        />
+      </div>
 
-      <main className="flex min-h-[calc(100vh-7rem)] items-start justify-center px-6 pt-8 pb-16 sm:px-8 sm:pt-12">
-        <section className="w-full max-w-[440px]">
-          <h1 className="text-center text-[34px] leading-none font-semibold sm:text-[46px]">
-            Log In
-          </h1>
+      <div className="my-8 flex h-[34px] items-center gap-4 py-2">
+        <div className="bg-login-divider-line h-px flex-1" />
+        <span className="text-login-divider-label text-xs leading-5 font-normal tracking-[0.18em]">
+          OR
+        </span>
+        <div className="bg-login-divider-line h-px flex-1" />
+      </div>
 
-          <div className="mt-12 space-y-4">
-            <SocialLoginButton
-              label="Google로 로그인하기"
-              icon={<GoogleIcon />}
-              className="bg-login-google border-login-google h-[61px] border"
-              labelClassName="text-white"
-            />
-            <SocialLoginButton
-              label="카카오로 로그인하기"
-              icon={<KakaoIcon />}
-              className="bg-login-kakao h-[59px]"
-              labelClassName="text-login-kakao-label"
-            />
-            <SocialLoginButton
-              label="네이버로 로그인하기"
-              icon={<NaverIcon />}
-              className="bg-login-naver h-[59px]"
-              labelClassName="text-white"
-            />
-          </div>
+      <form className="space-y-5" onSubmit={(event) => event.preventDefault()}>
+        <AuthInputField
+          id="login-id"
+          name="id"
+          label="아이디"
+          type="text"
+          autoComplete="username"
+          placeholder="ID"
+        />
 
-          <div className="my-8 flex h-[34px] items-center gap-4 py-2">
-            <div className="bg-login-divider-line h-px flex-1" />
-            <span className="text-login-divider-label text-[12px] leading-[150%] font-normal tracking-[0.18em]">
-              OR
-            </span>
-            <div className="bg-login-divider-line h-px flex-1" />
-          </div>
+        <AuthInputField
+          id="login-password"
+          name="password"
+          label="비밀번호"
+          type="password"
+          autoComplete="current-password"
+          placeholder="PASSWORD"
+        />
 
-          <form
-            className="space-y-5"
-            onSubmit={(event) => event.preventDefault()}
+        <div className="flex justify-end">
+          <button
+            type="button"
+            className="text-login-muted text-sm font-medium transition-colors hover:text-white/80"
           >
-            <div className="space-y-3">
-              <label
-                htmlFor="login-id"
-                className="text-login-label block text-[15px] font-medium"
-              >
-                아이디
-              </label>
-              <input
-                id="login-id"
-                name="id"
-                type="text"
-                autoComplete="username"
-                placeholder="ID"
-                className="placeholder-login-muted bg-login-field border-login-field h-[56px] w-full rounded-[12px] border px-4 text-base text-white transition outline-none focus-visible:ring-2 focus-visible:ring-white/20"
-              />
-            </div>
+            아이디/비밀번호를 잊어버리셨나요?
+          </button>
+        </div>
 
-            <div className="space-y-3">
-              <label
-                htmlFor="login-password"
-                className="text-login-label block text-[15px] font-medium"
-              >
-                비밀번호
-              </label>
-              <input
-                id="login-password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                placeholder="PASSWORD"
-                className="placeholder-login-muted bg-login-field border-login-field h-[56px] w-full rounded-[12px] border px-4 text-base text-white transition outline-none focus-visible:ring-2 focus-visible:ring-white/20"
-              />
-            </div>
+        <button
+          type="submit"
+          className="shadow-login-primary bg-login-primary hover:bg-login-primary-hover mt-4 h-14 w-full rounded-full text-lg leading-7 font-semibold text-white transition-colors"
+        >
+          로그인
+        </button>
+      </form>
 
-            <div className="flex justify-end">
-              <button
-                type="button"
-                className="text-login-muted text-sm font-medium transition-colors hover:text-white/80"
-              >
-                아이디/비밀번호를 잊어버리셨나요?
-              </button>
-            </div>
-
-            <button
-              type="submit"
-              className="shadow-login-primary bg-login-primary hover:bg-login-primary-hover mt-4 h-[56px] w-full rounded-full text-[18px] leading-[150%] font-semibold text-white transition-colors"
-            >
-              로그인
-            </button>
-          </form>
-
-          <div className="border-login-divider mt-8 border-t pt-8">
-            <p className="text-login-helper text-center text-[14px] leading-[150%] font-normal">
-              아직 PGTI 회원이 아니신가요?
-            </p>
-            <button
-              type="button"
-              className="border-login-outline mt-5 h-14 w-full rounded-full border bg-transparent text-[18px] leading-[150%] font-semibold text-white transition-colors hover:border-white/25 hover:bg-white/5"
-            >
-              회원가입
-            </button>
-          </div>
-        </section>
-      </main>
-    </div>
+      <div className="border-login-divider mt-8 border-t pt-8">
+        <p className="text-login-helper text-center text-sm leading-5 font-normal">
+          아직 PGTI 회원이 아니신가요?
+        </p>
+        <button
+          type="button"
+          className="border-login-outline mt-5 h-14 w-full rounded-full border bg-transparent text-lg leading-7 font-semibold text-white transition-colors hover:border-white/25 hover:bg-white/5"
+        >
+          회원가입
+        </button>
+      </div>
+    </AuthLayout>
   );
 }
 


### PR DESCRIPTION
## 관련 이슈

- closes #21 

## 변경 내용

-

## 검증

- 로그인 페이지 UI를 별도 `LoginPage` 컴포넌트로 분리했습니다.
- App.tsx는 라우팅용 Outlet만 렌더하도록 정리했습니다.
- 메인 라우터에 로그인 페이지를 연결했습니다.
- 로그인 페이지의 소셜 로그인 버튼, 입력창, 구분선, 로그인 버튼, 회원가입 영역을 시안 기준으로 구현했습니다.
- Tailwind 유틸리티와 index.css 컬러토큰을 정리해 로그인 페이지 전용 색상/스타일을 적용했습니다.
- `react-router-dom` 의존성을 제거하고 `react-router` 기준으로 정리했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷
<img width="3456" height="1724" alt="image" src="https://github.com/user-attachments/assets/3797edc9-8a13-4ceb-9dae-d3b268bc8c52" />

UI 변경이 있으면 첨부합니다.

## 참고사항

- 현재 작업은 로그인 페이지 UI 및 라우팅 구조만 되어있고 실제 일반 로그인 및 소셜 로그인 연동은 백엔드/API 작업 이후 연결 예정입니다
