### PR TITLE
[Style] Header 높이와 버튼 반응형 정리

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -9,45 +9,51 @@ type HeaderProps = {
 const Header = ({ isLoggedIn = false, fixed = true }: HeaderProps) => {
   return (
     <header
-      className={`header-shell flex h-20 w-full items-center justify-between px-4 py-4 sm:h-24 sm:px-6 sm:py-6 md:h-28 md:px-12 md:py-8 ${
+      className={`header-shell h-16 w-full lg:h-18 ${
         fixed ? 'fixed top-0 z-50' : 'relative'
       }`}
     >
-      <Link
-        to="/"
-        aria-label="메인 페이지로 이동"
-        className="flex h-10 w-[88px] cursor-pointer items-center justify-center sm:h-11 sm:w-[96px] md:h-12 md:w-[102px]"
-      >
-        <h1 className="header-logo text-[26px] leading-[150%] font-bold sm:text-[30px] md:text-[32px]">
-          PGTI
-        </h1>
-      </Link>
+      <div className="flex h-full w-full items-center justify-between px-[clamp(1rem,5vw,20rem)] py-3">
+        <Link
+          to="/"
+          aria-label="메인 페이지로 이동"
+          className="flex h-9 w-18 cursor-pointer items-center justify-center"
+        >
+          <h1 className="header-logo text-2xl leading-none font-bold lg:text-[26px]">
+            PGTI
+          </h1>
+        </Link>
 
-      <div className="flex items-center gap-2 sm:gap-3 md:gap-4">
-        {!isLoggedIn ? (
-          <>
-            <button
-              type="button"
-              className="header-btn-outline flex h-10 min-w-[72px] items-center justify-center rounded-[6px] border px-3 py-2 text-sm transition-all sm:h-[42px] sm:min-w-[88px] sm:px-5 sm:text-base md:min-w-[92px] md:px-6"
-            >
-              <span className="leading-[150%] font-normal">로그인</span>
-            </button>
-            <button
-              type="button"
-              className="header-btn-solid flex h-10 min-w-[84px] items-center justify-center rounded-[6px] border px-3 py-2 text-sm transition-all sm:h-[42px] sm:min-w-[100px] sm:px-5 sm:text-base md:min-w-[106px] md:px-6"
-            >
-              <span className="leading-[150%] font-normal">회원가입</span>
-            </button>
-          </>
-        ) : (
-          <div className="h-11 w-11 cursor-pointer overflow-hidden rounded-full border-2 border-transparent transition-all hover:border-[var(--color-header-accent)] sm:h-[52px] sm:w-[52px] md:h-[60px] md:w-[60px]">
-            <img
-              src={profileImg}
-              alt="Profile"
-              className="h-full w-full object-cover"
-            />
-          </div>
-        )}
+        <div className="flex items-center gap-2 sm:gap-3">
+          {!isLoggedIn ? (
+            <>
+              <button
+                type="button"
+                className="header-btn-outline flex h-9 w-20 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all"
+              >
+                <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
+                  로그인
+                </span>
+              </button>
+              <button
+                type="button"
+                className="header-btn-solid flex h-9 w-22 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all"
+              >
+                <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
+                  회원가입
+                </span>
+              </button>
+            </>
+          ) : (
+            <div className="hover:border-header-accent h-10 w-10 cursor-pointer overflow-hidden rounded-full border-2 border-transparent transition-all">
+              <img
+                src={profileImg}
+                alt="Profile"
+                className="h-full w-full object-cover"
+              />
+            </div>
+          )}
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## 관련 이슈

- closes #29

## 변경 내용

- Header 높이를 전체적으로 줄여 메인 페이지와 더 자연스러운 비율로 맞췄습니다.
  - 모바일: `h-16`
  - 데스크톱: `lg:h-18`
- Header 내부 좌우 정렬 기준을 메인 페이지 rail 기준과 맞췄습니다.
  - `px-[clamp(1rem,5vw,20rem)]`
- 로고 크기와 버튼 크기를 반응형 기준으로 조정했습니다.
- 로그인/회원가입 버튼에 `cursor-pointer`를 추가했습니다.
- 로그인 상태 프로필 이미지 크기를 줄였습니다.
- `dev` 브랜치 기준에 맞춰 라우터 import를 `react-router`로 유지했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="1905" height="106" alt="스크린샷 2026-04-15 오후 2 12 31" src="https://github.com/user-attachments/assets/65797361-98ba-4aec-9415-e9a30dc208c5" />

## 참고사항

- 이번 PR은 Header 반응형 스타일만 정리합니다.
- 메인 페이지 UI, Swiper, 검색/장르 필터 구현은 별도 PR에서 진행합니다.
- 현재 로컬 작업트리에 메인 페이지 PR용 untracked 파일이 있어 pre-push hook이 로컬 전체 `src`를 빌드할 때 영향을 받을 수 있습니다.
- PR2 커밋만 있는 clean worktree에서 `npm run lint`, `npm run build` 통과를 확인했습니다.
