### PR TITLE
[Feat] 게임 목록 데이터/API 계층 추가

### DIFF
--- a/src/features/games/gameApi.ts
+++ b/src/features/games/gameApi.ts
@@ -1,0 +1,98 @@
+import { api } from '../../api/axios';
+import { matchesGenreFilter } from './genres';
+import { mockTopGames } from './mockGames';
+import type {
+  GameListItem,
+  GameListResponse,
+  GetTopGamesParams,
+  RawGameListItem,
+  SearchGamesParams,
+} from './types';
+
+const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_SORT = 'rating_desc';
+
+const hasApiBaseUrl = Boolean(import.meta.env.VITE_API_BASE_URL);
+
+const normalizeGameListItem = (game: RawGameListItem): GameListItem => ({
+  gameId: game.game_id,
+  name: game.name || 'N/A',
+  genres: game.genres?.length ? game.genres : ['N/A'],
+  thumbnailUrl: game.thumbnail_url,
+  rating: game.rating,
+});
+
+const filterGames = (
+  games: GameListItem[],
+  {
+    search = '',
+    genre = '전체',
+  }: {
+    search?: string;
+    genre?: GetTopGamesParams['genre'];
+  } = {},
+) => {
+  const normalizedSearch = search.trim().toLowerCase();
+
+  return games.filter((game) => {
+    const matchesSearch =
+      !normalizedSearch ||
+      [game.name, ...game.genres].some((keyword) =>
+        keyword.toLowerCase().includes(normalizedSearch),
+      );
+    const matchesGenre = matchesGenreFilter(game.genres, genre);
+
+    return matchesSearch && matchesGenre;
+  });
+};
+
+export const getTopGames = async ({
+  genre = '전체',
+}: GetTopGamesParams = {}): Promise<GameListItem[]> => {
+  if (!hasApiBaseUrl) {
+    return filterGames(mockTopGames, { genre });
+  }
+
+  try {
+    const response = await api.get<GameListResponse>(
+      '/api/v1/games/list/top100',
+    );
+
+    return filterGames(response.data.results.map(normalizeGameListItem), {
+      genre,
+    });
+  } catch {
+    return filterGames(mockTopGames, { genre });
+  }
+};
+
+export const searchGames = async ({
+  search,
+  genre = '전체',
+  page = 1,
+  pageSize = DEFAULT_PAGE_SIZE,
+  sort = DEFAULT_SORT,
+}: SearchGamesParams): Promise<GameListItem[]> => {
+  if (!hasApiBaseUrl) {
+    return filterGames(mockTopGames, { search, genre });
+  }
+
+  try {
+    const response = await api.get<GameListResponse>('/api/v1/games/list', {
+      params: {
+        search,
+        fuzzy: true,
+        sort,
+        page,
+        page_size: pageSize,
+      },
+    });
+
+    return filterGames(response.data.results.map(normalizeGameListItem), {
+      search,
+      genre,
+    });
+  } catch {
+    return filterGames(mockTopGames, { search, genre });
+  }
+};

--- a/src/features/games/genres.ts
+++ b/src/features/games/genres.ts
@@ -1,0 +1,54 @@
+export const GAME_GENRE_FILTERS = [
+  '전체',
+  '액션',
+  '어드벤처',
+  'RPG',
+  '슈팅',
+  '전략',
+  '시뮬레이션',
+  '스포츠',
+  '레이싱',
+  '퍼즐',
+  '플랫폼',
+  '대전 / 격투',
+  '카드 / 보드',
+  '음악 / 리듬',
+  '비주얼 노벨',
+] as const;
+
+export type GameGenreFilter = (typeof GAME_GENRE_FILTERS)[number];
+
+const GENRE_ALIASES: Record<Exclude<GameGenreFilter, '전체'>, string[]> = {
+  액션: ['액션', 'action'],
+  어드벤처: ['어드벤처', 'adventure'],
+  RPG: ['rpg'],
+  슈팅: ['슈팅', 'shooter', 'shooting'],
+  전략: ['전략', 'strategy'],
+  시뮬레이션: ['시뮬레이션', 'simulation'],
+  스포츠: ['스포츠', 'sports'],
+  레이싱: ['레이싱', 'racing'],
+  퍼즐: ['퍼즐', 'puzzle'],
+  플랫폼: ['플랫폼', 'platform', 'metroidvania'],
+  '대전 / 격투': ['대전', '격투', 'fighting'],
+  '카드 / 보드': ['카드', '보드', 'card', 'board'],
+  '음악 / 리듬': ['음악', '리듬', 'music', 'rhythm'],
+  '비주얼 노벨': ['비주얼 노벨', 'visual novel'],
+};
+
+const normalizeGenreKeyword = (value: string) => value.trim().toLowerCase();
+
+export const matchesGenreFilter = (
+  genres: string[],
+  selectedGenre: GameGenreFilter,
+) => {
+  if (selectedGenre === '전체') {
+    return true;
+  }
+
+  const aliases = GENRE_ALIASES[selectedGenre].map(normalizeGenreKeyword);
+  const gameGenres = genres.map(normalizeGenreKeyword);
+
+  return gameGenres.some((genre) =>
+    aliases.some((alias) => genre.includes(alias) || alias.includes(genre)),
+  );
+};

--- a/src/features/games/hooks/useDebouncedValue.ts
+++ b/src/features/games/hooks/useDebouncedValue.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export const useDebouncedValue = <T>(value: T, delayMs: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [value, delayMs]);
+
+  return debouncedValue;
+};

--- a/src/features/games/mockGames.ts
+++ b/src/features/games/mockGames.ts
@@ -1,0 +1,164 @@
+import type { GameListItem } from './types';
+
+export const mockTopGames: GameListItem[] = [
+  {
+    gameId: 1245620,
+    name: '엘든 링',
+    genres: ['액션', 'RPG'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1245620/header.jpg',
+    rating: 9.2,
+  },
+  {
+    gameId: 2358720,
+    name: '검은 신화: 오공',
+    genres: ['RPG'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/2358720/header.jpg',
+    rating: 9.1,
+  },
+  {
+    gameId: 2679460,
+    name: '메타포: 리판타지오',
+    genres: ['RPG', '전략'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/2679460/header.jpg',
+    rating: 9.3,
+  },
+  {
+    gameId: 1845910,
+    name: '드래곤 에이지: 베일가드',
+    genres: ['RPG', '어드벤처'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1845910/header.jpg',
+    rating: 8.8,
+  },
+  {
+    gameId: 1086940,
+    name: '발더스 게이트 3',
+    genres: ['RPG'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1086940/header.jpg',
+    rating: 9.4,
+  },
+  {
+    gameId: 292030,
+    name: '더 위쳐 3',
+    genres: ['어드벤처', 'RPG'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/292030/header.jpg',
+    rating: 9.0,
+  },
+  {
+    gameId: 1091500,
+    name: '사이버펑크 2077',
+    genres: ['RPG', '액션'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1091500/header.jpg',
+    rating: 8.9,
+  },
+  {
+    gameId: 582010,
+    name: '몬스터 헌터: 월드',
+    genres: ['액션', '어드벤처'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/582010/header.jpg',
+    rating: 8.8,
+  },
+  {
+    gameId: 814380,
+    name: '세키로: 섀도우 다이 트와이스',
+    genres: ['액션', '어드벤처'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/814380/header.jpg',
+    rating: 9.0,
+  },
+  {
+    gameId: 2050650,
+    name: '바이오하자드 RE:4',
+    genres: ['액션', '슈팅'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/2050650/header.jpg',
+    rating: 8.9,
+  },
+  {
+    gameId: 553850,
+    name: '헬다이버즈 2',
+    genres: ['슈팅', '액션'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/553850/header.jpg',
+    rating: 8.7,
+  },
+  {
+    gameId: 1623730,
+    name: '팰월드',
+    genres: ['어드벤처', '시뮬레이션'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1623730/header.jpg',
+    rating: 8.3,
+  },
+  {
+    gameId: 1145350,
+    name: '하데스 2',
+    genres: ['액션', '어드벤처'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1145350/header.jpg',
+    rating: 8.9,
+  },
+  {
+    gameId: 367520,
+    name: '할로우 나이트',
+    genres: ['어드벤처', '플랫폼'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/367520/header.jpg',
+    rating: 9.4,
+  },
+  {
+    gameId: 1627720,
+    name: 'P의 거짓',
+    genres: ['액션', 'RPG'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1627720/header.jpg',
+    rating: 8.6,
+  },
+  {
+    gameId: 1868140,
+    name: '데이브 더 다이버',
+    genres: ['어드벤처', '시뮬레이션'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1868140/header.jpg',
+    rating: 8.8,
+  },
+  {
+    gameId: 646570,
+    name: '슬레이 더 스파이어',
+    genres: ['전략', '카드 / 보드'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/646570/header.jpg',
+    rating: 9.1,
+  },
+  {
+    gameId: 2379780,
+    name: '발라트로',
+    genres: ['카드 / 보드', '전략'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/2379780/header.jpg',
+    rating: 9.2,
+  },
+  {
+    gameId: 548430,
+    name: '딥 락 갤럭틱',
+    genres: ['슈팅', '액션'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/548430/header.jpg',
+    rating: 8.9,
+  },
+  {
+    gameId: 105600,
+    name: '테라리아',
+    genres: ['어드벤처', '플랫폼'],
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/105600/header.jpg',
+    rating: 9.3,
+  },
+];

--- a/src/features/games/types.ts
+++ b/src/features/games/types.ts
@@ -1,0 +1,35 @@
+import type { GameGenreFilter } from './genres';
+
+export type GameListItem = {
+  gameId: number;
+  name: string;
+  genres: string[];
+  thumbnailUrl: string | null;
+  rating: number | null;
+};
+
+export type GameListResponse = {
+  count?: number;
+  ranked_at?: string;
+  results: RawGameListItem[];
+};
+
+export type RawGameListItem = {
+  game_id: number;
+  name: string | null;
+  genres: string[] | null;
+  thumbnail_url: string | null;
+  rating: number | null;
+};
+
+export type GetTopGamesParams = {
+  genre?: GameGenreFilter;
+};
+
+export type SearchGamesParams = {
+  search: string;
+  genre?: GameGenreFilter;
+  page?: number;
+  pageSize?: number;
+  sort?: 'rating_desc' | 'like_desc' | 'created_at';
+};


### PR DESCRIPTION
## 관련 이슈

- closes #28

## 변경 내용

- 게임 목록 화면에서 사용할 타입과 API 계층을 추가했습니다.
  - `GameListItem`
  - API raw response 타입
  - TOP100 목록 조회 함수
  - 검색 목록 조회 함수
- API 응답 필드명을 화면 타입으로 정규화했습니다.
  - `game_id` → `gameId`
  - `thumbnail_url` → `thumbnailUrl`
- 정의서 기준 장르 필터 목록과 장르 매칭 로직을 추가했습니다.
- 한국어 mock 게임 데이터를 추가했습니다.
- 검색 입력 debounce에 사용할 hook을 추가했습니다.
- `VITE_API_BASE_URL`이 없거나 API 연결 실패 시 v1 개발용 mock 데이터로 fallback하도록 구성했습니다.

## 검증

- [ ] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- 이번 PR은 메인 페이지 UI 구현 전, 게임 목록 데이터/API 계층만 추가하는 PR입니다.
- `genre_id`는 현재 정의서/API 명세에서 장르명과 ID 매핑이 확정되지 않아 API 요청에 포함하지 않았습니다.
- 장르 선택은 우선 프론트 mock/API 응답 결과를 기준으로 필터링합니다.
- API 실패 시 v1 개발 편의를 위해 mock 데이터로 fallback합니다.
