### PR TITLE
[Feat] 회원가입 페이지 UI

### DIFF
--- a/src/components/auth/AuthButton.tsx
+++ b/src/components/auth/AuthButton.tsx
@@ -1,0 +1,41 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+type AuthButtonVariant = 'primary' | 'secondary' | 'ghost';
+
+type AuthButtonProps = {
+  children: ReactNode;
+  variant?: AuthButtonVariant;
+  className?: string;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+const baseClassName =
+  'flex h-14 items-center justify-center transition-colors disabled:pointer-events-none disabled:opacity-60';
+
+const variantClassNames: Record<AuthButtonVariant, string> = {
+  primary:
+    'shadow-login-primary bg-login-primary hover:bg-login-primary-hover rounded-full text-lg/7 font-semibold text-white',
+  secondary:
+    'bg-login-field border-login-field text-login-label hover:border-white/20 hover:text-white rounded-xl border text-sm/5 font-medium',
+  ghost:
+    'border-login-outline hover:border-white/25 hover:bg-white/5 rounded-full border bg-transparent text-lg/7 font-semibold text-white',
+};
+
+function AuthButton({
+  children,
+  variant = 'primary',
+  className = '',
+  type = 'button',
+  ...props
+}: AuthButtonProps) {
+  return (
+    <button
+      type={type}
+      className={`${baseClassName} ${variantClassNames[variant]} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default AuthButton;

--- a/src/components/auth/AuthDivider.tsx
+++ b/src/components/auth/AuthDivider.tsx
@@ -1,14 +1,13 @@
 type AuthDividerProps = {
-  label: string;
   className?: string;
 };
 
-function AuthDivider({ label, className = '' }: AuthDividerProps) {
+function AuthDivider({ className = '' }: AuthDividerProps) {
   return (
     <div className={`flex items-center gap-4 py-1 ${className}`}>
       <div className="bg-login-divider-line h-px flex-1" />
       <span className="text-login-divider-label text-xs/5 font-normal tracking-[0.18em]">
-        {label}
+        OR
       </span>
       <div className="bg-login-divider-line h-px flex-1" />
     </div>

--- a/src/components/auth/AuthDivider.tsx
+++ b/src/components/auth/AuthDivider.tsx
@@ -1,0 +1,18 @@
+type AuthDividerProps = {
+  label: string;
+  className?: string;
+};
+
+function AuthDivider({ label, className = '' }: AuthDividerProps) {
+  return (
+    <div className={`flex items-center gap-4 py-1 ${className}`}>
+      <div className="bg-login-divider-line h-px flex-1" />
+      <span className="text-login-divider-label text-xs/5 font-normal tracking-[0.18em]">
+        {label}
+      </span>
+      <div className="bg-login-divider-line h-px flex-1" />
+    </div>
+  );
+}
+
+export default AuthDivider;

--- a/src/components/auth/AuthInputActionButton.tsx
+++ b/src/components/auth/AuthInputActionButton.tsx
@@ -1,13 +1,15 @@
+import type { ReactNode } from 'react';
+
 import AuthButton from './AuthButton';
 
 type AuthInputActionButtonProps = {
-  label: string;
+  children: ReactNode;
 };
 
-function AuthInputActionButton({ label }: AuthInputActionButtonProps) {
+function AuthInputActionButton({ children }: AuthInputActionButtonProps) {
   return (
     <AuthButton variant="secondary" className="w-24 shrink-0">
-      {label}
+      {children}
     </AuthButton>
   );
 }

--- a/src/components/auth/AuthInputActionButton.tsx
+++ b/src/components/auth/AuthInputActionButton.tsx
@@ -1,0 +1,15 @@
+import AuthButton from './AuthButton';
+
+type AuthInputActionButtonProps = {
+  label: string;
+};
+
+function AuthInputActionButton({ label }: AuthInputActionButtonProps) {
+  return (
+    <AuthButton variant="secondary" className="w-24 shrink-0">
+      {label}
+    </AuthButton>
+  );
+}
+
+export default AuthInputActionButton;

--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -1,33 +1,21 @@
-import type { ChangeEventHandler, FocusEventHandler, ReactNode } from 'react';
+import type { InputHTMLAttributes, ReactNode } from 'react';
 
 type AuthInputFieldProps = {
   id: string;
-  name: string;
   label: string;
-  type: 'text' | 'password' | 'email';
-  autoComplete?: string;
-  placeholder: string;
-  value?: string;
-  onChange?: ChangeEventHandler<HTMLInputElement>;
-  onBlur?: FocusEventHandler<HTMLInputElement>;
   errorMessage?: string;
   action?: ReactNode;
   containerClassName?: string;
-};
+} & InputHTMLAttributes<HTMLInputElement>;
 
 function AuthInputField({
   id,
-  name,
   label,
-  type,
-  autoComplete,
-  placeholder,
-  value,
-  onChange,
-  onBlur,
   errorMessage,
   action,
   containerClassName = '',
+  className = '',
+  ...inputProps
 }: AuthInputFieldProps) {
   return (
     <div className={`space-y-2.5 ${containerClassName}`}>
@@ -40,15 +28,9 @@ function AuthInputField({
       <div className="flex items-stretch gap-3">
         <input
           id={id}
-          name={name}
-          type={type}
-          autoComplete={autoComplete}
-          placeholder={placeholder}
-          value={value}
-          onChange={onChange}
-          onBlur={onBlur}
+          {...inputProps}
           aria-invalid={Boolean(errorMessage)}
-          className={`placeholder-login-muted bg-login-field h-14 min-w-0 flex-1 rounded-xl border px-4 text-base text-white transition outline-none focus-visible:ring-2 ${
+          className={`placeholder-login-muted bg-login-field h-14 min-w-0 flex-1 rounded-xl border px-4 text-base text-white transition outline-none focus-visible:ring-2 ${className} ${
             errorMessage
               ? 'border-red-500 focus-visible:ring-red-500/20'
               : 'border-login-field focus-visible:ring-white/20'

--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -1,3 +1,5 @@
+import type { ChangeEventHandler, FocusEventHandler, ReactNode } from 'react';
+
 type AuthInputFieldProps = {
   id: string;
   name: string;
@@ -5,6 +7,12 @@ type AuthInputFieldProps = {
   type: 'text' | 'password' | 'email';
   autoComplete?: string;
   placeholder: string;
+  value?: string;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  onBlur?: FocusEventHandler<HTMLInputElement>;
+  errorMessage?: string;
+  action?: ReactNode;
+  containerClassName?: string;
 };
 
 function AuthInputField({
@@ -14,23 +22,45 @@ function AuthInputField({
   type,
   autoComplete,
   placeholder,
+  value,
+  onChange,
+  onBlur,
+  errorMessage,
+  action,
+  containerClassName = '',
 }: AuthInputFieldProps) {
   return (
-    <div className="space-y-3">
+    <div className={`space-y-2.5 ${containerClassName}`}>
       <label
         htmlFor={id}
-        className="text-login-label block text-[15px] font-medium"
+        className="text-login-label block text-sm font-medium"
       >
         {label}
       </label>
-      <input
-        id={id}
-        name={name}
-        type={type}
-        autoComplete={autoComplete}
-        placeholder={placeholder}
-        className="placeholder-login-muted bg-login-field border-login-field h-[56px] w-full rounded-[12px] border px-4 text-base text-white transition outline-none focus-visible:ring-2 focus-visible:ring-white/20"
-      />
+      <div className="flex items-stretch gap-3">
+        <input
+          id={id}
+          name={name}
+          type={type}
+          autoComplete={autoComplete}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+          aria-invalid={Boolean(errorMessage)}
+          className={`placeholder-login-muted bg-login-field h-14 min-w-0 flex-1 rounded-xl border px-4 text-base text-white transition outline-none focus-visible:ring-2 ${
+            errorMessage
+              ? 'border-red-500 focus-visible:ring-red-500/20'
+              : 'border-login-field focus-visible:ring-white/20'
+          }`}
+        />
+        {action}
+      </div>
+      {errorMessage ? (
+        <p className="pl-1 text-sm/5 font-medium text-red-400">
+          {errorMessage}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/src/components/auth/AuthLinkButton.tsx
+++ b/src/components/auth/AuthLinkButton.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react';
+import { Link, type LinkProps } from 'react-router';
+
+type AuthLinkButtonVariant = 'ghost';
+
+type AuthLinkButtonProps = {
+  variant?: AuthLinkButtonVariant;
+  className?: string;
+  children: ReactNode;
+} & LinkProps;
+
+const baseClassName =
+  'flex h-14 items-center justify-center transition-colors disabled:pointer-events-none disabled:opacity-60';
+
+const variantClassNames: Record<AuthLinkButtonVariant, string> = {
+  ghost:
+    'border-login-outline hover:border-white/25 hover:bg-white/5 rounded-full border bg-transparent text-lg/7 font-semibold text-white',
+};
+
+function AuthLinkButton({
+  variant = 'ghost',
+  className = '',
+  children,
+  ...props
+}: AuthLinkButtonProps) {
+  return (
+    <Link
+      className={`${baseClassName} ${variantClassNames[variant]} ${className}`}
+      {...props}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export default AuthLinkButton;

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -1,0 +1,50 @@
+type AuthRadioOption = {
+  label: string;
+  value: string;
+};
+
+type AuthRadioGroupProps = {
+  label: string;
+  name: string;
+  options: AuthRadioOption[];
+  defaultValue?: string;
+};
+
+function AuthRadioGroup({
+  label,
+  name,
+  options,
+  defaultValue,
+}: AuthRadioGroupProps) {
+  return (
+    <fieldset className="space-y-3.5">
+      <legend className="text-login-label block text-sm font-medium">
+        {label}
+      </legend>
+      <div className="flex items-center justify-between gap-3 pt-1">
+        {options.map((option) => (
+          <label
+            key={option.value}
+            className="flex min-w-0 flex-1 cursor-pointer items-center justify-center gap-2"
+          >
+            <input
+              type="radio"
+              name={name}
+              value={option.value}
+              defaultChecked={defaultValue === option.value}
+              className="peer sr-only"
+            />
+            <span className="border-login-field peer-checked:border-login-primary flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors">
+              <span className="bg-login-primary h-2 w-2 rounded-full opacity-0 transition-opacity peer-checked:opacity-100" />
+            </span>
+            <span className="text-login-helper truncate text-sm/5 font-medium transition-colors peer-checked:text-white">
+              {option.label}
+            </span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+export default AuthRadioGroup;

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -1,3 +1,5 @@
+import type { ChangeEventHandler } from 'react';
+
 type AuthRadioOption = {
   label: string;
   value: string;
@@ -6,15 +8,23 @@ type AuthRadioOption = {
 type AuthRadioGroupProps = {
   label: string;
   name: string;
-  options: AuthRadioOption[];
+  options: readonly AuthRadioOption[];
+  value?: string;
   defaultValue?: string;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  errorMessage?: string;
+  required?: boolean;
 };
 
 function AuthRadioGroup({
   label,
   name,
   options,
+  value,
   defaultValue,
+  onChange,
+  errorMessage,
+  required = false,
 }: AuthRadioGroupProps) {
   return (
     <fieldset className="space-y-3.5">
@@ -31,10 +41,19 @@ function AuthRadioGroup({
               type="radio"
               name={name}
               value={option.value}
-              defaultChecked={defaultValue === option.value}
+              checked={value !== undefined ? value === option.value : undefined}
+              defaultChecked={
+                value !== undefined ? undefined : defaultValue === option.value
+              }
+              onChange={onChange}
+              required={required}
               className="peer sr-only"
             />
-            <span className="border-login-field peer-checked:border-login-primary flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors">
+            <span
+              className={`peer-checked:border-login-primary flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors ${
+                errorMessage ? 'border-red-500' : 'border-login-field'
+              }`}
+            >
               <span className="bg-login-primary h-2 w-2 rounded-full opacity-0 transition-opacity peer-checked:opacity-100" />
             </span>
             <span className="text-login-helper truncate text-sm/5 font-medium transition-colors peer-checked:text-white">
@@ -43,6 +62,11 @@ function AuthRadioGroup({
           </label>
         ))}
       </div>
+      {errorMessage ? (
+        <p className="pl-1 text-sm/5 font-medium text-red-400">
+          {errorMessage}
+        </p>
+      ) : null}
     </fieldset>
   );
 }

--- a/src/components/auth/AuthSocialLoginGroup.tsx
+++ b/src/components/auth/AuthSocialLoginGroup.tsx
@@ -1,0 +1,71 @@
+import SocialLoginButton from '../login/SocialLoginButton';
+
+type AuthSocialLoginGroupProps = {
+  className?: string;
+};
+
+const GoogleIcon = () => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
+    <path
+      fill="#4285F4"
+      d="M21.805 10.041H12.61v3.949h5.268c-.229 1.276-.955 2.356-2.036 3.083v2.526h3.304c1.937-1.783 3.056-4.41 3.056-7.548 0-.676-.061-1.315-.397-2.01Z"
+    />
+    <path
+      fill="#34A853"
+      d="M12.61 22.5c2.619 0 4.816-.867 6.421-2.352l-3.304-2.526c-.918.62-2.091.986-3.117.986-2.396 0-4.427-1.615-5.153-3.79H4.048v2.604A9.692 9.692 0 0 0 12.61 22.5Z"
+    />
+    <path
+      fill="#FBBC04"
+      d="M7.457 14.818a5.81 5.81 0 0 1-.291-1.818c0-.631.108-1.243.291-1.818V8.578H4.048A9.694 9.694 0 0 0 3 13c0 1.559.374 3.035 1.048 4.422l3.409-2.604Z"
+    />
+    <path
+      fill="#EA4335"
+      d="M12.61 7.392c1.422 0 2.697.489 3.703 1.447l2.777-2.777C17.421 4.509 15.229 3.5 12.61 3.5a9.692 9.692 0 0 0-8.562 5.078l3.409 2.604c.726-2.175 2.757-3.79 5.153-3.79Z"
+    />
+  </svg>
+);
+
+const KakaoIcon = () => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
+    <path
+      fill="#181600"
+      d="M12 4.2c-5.19 0-9.4 3.14-9.4 7.02 0 2.48 1.72 4.65 4.33 5.88l-1.08 3.96a.36.36 0 0 0 .55.4l4.57-3.1c.34.03.68.05 1.03.05 5.19 0 9.4-3.14 9.4-7.02S17.19 4.2 12 4.2Z"
+    />
+  </svg>
+);
+
+const NaverIcon = () => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
+    <path
+      fill="currentColor"
+      d="M6 5.5h4.57l2.94 4.19V5.5H18v13h-4.57l-2.94-4.19v4.19H6v-13Z"
+    />
+  </svg>
+);
+
+function AuthSocialLoginGroup({ className = '' }: AuthSocialLoginGroupProps) {
+  return (
+    <div className={`space-y-3.5 ${className}`}>
+      <SocialLoginButton
+        label="Google로 로그인하기"
+        icon={<GoogleIcon />}
+        className="bg-login-google border-login-google h-[61px] border"
+        labelClassName="text-white"
+      />
+      <SocialLoginButton
+        label="카카오로 로그인하기"
+        icon={<KakaoIcon />}
+        className="bg-login-kakao h-[59px]"
+        labelClassName="text-login-kakao-label"
+      />
+      <SocialLoginButton
+        label="네이버로 로그인하기"
+        icon={<NaverIcon />}
+        className="bg-login-naver h-[59px]"
+        labelClassName="text-white"
+      />
+    </div>
+  );
+}
+
+export default AuthSocialLoginGroup;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router';
 import profileImg from '../../assets/프로필 이미지.png';
+import { ROUTES } from '../../constants/routes';
 
 type HeaderProps = {
   isLoggedIn?: boolean;
@@ -27,22 +28,22 @@ const Header = ({ isLoggedIn = false, fixed = true }: HeaderProps) => {
         <div className="flex items-center gap-2 sm:gap-3">
           {!isLoggedIn ? (
             <>
-              <button
-                type="button"
+              <Link
+                to={`/${ROUTES.LOGIN}`}
                 className="header-btn-outline flex h-9 w-20 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all"
               >
                 <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
                   로그인
                 </span>
-              </button>
-              <button
-                type="button"
+              </Link>
+              <Link
+                to={`/${ROUTES.SIGNUP}`}
                 className="header-btn-solid flex h-9 w-22 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all"
               >
                 <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
                   회원가입
                 </span>
-              </button>
+              </Link>
             </>
           ) : (
             <div className="hover:border-header-accent h-10 w-10 cursor-pointer overflow-hidden rounded-full border-2 border-transparent transition-all">

--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -3,21 +3,55 @@ import Header from '../common/Header';
 
 type AuthLayoutProps = {
   title: string;
+  subtitle?: string;
+  withPanel?: boolean;
+  titleClassName?: string;
+  subtitleClassName?: string;
+  panelClassName?: string;
   children: ReactNode;
 };
 
-function AuthLayout({ title, children }: AuthLayoutProps) {
+function AuthLayout({
+  title,
+  subtitle,
+  withPanel = false,
+  titleClassName = '',
+  subtitleClassName = '',
+  panelClassName = '',
+  children,
+}: AuthLayoutProps) {
+  const content = (
+    <>
+      <h1
+        className={`text-center text-4xl leading-none font-semibold sm:text-5xl ${titleClassName}`}
+      >
+        {title}
+      </h1>
+      {subtitle ? (
+        <p
+          className={`text-login-helper mt-3 text-center text-sm/5 font-normal ${subtitleClassName}`}
+        >
+          {subtitle}
+        </p>
+      ) : null}
+      {children}
+    </>
+  );
+
   return (
     <div className="bg-login-page flex min-h-screen flex-col text-white">
       <Header fixed={false} />
 
       <main className="flex flex-1 items-start justify-center px-6 pt-8 pb-16 sm:px-8 sm:pt-12">
-        <section className="w-full max-w-[440px]">
-          <h1 className="text-center text-[34px] leading-none font-semibold sm:text-[46px]">
-            {title}
-          </h1>
-          {children}
-        </section>
+        {withPanel ? (
+          <section
+            className={`bg-auth-panel border-auth-panel shadow-auth-panel w-full max-w-[520px] rounded-3xl border px-5 py-6 backdrop-blur-sm sm:px-8 sm:py-8 ${panelClassName}`}
+          >
+            <div className="mx-auto w-full max-w-[440px]">{content}</div>
+          </section>
+        ) : (
+          <section className="w-full max-w-[440px]">{content}</section>
+        )}
       </main>
     </div>
   );

--- a/src/components/login/SocialLoginButton.tsx
+++ b/src/components/login/SocialLoginButton.tsx
@@ -16,12 +16,10 @@ function SocialLoginButton({
   return (
     <button
       type="button"
-      className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-transform duration-200 hover:-translate-y-0.5 ${className}`}
+      className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-all duration-200 hover:-translate-y-0.5 hover:brightness-105 active:translate-y-0 ${className}`}
     >
       {icon}
-      <span className={`text-lg leading-7 font-normal ${labelClassName}`}>
-        {label}
-      </span>
+      <span className={`text-lg/7 font-normal ${labelClassName}`}>{label}</span>
     </button>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,9 @@
   --color-login-naver: #03c75a;
   --color-login-primary: #f20f17;
   --color-login-primary-hover: #dd0d14;
+  --color-auth-panel: #111111;
+  --color-auth-panel-border: rgba(255, 255, 255, 0.08);
+  --shadow-auth-panel: rgba(0, 0, 0, 0.34);
   --shadow-login-primary: rgba(242, 15, 23, 0.42);
   --color-surface-elevated: rgba(255, 255, 255, 0.04);
   --color-surface-border: rgba(255, 255, 255, 0.08);
@@ -212,6 +215,10 @@
   background-color: var(--color-login-primary-hover);
 }
 
+@utility bg-auth-panel {
+  background-color: var(--color-auth-panel);
+}
+
 @utility text-login-label {
   color: var(--color-login-label);
 }
@@ -246,6 +253,18 @@
 
 @utility border-login-google {
   border-color: var(--color-login-google-border);
+}
+
+@utility border-login-primary {
+  border-color: var(--color-login-primary);
+}
+
+@utility border-auth-panel {
+  border-color: var(--color-auth-panel-border);
+}
+
+@utility shadow-auth-panel {
+  box-shadow: 0 28px 60px -28px var(--shadow-auth-panel);
 }
 
 @utility shadow-login-primary {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import MainPage from './pages/main/MainPage';
 import RecommendationListPage from './pages/recommendation/RecommendationListPage';
 import SurveyPage from './pages/survey/SurveyPage';
 import LoginPage from './pages/LoginPage';
+import SignupPage from './pages/SignupPage';
 import './index.css';
 
 const queryClient = new QueryClient();
@@ -45,6 +46,10 @@ const router = createBrowserRouter([
       {
         path: ROUTES.LOGIN,
         element: <LoginPage />,
+      },
+      {
+        path: ROUTES.SIGNUP,
+        element: <SignupPage />,
       },
     ],
   },

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,79 +1,19 @@
-import AuthInputField from '../components/auth/AuthInputField';
-import SocialLoginButton from '../components/login/SocialLoginButton';
+import AuthButton from '../components/auth/AuthButton';
+import AuthDivider from '../components/auth/AuthDivider';
+import AuthLinkButton from '../components/auth/AuthLinkButton';
 import AuthLayout from '../components/layout/AuthLayout';
-
-const GoogleIcon = () => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
-    <path
-      fill="#4285F4"
-      d="M21.805 10.041H12.61v3.949h5.268c-.229 1.276-.955 2.356-2.036 3.083v2.526h3.304c1.937-1.783 3.056-4.41 3.056-7.548 0-.676-.061-1.315-.397-2.01Z"
-    />
-    <path
-      fill="#34A853"
-      d="M12.61 22.5c2.619 0 4.816-.867 6.421-2.352l-3.304-2.526c-.918.62-2.091.986-3.117.986-2.396 0-4.427-1.615-5.153-3.79H4.048v2.604A9.692 9.692 0 0 0 12.61 22.5Z"
-    />
-    <path
-      fill="#FBBC04"
-      d="M7.457 14.818a5.81 5.81 0 0 1-.291-1.818c0-.631.108-1.243.291-1.818V8.578H4.048A9.694 9.694 0 0 0 3 13c0 1.559.374 3.035 1.048 4.422l3.409-2.604Z"
-    />
-    <path
-      fill="#EA4335"
-      d="M12.61 7.392c1.422 0 2.697.489 3.703 1.447l2.777-2.777C17.421 4.509 15.229 3.5 12.61 3.5a9.692 9.692 0 0 0-8.562 5.078l3.409 2.604c.726-2.175 2.757-3.79 5.153-3.79Z"
-    />
-  </svg>
-);
-
-const KakaoIcon = () => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
-    <path
-      fill="#181600"
-      d="M12 4.2c-5.19 0-9.4 3.14-9.4 7.02 0 2.48 1.72 4.65 4.33 5.88l-1.08 3.96a.36.36 0 0 0 .55.4l4.57-3.1c.34.03.68.05 1.03.05 5.19 0 9.4-3.14 9.4-7.02S17.19 4.2 12 4.2Z"
-    />
-  </svg>
-);
-
-const NaverIcon = () => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
-    <path
-      fill="currentColor"
-      d="M6 5.5h4.57l2.94 4.19V5.5H18v13h-4.57l-2.94-4.19v4.19H6v-13Z"
-    />
-  </svg>
-);
+import AuthInputField from '../components/auth/AuthInputField';
+import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
+import { ROUTES } from '../constants/routes';
 
 function LoginPage() {
   return (
     <AuthLayout title="Log In">
-      <div className="mt-12 space-y-4">
-        <SocialLoginButton
-          label="Google로 로그인하기"
-          icon={<GoogleIcon />}
-          className="bg-login-google border-login-google h-[61px] border"
-          labelClassName="text-white"
-        />
-        <SocialLoginButton
-          label="카카오로 로그인하기"
-          icon={<KakaoIcon />}
-          className="bg-login-kakao h-[59px]"
-          labelClassName="text-login-kakao-label"
-        />
-        <SocialLoginButton
-          label="네이버로 로그인하기"
-          icon={<NaverIcon />}
-          className="bg-login-naver h-[59px]"
-          labelClassName="text-white"
-        />
-      </div>
+      <AuthSocialLoginGroup className="mt-10" />
 
-      <div className="my-8 flex h-[34px] items-center gap-4 py-2">
-        <div className="bg-login-divider-line h-px flex-1" />
-        <span className="text-login-divider-label text-xs leading-5 font-normal tracking-[0.18em]">
-          OR
-        </span>
-        <div className="bg-login-divider-line h-px flex-1" />
-      </div>
+      <AuthDivider label="OR" className="my-7" />
 
-      <form className="space-y-5" onSubmit={(event) => event.preventDefault()}>
+      <form className="space-y-4" onSubmit={(event) => event.preventDefault()}>
         <AuthInputField
           id="login-id"
           name="id"
@@ -81,6 +21,7 @@ function LoginPage() {
           type="text"
           autoComplete="username"
           placeholder="ID"
+          containerClassName="pt-1"
         />
 
         <AuthInputField
@@ -101,24 +42,18 @@ function LoginPage() {
           </button>
         </div>
 
-        <button
-          type="submit"
-          className="shadow-login-primary bg-login-primary hover:bg-login-primary-hover mt-4 h-14 w-full rounded-full text-lg leading-7 font-semibold text-white transition-colors"
-        >
+        <AuthButton type="submit" className="mt-4 w-full">
           로그인
-        </button>
+        </AuthButton>
       </form>
 
-      <div className="border-login-divider mt-8 border-t pt-8">
-        <p className="text-login-helper text-center text-sm leading-5 font-normal">
+      <div className="border-login-divider mt-9 border-t pt-7">
+        <p className="text-login-helper text-center text-sm/5 font-normal">
           아직 PGTI 회원이 아니신가요?
         </p>
-        <button
-          type="button"
-          className="border-login-outline mt-5 h-14 w-full rounded-full border bg-transparent text-lg leading-7 font-semibold text-white transition-colors hover:border-white/25 hover:bg-white/5"
-        >
+        <AuthLinkButton to={`/${ROUTES.SIGNUP}`} className="mt-5 w-full">
           회원가입
-        </button>
+        </AuthLinkButton>
       </div>
     </AuthLayout>
   );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -16,7 +16,7 @@ function LoginPage() {
       <form className="space-y-4" onSubmit={(event) => event.preventDefault()}>
         <AuthInputField
           id="login-id"
-          name="id"
+          name="login_id"
           label="아이디"
           type="text"
           autoComplete="username"

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -11,7 +11,7 @@ function LoginPage() {
     <AuthLayout title="Log In">
       <AuthSocialLoginGroup className="mt-10" />
 
-      <AuthDivider label="OR" className="my-7" />
+      <AuthDivider className="my-7" />
 
       <form className="space-y-4" onSubmit={(event) => event.preventDefault()}>
         <AuthInputField

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -57,7 +57,7 @@ function SignupPage() {
     >
       <AuthSocialLoginGroup className="mt-7" />
 
-      <AuthDivider label="OR" className="my-6" />
+      <AuthDivider className="my-6" />
 
       <form className="space-y-4" onSubmit={handleSubmit}>
         <AuthInputField
@@ -77,7 +77,7 @@ function SignupPage() {
           type="text"
           autoComplete="username"
           placeholder="아이디를 입력하세요"
-          action={<AuthInputActionButton label="중복확인" />}
+          action={<AuthInputActionButton>중복확인</AuthInputActionButton>}
         />
 
         <AuthInputField
@@ -87,7 +87,7 @@ function SignupPage() {
           type="text"
           autoComplete="nickname"
           placeholder="닉네임을 입력하세요"
-          action={<AuthInputActionButton label="중복확인" />}
+          action={<AuthInputActionButton>중복확인</AuthInputActionButton>}
         />
 
         <AuthInputField

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -8,33 +8,44 @@ import AuthInputActionButton from '../components/auth/AuthInputActionButton';
 import AuthRadioGroup from '../components/auth/AuthRadioGroup';
 import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
 import AuthLayout from '../components/layout/AuthLayout';
+import type { AuthGender } from '../features/auth/types/auth';
+
+const signupGenderOptions = [
+  { label: '남성', value: 'M' },
+  { label: '여성', value: 'W' },
+] as const;
 
 function SignupPage() {
   const [password, setPassword] = useState('');
-  const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [passwordCheck, setPasswordCheck] = useState('');
+  const [gender, setGender] = useState<AuthGender | ''>('');
   const [passwordTouched, setPasswordTouched] = useState(false);
-  const [passwordConfirmTouched, setPasswordConfirmTouched] = useState(false);
+  const [passwordCheckTouched, setPasswordCheckTouched] = useState(false);
+  const [genderTouched, setGenderTouched] = useState(false);
 
   const trimmedPassword = password.trim();
-  const trimmedPasswordConfirm = passwordConfirm.trim();
+  const trimmedPasswordCheck = passwordCheck.trim();
 
   const passwordError =
-    passwordTouched && trimmedPassword.length > 0 && trimmedPassword.length < 8
+    passwordTouched && trimmedPassword.length > 0 && trimmedPassword.length <= 8
       ? '비밀번호가 8자 이하입니다.'
       : '';
 
-  const passwordConfirmError =
-    passwordConfirmTouched &&
+  const passwordCheckError =
+    passwordCheckTouched &&
     trimmedPassword.length > 0 &&
-    trimmedPasswordConfirm.length > 0 &&
-    trimmedPassword !== trimmedPasswordConfirm
+    trimmedPasswordCheck.length > 0 &&
+    trimmedPassword !== trimmedPasswordCheck
       ? '비밀번호와 일치하지 않습니다.'
       : '';
+
+  const genderError = genderTouched && !gender ? '성별을 선택해주세요.' : '';
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setPasswordTouched(true);
-    setPasswordConfirmTouched(true);
+    setPasswordCheckTouched(true);
+    setGenderTouched(true);
   };
 
   return (
@@ -61,7 +72,7 @@ function SignupPage() {
 
         <AuthInputField
           id="signup-id"
-          name="id"
+          name="login_id"
           label="아이디"
           type="text"
           autoComplete="username"
@@ -94,26 +105,24 @@ function SignupPage() {
 
         <AuthInputField
           id="signup-password-confirm"
-          name="passwordConfirm"
+          name="password_check"
           label="비밀번호 확인"
           type="password"
           autoComplete="new-password"
           placeholder="비밀번호를 한번 더 입력하세요"
-          value={passwordConfirm}
-          onChange={(event) => setPasswordConfirm(event.target.value)}
-          onBlur={() => setPasswordConfirmTouched(true)}
-          errorMessage={passwordConfirmError}
+          value={passwordCheck}
+          onChange={(event) => setPasswordCheck(event.target.value)}
+          onBlur={() => setPasswordCheckTouched(true)}
+          errorMessage={passwordCheckError}
         />
 
         <AuthRadioGroup
           label="성별"
           name="gender"
-          defaultValue="UNSPECIFIED"
-          options={[
-            { label: '선택안함', value: 'UNSPECIFIED' },
-            { label: '남성', value: 'MALE' },
-            { label: '여성', value: 'FEMALE' },
-          ]}
+          value={gender}
+          options={signupGenderOptions}
+          onChange={(event) => setGender(event.target.value as AuthGender)}
+          errorMessage={genderError}
         />
 
         <AuthButton type="submit" className="mt-2 w-full">

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,127 @@
+import type { FormEvent } from 'react';
+import { useState } from 'react';
+
+import AuthButton from '../components/auth/AuthButton';
+import AuthDivider from '../components/auth/AuthDivider';
+import AuthInputField from '../components/auth/AuthInputField';
+import AuthInputActionButton from '../components/auth/AuthInputActionButton';
+import AuthRadioGroup from '../components/auth/AuthRadioGroup';
+import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
+import AuthLayout from '../components/layout/AuthLayout';
+
+function SignupPage() {
+  const [password, setPassword] = useState('');
+  const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [passwordTouched, setPasswordTouched] = useState(false);
+  const [passwordConfirmTouched, setPasswordConfirmTouched] = useState(false);
+
+  const trimmedPassword = password.trim();
+  const trimmedPasswordConfirm = passwordConfirm.trim();
+
+  const passwordError =
+    passwordTouched && trimmedPassword.length > 0 && trimmedPassword.length < 8
+      ? '비밀번호가 8자 이하입니다.'
+      : '';
+
+  const passwordConfirmError =
+    passwordConfirmTouched &&
+    trimmedPassword.length > 0 &&
+    trimmedPasswordConfirm.length > 0 &&
+    trimmedPassword !== trimmedPasswordConfirm
+      ? '비밀번호와 일치하지 않습니다.'
+      : '';
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPasswordTouched(true);
+    setPasswordConfirmTouched(true);
+  };
+
+  return (
+    <AuthLayout
+      title="Join"
+      subtitle="회원가입 후 취향 기반 게임 추천을 시작해보세요"
+      withPanel
+      subtitleClassName="mx-auto max-w-[290px]"
+    >
+      <AuthSocialLoginGroup className="mt-7" />
+
+      <AuthDivider label="OR" className="my-6" />
+
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <AuthInputField
+          id="signup-name"
+          name="name"
+          label="이름"
+          type="text"
+          autoComplete="name"
+          placeholder="이름을 입력하세요"
+          containerClassName="pt-1"
+        />
+
+        <AuthInputField
+          id="signup-id"
+          name="id"
+          label="아이디"
+          type="text"
+          autoComplete="username"
+          placeholder="아이디를 입력하세요"
+          action={<AuthInputActionButton label="중복확인" />}
+        />
+
+        <AuthInputField
+          id="signup-nickname"
+          name="nickname"
+          label="닉네임"
+          type="text"
+          autoComplete="nickname"
+          placeholder="닉네임을 입력하세요"
+          action={<AuthInputActionButton label="중복확인" />}
+        />
+
+        <AuthInputField
+          id="signup-password"
+          name="password"
+          label="비밀번호"
+          type="password"
+          autoComplete="new-password"
+          placeholder="비밀번호를 입력하세요"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          onBlur={() => setPasswordTouched(true)}
+          errorMessage={passwordError}
+        />
+
+        <AuthInputField
+          id="signup-password-confirm"
+          name="passwordConfirm"
+          label="비밀번호 확인"
+          type="password"
+          autoComplete="new-password"
+          placeholder="비밀번호를 한번 더 입력하세요"
+          value={passwordConfirm}
+          onChange={(event) => setPasswordConfirm(event.target.value)}
+          onBlur={() => setPasswordConfirmTouched(true)}
+          errorMessage={passwordConfirmError}
+        />
+
+        <AuthRadioGroup
+          label="성별"
+          name="gender"
+          defaultValue="UNSPECIFIED"
+          options={[
+            { label: '선택안함', value: 'UNSPECIFIED' },
+            { label: '남성', value: 'MALE' },
+            { label: '여성', value: 'FEMALE' },
+          ]}
+        />
+
+        <AuthButton type="submit" className="mt-2 w-full">
+          회원가입
+        </AuthButton>
+      </form>
+    </AuthLayout>
+  );
+}
+
+export default SignupPage;


### PR DESCRIPTION
## 관련 이슈

- closes #35 

## 변경 내용

- 회원가입 페이지 UI를 추가했습니다.
- 로그인/회원가입 공통 auth 컴포넌트를 분리하고 재사용 구조로 정리했습니다.
- `AuthLayout`, `AuthInputField`, `AuthRadioGroup`, `AuthSocialLoginGroup` 등을 확장해 회원가입 화면에 맞게 구성했습니다.
- 로그인 페이지와 회원가입 페이지의 헤더 버튼 및 하단 CTA를 실제 라우팅으로 연결했습니다.
- 회원가입 폼 필드명을 요구사항 정의서 및 API 명세 기준에 맞게 정리했습니다.
- 회원가입 페이지에서 비밀번호 길이 및 비밀번호 확인 불일치 에러 문구가 표시되도록 처리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3238" height="1690" alt="image" src="https://github.com/user-attachments/assets/70b057c7-4a88-44d7-afd4-71f5ac7e8796" />


## 참고사항

- 이번 PR은 UI 및 공통 컴포넌트 구조 정리까지 포함합니다.
- 실제 로그인/회원가입 API 호출, 중복확인 버튼 동작, 제출 처리 등은 후속 PR에서 연결 예정입니다.
- 회원가입 페이지는 API 명세 기준으로 `login_id`, `password_check`, `gender(M/W)` 구조를 반영했습니다.
