### PR TITLE
[Feat] 매칭 장르 선택 진입 UI 구현 및 메인페이지 CTA 연결

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -2,6 +2,7 @@ export const ROUTES = {
   HOME: '/',
   SURVEY: 'survey',
   MATCHING_LIST: 'matching-list',
+  MATCHING_GENRE_DETAIL: 'matching-list/:genreSlug',
   RECOMMENDATION_LIST: 'recommendation-list',
   LOGIN: 'login',
   SIGNUP: 'signup',

--- a/src/features/matching/genres.ts
+++ b/src/features/matching/genres.ts
@@ -1,0 +1,92 @@
+import type { MatchingGenreCard, MatchingGenreSlug } from './types';
+
+export const MATCHING_GENRES: MatchingGenreCard[] = [
+  {
+    slug: 'action-fighting',
+    title: '액션 / 격투',
+    subtitle: '빠른 손맛과 정면 승부',
+    description:
+      '속도감 있는 액션과 강한 타격감을 즐기는 플레이어에게 어울려요.',
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1778820/header.jpg',
+  },
+  {
+    slug: 'adventure-platform',
+    title: '어드벤처 / 플랫폼',
+    subtitle: '탐험과 리듬감 있는 진행',
+    description: '가볍게 몰입하면서도 손으로 직접 뛰고 넘는 재미를 느껴보세요.',
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1426210/header.jpg',
+  },
+  {
+    slug: 'rpg-story',
+    title: 'RPG / 스토리',
+    subtitle: '서사와 성장의 몰입감',
+    description:
+      '캐릭터의 성장과 깊은 이야기를 함께 따라가고 싶은 분께 추천해요.',
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/292030/header.jpg',
+  },
+  {
+    slug: 'strategy-simulation',
+    title: '전략 / 시뮬',
+    subtitle: '판단과 운영의 재미',
+    description:
+      '장기적인 계획과 운영 감각이 중요한 플레이를 선호할 때 잘 맞아요.',
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/289070/header.jpg',
+  },
+  {
+    slug: 'sports-racing',
+    title: '스포츠 / 레이싱',
+    subtitle: '속도감과 경쟁의 짜릿함',
+    description:
+      '한 판 승부의 긴장감과 시원한 질주 감각을 원하는 플레이어에게 적합해요.',
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1551360/header.jpg',
+  },
+  {
+    slug: 'brain-strategy',
+    title: '두뇌 / 전략',
+    subtitle: '생각할수록 즐거운 플레이',
+    description:
+      '판을 읽고 선택을 쌓아가는 재미를 좋아하는 취향에 어울리는 장르예요.',
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/2379780/header.jpg',
+  },
+  {
+    slug: 'shooting',
+    title: '슈팅',
+    subtitle: '반응속도와 타격감',
+    description:
+      '짧은 순간의 판단과 손맛이 중요한 플레이를 선호한다면 잘 맞습니다.',
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/730/header.jpg',
+  },
+  {
+    slug: 'rhythm',
+    title: '음악 / 리듬',
+    subtitle: '비트에 맞춘 템포 플레이',
+    description:
+      '리듬감과 감각적인 연출을 함께 즐기고 싶은 플레이어를 위한 카테고리예요.',
+    thumbnailUrl:
+      'https://cdn.cloudflare.steamstatic.com/steam/apps/1817230/header.jpg',
+  },
+];
+
+const matchingGenreMap = new Map<MatchingGenreSlug, MatchingGenreCard>(
+  MATCHING_GENRES.map((genre) => [genre.slug, genre]),
+);
+
+export const getMatchingGenreBySlug = (genreSlug?: string) => {
+  if (!genreSlug) {
+    return undefined;
+  }
+
+  return matchingGenreMap.get(genreSlug as MatchingGenreSlug);
+};
+
+export const isMatchingGenreSlug = (
+  genreSlug: string,
+): genreSlug is MatchingGenreSlug =>
+  matchingGenreMap.has(genreSlug as MatchingGenreSlug);

--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -1,0 +1,17 @@
+export type MatchingGenreSlug =
+  | 'action-fighting'
+  | 'adventure-platform'
+  | 'rpg-story'
+  | 'strategy-simulation'
+  | 'sports-racing'
+  | 'brain-strategy'
+  | 'shooting'
+  | 'rhythm';
+
+export type MatchingGenreCard = {
+  slug: MatchingGenreSlug;
+  title: string;
+  subtitle: string;
+  description: string;
+  thumbnailUrl: string;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import App from './App';
 import { ROUTES } from './constants/routes';
 import { isMockServiceWorkerEnabled } from './lib/env';
 import MatchingListPage from './pages/matching/MatchingListPage';
+import MatchingGenreDetailPage from './pages/matching/MatchingGenreDetailPage';
 import MainPage from './pages/main/MainPage';
 import RecommendationListPage from './pages/recommendation/RecommendationListPage';
 import SurveyPage from './pages/survey/SurveyPage';
@@ -33,6 +34,10 @@ const router = createBrowserRouter([
       {
         path: ROUTES.MATCHING_LIST,
         element: <MatchingListPage />,
+      },
+      {
+        path: ROUTES.MATCHING_GENRE_DETAIL,
+        element: <MatchingGenreDetailPage />,
       },
       {
         path: ROUTES.RECOMMENDATION_LIST,

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -8,9 +8,11 @@ import {
 } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import type { Swiper as SwiperInstance } from 'swiper';
 import Header from '../../components/common/Header';
+import { ROUTES } from '../../constants/routes';
 import GameCard from '../../features/games/components/GameCard';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
 import { getTopGames, searchGames } from '../../features/games/gameApi';
@@ -124,7 +126,8 @@ const MainPage = () => {
               iconLabel="게임 찾기"
               title="매칭 시작"
               description="어떤 게임을 할지 고민? 당신의 취향에 맞는 게임을 추천해드립니다!"
-              buttonLabel="추천게임"
+              buttonLabel="장르별 매칭"
+              to={`/${ROUTES.MATCHING_LIST}`}
             />
           </section>
         </section>
@@ -360,6 +363,7 @@ type RecommendationCtaProps = {
   title: string;
   description: string;
   buttonLabel: string;
+  to?: string;
 };
 
 const RecommendationCta = ({
@@ -368,11 +372,14 @@ const RecommendationCta = ({
   title,
   description,
   buttonLabel,
+  to,
 }: RecommendationCtaProps) => {
   const Icon = icon;
   const showPendingMessage = () => {
     window.alert(CTA_PENDING_MESSAGE);
   };
+  const actionClassName =
+    'hover:bg-header-accent-hover mt-7 inline-flex h-11 cursor-pointer items-center justify-center rounded-md bg-[#d20b12] px-7 text-sm font-semibold text-white transition focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]';
 
   return (
     <article className="flex min-h-65 flex-col items-center justify-center rounded-lg border border-[#3a0b0d] bg-[#050505] px-6 py-9 text-center sm:min-h-70">
@@ -389,14 +396,20 @@ const RecommendationCta = ({
       <p className="mt-5 max-w-xl text-sm leading-6 text-white/70 sm:text-base">
         {description}
       </p>
-      <button
-        type="button"
-        onClick={showPendingMessage}
-        title="준비 중입니다."
-        className="hover:bg-header-accent-hover mt-7 h-11 cursor-pointer rounded-md bg-[#d20b12] px-7 text-sm font-semibold text-white transition focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]"
-      >
-        {buttonLabel}
-      </button>
+      {to ? (
+        <Link to={to} className={actionClassName}>
+          {buttonLabel}
+        </Link>
+      ) : (
+        <button
+          type="button"
+          onClick={showPendingMessage}
+          title="준비 중입니다."
+          className={actionClassName}
+        >
+          {buttonLabel}
+        </button>
+      )}
     </article>
   );
 };

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -1,0 +1,99 @@
+import { ChevronLeft, Sparkles } from 'lucide-react';
+import { Link, useParams } from 'react-router';
+
+import Header from '../../components/common/Header';
+import { ROUTES } from '../../constants/routes';
+import {
+  getMatchingGenreBySlug,
+  isMatchingGenreSlug,
+} from '../../features/matching/genres';
+import { getAccessToken } from '../../utils/auth';
+
+function MatchingGenreDetailPage() {
+  const { genreSlug } = useParams();
+  const hasAccessToken = Boolean(getAccessToken());
+  const isValidGenreSlug = genreSlug ? isMatchingGenreSlug(genreSlug) : false;
+  const genre = genreSlug ? getMatchingGenreBySlug(genreSlug) : undefined;
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.12),transparent_24%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
+      <Header fixed isLoggedIn={hasAccessToken} />
+
+      <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1180px] px-4 pt-24 pb-14 sm:px-6 sm:pt-28 md:px-8 md:pt-32 md:pb-18">
+        {!genre || !isValidGenreSlug ? (
+          <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 sm:px-8 sm:py-12">
+            <p className="text-sm font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
+              Matching
+            </p>
+            <h1 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl">
+              선택한 장르를 찾을 수 없어요.
+            </h1>
+            <p className="mt-4 max-w-[52ch] text-sm leading-7 break-keep text-white/60 sm:text-base">
+              잘못된 경로로 접근했거나 아직 준비되지 않은 장르입니다. 장르 선택
+              화면으로 돌아가서 다시 시작해보세요.
+            </p>
+            <Link
+              to={`/${ROUTES.MATCHING_LIST}`}
+              className="mt-7 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
+            >
+              <ChevronLeft size={16} />
+              장르 선택으로 돌아가기
+            </Link>
+          </section>
+        ) : (
+          <section className="mx-auto grid max-w-[980px] gap-6 lg:grid-cols-[1.15fr_0.85fr] lg:items-stretch">
+            <article className="overflow-hidden rounded-[28px] border border-white/8 bg-[#0d0d0f] shadow-[0_28px_56px_rgba(0,0,0,0.32)]">
+              <div className="relative h-full min-h-[280px]">
+                <img
+                  src={genre.thumbnailUrl}
+                  alt={genre.title}
+                  className="h-full w-full object-cover"
+                />
+                <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(8,8,10,0.18),rgba(8,8,10,0.78))]" />
+                <div className="absolute right-0 bottom-0 left-0 p-6 sm:p-8">
+                  <p className="text-[11px] font-medium tracking-[0.22em] text-white/68 uppercase">
+                    {genre.subtitle}
+                  </p>
+                  <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-[40px]">
+                    {genre.title}
+                  </h1>
+                </div>
+              </div>
+            </article>
+
+            <article className="survey-panel px-6 py-8 sm:px-8 sm:py-9">
+              <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-xs font-semibold tracking-[0.18em] text-white/52 uppercase">
+                <Sparkles size={14} />
+                Genre Selected
+              </div>
+              <h2 className="mt-5 text-2xl font-semibold tracking-[-0.02em] text-white sm:text-[30px]">
+                {genre.title}
+              </h2>
+              <p className="mt-3 text-base leading-7 break-keep text-white/60">
+                {genre.description}
+              </p>
+              <div className="mt-6 rounded-[22px] border border-white/8 bg-white/[0.03] px-5 py-5">
+                <p className="text-sm leading-7 break-keep text-white/68">
+                  2단계에서는 이 장르에 맞는 5개 게임 카드가 순서대로 등장하고,
+                  별점과 찜 여부를 남기면서 실제 매칭 플로우를 진행하게 됩니다.
+                </p>
+              </div>
+              <div className="mt-7 flex flex-wrap gap-3">
+                <Link
+                  to={`/${ROUTES.MATCHING_LIST}`}
+                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
+                >
+                  <ChevronLeft size={16} />
+                  다른 장르 보기
+                </Link>
+              </div>
+            </article>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}
+
+export default MatchingGenreDetailPage;

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -1,4 +1,9 @@
+import { ChevronRight } from 'lucide-react';
+import { Link } from 'react-router';
+
 import Header from '../../components/common/Header';
+import { ROUTES } from '../../constants/routes';
+import { MATCHING_GENRES } from '../../features/matching/genres';
 import { getAccessToken } from '../../utils/auth';
 
 function MatchingListPage() {
@@ -6,22 +11,57 @@ function MatchingListPage() {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
-      <div className="app-aurora pointer-events-none absolute inset-0 opacity-75" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.18),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
       <Header fixed isLoggedIn={hasAccessToken} />
 
-      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] px-5 pt-32 pb-16 md:px-8">
-        <section className="survey-panel my-auto w-full px-8 py-10">
-          <p className="text-sm font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
-            Matching List
-          </p>
-          <h1 className="mt-4 text-3xl font-bold text-white md:text-4xl">
-            매칭 페이지는 다음 단계에서 이어집니다.
-          </h1>
-          <p className="mt-4 max-w-2xl text-base leading-7 text-white/60">
-            현재는 설문 플로우와 추천 결과 연결을 먼저 고정해두었습니다. 이후
-            장르 기반 카드, 평가 입력, 결과 정렬 UI를 이 페이지에 확장하면
-            됩니다.
-          </p>
+      <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1180px] px-4 pt-24 pb-14 sm:px-6 sm:pt-28 md:px-8 md:pt-32 md:pb-18">
+        <section className="mx-auto max-w-[920px]">
+          <div className="mb-10 text-center sm:mb-12">
+            <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
+              Matching
+            </p>
+            <h1 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[44px]">
+              장르별 게임 매칭
+            </h1>
+            <p className="mt-4 text-sm leading-6 break-keep text-white/58 sm:text-base">
+              다양한 카테고리의 게임을 만나보세요!
+            </p>
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            {MATCHING_GENRES.map((genre) => (
+              <Link
+                key={genre.slug}
+                to={`/${ROUTES.MATCHING_LIST}/${genre.slug}`}
+                className="group overflow-hidden rounded-[26px] border border-white/8 bg-[#0c0c0d] p-3 shadow-[0_20px_42px_rgba(0,0,0,0.28)] transition hover:border-[#a31c1c]/65 hover:bg-[#111112]"
+              >
+                <div className="relative overflow-hidden rounded-[20px]">
+                  <img
+                    src={genre.thumbnailUrl}
+                    alt={genre.title}
+                    className="aspect-[16/9] w-full object-cover transition duration-300 group-hover:scale-[1.025] group-hover:brightness-110"
+                  />
+                  <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,6,8,0.18),rgba(6,6,8,0.72))]" />
+                  <p className="absolute top-4 left-4 text-[11px] font-medium tracking-[0.2em] text-white/76 uppercase">
+                    {genre.subtitle}
+                  </p>
+                  <div className="absolute right-4 bottom-4 left-4 flex items-end justify-between gap-4">
+                    <div>
+                      <h2 className="text-2xl font-semibold tracking-[-0.02em] text-white">
+                        {genre.title}
+                      </h2>
+                      <p className="mt-2 max-w-[28ch] text-sm leading-6 break-keep text-white/72">
+                        {genre.description}
+                      </p>
+                    </div>
+                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-black/28 text-white/78 transition group-hover:border-[#b02525]/60 group-hover:text-white">
+                      <ChevronRight size={18} />
+                    </span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
         </section>
       </main>
     </div>


### PR DESCRIPTION
## 관련 이슈

- closed #58 

## 변경 내용

- 메인페이지 장르별 매칭 CTA 실제 라우팅 연결
- 메인페이지 추천게임-> 장르별 매칭으로 문구 수정
- 매칭 전용 장르 설정 추가 
- 매칭 리스트 UI 구현

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="1725" height="891" alt="스크린샷 2026-04-16 오후 3 08 50" src="https://github.com/user-attachments/assets/67d77555-8f7a-4572-8794-d9a5f231bbf8" />


## 참고사항

-
