### PR TITLE
[Refactor] 로그인 및 회원가입 페이지 반응형 개선

### DIFF
--- a/src/components/auth/AuthInputActionButton.tsx
+++ b/src/components/auth/AuthInputActionButton.tsx
@@ -15,7 +15,7 @@ function AuthInputActionButton({
     <AuthButton
       type={type}
       variant="secondary"
-      className="w-24 shrink-0"
+      className="w-full sm:w-24 sm:shrink-0"
       {...props}
     >
       {children}

--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -31,14 +31,14 @@ function AuthInputField({
       : 'text-login-helper';
 
   return (
-    <div className={`space-y-2.5 ${containerClassName}`}>
+    <div className={`space-y-2 ${containerClassName} sm:space-y-2.5`}>
       <label
         htmlFor={id}
         className="text-login-label block text-sm font-medium"
       >
         {label}
       </label>
-      <div className="flex items-stretch gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
         <input
           id={id}
           {...inputProps}

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -33,11 +33,11 @@ function AuthRadioGroup({
       <legend className="text-login-label block text-sm font-medium">
         {label}
       </legend>
-      <div className="flex items-center justify-between gap-3 pt-1">
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-3 pt-1 sm:flex-nowrap sm:justify-between">
         {options.map((option) => (
           <label
             key={option.value}
-            className="group flex min-w-0 flex-1 cursor-pointer items-center justify-center gap-2"
+            className="group flex min-w-0 flex-1 cursor-pointer items-center justify-start gap-2 sm:justify-center"
           >
             <input
               type="radio"
@@ -59,7 +59,7 @@ function AuthRadioGroup({
             >
               <span className="bg-login-primary h-2 w-2 rounded-full opacity-0 transition-opacity peer-checked:opacity-100" />
             </span>
-            <span className="text-login-helper truncate text-sm/5 font-medium transition-colors group-hover:text-white/85 peer-checked:text-white peer-disabled:opacity-60">
+            <span className="text-login-helper text-sm/5 font-medium transition-colors group-hover:text-white/85 peer-checked:text-white peer-disabled:opacity-60">
               {option.label}
             </span>
           </label>

--- a/src/components/auth/AuthSocialLoginGroup.tsx
+++ b/src/components/auth/AuthSocialLoginGroup.tsx
@@ -45,23 +45,23 @@ const NaverIcon = () => (
 
 function AuthSocialLoginGroup({ className = '' }: AuthSocialLoginGroupProps) {
   return (
-    <div className={`space-y-3.5 ${className}`}>
+    <div className={`space-y-3 ${className} sm:space-y-3.5`}>
       <SocialLoginButton
         label="Google로 로그인하기"
         icon={<GoogleIcon />}
-        className="bg-login-google border-login-google h-[61px] border"
+        className="bg-login-google border-login-google h-14 border sm:h-[61px]"
         labelClassName="text-white"
       />
       <SocialLoginButton
         label="카카오로 로그인하기"
         icon={<KakaoIcon />}
-        className="bg-login-kakao h-[59px]"
+        className="bg-login-kakao h-14 sm:h-[59px]"
         labelClassName="text-login-kakao-label"
       />
       <SocialLoginButton
         label="네이버로 로그인하기"
         icon={<NaverIcon />}
-        className="bg-login-naver h-[59px]"
+        className="bg-login-naver h-14 sm:h-[59px]"
         labelClassName="text-white"
       />
     </div>

--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -23,13 +23,13 @@ function AuthLayout({
   const content = (
     <>
       <h1
-        className={`text-center text-4xl leading-none font-semibold sm:text-5xl ${titleClassName}`}
+        className={`text-center text-[clamp(2rem,4.8vw,3rem)] leading-none font-semibold ${titleClassName}`}
       >
         {title}
       </h1>
       {subtitle ? (
         <p
-          className={`text-login-helper mt-3 text-center text-sm/5 font-normal ${subtitleClassName}`}
+          className={`text-login-helper mt-2.5 text-center text-sm/5 font-normal sm:mt-3 ${subtitleClassName}`}
         >
           {subtitle}
         </p>
@@ -42,10 +42,10 @@ function AuthLayout({
     <div className="bg-login-page flex min-h-screen flex-col text-white">
       <Header fixed={false} />
 
-      <main className="flex flex-1 items-start justify-center px-6 pt-8 pb-16 sm:px-8 sm:pt-12">
+      <main className="flex flex-1 items-start justify-center px-[clamp(1rem,5vw,20rem)] pt-6 pb-14 sm:pt-10 sm:pb-16">
         {withPanel ? (
           <section
-            className={`bg-auth-panel border-auth-panel shadow-auth-panel w-full max-w-[520px] rounded-3xl border px-5 py-6 backdrop-blur-sm sm:px-8 sm:py-8 ${panelClassName}`}
+            className={`bg-auth-panel border-auth-panel shadow-auth-panel w-full max-w-[520px] rounded-[28px] border px-4 py-5 backdrop-blur-sm sm:rounded-3xl sm:px-8 sm:py-8 ${panelClassName}`}
           >
             <div className="mx-auto w-full max-w-[440px]">{content}</div>
           </section>

--- a/src/components/login/SocialLoginButton.tsx
+++ b/src/components/login/SocialLoginButton.tsx
@@ -19,7 +19,11 @@ function SocialLoginButton({
       className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-all duration-200 hover:-translate-y-0.5 hover:brightness-105 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none active:translate-y-0 ${className}`}
     >
       {icon}
-      <span className={`text-lg/7 font-normal ${labelClassName}`}>{label}</span>
+      <span
+        className={`text-base/6 font-normal sm:text-lg/7 ${labelClassName}`}
+      >
+        {label}
+      </span>
     </button>
   );
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -131,9 +131,9 @@ function LoginPage() {
 
   return (
     <AuthLayout title="Log In">
-      <AuthSocialLoginGroup className="mt-10" />
+      <AuthSocialLoginGroup className="mt-8 sm:mt-10" />
 
-      <AuthDivider className="my-7" />
+      <AuthDivider className="my-6 sm:my-7" />
 
       <form className="space-y-4" onSubmit={handleSubmit}>
         <AuthInputField
@@ -199,11 +199,14 @@ function LoginPage() {
         </AuthButton>
       </form>
 
-      <div className="border-login-divider mt-9 border-t pt-7">
+      <div className="border-login-divider mt-8 border-t pt-6 sm:mt-9 sm:pt-7">
         <p className="text-login-helper text-center text-sm/5 font-normal">
           아직 PGTI 회원이 아니신가요?
         </p>
-        <AuthLinkButton to={`/${ROUTES.SIGNUP}`} className="mt-5 w-full">
+        <AuthLinkButton
+          to={`/${ROUTES.SIGNUP}`}
+          className="mt-4 w-full sm:mt-5"
+        >
           회원가입
         </AuthLinkButton>
       </div>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -357,13 +357,13 @@ function SignupPage() {
       title="Join"
       subtitle="회원가입 후 취향 기반 게임 추천을 시작해보세요"
       withPanel
-      subtitleClassName="mx-auto max-w-[290px]"
+      subtitleClassName="mx-auto max-w-[290px] sm:max-w-[320px]"
     >
-      <AuthSocialLoginGroup className="mt-7" />
+      <AuthSocialLoginGroup className="mt-6 sm:mt-7" />
 
-      <AuthDivider className="my-6" />
+      <AuthDivider className="my-5 sm:my-6" />
 
-      <form className="space-y-4" onSubmit={handleSubmit}>
+      <form className="space-y-3.5 sm:space-y-4" onSubmit={handleSubmit}>
         <AuthInputField
           id="signup-name"
           name="name"
@@ -518,7 +518,7 @@ function SignupPage() {
 
         <AuthButton
           type="submit"
-          className="mt-2 w-full"
+          className="mt-1 w-full sm:mt-2"
           disabled={isSubmitting}
         >
           {isSubmitting ? '회원가입 중...' : '회원가입'}


### PR DESCRIPTION
## 관련 이슈

- closes #40

## 변경 내용

- 로그인/회원가입 공통 auth 레이아웃의 반응형 여백과 카드 패딩을 조정했습니다.
- 작은 화면에서 제목, 보조 문구, 구분선, 하단 CTA 간격이 더 자연스럽게 보이도록 정리했습니다.
- 회원가입 페이지의 중복확인 버튼이 모바일에서 입력 필드 아래로 자연스럽게 쌓이도록 개선했습니다.
- 로그인/회원가입 소셜 로그인 버튼 높이와 텍스트 크기를 화면 크기에 따라 조정했습니다.
- 성별 선택 영역이 작은 화면에서도 덜 답답하게 보이도록 라디오 그룹 레이아웃을 보완했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷
<img width="3416" height="1754" alt="image" src="https://github.com/user-attachments/assets/c4dadd51-a8e0-471e-9f41-a45d2a6e7e39" />



## 참고사항

- 이번 PR은 로그인/회원가입 페이지의 반응형 레이아웃 개선 범위만 포함합니다.
- 인증 API 연동 및 폼 동작 로직 변경은 포함하지 않습니다.
- 데스크톱 UI 구조는 유지하면서 모바일/좁은 화면에서의 배치와 여백을 중심으로 조정했습니다.
