### PR TITLE
[Feat] 로그인 및 회원가입 폼 

### DIFF
--- a/src/components/auth/AuthButton.tsx
+++ b/src/components/auth/AuthButton.tsx
@@ -9,15 +9,15 @@ type AuthButtonProps = {
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 const baseClassName =
-  'flex h-14 items-center justify-center transition-colors disabled:pointer-events-none disabled:opacity-60';
+  'flex h-14 items-center justify-center transition-all duration-200 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-60';
 
 const variantClassNames: Record<AuthButtonVariant, string> = {
   primary:
-    'shadow-login-primary bg-login-primary hover:bg-login-primary-hover rounded-full text-lg/7 font-semibold text-white',
+    'shadow-login-primary bg-login-primary hover:bg-login-primary-hover active:translate-y-0 rounded-full text-lg/7 font-semibold text-white hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-red-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-black',
   secondary:
-    'bg-login-field border-login-field text-login-label hover:border-white/20 hover:text-white rounded-xl border text-sm/5 font-medium',
+    'bg-login-field border-login-field text-login-label active:translate-y-0 rounded-xl border text-sm/5 font-medium hover:-translate-y-0.5 hover:border-white/20 hover:text-white focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black',
   ghost:
-    'border-login-outline hover:border-white/25 hover:bg-white/5 rounded-full border bg-transparent text-lg/7 font-semibold text-white',
+    'border-login-outline active:translate-y-0 rounded-full border bg-transparent text-lg/7 font-semibold text-white hover:-translate-y-0.5 hover:border-white/25 hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black',
 };
 
 function AuthButton({

--- a/src/components/auth/AuthFormMessage.tsx
+++ b/src/components/auth/AuthFormMessage.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+
+type AuthFormMessageTone = 'error' | 'success';
+
+type AuthFormMessageProps = {
+  children: ReactNode;
+  tone?: AuthFormMessageTone;
+  className?: string;
+};
+
+const toneClassNames: Record<AuthFormMessageTone, string> = {
+  error: 'border-red-500/20 bg-red-500/10 text-red-300',
+  success: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-300',
+};
+
+function AuthFormMessage({
+  children,
+  tone = 'error',
+  className = '',
+}: AuthFormMessageProps) {
+  return (
+    <div
+      role={tone === 'error' ? 'alert' : 'status'}
+      className={`rounded-xl border px-4 py-3 text-sm/5 font-medium ${toneClassNames[tone]} ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default AuthFormMessage;

--- a/src/components/auth/AuthInputActionButton.tsx
+++ b/src/components/auth/AuthInputActionButton.tsx
@@ -1,14 +1,23 @@
-import type { ReactNode } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
 import AuthButton from './AuthButton';
 
 type AuthInputActionButtonProps = {
   children: ReactNode;
-};
+} & ButtonHTMLAttributes<HTMLButtonElement>;
 
-function AuthInputActionButton({ children }: AuthInputActionButtonProps) {
+function AuthInputActionButton({
+  children,
+  type = 'button',
+  ...props
+}: AuthInputActionButtonProps) {
   return (
-    <AuthButton variant="secondary" className="w-24 shrink-0">
+    <AuthButton
+      type={type}
+      variant="secondary"
+      className="w-24 shrink-0"
+      {...props}
+    >
       {children}
     </AuthButton>
   );

--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -1,9 +1,13 @@
 import type { InputHTMLAttributes, ReactNode } from 'react';
 
+type AuthInputFieldMessageTone = 'success' | 'muted';
+
 type AuthInputFieldProps = {
   id: string;
   label: string;
   errorMessage?: string;
+  helperMessage?: string;
+  helperMessageTone?: AuthInputFieldMessageTone;
   action?: ReactNode;
   containerClassName?: string;
 } & InputHTMLAttributes<HTMLInputElement>;
@@ -12,11 +16,20 @@ function AuthInputField({
   id,
   label,
   errorMessage,
+  helperMessage,
+  helperMessageTone = 'muted',
   action,
   containerClassName = '',
   className = '',
   ...inputProps
 }: AuthInputFieldProps) {
+  const resolvedMessage = errorMessage ?? helperMessage;
+  const resolvedMessageClassName = errorMessage
+    ? 'text-red-400'
+    : helperMessageTone === 'success'
+      ? 'text-emerald-400'
+      : 'text-login-helper';
+
   return (
     <div className={`space-y-2.5 ${containerClassName}`}>
       <label
@@ -32,15 +45,15 @@ function AuthInputField({
           aria-invalid={Boolean(errorMessage)}
           className={`placeholder-login-muted bg-login-field h-14 min-w-0 flex-1 rounded-xl border px-4 text-base text-white transition outline-none focus-visible:ring-2 ${className} ${
             errorMessage
-              ? 'border-red-500 focus-visible:ring-red-500/20'
-              : 'border-login-field focus-visible:ring-white/20'
+              ? 'border-red-500 hover:border-red-400 focus-visible:ring-red-500/20'
+              : 'border-login-field hover:border-white/15 focus-visible:ring-white/20'
           }`}
         />
         {action}
       </div>
-      {errorMessage ? (
-        <p className="pl-1 text-sm/5 font-medium text-red-400">
-          {errorMessage}
+      {resolvedMessage ? (
+        <p className={`pl-1 text-sm/5 font-medium ${resolvedMessageClassName}`}>
+          {resolvedMessage}
         </p>
       ) : null}
     </div>

--- a/src/components/auth/AuthLinkButton.tsx
+++ b/src/components/auth/AuthLinkButton.tsx
@@ -10,11 +10,11 @@ type AuthLinkButtonProps = {
 } & LinkProps;
 
 const baseClassName =
-  'flex h-14 items-center justify-center transition-colors disabled:pointer-events-none disabled:opacity-60';
+  'flex h-14 items-center justify-center transition-all duration-200 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-60';
 
 const variantClassNames: Record<AuthLinkButtonVariant, string> = {
   ghost:
-    'border-login-outline hover:border-white/25 hover:bg-white/5 rounded-full border bg-transparent text-lg/7 font-semibold text-white',
+    'border-login-outline active:translate-y-0 rounded-full border bg-transparent text-lg/7 font-semibold text-white hover:-translate-y-0.5 hover:border-white/25 hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black',
 };
 
 function AuthLinkButton({

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -14,6 +14,7 @@ type AuthRadioGroupProps = {
   onChange?: ChangeEventHandler<HTMLInputElement>;
   errorMessage?: string;
   required?: boolean;
+  disabled?: boolean;
 };
 
 function AuthRadioGroup({
@@ -25,6 +26,7 @@ function AuthRadioGroup({
   onChange,
   errorMessage,
   required = false,
+  disabled = false,
 }: AuthRadioGroupProps) {
   return (
     <fieldset className="space-y-3.5">
@@ -35,7 +37,7 @@ function AuthRadioGroup({
         {options.map((option) => (
           <label
             key={option.value}
-            className="flex min-w-0 flex-1 cursor-pointer items-center justify-center gap-2"
+            className="group flex min-w-0 flex-1 cursor-pointer items-center justify-center gap-2"
           >
             <input
               type="radio"
@@ -47,16 +49,17 @@ function AuthRadioGroup({
               }
               onChange={onChange}
               required={required}
+              disabled={disabled}
               className="peer sr-only"
             />
             <span
-              className={`peer-checked:border-login-primary flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors ${
+              className={`peer-checked:border-login-primary flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors group-hover:border-white/25 peer-disabled:opacity-60 ${
                 errorMessage ? 'border-red-500' : 'border-login-field'
               }`}
             >
               <span className="bg-login-primary h-2 w-2 rounded-full opacity-0 transition-opacity peer-checked:opacity-100" />
             </span>
-            <span className="text-login-helper truncate text-sm/5 font-medium transition-colors peer-checked:text-white">
+            <span className="text-login-helper truncate text-sm/5 font-medium transition-colors group-hover:text-white/85 peer-checked:text-white peer-disabled:opacity-60">
               {option.label}
             </span>
           </label>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -30,7 +30,7 @@ const Header = ({ isLoggedIn = false, fixed = true }: HeaderProps) => {
             <>
               <Link
                 to={`/${ROUTES.LOGIN}`}
-                className="header-btn-outline flex h-9 w-20 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all"
+                className="header-btn-outline flex h-9 w-20 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
               >
                 <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
                   로그인
@@ -38,7 +38,7 @@ const Header = ({ isLoggedIn = false, fixed = true }: HeaderProps) => {
               </Link>
               <Link
                 to={`/${ROUTES.SIGNUP}`}
-                className="header-btn-solid flex h-9 w-22 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all"
+                className="header-btn-solid flex h-9 w-22 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
               >
                 <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
                   회원가입

--- a/src/components/login/SocialLoginButton.tsx
+++ b/src/components/login/SocialLoginButton.tsx
@@ -16,7 +16,7 @@ function SocialLoginButton({
   return (
     <button
       type="button"
-      className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-all duration-200 hover:-translate-y-0.5 hover:brightness-105 active:translate-y-0 ${className}`}
+      className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-all duration-200 hover:-translate-y-0.5 hover:brightness-105 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none active:translate-y-0 ${className}`}
     >
       {icon}
       <span className={`text-lg/7 font-normal ${labelClassName}`}>{label}</span>

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -80,6 +80,43 @@ const extractFieldErrorMessage = (
   return null;
 };
 
+const extractFieldErrors = (
+  value?: string | Record<string, string[]>,
+): Record<string, string> => {
+  if (!value || typeof value === 'string') {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([fieldName, messages]) => {
+        if (typeof messages === 'string') {
+          return [fieldName, messages];
+        }
+
+        if (Array.isArray(messages) && messages[0]) {
+          return [fieldName, messages[0]];
+        }
+
+        return null;
+      })
+      .filter((entry): entry is [string, string] => Boolean(entry)),
+  );
+};
+
+export const extractAuthApiFieldErrors = (error: unknown) => {
+  if (!(error instanceof AxiosError)) {
+    return {};
+  }
+
+  const data = error.response?.data as ErrorResponseBody | undefined;
+
+  return {
+    ...extractFieldErrors(data?.detail),
+    ...extractFieldErrors(data?.error_detail),
+  };
+};
+
 export const extractAuthApiErrorMessage = (error: unknown) => {
   if (!(error instanceof AxiosError)) {
     return '요청을 처리하는 중 알 수 없는 오류가 발생했습니다.';

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,19 +1,141 @@
+import type { FormEvent } from 'react';
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 import AuthButton from '../components/auth/AuthButton';
 import AuthDivider from '../components/auth/AuthDivider';
+import AuthFormMessage from '../components/auth/AuthFormMessage';
 import AuthLinkButton from '../components/auth/AuthLinkButton';
 import AuthLayout from '../components/layout/AuthLayout';
 import AuthInputField from '../components/auth/AuthInputField';
 import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
 import { ROUTES } from '../constants/routes';
+import {
+  extractAuthApiErrorMessage,
+  extractAuthApiFieldErrors,
+} from '../features/auth/api/auth';
+import { useLoginMutation } from '../features/auth/api/useAuthApi';
+import type { LoginRequest } from '../features/auth/types/auth';
+import { setAuthTokens } from '../utils/auth';
+
+type LoginFieldName = keyof LoginRequest;
+type LoginFieldErrors = Partial<Record<LoginFieldName, string>>;
+type LoginTouchedState = Record<LoginFieldName, boolean>;
+type LoginLocationState = {
+  noticeMessage?: string;
+};
+
+const getLoginFieldErrors = (
+  values: LoginRequest,
+  touchedState: LoginTouchedState,
+) => {
+  const trimmedLoginId = values.login_id.trim();
+  const trimmedPassword = values.password.trim();
+
+  return {
+    login_id:
+      touchedState.login_id && !trimmedLoginId ? '아이디를 입력해주세요.' : '',
+    password:
+      touchedState.password && !trimmedPassword
+        ? '비밀번호를 입력해주세요.'
+        : '',
+  } satisfies Record<LoginFieldName, string>;
+};
 
 function LoginPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const loginMutation = useLoginMutation();
+  const [formValues, setFormValues] = useState<LoginRequest>({
+    login_id: '',
+    password: '',
+  });
+  const [touchedState, setTouchedState] = useState<LoginTouchedState>({
+    login_id: false,
+    password: false,
+  });
+  const [apiFieldErrors, setApiFieldErrors] = useState<LoginFieldErrors>({});
+  const [formMessage, setFormMessage] = useState('');
+  const locationState = location.state as LoginLocationState | null;
+  const [noticeMessage, setNoticeMessage] = useState(
+    locationState?.noticeMessage ?? '',
+  );
+  const fieldErrors = getLoginFieldErrors(formValues, touchedState);
+  const resolvedFieldErrors: Record<LoginFieldName, string> = {
+    login_id: apiFieldErrors.login_id ?? fieldErrors.login_id,
+    password: apiFieldErrors.password ?? fieldErrors.password,
+  };
+
+  const handleChange = (fieldName: LoginFieldName, value: string) => {
+    setFormValues((previous) => ({
+      ...previous,
+      [fieldName]: value,
+    }));
+
+    setApiFieldErrors((previous) => {
+      if (!previous[fieldName]) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        [fieldName]: '',
+      };
+    });
+
+    setFormMessage('');
+    setNoticeMessage('');
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const nextTouchedState = {
+      login_id: true,
+      password: true,
+    } satisfies LoginTouchedState;
+
+    setTouchedState(nextTouchedState);
+    setApiFieldErrors({});
+    setFormMessage('');
+    setNoticeMessage('');
+
+    const nextFieldErrors = getLoginFieldErrors(formValues, nextTouchedState);
+    const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
+
+    if (hasLocalError) {
+      return;
+    }
+
+    const payload: LoginRequest = {
+      login_id: formValues.login_id.trim(),
+      password: formValues.password.trim(),
+    };
+
+    try {
+      const response = await loginMutation.mutateAsync(payload);
+
+      setAuthTokens(response.access_token, response.refresh_token);
+      navigate(ROUTES.HOME);
+    } catch (error) {
+      const nextApiFieldErrors = extractAuthApiFieldErrors(error);
+
+      if (Object.keys(nextApiFieldErrors).length > 0) {
+        setApiFieldErrors(nextApiFieldErrors);
+        return;
+      }
+
+      setFormMessage(extractAuthApiErrorMessage(error));
+    }
+  };
+
   return (
     <AuthLayout title="Log In">
       <AuthSocialLoginGroup className="mt-10" />
 
       <AuthDivider className="my-7" />
 
-      <form className="space-y-4" onSubmit={(event) => event.preventDefault()}>
+      <form className="space-y-4" onSubmit={handleSubmit}>
         <AuthInputField
           id="login-id"
           name="login_id"
@@ -21,6 +143,16 @@ function LoginPage() {
           type="text"
           autoComplete="username"
           placeholder="ID"
+          value={formValues.login_id}
+          onChange={(event) => handleChange('login_id', event.target.value)}
+          onBlur={() =>
+            setTouchedState((previous) => ({
+              ...previous,
+              login_id: true,
+            }))
+          }
+          errorMessage={resolvedFieldErrors.login_id}
+          disabled={loginMutation.isPending}
           containerClassName="pt-1"
         />
 
@@ -31,7 +163,23 @@ function LoginPage() {
           type="password"
           autoComplete="current-password"
           placeholder="PASSWORD"
+          value={formValues.password}
+          onChange={(event) => handleChange('password', event.target.value)}
+          onBlur={() =>
+            setTouchedState((previous) => ({
+              ...previous,
+              password: true,
+            }))
+          }
+          errorMessage={resolvedFieldErrors.password}
+          disabled={loginMutation.isPending}
         />
+
+        {noticeMessage ? (
+          <AuthFormMessage tone="success">{noticeMessage}</AuthFormMessage>
+        ) : null}
+
+        {formMessage ? <AuthFormMessage>{formMessage}</AuthFormMessage> : null}
 
         <div className="flex justify-end">
           <button
@@ -42,8 +190,12 @@ function LoginPage() {
           </button>
         </div>
 
-        <AuthButton type="submit" className="mt-4 w-full">
-          로그인
+        <AuthButton
+          type="submit"
+          className="mt-4 w-full"
+          disabled={loginMutation.isPending}
+        >
+          {loginMutation.isPending ? '로그인 중...' : '로그인'}
         </AuthButton>
       </form>
 

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,51 +1,355 @@
 import type { FormEvent } from 'react';
 import { useState } from 'react';
+import { useNavigate } from 'react-router';
 
 import AuthButton from '../components/auth/AuthButton';
 import AuthDivider from '../components/auth/AuthDivider';
-import AuthInputField from '../components/auth/AuthInputField';
+import AuthFormMessage from '../components/auth/AuthFormMessage';
 import AuthInputActionButton from '../components/auth/AuthInputActionButton';
+import AuthInputField from '../components/auth/AuthInputField';
 import AuthRadioGroup from '../components/auth/AuthRadioGroup';
 import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
 import AuthLayout from '../components/layout/AuthLayout';
-import type { AuthGender } from '../features/auth/types/auth';
+import { ROUTES } from '../constants/routes';
+import {
+  extractAuthApiErrorMessage,
+  extractAuthApiFieldErrors,
+} from '../features/auth/api/auth';
+import {
+  useCheckIdDuplicateMutation,
+  useCheckNicknameDuplicateMutation,
+  useLoginMutation,
+  useSignupMutation,
+} from '../features/auth/api/useAuthApi';
+import type { AuthGender, SignupRequest } from '../features/auth/types/auth';
+import { setAuthTokens } from '../utils/auth';
+
+type SignupFormValues = Omit<SignupRequest, 'gender'> & {
+  gender: AuthGender | '';
+};
+
+type SignupFieldName = keyof SignupFormValues;
+type SignupFieldErrors = Partial<Record<SignupFieldName, string>>;
+type SignupTouchedState = Record<SignupFieldName, boolean>;
+
+type DuplicateCheckState = {
+  verifiedValue: string | null;
+  message: string;
+  tone: 'success' | 'error' | null;
+};
 
 const signupGenderOptions = [
   { label: '남성', value: 'M' },
   { label: '여성', value: 'W' },
 ] as const;
 
+const initialDuplicateCheckState: DuplicateCheckState = {
+  verifiedValue: null,
+  message: '',
+  tone: null,
+};
+
+const getSignupFieldErrors = (
+  values: SignupFormValues,
+  touchedState: SignupTouchedState,
+  loginIdVerified: boolean,
+  nicknameVerified: boolean,
+) => {
+  const trimmedName = values.name.trim();
+  const trimmedLoginId = values.login_id.trim();
+  const trimmedNickname = values.nickname.trim();
+  const trimmedPassword = values.password.trim();
+  const trimmedPasswordCheck = values.password_check.trim();
+
+  return {
+    name: touchedState.name && !trimmedName ? '이름을 입력해주세요.' : '',
+    login_id:
+      touchedState.login_id && !trimmedLoginId
+        ? '아이디를 입력해주세요.'
+        : touchedState.login_id && trimmedLoginId && !loginIdVerified
+          ? '아이디 중복확인을 해주세요.'
+          : '',
+    nickname:
+      touchedState.nickname && !trimmedNickname
+        ? '닉네임을 입력해주세요.'
+        : touchedState.nickname && trimmedNickname && !nicknameVerified
+          ? '닉네임 중복확인을 해주세요.'
+          : '',
+    password:
+      touchedState.password && !trimmedPassword
+        ? '비밀번호를 입력해주세요.'
+        : touchedState.password &&
+            trimmedPassword.length > 0 &&
+            trimmedPassword.length <= 8
+          ? '비밀번호가 8자 이하입니다.'
+          : '',
+    password_check:
+      touchedState.password_check && !trimmedPasswordCheck
+        ? '비밀번호를 한번 더 입력해주세요.'
+        : touchedState.password_check &&
+            trimmedPassword.length > 0 &&
+            trimmedPasswordCheck.length > 0 &&
+            trimmedPassword !== trimmedPasswordCheck
+          ? '비밀번호와 일치하지 않습니다.'
+          : '',
+    gender: touchedState.gender && !values.gender ? '성별을 선택해주세요.' : '',
+  } satisfies Record<SignupFieldName, string>;
+};
+
 function SignupPage() {
-  const [password, setPassword] = useState('');
-  const [passwordCheck, setPasswordCheck] = useState('');
-  const [gender, setGender] = useState<AuthGender | ''>('');
-  const [passwordTouched, setPasswordTouched] = useState(false);
-  const [passwordCheckTouched, setPasswordCheckTouched] = useState(false);
-  const [genderTouched, setGenderTouched] = useState(false);
+  const navigate = useNavigate();
+  const signupMutation = useSignupMutation();
+  const loginMutation = useLoginMutation();
+  const checkIdDuplicateMutation = useCheckIdDuplicateMutation();
+  const checkNicknameDuplicateMutation = useCheckNicknameDuplicateMutation();
+  const [formValues, setFormValues] = useState<SignupFormValues>({
+    name: '',
+    login_id: '',
+    nickname: '',
+    password: '',
+    password_check: '',
+    gender: '',
+  });
+  const [touchedState, setTouchedState] = useState<SignupTouchedState>({
+    name: false,
+    login_id: false,
+    nickname: false,
+    password: false,
+    password_check: false,
+    gender: false,
+  });
+  const [apiFieldErrors, setApiFieldErrors] = useState<SignupFieldErrors>({});
+  const [formMessage, setFormMessage] = useState('');
+  const [loginIdCheckState, setLoginIdCheckState] =
+    useState<DuplicateCheckState>(initialDuplicateCheckState);
+  const [nicknameCheckState, setNicknameCheckState] =
+    useState<DuplicateCheckState>(initialDuplicateCheckState);
 
-  const trimmedPassword = password.trim();
-  const trimmedPasswordCheck = passwordCheck.trim();
+  const trimmedLoginId = formValues.login_id.trim();
+  const trimmedNickname = formValues.nickname.trim();
+  const trimmedPassword = formValues.password.trim();
 
-  const passwordError =
-    passwordTouched && trimmedPassword.length > 0 && trimmedPassword.length <= 8
-      ? '비밀번호가 8자 이하입니다.'
-      : '';
+  const isLoginIdVerified =
+    loginIdCheckState.tone === 'success' &&
+    loginIdCheckState.verifiedValue === trimmedLoginId;
+  const isNicknameVerified =
+    nicknameCheckState.tone === 'success' &&
+    nicknameCheckState.verifiedValue === trimmedNickname;
 
-  const passwordCheckError =
-    passwordCheckTouched &&
-    trimmedPassword.length > 0 &&
-    trimmedPasswordCheck.length > 0 &&
-    trimmedPassword !== trimmedPasswordCheck
-      ? '비밀번호와 일치하지 않습니다.'
-      : '';
+  const localFieldErrors = getSignupFieldErrors(
+    formValues,
+    touchedState,
+    isLoginIdVerified,
+    isNicknameVerified,
+  );
 
-  const genderError = genderTouched && !gender ? '성별을 선택해주세요.' : '';
+  const resolvedFieldErrors: Record<SignupFieldName, string> = {
+    name: apiFieldErrors.name ?? localFieldErrors.name,
+    login_id:
+      apiFieldErrors.login_id ||
+      (loginIdCheckState.tone === 'error' ? loginIdCheckState.message : '') ||
+      localFieldErrors.login_id,
+    nickname:
+      apiFieldErrors.nickname ||
+      (nicknameCheckState.tone === 'error' ? nicknameCheckState.message : '') ||
+      localFieldErrors.nickname,
+    password: apiFieldErrors.password ?? localFieldErrors.password,
+    password_check:
+      apiFieldErrors.password_check ?? localFieldErrors.password_check,
+    gender: apiFieldErrors.gender ?? localFieldErrors.gender,
+  };
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const isSubmitting = signupMutation.isPending || loginMutation.isPending;
+
+  const clearApiFieldError = (fieldName: SignupFieldName) => {
+    setApiFieldErrors((previous) => {
+      if (!previous[fieldName]) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        [fieldName]: '',
+      };
+    });
+  };
+
+  const handleFieldChange = (fieldName: SignupFieldName, value: string) => {
+    setFormValues((previous) => ({
+      ...previous,
+      [fieldName]: value,
+    }));
+
+    clearApiFieldError(fieldName);
+    setFormMessage('');
+
+    if (fieldName === 'login_id') {
+      setLoginIdCheckState((previous) =>
+        previous.verifiedValue === value.trim() && previous.tone === 'success'
+          ? previous
+          : initialDuplicateCheckState,
+      );
+    }
+
+    if (fieldName === 'nickname') {
+      setNicknameCheckState((previous) =>
+        previous.verifiedValue === value.trim() && previous.tone === 'success'
+          ? previous
+          : initialDuplicateCheckState,
+      );
+    }
+  };
+
+  const handleCheckLoginIdDuplicate = async () => {
+    setTouchedState((previous) => ({
+      ...previous,
+      login_id: true,
+    }));
+    setFormMessage('');
+
+    if (!trimmedLoginId) {
+      return;
+    }
+
+    try {
+      const response = await checkIdDuplicateMutation.mutateAsync({
+        login_id: trimmedLoginId,
+      });
+
+      setLoginIdCheckState({
+        verifiedValue: trimmedLoginId,
+        message: response.detail,
+        tone: 'success',
+      });
+      clearApiFieldError('login_id');
+    } catch (error) {
+      const fieldErrors = extractAuthApiFieldErrors(error);
+      const message = fieldErrors.login_id ?? extractAuthApiErrorMessage(error);
+
+      setLoginIdCheckState({
+        verifiedValue: null,
+        message,
+        tone: 'error',
+      });
+    }
+  };
+
+  const handleCheckNicknameDuplicate = async () => {
+    setTouchedState((previous) => ({
+      ...previous,
+      nickname: true,
+    }));
+    setFormMessage('');
+
+    if (!trimmedNickname) {
+      return;
+    }
+
+    try {
+      const response = await checkNicknameDuplicateMutation.mutateAsync({
+        nickname: trimmedNickname,
+      });
+
+      setNicknameCheckState({
+        verifiedValue: trimmedNickname,
+        message: response.detail,
+        tone: 'success',
+      });
+      clearApiFieldError('nickname');
+    } catch (error) {
+      const fieldErrors = extractAuthApiFieldErrors(error);
+      const message = fieldErrors.nickname ?? extractAuthApiErrorMessage(error);
+
+      setNicknameCheckState({
+        verifiedValue: null,
+        message,
+        tone: 'error',
+      });
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setPasswordTouched(true);
-    setPasswordCheckTouched(true);
-    setGenderTouched(true);
+
+    const nextTouchedState = {
+      name: true,
+      login_id: true,
+      nickname: true,
+      password: true,
+      password_check: true,
+      gender: true,
+    } satisfies SignupTouchedState;
+
+    setTouchedState(nextTouchedState);
+    setApiFieldErrors({});
+    setFormMessage('');
+
+    const nextFieldErrors = getSignupFieldErrors(
+      formValues,
+      nextTouchedState,
+      isLoginIdVerified,
+      isNicknameVerified,
+    );
+    const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
+
+    if (hasLocalError || !formValues.gender) {
+      return;
+    }
+
+    const payload: SignupRequest = {
+      name: formValues.name.trim(),
+      login_id: trimmedLoginId,
+      nickname: trimmedNickname,
+      password: trimmedPassword,
+      password_check: formValues.password_check.trim(),
+      gender: formValues.gender,
+    };
+
+    try {
+      await signupMutation.mutateAsync(payload);
+    } catch (error) {
+      const nextApiFieldErrors = extractAuthApiFieldErrors(error);
+      const nextMessage = extractAuthApiErrorMessage(error);
+
+      if (Object.keys(nextApiFieldErrors).length > 0) {
+        setApiFieldErrors(nextApiFieldErrors);
+      } else if (nextMessage.includes('닉네임')) {
+        setApiFieldErrors((previous) => ({
+          ...previous,
+          nickname: nextMessage,
+        }));
+      } else if (
+        nextMessage.includes('아이디') ||
+        nextMessage.includes('회원가입')
+      ) {
+        setApiFieldErrors((previous) => ({
+          ...previous,
+          login_id: nextMessage,
+        }));
+      } else {
+        setFormMessage(nextMessage);
+      }
+
+      return;
+    }
+
+    try {
+      const loginResponse = await loginMutation.mutateAsync({
+        login_id: payload.login_id,
+        password: payload.password,
+      });
+
+      setAuthTokens(loginResponse.access_token, loginResponse.refresh_token);
+      navigate(ROUTES.HOME);
+    } catch {
+      navigate(`/${ROUTES.LOGIN}`, {
+        replace: true,
+        state: {
+          noticeMessage:
+            '회원가입이 완료되었습니다. 로그인 후 서비스를 이용해 주세요.',
+        },
+      });
+    }
   };
 
   return (
@@ -67,6 +371,16 @@ function SignupPage() {
           type="text"
           autoComplete="name"
           placeholder="이름을 입력하세요"
+          value={formValues.name}
+          onChange={(event) => handleFieldChange('name', event.target.value)}
+          onBlur={() =>
+            setTouchedState((previous) => ({
+              ...previous,
+              name: true,
+            }))
+          }
+          errorMessage={resolvedFieldErrors.name}
+          disabled={isSubmitting}
           containerClassName="pt-1"
         />
 
@@ -77,7 +391,33 @@ function SignupPage() {
           type="text"
           autoComplete="username"
           placeholder="아이디를 입력하세요"
-          action={<AuthInputActionButton>중복확인</AuthInputActionButton>}
+          value={formValues.login_id}
+          onChange={(event) =>
+            handleFieldChange('login_id', event.target.value)
+          }
+          onBlur={() =>
+            setTouchedState((previous) => ({
+              ...previous,
+              login_id: true,
+            }))
+          }
+          errorMessage={resolvedFieldErrors.login_id}
+          helperMessage={
+            !resolvedFieldErrors.login_id &&
+            loginIdCheckState.tone === 'success'
+              ? loginIdCheckState.message
+              : ''
+          }
+          helperMessageTone="success"
+          disabled={isSubmitting}
+          action={
+            <AuthInputActionButton
+              onClick={handleCheckLoginIdDuplicate}
+              disabled={checkIdDuplicateMutation.isPending || isSubmitting}
+            >
+              {checkIdDuplicateMutation.isPending ? '확인 중...' : '중복확인'}
+            </AuthInputActionButton>
+          }
         />
 
         <AuthInputField
@@ -87,7 +427,37 @@ function SignupPage() {
           type="text"
           autoComplete="nickname"
           placeholder="닉네임을 입력하세요"
-          action={<AuthInputActionButton>중복확인</AuthInputActionButton>}
+          value={formValues.nickname}
+          onChange={(event) =>
+            handleFieldChange('nickname', event.target.value)
+          }
+          onBlur={() =>
+            setTouchedState((previous) => ({
+              ...previous,
+              nickname: true,
+            }))
+          }
+          errorMessage={resolvedFieldErrors.nickname}
+          helperMessage={
+            !resolvedFieldErrors.nickname &&
+            nicknameCheckState.tone === 'success'
+              ? nicknameCheckState.message
+              : ''
+          }
+          helperMessageTone="success"
+          disabled={isSubmitting}
+          action={
+            <AuthInputActionButton
+              onClick={handleCheckNicknameDuplicate}
+              disabled={
+                checkNicknameDuplicateMutation.isPending || isSubmitting
+              }
+            >
+              {checkNicknameDuplicateMutation.isPending
+                ? '확인 중...'
+                : '중복확인'}
+            </AuthInputActionButton>
+          }
         />
 
         <AuthInputField
@@ -97,10 +467,18 @@ function SignupPage() {
           type="password"
           autoComplete="new-password"
           placeholder="비밀번호를 입력하세요"
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-          onBlur={() => setPasswordTouched(true)}
-          errorMessage={passwordError}
+          value={formValues.password}
+          onChange={(event) =>
+            handleFieldChange('password', event.target.value)
+          }
+          onBlur={() =>
+            setTouchedState((previous) => ({
+              ...previous,
+              password: true,
+            }))
+          }
+          errorMessage={resolvedFieldErrors.password}
+          disabled={isSubmitting}
         />
 
         <AuthInputField
@@ -110,23 +488,40 @@ function SignupPage() {
           type="password"
           autoComplete="new-password"
           placeholder="비밀번호를 한번 더 입력하세요"
-          value={passwordCheck}
-          onChange={(event) => setPasswordCheck(event.target.value)}
-          onBlur={() => setPasswordCheckTouched(true)}
-          errorMessage={passwordCheckError}
+          value={formValues.password_check}
+          onChange={(event) =>
+            handleFieldChange('password_check', event.target.value)
+          }
+          onBlur={() =>
+            setTouchedState((previous) => ({
+              ...previous,
+              password_check: true,
+            }))
+          }
+          errorMessage={resolvedFieldErrors.password_check}
+          disabled={isSubmitting}
         />
 
         <AuthRadioGroup
           label="성별"
           name="gender"
-          value={gender}
+          value={formValues.gender}
           options={signupGenderOptions}
-          onChange={(event) => setGender(event.target.value as AuthGender)}
-          errorMessage={genderError}
+          onChange={(event) =>
+            handleFieldChange('gender', event.target.value as AuthGender)
+          }
+          errorMessage={resolvedFieldErrors.gender}
+          disabled={isSubmitting}
         />
 
-        <AuthButton type="submit" className="mt-2 w-full">
-          회원가입
+        {formMessage ? <AuthFormMessage>{formMessage}</AuthFormMessage> : null}
+
+        <AuthButton
+          type="submit"
+          className="mt-2 w-full"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? '회원가입 중...' : '회원가입'}
         </AuthButton>
       </form>
     </AuthLayout>


### PR DESCRIPTION
## 관련 이슈

- closes #38

## 변경 내용

- 로그인 페이지에 제어형 폼 상태와 로그인 API 연동을 추가했습니다.
- 회원가입 페이지에 제어형 폼 상태와 회원가입 API 연동을 추가했습니다.
- 아이디/닉네임 중복확인 버튼을 auth API 및 MSW mock과 연결했습니다.
- 회원가입 폼에서 값 변경 시 중복확인 상태가 초기화되도록 처리했습니다.
- 회원가입 성공 후 자동 로그인하고 메인 페이지로 이동하도록 처리했습니다.
- 자동 로그인에 실패할 경우 로그인 페이지로 이동하고 안내 메시지를 표시하도록 처리했습니다.
- 인증 폼 공통 메시지 컴포넌트를 추가하고, 필드/폼 에러 메시지 표시를 정리했습니다.
- 로그인/회원가입 화면의 버튼, 인풋, 라디오, 소셜 버튼에 hover/focus-visible 인터랙션을 보강했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷
- [x]

## 참고사항

- 이번 PR은 로그인/회원가입 일반 폼 연동 범위만 포함합니다.
- 소셜 로그인 버튼은 UI만 유지하고 있으며, 실제 소셜 인증 흐름은 후속 작업에서 연결 예정입니다.
- 회원가입 페이지 반응형 세부 보강은 후속 작업에서 추가로 다듬을 예정입니다.
