### PR TITLE
[Feat] 메인 페이지 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router": "^7.14.1",
+        "swiper": "^12.1.3",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -75,7 +76,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -5107,6 +5107,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.3.tgz",
+      "integrity": "sha512-XcWlVmkHFICI4fuoJKgbp8PscDcS4i7pBH8nwJRBi3dpQvhCySwsWRYm4bOf/BzKVWkHOYaFw7qz9uBSrY3oug==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/synckit": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.14.1",
+    "swiper": "^12.1.3",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/src/features/games/components/GameCard.tsx
+++ b/src/features/games/components/GameCard.tsx
@@ -1,0 +1,57 @@
+import { Link } from 'react-router';
+import { useState } from 'react';
+import type { GameListItem } from '../types';
+
+type GameCardProps = {
+  game: GameListItem;
+};
+
+const formatRating = (rating: number | null) =>
+  typeof rating === 'number' ? rating.toFixed(1) : 'N/A';
+
+const GameCard = ({ game }: GameCardProps) => {
+  const genreLabel = game.genres.length > 0 ? game.genres[0] : 'N/A';
+  const [isImageUnavailable, setIsImageUnavailable] = useState(false);
+  const thumbnailUrl = isImageUnavailable ? null : game.thumbnailUrl;
+
+  return (
+    <Link
+      to={`/games/${game.gameId}`}
+      className="group grid h-full w-full snap-start scroll-ml-2 grid-rows-[minmax(0,1fr)_92px] overflow-hidden rounded-lg border border-white/5 bg-[#141414] text-white transition hover:border-[#d20b12]/70 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]"
+      aria-label={`${game.name} 상세 페이지로 이동`}
+    >
+      <div className="relative aspect-4/5 overflow-hidden bg-[#090909]">
+        {thumbnailUrl ? (
+          <img
+            src={thumbnailUrl}
+            alt={`${game.name} 썸네일`}
+            className="h-full w-full object-cover opacity-80 transition duration-300 group-hover:scale-105 group-hover:opacity-100"
+            loading="lazy"
+            onError={() => setIsImageUnavailable(true)}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-white/45">
+            이미지 N/A
+          </div>
+        )}
+        <div className="absolute inset-0 bg-linear-to-t from-black/70 via-black/20 to-transparent" />
+      </div>
+
+      <div className="grid grid-cols-[1fr_auto] items-center gap-4 bg-[#151515] px-4 sm:px-5">
+        <div className="min-w-0">
+          <h3 className="truncate text-base leading-7 font-medium sm:text-lg">
+            {game.name}
+          </h3>
+          <p className="mt-1 truncate text-sm text-white/85 sm:text-base">
+            {genreLabel}
+          </p>
+        </div>
+        <span className="text-base font-medium text-[#e10d15]">
+          {formatRating(game.rating)}
+        </span>
+      </div>
+    </Link>
+  );
+};
+
+export default GameCard;

--- a/src/index.css
+++ b/src/index.css
@@ -146,6 +146,28 @@
   .survey-message-scroll::-webkit-scrollbar-track {
     background: transparent;
   }
+
+  .genre-menu-scrollbar {
+    scrollbar-color: rgb(255 255 255 / 0.22) transparent;
+    scrollbar-width: thin;
+  }
+
+  .genre-menu-scrollbar::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .genre-menu-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .genre-menu-scrollbar::-webkit-scrollbar-thumb {
+    background-color: rgb(255 255 255 / 0.18);
+    border-radius: 999px;
+  }
+
+  .genre-menu-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: rgb(255 255 255 / 0.32);
+  }
 }
 
 @media (max-width: 1024px) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,9 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import App from './App';
 import { ROUTES } from './constants/routes';
 import { isMockServiceWorkerEnabled } from './lib/env';
+import GameDetailPlaceholder from './pages/game/GameDetailPlaceholder';
 import MatchingListPage from './pages/matching/MatchingListPage';
+import MainPage from './pages/main/MainPage';
 import RecommendationListPage from './pages/recommendation/RecommendationListPage';
 import SurveyPage from './pages/survey/SurveyPage';
 import LoginPage from './pages/LoginPage';
@@ -22,7 +24,11 @@ const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <div>랜딩 페이지</div>,
+        element: <MainPage />,
+      },
+      {
+        path: 'games/:gameId',
+        element: <GameDetailPlaceholder />,
       },
       {
         path: ROUTES.SURVEY,

--- a/src/pages/game/GameDetailPlaceholder.tsx
+++ b/src/pages/game/GameDetailPlaceholder.tsx
@@ -1,0 +1,26 @@
+import { Link, useParams } from 'react-router';
+
+const GameDetailPlaceholder = () => {
+  const { gameId } = useParams();
+
+  return (
+    <main className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-[#050505] px-5 py-16 text-white lg:min-h-[calc(100vh-4.5rem)]">
+      <section className="w-full max-w-2xl rounded-lg border border-[#3a0b0d] bg-[#101010] px-6 py-10 text-center shadow-[0_0_36px_rgba(210,11,18,0.18)]">
+        <p className="text-sm font-semibold text-[#d20b12]">GAME DETAIL</p>
+        <h2 className="mt-4 text-3xl font-bold">상세페이지 준비 중</h2>
+        <p className="mt-4 text-base leading-7 text-white/70">
+          선택한 게임 상세 정보는 다음 작업에서 연결합니다.
+        </p>
+        <p className="mt-3 text-sm text-white/50">게임 ID: {gameId ?? 'N/A'}</p>
+        <Link
+          to="/"
+          className="hover:bg-header-accent-hover mt-8 inline-flex h-11 items-center justify-center rounded-md bg-[#d20b12] px-6 text-sm font-semibold text-white transition focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]"
+        >
+          메인으로 돌아가기
+        </Link>
+      </section>
+    </main>
+  );
+};
+
+export default GameDetailPlaceholder;

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,0 +1,387 @@
+import {
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ClipboardCheck,
+  Search,
+} from 'lucide-react';
+import { useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import type { Swiper as SwiperInstance } from 'swiper';
+import Header from '../../components/common/Header';
+import GameCard from '../../features/games/components/GameCard';
+import { getTopGames, searchGames } from '../../features/games/gameApi';
+import { GAME_GENRE_FILTERS } from '../../features/games/genres';
+import { useDebouncedValue } from '../../features/games/hooks/useDebouncedValue';
+import { getAccessToken } from '../../utils/auth';
+import type { GameListItem } from '../../features/games/types';
+import type { GameGenreFilter } from '../../features/games/genres';
+import 'swiper/swiper.css';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const MainPage = () => {
+  const hasAccessToken = Boolean(getAccessToken());
+  const [searchText, setSearchText] = useState('');
+  const [selectedGenre, setSelectedGenre] = useState<GameGenreFilter>('전체');
+  const debouncedSearchText = useDebouncedValue(
+    searchText.trim(),
+    SEARCH_DEBOUNCE_MS,
+  );
+  const isSearchMode = debouncedSearchText.length > 0;
+
+  const gamesQuery = useQuery({
+    queryKey: [
+      'games',
+      isSearchMode ? 'search' : 'top100',
+      debouncedSearchText,
+      selectedGenre,
+    ],
+    queryFn: () =>
+      isSearchMode
+        ? searchGames({ search: debouncedSearchText, genre: selectedGenre })
+        : getTopGames({ genre: selectedGenre }),
+    staleTime: 60_000,
+  });
+
+  const games = gamesQuery.data ?? [];
+  const sectionTitle = isSearchMode
+    ? `"${debouncedSearchText}" 검색 결과`
+    : '인기 TOP 100 🔥';
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+      <Header fixed isLoggedIn={hasAccessToken} />
+      <main className="min-h-screen pt-24 pb-10 text-white sm:pt-28 sm:pb-14 lg:pt-32">
+        <section className="w-full">
+          <div className="flex flex-col gap-4 px-[clamp(1rem,5vw,20rem)] sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4 lg:flex-nowrap">
+              <h2 className="min-w-0 text-xl leading-tight font-bold wrap-break-word text-white sm:text-2xl lg:text-[28px]">
+                {sectionTitle}
+              </h2>
+              <GenreFilter
+                selectedGenre={selectedGenre}
+                onSelectGenre={setSelectedGenre}
+              />
+            </div>
+
+            <label className="relative block w-full sm:w-52 lg:w-56 xl:w-60">
+              <span className="sr-only">게임명 검색</span>
+              <Search
+                aria-hidden="true"
+                className="pointer-events-none absolute top-1/2 left-4 h-5 w-5 -translate-y-1/2 text-white/75"
+              />
+              <input
+                type="search"
+                value={searchText}
+                onChange={(event) => setSearchText(event.target.value)}
+                placeholder="검색"
+                className="h-10 w-full rounded-lg border border-white/35 bg-[#080808] pr-4 pl-12 text-sm text-white transition outline-none placeholder:text-white/75 focus:border-[#d20b12] focus:ring-2 focus:ring-[#d20b12]/30 sm:h-11 sm:text-base"
+              />
+            </label>
+          </div>
+
+          <div className="mt-4 sm:mt-5">
+            {gamesQuery.isLoading ? (
+              <GameCardSkeletonList />
+            ) : games.length > 0 ? (
+              <GameCarousel
+                key={`${debouncedSearchText}-${selectedGenre}`}
+                games={games}
+              />
+            ) : (
+              <div className="px-[clamp(1rem,5vw,20rem)]">
+                <EmptyGameList
+                  isFiltered={isSearchMode || selectedGenre !== '전체'}
+                />
+              </div>
+            )}
+
+            {gamesQuery.isFetching && !gamesQuery.isLoading ? (
+              <p className="mt-3 px-[clamp(1rem,5vw,20rem)] text-sm text-white/50">
+                목록을 업데이트하는 중입니다.
+              </p>
+            ) : null}
+          </div>
+
+          <section className="mt-14 grid gap-6 px-[clamp(1rem,5vw,20rem)] lg:grid-cols-2">
+            <RecommendationCta
+              icon={ClipboardCheck}
+              iconLabel="설문 작성"
+              title="설문 조사"
+              description="설문에 참여하고 나에게 꼭 맞는 게임을 찾아보세요!"
+              buttonLabel="설문 조사 하러가기"
+            />
+            <RecommendationCta
+              icon={Search}
+              iconLabel="게임 찾기"
+              title="매칭 시작"
+              description="어떤 게임을 할지 고민? 당신의 취향에 맞는 게임을 추천해드립니다!"
+              buttonLabel="추천게임"
+            />
+          </section>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+type GenreFilterProps = {
+  selectedGenre: GameGenreFilter;
+  onSelectGenre: (genre: GameGenreFilter) => void;
+};
+
+const GenreFilter = ({ selectedGenre, onSelectGenre }: GenreFilterProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const selectGenre = (genre: GameGenreFilter) => {
+    onSelectGenre(genre);
+    setIsOpen(false);
+  };
+
+  return (
+    <div
+      className="relative w-full sm:w-36"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setIsOpen(false);
+        }
+      }}
+    >
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((current) => !current)}
+        className="flex h-10 w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-white/25 bg-[#0f0f0f] px-3 text-left text-sm font-semibold text-white shadow-[0_10px_30px_rgba(0,0,0,0.28)] transition hover:border-[#d20b12]/70 hover:bg-[#151515] focus-visible:border-[#d20b12] focus-visible:ring-2 focus-visible:ring-[#d20b12]/30 focus-visible:outline-none sm:h-11"
+      >
+        <span className="truncate">{selectedGenre}</span>
+        <ChevronDown
+          aria-hidden="true"
+          className={`h-4 w-4 shrink-0 text-white/70 transition-transform ${
+            isOpen ? 'rotate-180' : ''
+          }`}
+        />
+      </button>
+
+      {isOpen ? (
+        <ul
+          role="listbox"
+          aria-label="게임 장르 선택"
+          className="genre-menu-scrollbar absolute top-full left-0 z-30 mt-2 max-h-72 w-full overflow-y-auto rounded-lg border border-white/15 bg-[#101010] p-1 shadow-[0_18px_50px_rgba(0,0,0,0.55)]"
+        >
+          {GAME_GENRE_FILTERS.map((genre) => {
+            const isSelected = genre === selectedGenre;
+
+            return (
+              <li key={genre} role="option" aria-selected={isSelected}>
+                <button
+                  type="button"
+                  onClick={() => selectGenre(genre)}
+                  className={`flex min-h-10 w-full cursor-pointer items-center justify-between gap-3 rounded-md px-3 text-left text-sm transition ${
+                    isSelected
+                      ? 'bg-[#d20b12] font-semibold text-white'
+                      : 'text-white/75 hover:bg-white/10 hover:text-white'
+                  }`}
+                >
+                  <span className="whitespace-nowrap">{genre}</span>
+                  {isSelected ? (
+                    <Check aria-hidden="true" className="h-4 w-4 shrink-0" />
+                  ) : null}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </div>
+  );
+};
+
+type GameCarouselProps = {
+  games: GameListItem[];
+};
+
+const GameCarousel = ({ games }: GameCarouselProps) => {
+  const swiperRef = useRef<SwiperInstance | null>(null);
+
+  const scrollCards = (direction: 'previous' | 'next') => {
+    const swiper = swiperRef.current;
+
+    if (!swiper) {
+      return;
+    }
+
+    if (direction === 'previous') {
+      swiper.slidePrev();
+      return;
+    }
+
+    swiper.slideNext();
+  };
+
+  return (
+    <div className="group/carousel relative left-1/2 w-screen -translate-x-1/2">
+      <SlideButton
+        direction="previous"
+        onClick={() => scrollCards('previous')}
+      />
+
+      <div className="px-[clamp(1rem,5vw,20rem)] py-2">
+        <Swiper
+          onSwiper={(swiper) => {
+            swiperRef.current = swiper;
+          }}
+          slidesPerView={1}
+          slidesPerGroup={1}
+          spaceBetween={20}
+          speed={450}
+          watchOverflow
+          breakpoints={{
+            640: {
+              slidesPerView: 2,
+              slidesPerGroup: 2,
+              spaceBetween: 20,
+            },
+            768: {
+              slidesPerView: 3,
+              slidesPerGroup: 3,
+              spaceBetween: 24,
+            },
+            1024: {
+              slidesPerView: 4,
+              slidesPerGroup: 4,
+              spaceBetween: 24,
+            },
+            1280: {
+              slidesPerView: 5,
+              slidesPerGroup: 5,
+              spaceBetween: 24,
+            },
+            1440: {
+              slidesPerView: 6,
+              slidesPerGroup: 6,
+              spaceBetween: 24,
+            },
+          }}
+          className="overflow-visible!"
+        >
+          {games.map((game) => (
+            <SwiperSlide key={game.gameId} className="h-auto!">
+              <GameCard game={game} />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+
+      <SlideButton direction="next" onClick={() => scrollCards('next')} />
+    </div>
+  );
+};
+
+type SlideButtonProps = {
+  direction: 'previous' | 'next';
+  onClick: () => void;
+};
+
+const SlideButton = ({ direction, onClick }: SlideButtonProps) => {
+  const isPrevious = direction === 'previous';
+  const Icon = isPrevious ? ChevronLeft : ChevronRight;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={isPrevious ? '이전 게임 보기' : '다음 게임 보기'}
+      className={`group/slide-button absolute top-0 bottom-0 z-20 flex w-[clamp(1rem,5vw,20rem)] cursor-pointer items-center justify-center bg-black/50 text-white opacity-45 transition-opacity duration-200 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[#d20b12] md:opacity-0 md:group-hover/carousel:opacity-100 ${
+        isPrevious ? 'left-0' : 'right-0'
+      }`}
+    >
+      <Icon
+        aria-hidden="true"
+        className="relative z-10 h-7 w-7 transition-transform duration-200 group-hover/slide-button:scale-110"
+      />
+    </button>
+  );
+};
+
+const GameCardSkeletonList = () => (
+  <div className="relative left-1/2 w-screen -translate-x-1/2 overflow-hidden py-2">
+    <div className="grid auto-cols-[100%] grid-flow-col gap-5 px-[clamp(1rem,5vw,20rem)] min-[1440px]:auto-cols-[calc((100%-120px)/6)] sm:auto-cols-[calc((100%-20px)/2)] md:auto-cols-[calc((100%-48px)/3)] lg:auto-cols-[calc((100%-72px)/4)] lg:gap-6 xl:auto-cols-[calc((100%-96px)/5)]">
+      {Array.from({ length: 5 }, (_, index) => (
+        <div
+          key={index}
+          className="animate-pulse overflow-hidden rounded-lg bg-[#141414]"
+        >
+          <div className="aspect-4/5 bg-white/5" />
+          <div className="space-y-3 p-5">
+            <div className="h-5 w-40 rounded bg-white/10" />
+            <div className="h-4 w-24 rounded bg-white/10" />
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+type EmptyGameListProps = {
+  isFiltered: boolean;
+};
+
+const EmptyGameList = ({ isFiltered }: EmptyGameListProps) => (
+  <div className="flex min-h-80 items-center justify-center rounded-lg border border-white/10 bg-[#101010] px-6 text-center sm:min-h-90 lg:min-h-100">
+    <p className="text-base text-white/65">
+      {isFiltered
+        ? '조건에 맞는 게임 목록이 없습니다.'
+        : '표시할 인기 게임 목록이 없습니다.'}
+    </p>
+  </div>
+);
+
+type RecommendationCtaProps = {
+  icon: typeof Search;
+  iconLabel: string;
+  title: string;
+  description: string;
+  buttonLabel: string;
+};
+
+const RecommendationCta = ({
+  icon,
+  iconLabel,
+  title,
+  description,
+  buttonLabel,
+}: RecommendationCtaProps) => {
+  const Icon = icon;
+
+  return (
+    <article className="flex min-h-65 flex-col items-center justify-center rounded-lg border border-[#3a0b0d] bg-[#050505] px-6 py-9 text-center sm:min-h-70">
+      <div
+        role="img"
+        aria-label={iconLabel}
+        className="flex h-12 w-12 items-center justify-center rounded-lg border border-[#5a1115]/70 bg-[#1f0809] text-[#ff4b55] shadow-[inset_0_0_22px_rgba(255,75,85,0.12),0_12px_28px_rgba(0,0,0,0.24)] sm:h-14 sm:w-14"
+      >
+        <Icon aria-hidden="true" className="h-6 w-6 sm:h-7 sm:w-7" />
+      </div>
+      <h3 className="mt-7 text-2xl leading-tight font-bold sm:text-3xl">
+        {title}
+      </h3>
+      <p className="mt-5 max-w-xl text-sm leading-6 text-white/70 sm:text-base">
+        {description}
+      </p>
+      <button
+        type="button"
+        disabled
+        title="준비 중입니다."
+        className="mt-7 h-11 cursor-pointer rounded-md bg-[#d20b12] px-7 text-sm font-semibold text-white transition disabled:cursor-pointer disabled:opacity-70"
+      >
+        {buttonLabel}
+      </button>
+    </article>
+  );
+};
+
+export default MainPage;


### PR DESCRIPTION
## 관련 이슈

- closes #30

## 변경 내용

- 홈 index 라우트를 기존 `랜딩 페이지` 임시 텍스트에서 메인 페이지로 교체했습니다.
- `/games/:gameId` 상세 준비 중 라우트를 추가했습니다.
- 메인 페이지 v1 UI를 구현했습니다.
  - Header 포함 메인 화면
  - 인기 TOP 100 게임 목록
  - Swiper 기반 게임 카드 레일
  - 커스텀 좌우 네비게이션 버튼
  - 검색 입력
  - 장르 선택 드롭다운
  - 로딩 스켈레톤
  - 빈 결과 상태
  - 설문 조사 / 매칭 시작 CTA
- 게임 카드 컴포넌트를 추가했습니다.
  - 썸네일
  - 게임명
  - 장르
  - 평점
  - 이미지 fallback
- `swiper` 의존성을 추가했습니다.
- 장르 드롭다운 스크롤바 스타일을 추가했습니다.
- 기존 팀원 라우트 구조는 유지했습니다.
  - 설문 페이지
  - 매칭 페이지
  - 추천 리스트 페이지
  - 로그인 페이지
  - MSW 초기화 흐름

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

![무제](https://github.com/user-attachments/assets/ecdcfc21-433f-480b-bab5-02fa48fff6e2)

## 참고사항

- 이번 PR은 메인 페이지 v1 UI 구현 범위입니다.
- 실제 상세 페이지 구현은 포함하지 않고 `/games/:gameId` 상세 준비 중 페이지까지만 연결했습니다.
- 게임 목록 데이터/API 계층은 선행 PR에서 추가된 구조를 사용합니다.
- `genre_id`는 아직 장르명과 ID 매핑이 확정되지 않아 API 요청에 포함하지 않았습니다.
- 장르 필터는 현재 프론트에서 선택 장르와 검색어 조건을 함께 적용합니다.
- Swiper 기본 Navigation 모듈은 사용하지 않고, 커스텀 버튼에서 Swiper ref로 `slidePrev` / `slideNext`를 호출합니다.
