### PR TITLE
[Feat] 인증 feature 기본 구조 및 MSW 핸들러 추가

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -4,4 +4,5 @@ export const ROUTES = {
   MATCHING_LIST: 'matching-list',
   RECOMMENDATION_LIST: 'recommendation-list',
   LOGIN: 'login',
+  SIGNUP: 'signup',
 } as const;

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,0 +1,87 @@
+import { AxiosError } from 'axios';
+
+import { api } from '../../../api/axios';
+import type {
+  DuplicateCheckResponse,
+  LoginRequest,
+  LoginResponse,
+  SignupRequest,
+  SignupResponse,
+} from '../types/auth';
+
+interface ErrorResponseBody {
+  detail?: string;
+  error_detail?: string | Record<string, string[]>;
+}
+
+const AUTH_BASE_PATH = '/api/v1/auth';
+
+export const login = async (payload: LoginRequest) => {
+  const response = await api.post<LoginResponse>(
+    `${AUTH_BASE_PATH}/login`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const signup = async (payload: SignupRequest) => {
+  const response = await api.post<SignupResponse>(
+    `${AUTH_BASE_PATH}/signup`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const checkIdDuplicate = async (value: string) => {
+  const response = await api.get<DuplicateCheckResponse>(
+    `${AUTH_BASE_PATH}/check-id`,
+    {
+      params: { value },
+    },
+  );
+
+  return response.data;
+};
+
+export const checkNicknameDuplicate = async (value: string) => {
+  const response = await api.get<DuplicateCheckResponse>(
+    `${AUTH_BASE_PATH}/check-nickname`,
+    {
+      params: { value },
+    },
+  );
+
+  return response.data;
+};
+
+export const extractAuthApiErrorMessage = (error: unknown) => {
+  if (!(error instanceof AxiosError)) {
+    return '요청을 처리하는 중 알 수 없는 오류가 발생했습니다.';
+  }
+
+  const data = error.response?.data as ErrorResponseBody | undefined;
+
+  if (typeof data?.detail === 'string') {
+    return data.detail;
+  }
+
+  if (typeof data?.error_detail === 'string') {
+    return data.error_detail;
+  }
+
+  if (data?.error_detail && typeof data.error_detail === 'object') {
+    const [firstMessageGroup] = Object.values(data.error_detail);
+
+    if (typeof firstMessageGroup === 'string') {
+      return firstMessageGroup;
+    }
+
+    if (Array.isArray(firstMessageGroup) && firstMessageGroup[0]) {
+      return firstMessageGroup[0];
+    }
+  }
+
+  return '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+};

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,26 +1,30 @@
 import { AxiosError } from 'axios';
 
-import { api } from '../../../api/axios';
+import { api } from '@/api/axios';
+import { AUTH_BASE_PATH } from '../constants/auth';
 import type {
+  CheckIdDuplicateRequest,
+  CheckNicknameDuplicateRequest,
   DuplicateCheckResponse,
+  ErrorResponseBody,
   LoginRequest,
   LoginResponse,
+  LogoutResponse,
   SignupRequest,
   SignupResponse,
 } from '../types/auth';
-
-interface ErrorResponseBody {
-  detail?: string;
-  error_detail?: string | Record<string, string[]>;
-}
-
-const AUTH_BASE_PATH = '/api/v1/auth';
 
 export const login = async (payload: LoginRequest) => {
   const response = await api.post<LoginResponse>(
     `${AUTH_BASE_PATH}/login`,
     payload,
   );
+
+  return response.data;
+};
+
+export const logout = async () => {
+  const response = await api.post<LogoutResponse>(`${AUTH_BASE_PATH}/logout`);
 
   return response.data;
 };
@@ -34,26 +38,46 @@ export const signup = async (payload: SignupRequest) => {
   return response.data;
 };
 
-export const checkIdDuplicate = async (value: string) => {
-  const response = await api.get<DuplicateCheckResponse>(
+export const checkIdDuplicate = async (payload: CheckIdDuplicateRequest) => {
+  const response = await api.post<DuplicateCheckResponse>(
     `${AUTH_BASE_PATH}/check-id`,
-    {
-      params: { value },
-    },
+    payload,
   );
 
   return response.data;
 };
 
-export const checkNicknameDuplicate = async (value: string) => {
-  const response = await api.get<DuplicateCheckResponse>(
+export const checkNicknameDuplicate = async (
+  payload: CheckNicknameDuplicateRequest,
+) => {
+  const response = await api.post<DuplicateCheckResponse>(
     `${AUTH_BASE_PATH}/check-nickname`,
-    {
-      params: { value },
-    },
+    payload,
   );
 
   return response.data;
+};
+
+const extractFieldErrorMessage = (
+  value?: string | Record<string, string[]>,
+) => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value && typeof value === 'object') {
+    const [firstMessageGroup] = Object.values(value);
+
+    if (typeof firstMessageGroup === 'string') {
+      return firstMessageGroup;
+    }
+
+    if (Array.isArray(firstMessageGroup) && firstMessageGroup[0]) {
+      return firstMessageGroup[0];
+    }
+  }
+
+  return null;
 };
 
 export const extractAuthApiErrorMessage = (error: unknown) => {
@@ -63,24 +87,16 @@ export const extractAuthApiErrorMessage = (error: unknown) => {
 
   const data = error.response?.data as ErrorResponseBody | undefined;
 
-  if (typeof data?.detail === 'string') {
-    return data.detail;
+  const detailMessage = extractFieldErrorMessage(data?.detail);
+
+  if (detailMessage) {
+    return detailMessage;
   }
 
-  if (typeof data?.error_detail === 'string') {
-    return data.error_detail;
-  }
+  const errorDetailMessage = extractFieldErrorMessage(data?.error_detail);
 
-  if (data?.error_detail && typeof data.error_detail === 'object') {
-    const [firstMessageGroup] = Object.values(data.error_detail);
-
-    if (typeof firstMessageGroup === 'string') {
-      return firstMessageGroup;
-    }
-
-    if (Array.isArray(firstMessageGroup) && firstMessageGroup[0]) {
-      return firstMessageGroup[0];
-    }
+  if (errorDetailMessage) {
+    return errorDetailMessage;
   }
 
   return '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+
+import {
+  checkIdDuplicate,
+  checkNicknameDuplicate,
+  login,
+  signup,
+} from './auth';
+
+export const useLoginMutation = () =>
+  useMutation({
+    mutationFn: login,
+  });
+
+export const useSignupMutation = () =>
+  useMutation({
+    mutationFn: signup,
+  });
+
+export const useCheckIdDuplicateMutation = () =>
+  useMutation({
+    mutationFn: checkIdDuplicate,
+  });
+
+export const useCheckNicknameDuplicateMutation = () =>
+  useMutation({
+    mutationFn: checkNicknameDuplicate,
+  });

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -4,25 +4,36 @@ import {
   checkIdDuplicate,
   checkNicknameDuplicate,
   login,
+  logout,
   signup,
 } from './auth';
 
 export const useLoginMutation = () =>
   useMutation({
+    mutationKey: ['auth', 'login'],
     mutationFn: login,
   });
 
 export const useSignupMutation = () =>
   useMutation({
+    mutationKey: ['auth', 'signup'],
     mutationFn: signup,
+  });
+
+export const useLogoutMutation = () =>
+  useMutation({
+    mutationKey: ['auth', 'logout'],
+    mutationFn: logout,
   });
 
 export const useCheckIdDuplicateMutation = () =>
   useMutation({
+    mutationKey: ['auth', 'check-id-duplicate'],
     mutationFn: checkIdDuplicate,
   });
 
 export const useCheckNicknameDuplicateMutation = () =>
   useMutation({
+    mutationKey: ['auth', 'check-nickname-duplicate'],
     mutationFn: checkNicknameDuplicate,
   });

--- a/src/features/auth/constants/auth.ts
+++ b/src/features/auth/constants/auth.ts
@@ -1,0 +1,1 @@
+export const AUTH_BASE_PATH = '/api/v1/accounts';

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -1,18 +1,24 @@
 import { delay, http, HttpResponse } from 'msw';
 
+import { AUTH_BASE_PATH } from '../constants/auth';
 import type {
   AuthGender,
-  AuthUser,
+  CheckIdDuplicateRequest,
+  CheckNicknameDuplicateRequest,
   LoginRequest,
+  LogoutResponse,
   SignupRequest,
 } from '../types/auth';
 
-type MockUserRecord = AuthUser & {
+type MockUserRecord = {
+  id: number;
   loginId: string;
   password: string;
+  name: string;
+  nickname: string;
+  gender: AuthGender;
+  suspended?: boolean;
 };
-
-const AUTH_BASE_PATH = '/api/v1/auth';
 
 const mockUsers = new Map<string, MockUserRecord>([
   [
@@ -23,7 +29,7 @@ const mockUsers = new Map<string, MockUserRecord>([
       password: 'demo1234',
       name: 'PGTI 데모',
       nickname: '데모유저',
-      gender: 'UNSPECIFIED',
+      gender: 'M',
     },
   ],
   [
@@ -34,14 +40,27 @@ const mockUsers = new Map<string, MockUserRecord>([
       password: 'demo1234',
       name: '기존 사용자',
       nickname: '중복닉네임',
-      gender: 'FEMALE',
+      gender: 'W',
+    },
+  ],
+  [
+    'suspended-user',
+    {
+      id: 3,
+      loginId: 'suspended-user',
+      password: 'demo1234',
+      name: '정지 사용자',
+      nickname: '정지계정',
+      gender: 'M',
+      suspended: true,
     },
   ],
 ]);
 
-const validGenders: AuthGender[] = ['UNSPECIFIED', 'MALE', 'FEMALE'];
+const validGenders: AuthGender[] = ['M', 'W'];
 
 const createAccessToken = (loginId: string) => `mock-access-token-${loginId}`;
+const createRefreshToken = (loginId: string) => `mock-refresh-token-${loginId}`;
 
 const getDuplicateError = (message: string) =>
   HttpResponse.json(
@@ -51,10 +70,12 @@ const getDuplicateError = (message: string) =>
     { status: 409 },
   );
 
-const getValidationError = (message: string) =>
+const getFieldValidationError = (fieldName: string, message: string) =>
   HttpResponse.json(
     {
-      error_detail: message,
+      detail: {
+        [fieldName]: [message],
+      },
     },
     { status: 400 },
   );
@@ -70,57 +91,121 @@ const getUnauthorizedError = (message: string) =>
 const findUserByNickname = (nickname: string) =>
   [...mockUsers.values()].find((user) => user.nickname === nickname);
 
-export const authHandlers = [
+const loginHandlers = [
   http.post(`${AUTH_BASE_PATH}/login`, async ({ request }) => {
     const body = (await request.json()) as LoginRequest;
-    const loginId = body.id.trim();
+    const loginId = body.login_id.trim();
     const password = body.password.trim();
 
-    if (!loginId || !password) {
-      return getValidationError('아이디와 비밀번호를 입력해 주세요.');
+    if (!loginId) {
+      return getFieldValidationError(
+        'login_id',
+        '"login_id"이 필드는 필수 항목입니다.',
+      );
+    }
+
+    if (!password) {
+      return getFieldValidationError(
+        'password',
+        '"password"이 필드는 필수 항목입니다.',
+      );
     }
 
     const user = mockUsers.get(loginId);
 
     if (!user || user.password !== password) {
-      return getUnauthorizedError('아이디 또는 비밀번호가 올바르지 않습니다.');
+      return getUnauthorizedError(
+        '로그인 아이디 또는 비밀번호가 올바르지 않습니다.',
+      );
+    }
+
+    if (user.suspended) {
+      return HttpResponse.json(
+        {
+          error_detail: '정지된 계정입니다.',
+        },
+        { status: 403 },
+      );
     }
 
     await delay(500);
 
     return HttpResponse.json({
       access_token: createAccessToken(user.loginId),
-      user: {
-        id: user.id,
-        name: user.name,
-        nickname: user.nickname,
-        gender: user.gender,
-      },
+      refresh_token: createRefreshToken(user.loginId),
     });
   }),
+];
 
+const signupHandlers = [
   http.post(`${AUTH_BASE_PATH}/signup`, async ({ request }) => {
     const body = (await request.json()) as SignupRequest;
-    const loginId = body.id.trim();
+    const loginId = body.login_id.trim();
     const name = body.name.trim();
     const nickname = body.nickname.trim();
     const password = body.password.trim();
+    const passwordCheck = body.password_check.trim();
     const gender = body.gender;
 
-    if (!loginId || !name || !nickname || !password) {
-      return getValidationError('필수 입력값을 모두 입력해 주세요.');
+    if (!loginId) {
+      return getFieldValidationError(
+        'login_id',
+        '"login_id"이 필드는 필수 항목입니다.',
+      );
+    }
+
+    if (!password) {
+      return getFieldValidationError(
+        'password',
+        '"password"이 필드는 필수 항목입니다.',
+      );
+    }
+
+    if (!passwordCheck) {
+      return getFieldValidationError(
+        'password_check',
+        '"password_check"이 필드는 필수 항목입니다.',
+      );
+    }
+
+    if (!nickname) {
+      return getFieldValidationError(
+        'nickname',
+        '"nickname"이 필드는 필수 항목입니다.',
+      );
+    }
+
+    if (!name) {
+      return getFieldValidationError(
+        'name',
+        '"name"이 필드는 필수 항목입니다.',
+      );
     }
 
     if (!validGenders.includes(gender)) {
-      return getValidationError('올바른 성별 값을 선택해 주세요.');
+      return getFieldValidationError(
+        'gender',
+        '"gender"이 필드는 필수 항목입니다.',
+      );
+    }
+
+    if (password.length <= 8) {
+      return getFieldValidationError('password', '비밀번호가 8자 이하입니다.');
+    }
+
+    if (password !== passwordCheck) {
+      return getFieldValidationError(
+        'password_check',
+        '비밀번호와 일치하지 않습니다.',
+      );
     }
 
     if (mockUsers.has(loginId)) {
-      return getDuplicateError('이미 사용 중인 아이디입니다.');
+      return getDuplicateError('이미 중복된 회원가입 내역이 존재합니다.');
     }
 
     if (findUserByNickname(nickname)) {
-      return getDuplicateError('이미 사용 중인 닉네임입니다.');
+      return getDuplicateError('이미 중복된 닉네임이 존재합니다.');
     }
 
     const createdUser: MockUserRecord = {
@@ -136,52 +221,87 @@ export const authHandlers = [
 
     await delay(600);
 
-    return HttpResponse.json({
-      access_token: createAccessToken(createdUser.loginId),
-      user: {
-        id: createdUser.id,
-        name: createdUser.name,
-        nickname: createdUser.nickname,
-        gender: createdUser.gender,
+    return HttpResponse.json(
+      {
+        detail: '회원가입이 완료되었습니다.',
       },
-    });
+      { status: 201 },
+    );
   }),
+];
 
-  http.get(`${AUTH_BASE_PATH}/check-id`, async ({ request }) => {
-    const url = new URL(request.url);
-    const value = url.searchParams.get('value')?.trim() ?? '';
+const logoutHandlers = [
+  http.post(`${AUTH_BASE_PATH}/logout`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+
+    if (!authorization?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        {
+          error_detail: '인증 정보가 유효하지 않거나 만료되었습니다.',
+        } satisfies LogoutResponse | { error_detail: string },
+        { status: 401 },
+      );
+    }
+
+    await delay(200);
+
+    return HttpResponse.json({
+      detail: '로그아웃 되었습니다.',
+    } satisfies LogoutResponse);
+  }),
+];
+
+const duplicateCheckHandlers = [
+  http.post(`${AUTH_BASE_PATH}/check-id`, async ({ request }) => {
+    const body = (await request.json()) as CheckIdDuplicateRequest;
+    const value = body.login_id.trim();
 
     if (!value) {
-      return getValidationError('확인할 아이디를 입력해 주세요.');
+      return getFieldValidationError(
+        'login_id',
+        '"login_id"이 필드는 필수 항목입니다.',
+      );
     }
 
     await delay(250);
 
+    if (mockUsers.has(value)) {
+      return getDuplicateError('중복된 아이디가 존재합니다.');
+    }
+
     return HttpResponse.json({
-      available: !mockUsers.has(value),
-      message: mockUsers.has(value)
-        ? '이미 사용 중인 아이디입니다.'
-        : '사용 가능한 아이디입니다.',
+      detail: '사용가능한 아이디 입니다.',
     });
   }),
 
-  http.get(`${AUTH_BASE_PATH}/check-nickname`, async ({ request }) => {
-    const url = new URL(request.url);
-    const value = url.searchParams.get('value')?.trim() ?? '';
+  http.post(`${AUTH_BASE_PATH}/check-nickname`, async ({ request }) => {
+    const body = (await request.json()) as CheckNicknameDuplicateRequest;
+    const value = body.nickname.trim();
 
     if (!value) {
-      return getValidationError('확인할 닉네임을 입력해 주세요.');
+      return getFieldValidationError(
+        'nickname',
+        '"nickname"이 필드는 필수 항목입니다.',
+      );
     }
 
     await delay(250);
 
     const isDuplicate = Boolean(findUserByNickname(value));
 
+    if (isDuplicate) {
+      return getDuplicateError('중복된 닉네임이 존재합니다.');
+    }
+
     return HttpResponse.json({
-      available: !isDuplicate,
-      message: isDuplicate
-        ? '이미 사용 중인 닉네임입니다.'
-        : '사용 가능한 닉네임입니다.',
+      detail: '사용가능한 닉네임 입니다.',
     });
   }),
+];
+
+export const authHandlers = [
+  ...loginHandlers,
+  ...signupHandlers,
+  ...logoutHandlers,
+  ...duplicateCheckHandlers,
 ];

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -1,0 +1,187 @@
+import { delay, http, HttpResponse } from 'msw';
+
+import type {
+  AuthGender,
+  AuthUser,
+  LoginRequest,
+  SignupRequest,
+} from '../types/auth';
+
+type MockUserRecord = AuthUser & {
+  loginId: string;
+  password: string;
+};
+
+const AUTH_BASE_PATH = '/api/v1/auth';
+
+const mockUsers = new Map<string, MockUserRecord>([
+  [
+    'pgti-demo',
+    {
+      id: 1,
+      loginId: 'pgti-demo',
+      password: 'demo1234',
+      name: 'PGTI 데모',
+      nickname: '데모유저',
+      gender: 'UNSPECIFIED',
+    },
+  ],
+  [
+    'already-used',
+    {
+      id: 2,
+      loginId: 'already-used',
+      password: 'demo1234',
+      name: '기존 사용자',
+      nickname: '중복닉네임',
+      gender: 'FEMALE',
+    },
+  ],
+]);
+
+const validGenders: AuthGender[] = ['UNSPECIFIED', 'MALE', 'FEMALE'];
+
+const createAccessToken = (loginId: string) => `mock-access-token-${loginId}`;
+
+const getDuplicateError = (message: string) =>
+  HttpResponse.json(
+    {
+      error_detail: message,
+    },
+    { status: 409 },
+  );
+
+const getValidationError = (message: string) =>
+  HttpResponse.json(
+    {
+      error_detail: message,
+    },
+    { status: 400 },
+  );
+
+const getUnauthorizedError = (message: string) =>
+  HttpResponse.json(
+    {
+      error_detail: message,
+    },
+    { status: 401 },
+  );
+
+const findUserByNickname = (nickname: string) =>
+  [...mockUsers.values()].find((user) => user.nickname === nickname);
+
+export const authHandlers = [
+  http.post(`${AUTH_BASE_PATH}/login`, async ({ request }) => {
+    const body = (await request.json()) as LoginRequest;
+    const loginId = body.id.trim();
+    const password = body.password.trim();
+
+    if (!loginId || !password) {
+      return getValidationError('아이디와 비밀번호를 입력해 주세요.');
+    }
+
+    const user = mockUsers.get(loginId);
+
+    if (!user || user.password !== password) {
+      return getUnauthorizedError('아이디 또는 비밀번호가 올바르지 않습니다.');
+    }
+
+    await delay(500);
+
+    return HttpResponse.json({
+      access_token: createAccessToken(user.loginId),
+      user: {
+        id: user.id,
+        name: user.name,
+        nickname: user.nickname,
+        gender: user.gender,
+      },
+    });
+  }),
+
+  http.post(`${AUTH_BASE_PATH}/signup`, async ({ request }) => {
+    const body = (await request.json()) as SignupRequest;
+    const loginId = body.id.trim();
+    const name = body.name.trim();
+    const nickname = body.nickname.trim();
+    const password = body.password.trim();
+    const gender = body.gender;
+
+    if (!loginId || !name || !nickname || !password) {
+      return getValidationError('필수 입력값을 모두 입력해 주세요.');
+    }
+
+    if (!validGenders.includes(gender)) {
+      return getValidationError('올바른 성별 값을 선택해 주세요.');
+    }
+
+    if (mockUsers.has(loginId)) {
+      return getDuplicateError('이미 사용 중인 아이디입니다.');
+    }
+
+    if (findUserByNickname(nickname)) {
+      return getDuplicateError('이미 사용 중인 닉네임입니다.');
+    }
+
+    const createdUser: MockUserRecord = {
+      id: mockUsers.size + 1,
+      loginId,
+      password,
+      name,
+      nickname,
+      gender,
+    };
+
+    mockUsers.set(loginId, createdUser);
+
+    await delay(600);
+
+    return HttpResponse.json({
+      access_token: createAccessToken(createdUser.loginId),
+      user: {
+        id: createdUser.id,
+        name: createdUser.name,
+        nickname: createdUser.nickname,
+        gender: createdUser.gender,
+      },
+    });
+  }),
+
+  http.get(`${AUTH_BASE_PATH}/check-id`, async ({ request }) => {
+    const url = new URL(request.url);
+    const value = url.searchParams.get('value')?.trim() ?? '';
+
+    if (!value) {
+      return getValidationError('확인할 아이디를 입력해 주세요.');
+    }
+
+    await delay(250);
+
+    return HttpResponse.json({
+      available: !mockUsers.has(value),
+      message: mockUsers.has(value)
+        ? '이미 사용 중인 아이디입니다.'
+        : '사용 가능한 아이디입니다.',
+    });
+  }),
+
+  http.get(`${AUTH_BASE_PATH}/check-nickname`, async ({ request }) => {
+    const url = new URL(request.url);
+    const value = url.searchParams.get('value')?.trim() ?? '';
+
+    if (!value) {
+      return getValidationError('확인할 닉네임을 입력해 주세요.');
+    }
+
+    await delay(250);
+
+    const isDuplicate = Boolean(findUserByNickname(value));
+
+    return HttpResponse.json({
+      available: !isDuplicate,
+      message: isDuplicate
+        ? '이미 사용 중인 닉네임입니다.'
+        : '사용 가능한 닉네임입니다.',
+    });
+  }),
+];

--- a/src/features/auth/types/api.ts
+++ b/src/features/auth/types/api.ts
@@ -1,0 +1,4 @@
+export interface ErrorResponseBody {
+  detail?: string | Record<string, string[]>;
+  error_detail?: string | Record<string, string[]>;
+}

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -1,0 +1,36 @@
+export type AuthGender = 'UNSPECIFIED' | 'MALE' | 'FEMALE';
+
+export interface AuthUser {
+  id: number;
+  name: string;
+  nickname: string;
+  gender: AuthGender;
+}
+
+export interface LoginRequest {
+  id: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  access_token: string;
+  user: AuthUser;
+}
+
+export interface SignupRequest {
+  name: string;
+  id: string;
+  nickname: string;
+  password: string;
+  gender: AuthGender;
+}
+
+export interface SignupResponse {
+  access_token: string;
+  user: AuthUser;
+}
+
+export interface DuplicateCheckResponse {
+  available: boolean;
+  message: string;
+}

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -1,36 +1,42 @@
-export type AuthGender = 'UNSPECIFIED' | 'MALE' | 'FEMALE';
-
-export interface AuthUser {
-  id: number;
-  name: string;
-  nickname: string;
-  gender: AuthGender;
-}
+export type AuthGender = 'M' | 'W';
 
 export interface LoginRequest {
-  id: string;
+  login_id: string;
   password: string;
 }
 
 export interface LoginResponse {
   access_token: string;
-  user: AuthUser;
+  refresh_token: string;
+}
+
+export interface LogoutResponse {
+  detail: string;
 }
 
 export interface SignupRequest {
+  login_id: string;
+  password_check: string;
   name: string;
-  id: string;
   nickname: string;
   password: string;
   gender: AuthGender;
 }
 
 export interface SignupResponse {
-  access_token: string;
-  user: AuthUser;
+  detail: string;
+}
+
+export interface CheckNicknameDuplicateRequest {
+  nickname: string;
+}
+
+export interface CheckIdDuplicateRequest {
+  login_id: string;
 }
 
 export interface DuplicateCheckResponse {
-  available: boolean;
-  message: string;
+  detail: string;
 }
+
+export type { ErrorResponseBody } from './api';

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { authHandlers } from '../features/auth/mocks/handlers';
 import { surveyHandlers } from '../features/survey/mocks/handlers';
 
-export const handlers = [...surveyHandlers];
+export const handlers = [...authHandlers, ...surveyHandlers];

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+const AUTH_STORAGE_KEY = 'auth-storage';
+const LEGACY_ACCESS_TOKEN_KEYS = ['accessToken', 'access_token'] as const;
+const LEGACY_REFRESH_TOKEN_KEYS = ['refreshToken', 'refresh_token'] as const;
+
+const getLegacyAccessToken = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  for (const key of LEGACY_ACCESS_TOKEN_KEYS) {
+    const token = window.localStorage.getItem(key);
+
+    if (token) {
+      return token;
+    }
+  }
+
+  return null;
+};
+
+const getLegacyRefreshToken = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  for (const key of LEGACY_REFRESH_TOKEN_KEYS) {
+    const token = window.localStorage.getItem(key);
+
+    if (token) {
+      return token;
+    }
+  }
+
+  return null;
+};
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  setAuthTokens: (accessToken: string, refreshToken: string) => void;
+  setAccessToken: (token: string) => void;
+  clearAuthTokens: () => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      accessToken: getLegacyAccessToken(),
+      refreshToken: getLegacyRefreshToken(),
+      setAuthTokens: (accessToken, refreshToken) =>
+        set({ accessToken, refreshToken }),
+      setAccessToken: (token) => set({ accessToken: token }),
+      clearAuthTokens: () => set({ accessToken: null, refreshToken: null }),
+    }),
+    {
+      name: AUTH_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
+      }),
+    },
+  ),
+);
+
+export const clearLegacyAuthStorage = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  for (const key of LEGACY_ACCESS_TOKEN_KEYS) {
+    window.localStorage.removeItem(key);
+  }
+
+  for (const key of LEGACY_REFRESH_TOKEN_KEYS) {
+    window.localStorage.removeItem(key);
+  }
+};
+
+export const getLegacyAccessTokenFromStorage = getLegacyAccessToken;
+export const getLegacyRefreshTokenFromStorage = getLegacyRefreshToken;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,4 +1,5 @@
 const ACCESS_TOKEN_KEYS = ['accessToken', 'access_token'] as const;
+const PRIMARY_ACCESS_TOKEN_KEY = ACCESS_TOKEN_KEYS[0];
 
 export const getAccessToken = () => {
   if (typeof window === 'undefined') {
@@ -14,4 +15,26 @@ export const getAccessToken = () => {
   }
 
   return null;
+};
+
+export const setAccessToken = (token: string) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(PRIMARY_ACCESS_TOKEN_KEY, token);
+
+  for (const key of ACCESS_TOKEN_KEYS.slice(1)) {
+    window.localStorage.removeItem(key);
+  }
+};
+
+export const clearAccessToken = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  for (const key of ACCESS_TOKEN_KEYS) {
+    window.localStorage.removeItem(key);
+  }
 };

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,40 +1,35 @@
-const ACCESS_TOKEN_KEYS = ['accessToken', 'access_token'] as const;
-const PRIMARY_ACCESS_TOKEN_KEY = ACCESS_TOKEN_KEYS[0];
+import {
+  clearLegacyAuthStorage,
+  getLegacyAccessTokenFromStorage,
+  getLegacyRefreshTokenFromStorage,
+  useAuthStore,
+} from '../store/useAuthStore';
 
 export const getAccessToken = () => {
-  if (typeof window === 'undefined') {
-    return null;
-  }
+  return (
+    useAuthStore.getState().accessToken ?? getLegacyAccessTokenFromStorage()
+  );
+};
 
-  for (const key of ACCESS_TOKEN_KEYS) {
-    const token = window.localStorage.getItem(key);
+export const getRefreshToken = () => {
+  return (
+    useAuthStore.getState().refreshToken ?? getLegacyRefreshTokenFromStorage()
+  );
+};
 
-    if (token) {
-      return token;
-    }
-  }
-
-  return null;
+export const setAuthTokens = (accessToken: string, refreshToken: string) => {
+  useAuthStore.getState().setAuthTokens(accessToken, refreshToken);
+  clearLegacyAuthStorage();
 };
 
 export const setAccessToken = (token: string) => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  window.localStorage.setItem(PRIMARY_ACCESS_TOKEN_KEY, token);
-
-  for (const key of ACCESS_TOKEN_KEYS.slice(1)) {
-    window.localStorage.removeItem(key);
-  }
+  useAuthStore.getState().setAccessToken(token);
+  clearLegacyAuthStorage();
 };
 
 export const clearAccessToken = () => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  for (const key of ACCESS_TOKEN_KEYS) {
-    window.localStorage.removeItem(key);
-  }
+  useAuthStore.getState().clearAuthTokens();
+  clearLegacyAuthStorage();
 };
+
+export const clearAuthTokens = clearAccessToken;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,6 +4,9 @@
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "esnext",
     "types": ["vite/client"],
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath, URL } from 'node:url';
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
@@ -5,4 +7,9 @@ import tailwindcss from '@tailwindcss/vite';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
 });


### PR DESCRIPTION
## 관련 이슈

- closes #25 

## 변경 내용

- src/features/auth를 추가하고 api, types, mocks 구조를 구성했습니다.
- 로그인, 회원가입, 아이디 중복확인, 닉네임 중복확인용 auth API 함수를 추가했습니다.
- auth 관련 React Query mutation hook을 추가했습니다.
- auth MSW 핸들러를 추가하고 기존 루트 mock handler에 연결했습니다.
- 인증 토큰 조회 외에 저장/삭제 유틸을 src/utils/auth.ts에 추가했습니다.
- 이후 회원가입 라우트 연결을 위한 ROUTES.SIGNUP 상수를 추가했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 인증 기능의 기반 작업만 포함합니다.
- 실제 로그인/회원가입 폼 연결 및 회원가입 페이지 UI는 후속 PR에서 진행합니다.
- 추가된 auth API 및 MSW 범위는 로그인, 회원가입, 아이디 중복확인, 닉네임 중복확인입니다.
