### PR TITLE
[Feat] 마이페이지용 인증 API 및 mock 추가

### DIFF
--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -5,6 +5,10 @@ import { AUTH_BASE_PATH } from '../constants/auth';
 import type {
   CheckIdDuplicateRequest,
   CheckNicknameDuplicateRequest,
+  ChangePasswordRequest,
+  ChangePasswordResponse,
+  CurrentUserProfileResponse,
+  DeleteAccountResponse,
   DuplicateCheckResponse,
   ErrorResponseBody,
   LoginRequest,
@@ -25,6 +29,31 @@ export const login = async (payload: LoginRequest) => {
 
 export const logout = async () => {
   const response = await api.post<LogoutResponse>(`${AUTH_BASE_PATH}/logout`);
+
+  return response.data;
+};
+
+export const getCurrentUserProfile = async () => {
+  const response = await api.get<CurrentUserProfileResponse>(
+    `${AUTH_BASE_PATH}/me`,
+  );
+
+  return response.data;
+};
+
+export const changePassword = async (payload: ChangePasswordRequest) => {
+  const response = await api.post<ChangePasswordResponse>(
+    `${AUTH_BASE_PATH}/change-password`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const deleteAccount = async () => {
+  const response = await api.post<DeleteAccountResponse>(
+    `${AUTH_BASE_PATH}/delete-account`,
+  );
 
   return response.data;
 };

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -1,8 +1,11 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 import {
   checkIdDuplicate,
   checkNicknameDuplicate,
+  changePassword,
+  deleteAccount,
+  getCurrentUserProfile,
   login,
   logout,
   signup,
@@ -24,6 +27,26 @@ export const useLogoutMutation = () =>
   useMutation({
     mutationKey: ['auth', 'logout'],
     mutationFn: logout,
+  });
+
+export const useCurrentUserProfileQuery = (enabled = true) =>
+  useQuery({
+    queryKey: ['auth', 'me'],
+    queryFn: getCurrentUserProfile,
+    enabled,
+    staleTime: 60_000,
+  });
+
+export const useChangePasswordMutation = () =>
+  useMutation({
+    mutationKey: ['auth', 'change-password'],
+    mutationFn: changePassword,
+  });
+
+export const useDeleteAccountMutation = () =>
+  useMutation({
+    mutationKey: ['auth', 'delete-account'],
+    mutationFn: deleteAccount,
   });
 
 export const useCheckIdDuplicateMutation = () =>

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -5,6 +5,10 @@ import type {
   AuthGender,
   CheckIdDuplicateRequest,
   CheckNicknameDuplicateRequest,
+  ChangePasswordRequest,
+  ChangePasswordResponse,
+  CurrentUserProfileResponse,
+  DeleteAccountResponse,
   LoginRequest,
   LogoutResponse,
   SignupRequest,
@@ -61,6 +65,21 @@ const validGenders: AuthGender[] = ['M', 'W'];
 
 const createAccessToken = (loginId: string) => `mock-access-token-${loginId}`;
 const createRefreshToken = (loginId: string) => `mock-refresh-token-${loginId}`;
+
+const getAuthorizedUser = (authorization: string | null) => {
+  if (!authorization?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authorization.replace('Bearer ', '').trim();
+  const loginId = token.replace(/^mock-access-token-/, '');
+
+  if (!loginId || loginId === token) {
+    return null;
+  }
+
+  return mockUsers.get(loginId) ?? null;
+};
 
 const getDuplicateError = (message: string) =>
   HttpResponse.json(
@@ -251,6 +270,113 @@ const logoutHandlers = [
   }),
 ];
 
+const accountHandlers = [
+  http.get(`${AUTH_BASE_PATH}/me`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+    const user = getAuthorizedUser(authorization);
+
+    if (!user) {
+      return getUnauthorizedError(
+        '인증 정보가 유효하지 않거나 만료되었습니다.',
+      );
+    }
+
+    await delay(180);
+
+    return HttpResponse.json({
+      login_id: user.loginId,
+      name: user.name,
+      nickname: user.nickname,
+      gender: user.gender,
+    } satisfies CurrentUserProfileResponse);
+  }),
+
+  http.post(`${AUTH_BASE_PATH}/change-password`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+    const user = getAuthorizedUser(authorization);
+
+    if (!user) {
+      return getUnauthorizedError(
+        '인증 정보가 유효하지 않거나 만료되었습니다.',
+      );
+    }
+
+    const body = (await request.json()) as ChangePasswordRequest;
+    const currentPassword = body.current_password.trim();
+    const nextPassword = body.new_password.trim();
+    const nextPasswordConfirm = body.new_password_confirm.trim();
+
+    if (!currentPassword) {
+      return getFieldValidationError(
+        'current_password',
+        '현재 비밀번호를 입력해주세요.',
+      );
+    }
+
+    if (!nextPassword) {
+      return getFieldValidationError(
+        'new_password',
+        '새 비밀번호를 입력해주세요.',
+      );
+    }
+
+    if (!nextPasswordConfirm) {
+      return getFieldValidationError(
+        'new_password_confirm',
+        '새 비밀번호를 한번 더 입력해주세요.',
+      );
+    }
+
+    if (user.password !== currentPassword) {
+      return getFieldValidationError(
+        'current_password',
+        '현재 비밀번호가 일치하지 않습니다.',
+      );
+    }
+
+    if (nextPassword.length <= 8) {
+      return getFieldValidationError(
+        'new_password',
+        '비밀번호가 8자 이하입니다.',
+      );
+    }
+
+    if (nextPassword !== nextPasswordConfirm) {
+      return getFieldValidationError(
+        'new_password_confirm',
+        '비밀번호와 일치하지 않습니다.',
+      );
+    }
+
+    user.password = nextPassword;
+
+    await delay(350);
+
+    return HttpResponse.json({
+      detail: '비밀번호가 변경되었습니다.',
+    } satisfies ChangePasswordResponse);
+  }),
+
+  http.post(`${AUTH_BASE_PATH}/delete-account`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+    const user = getAuthorizedUser(authorization);
+
+    if (!user) {
+      return getUnauthorizedError(
+        '인증 정보가 유효하지 않거나 만료되었습니다.',
+      );
+    }
+
+    await delay(400);
+
+    mockUsers.delete(user.loginId);
+
+    return HttpResponse.json({
+      detail: `${user.nickname} 계정이 탈퇴 처리되었습니다.`,
+    } satisfies DeleteAccountResponse);
+  }),
+];
+
 const duplicateCheckHandlers = [
   http.post(`${AUTH_BASE_PATH}/check-id`, async ({ request }) => {
     const body = (await request.json()) as CheckIdDuplicateRequest;
@@ -303,5 +429,6 @@ export const authHandlers = [
   ...loginHandlers,
   ...signupHandlers,
   ...logoutHandlers,
+  ...accountHandlers,
   ...duplicateCheckHandlers,
 ];

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -14,6 +14,27 @@ export interface LogoutResponse {
   detail: string;
 }
 
+export interface ChangePasswordRequest {
+  current_password: string;
+  new_password: string;
+  new_password_confirm: string;
+}
+
+export interface ChangePasswordResponse {
+  detail: string;
+}
+
+export interface DeleteAccountResponse {
+  detail: string;
+}
+
+export interface CurrentUserProfileResponse {
+  login_id: string;
+  name: string;
+  nickname: string;
+  gender: AuthGender;
+}
+
 export interface SignupRequest {
   login_id: string;
   password_check: string;


### PR DESCRIPTION
## 관련 이슈

- closes #52

## 변경 내용

- 마이페이지에서 사용할 인증 관련 API를 추가했습니다.
- 현재 로그인 사용자 프로필 조회 API를 추가했습니다.
- 비밀번호 변경 API를 추가했습니다.
- 회원탈퇴 API를 추가했습니다.
- 위 기능에 맞춰 auth mutation/query hook을 확장했습니다.
- MSW auth 핸들러에 프로필 조회, 비밀번호 변경, 회원탈퇴 mock 응답을 추가했습니다.
- 마이페이지에서 사용할 auth 타입을 확장했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

- UI 변경 없음

## 참고사항

- 이번 PR은 마이페이지에서 사용할 인증 관련 API 및 mock 기반만 포함합니다.
- 실제 마이페이지 화면, 라우팅, 드롭다운 UI는 다른 PR에서 분리해서 진행합니다.
- 현재 로그인 사용자 조회, 비밀번호 변경, 회원탈퇴는 MSW mock 기준으로 동작합니다.
