### PR TITLE
[Feat] 로그인 상태 프로필 드롭다운 추가

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router';
-import profileImg from '../../assets/프로필 이미지.png';
 import { ROUTES } from '../../constants/routes';
+import HeaderProfileMenu from './HeaderProfileMenu';
 
 type HeaderProps = {
   isLoggedIn?: boolean;
@@ -46,13 +46,7 @@ const Header = ({ isLoggedIn = false, fixed = true }: HeaderProps) => {
               </Link>
             </>
           ) : (
-            <div className="hover:border-header-accent h-10 w-10 cursor-pointer overflow-hidden rounded-full border-2 border-transparent transition-all">
-              <img
-                src={profileImg}
-                alt="Profile"
-                className="h-full w-full object-cover"
-              />
-            </div>
+            <HeaderProfileMenu />
           )}
         </div>
       </div>

--- a/src/components/common/HeaderProfileMenu.tsx
+++ b/src/components/common/HeaderProfileMenu.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useLocation } from 'react-router';
+
+import profileImg from '../../assets/프로필 이미지.png';
+import { ROUTES } from '../../constants/routes';
+import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
+
+function HeaderProfileMenu() {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { logout, isPending } = useLogoutAction();
+  const location = useLocation();
+  const isMyPage = location.pathname === `/${ROUTES.MY_PAGE}`;
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-label="프로필 메뉴 열기"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((current) => !current)}
+        className="hover:border-header-accent h-10 w-10 cursor-pointer overflow-hidden rounded-full border-2 border-transparent transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
+      >
+        <img
+          src={profileImg}
+          alt="Profile"
+          className="h-full w-full object-cover"
+        />
+      </button>
+
+      {isOpen ? (
+        <div
+          role="menu"
+          aria-label="프로필 메뉴"
+          className="bg-mypage-panel border-mypage-panel shadow-mypage-float absolute top-[calc(100%+0.85rem)] right-0 z-50 w-40 overflow-hidden rounded-2xl border p-2 backdrop-blur-xl"
+        >
+          <Link
+            to={`/${ROUTES.MY_PAGE}`}
+            role="menuitem"
+            aria-current={isMyPage ? 'page' : undefined}
+            onClick={() => setIsOpen(false)}
+            className={`flex min-h-12 items-center justify-center rounded-xl px-4 text-base font-medium transition focus-visible:outline-none ${
+              isMyPage
+                ? 'text-login-primary bg-white/8'
+                : 'text-white hover:bg-white/6 focus-visible:bg-white/6'
+            }`}
+          >
+            마이페이지
+          </Link>
+          <div className="border-mypage-divider mx-2 border-t" />
+          <button
+            type="button"
+            role="menuitem"
+            disabled={isPending}
+            onClick={() => {
+              setIsOpen(false);
+              void logout();
+            }}
+            className="flex min-h-12 w-full items-center justify-center rounded-xl px-4 text-base font-medium text-white transition hover:bg-white/6 focus-visible:bg-white/6 focus-visible:outline-none disabled:opacity-60"
+          >
+            {isPending ? '로그아웃 중...' : '로그아웃'}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default HeaderProfileMenu;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -6,4 +6,5 @@ export const ROUTES = {
   RECOMMENDATION_LIST: 'recommendation-list',
   LOGIN: 'login',
   SIGNUP: 'signup',
+  MY_PAGE: 'my-page',
 } as const;

--- a/src/features/auth/hooks/useLogoutAction.ts
+++ b/src/features/auth/hooks/useLogoutAction.ts
@@ -1,0 +1,35 @@
+import { useNavigate } from 'react-router';
+
+import { ROUTES } from '../../../constants/routes';
+import { clearAuthTokens } from '../../../utils/auth';
+import { useLogoutMutation } from '../api/useAuthApi';
+
+function useLogoutAction() {
+  const navigate = useNavigate();
+  const logoutMutation = useLogoutMutation();
+
+  const logout = async (
+    noticeMessage = '로그아웃 되었습니다. 다시 로그인해 주세요.',
+  ) => {
+    try {
+      await logoutMutation.mutateAsync();
+    } catch {
+      // Even if the API call fails, clear the local session so the user can recover.
+    }
+
+    clearAuthTokens();
+    navigate(`/${ROUTES.LOGIN}`, {
+      replace: true,
+      state: {
+        noticeMessage,
+      },
+    });
+  };
+
+  return {
+    logout,
+    isPending: logoutMutation.isPending,
+  };
+}
+
+export default useLogoutAction;


### PR DESCRIPTION
## 관련 이슈

- closes #55

## 변경 내용

- 로그인 상태의 헤더 우측 프로필 아바타를 드롭다운 메뉴 형태로 변경했습니다.
- 프로필 메뉴에 `마이페이지`, `로그아웃` 액션을 추가했습니다.
- 로그아웃 동작을 공통으로 사용할 수 있도록 `useLogoutAction` 훅을 추가했습니다.
- 헤더 드롭다운에서 마이페이지 라우트 상수를 참조할 수 있도록 `ROUTES.MY_PAGE`를 추가했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 헤더의 로그인 상태 UI와 로그아웃 액션 분리만 포함합니다.
- 마이페이지 실제 라우트 등록 및 화면 구현은 후속 PR에서 진행합니다.
