### PR TITLE
[Feat] 게임 목록 장르 필터를 genre_id 요청 기준으로 변경

### DIFF
--- a/docs/ai/api-contract.md
+++ b/docs/ai/api-contract.md
@@ -69,10 +69,10 @@ type GameDetail = {
 명세의 상세 응답에는 `create_date`와 예시의 `created_date`처럼 표기 차이가 있습니다.
 화면에서는 해당 값을 직접 사용하지 말고, 필요해지면 API 정규화 함수에서 처리합니다.
 
-## Known Uncertainties
+## Contract Notes and Uncertainties
 
-- `GET /api/v1/games/list`에는 요구사항상 장르 필터가 필요하지만 현재 명세에는 장르 파라미터가 없습니다.
-- `GET /api/v1/games/list/top100`은 `genre_id`가 비어 있거나 유효 범위를 벗어나면 전체 조회로 처리됩니다. 일반 목록 API에도 같은 규칙이 적용되는지는 확정되지 않았습니다.
+- `GET /api/v1/games/list/top100`과 `GET /api/v1/games/list`는 선택 장르가 있을 때 `genre_id`를 전달합니다.
+- `genre_id`는 1~14 범위를 사용하고, 전체 조회는 `genre_id`를 보내지 않습니다. 유효하지 않은 값은 `400 Bad Request`로 처리합니다.
 - 상세 응답 필드명은 `title`, 목록 응답 필드명은 `name`으로 다릅니다.
 - 좋아요 상태는 상세 응답의 `is_liked`와 별도 `like-status` API가 함께 존재합니다. 상세 조회 응답을 우선 사용하고, 백엔드 정책이 바뀌면 별도 조회로 전환합니다.
 
@@ -81,6 +81,6 @@ type GameDetail = {
 ## Temporary Frontend Defaults
 
 - 초기 장르 필터는 `전체`로 표시합니다.
-- TOP 100 전체 조회는 `genre_id`를 보내지 않는 방식으로 우선 구현하고, 장르 선택 시 명세의 장르 ID를 전달합니다.
-- 일반 검색 목록은 백엔드 확정 전까지 `search`, `fuzzy`, `sort`, `page`, `page_size`만 사용합니다.
+- TOP 100과 일반 검색 목록의 전체 조회는 `genre_id`를 보내지 않고, 장르 선택 시 명세의 장르 ID를 전달합니다.
+- 일반 검색 목록은 `search`, `fuzzy`, `sort`, `page`, `page_size`를 유지하고, 장르 선택 시 `genre_id`를 함께 전달합니다.
 - API URL과 응답 필드명은 컴포넌트 내부가 아니라 API 모듈에서만 다룹니다.

--- a/src/features/games/gameApi.ts
+++ b/src/features/games/gameApi.ts
@@ -1,5 +1,5 @@
 import { api } from '../../api/axios';
-import { matchesGenreFilter } from './genres';
+import { getGameGenreId, matchesGenreFilter } from './genres';
 import { mockTopGames } from './mockGames';
 import type {
   GameDetail,
@@ -15,6 +15,12 @@ const DEFAULT_PAGE_SIZE = 20;
 const DEFAULT_SORT = 'rating_desc';
 
 const hasApiBaseUrl = Boolean(import.meta.env.VITE_API_BASE_URL);
+
+const getGenreQueryParams = (genre: GetTopGamesParams['genre'] = '전체') => {
+  const genreId = getGameGenreId(genre);
+
+  return genreId ? { genre_id: genreId } : {};
+};
 
 const getMockDetail = async (gameId: number) => {
   const { getMockGameDetail } = await import('./mockGameDetails');
@@ -89,11 +95,12 @@ export const getTopGames = async ({
   try {
     const response = await api.get<GameListResponse>(
       '/api/v1/games/list/top100',
+      {
+        params: getGenreQueryParams(genre),
+      },
     );
 
-    return filterGames(response.data.results.map(normalizeGameListItem), {
-      genre,
-    });
+    return response.data.results.map(normalizeGameListItem);
   } catch {
     return filterGames(mockTopGames, { genre });
   }
@@ -118,13 +125,11 @@ export const searchGames = async ({
         sort,
         page,
         page_size: pageSize,
+        ...getGenreQueryParams(genre),
       },
     });
 
-    return filterGames(response.data.results.map(normalizeGameListItem), {
-      search,
-      genre,
-    });
+    return response.data.results.map(normalizeGameListItem);
   } catch {
     return filterGames(mockTopGames, { search, genre });
   }

--- a/src/features/games/genres.ts
+++ b/src/features/games/genres.ts
@@ -18,6 +18,26 @@ export const GAME_GENRE_FILTERS = [
 
 export type GameGenreFilter = (typeof GAME_GENRE_FILTERS)[number];
 
+export const GAME_GENRE_ID_MAP: Record<
+  Exclude<GameGenreFilter, '전체'>,
+  number
+> = {
+  액션: 1,
+  어드벤처: 2,
+  RPG: 3,
+  슈팅: 4,
+  전략: 5,
+  시뮬레이션: 6,
+  스포츠: 7,
+  레이싱: 8,
+  퍼즐: 9,
+  플랫폼: 10,
+  '대전 / 격투': 11,
+  '카드 / 보드': 12,
+  '음악 / 리듬': 13,
+  '비주얼 노벨': 14,
+};
+
 const GENRE_ALIASES: Record<Exclude<GameGenreFilter, '전체'>, string[]> = {
   액션: ['액션', 'action'],
   어드벤처: ['어드벤처', 'adventure'],
@@ -36,6 +56,9 @@ const GENRE_ALIASES: Record<Exclude<GameGenreFilter, '전체'>, string[]> = {
 };
 
 const normalizeGenreKeyword = (value: string) => value.trim().toLowerCase();
+
+export const getGameGenreId = (selectedGenre: GameGenreFilter) =>
+  selectedGenre === '전체' ? undefined : GAME_GENRE_ID_MAP[selectedGenre];
 
 export const matchesGenreFilter = (
   genres: string[],


### PR DESCRIPTION
## 관련 이슈

- closes #56 

## 변경 내용

- 장르명과 API 명세의 `genre_id`를 매핑하는 상수를 추가했습니다.
- `전체` 선택 시에는 `genre_id`를 요청 params에 포함하지 않도록 처리했습니다.
- 특정 장르 선택 시 `GET /api/v1/games/list/top100` 요청에 `genre_id`를 포함하도록 수정했습니다.
- 특정 장르 선택 시 `GET /api/v1/games/list` 요청에 `genre_id`를 포함하도록 수정했습니다.
- 실제 API 성공 경로에서는 프론트 장르명 후처리 필터를 제거하고 서버 필터 결과를 그대로 사용하도록 변경했습니다.
- API base URL이 없거나 요청 실패 fallback일 때는 기존 mock 장르 필터를 유지했습니다.
- `docs/ai/api-contract.md`의 장르 필터 계약을 최신 API 명세 기준으로 갱신했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- 장르 ID 매핑은 현재 API 명세서 기준을 따릅니다.

```text
1: 액션
2: 어드벤처
3: RPG
4: 슈팅
5: 전략
6: 시뮬레이션
7: 스포츠
8: 레이싱
9: 퍼즐
10: 플랫폼
11: 대전격투
12: 카드/보드
13: 음악/리듬
14: 비주얼 노벨
