### PR TITLE
[Feat] 마이페이지 UI 및 라우팅 구현

### DIFF
--- a/src/components/mypage/ConfirmModal.tsx
+++ b/src/components/mypage/ConfirmModal.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react';
+
+import AuthButton from '../auth/AuthButton';
+
+type ConfirmModalProps = {
+  open: boolean;
+  title: string;
+  description: ReactNode;
+  confirmLabel: string;
+  cancelLabel?: string;
+  isPending?: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+};
+
+function ConfirmModal({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = '취소',
+  isPending = false,
+  onConfirm,
+  onClose,
+}: ConfirmModalProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[80] flex items-center justify-center px-4">
+      <button
+        type="button"
+        aria-label="모달 닫기"
+        onClick={onClose}
+        className="bg-mypage-overlay absolute inset-0"
+      />
+
+      <div className="bg-mypage-panel border-mypage-panel shadow-mypage-float relative z-10 w-full max-w-md rounded-[28px] border px-5 py-6 backdrop-blur-xl sm:px-6">
+        <h2 className="text-2xl font-semibold text-white">{title}</h2>
+        <p className="text-mypage-muted mt-3 text-sm/6 sm:text-base/7">
+          {description}
+        </p>
+
+        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <AuthButton
+            type="button"
+            variant="secondary"
+            className="w-full sm:w-auto sm:min-w-28"
+            onClick={onClose}
+            disabled={isPending}
+          >
+            {cancelLabel}
+          </AuthButton>
+          <AuthButton
+            type="button"
+            className="bg-mypage-danger hover:bg-mypage-danger-hover w-full shadow-none sm:w-auto sm:min-w-32"
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {isPending ? '처리 중...' : confirmLabel}
+          </AuthButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ConfirmModal;

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -1,0 +1,44 @@
+import { Heart } from 'lucide-react';
+import { Link } from 'react-router';
+
+import type { FavoriteGamePreview } from '../../features/mypage/types';
+
+type FavoriteGameCardProps = {
+  game: FavoriteGamePreview;
+};
+
+function FavoriteGameCard({ game }: FavoriteGameCardProps) {
+  return (
+    <Link
+      to={`/games/${game.gameId}`}
+      className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover flex h-full flex-col overflow-hidden rounded-[24px] border transition duration-200"
+    >
+      <div className="bg-mypage-soft relative aspect-[16/10] overflow-hidden">
+        {game.thumbnailUrl ? (
+          <img
+            src={game.thumbnailUrl}
+            alt={`${game.title} 썸네일`}
+            className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
+            loading="lazy"
+          />
+        ) : (
+          <div className="text-mypage-muted flex h-full items-center justify-center px-6 text-center text-sm">
+            이미지 준비 중
+          </div>
+        )}
+        <div className="absolute inset-x-0 bottom-0 flex justify-end p-3">
+          <span className="bg-login-primary inline-flex h-10 w-10 items-center justify-center rounded-full text-white shadow-[0_12px_28px_rgba(242,15,23,0.25)]">
+            <Heart size={16} fill="currentColor" />
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-2 px-4 py-4 sm:px-5">
+        <h3 className="text-lg/7 font-semibold text-white">{game.title}</h3>
+        <p className="text-mypage-muted text-sm/6">{game.summary}</p>
+      </div>
+    </Link>
+  );
+}
+
+export default FavoriteGameCard;

--- a/src/components/mypage/FavoriteGamesEmptyState.tsx
+++ b/src/components/mypage/FavoriteGamesEmptyState.tsx
@@ -1,0 +1,19 @@
+import { HeartOff } from 'lucide-react';
+
+function FavoriteGamesEmptyState() {
+  return (
+    <div className="border-mypage-divider bg-mypage-card flex min-h-64 flex-col items-center justify-center rounded-[24px] border border-dashed px-6 py-10 text-center">
+      <span className="bg-mypage-soft mb-5 inline-flex h-14 w-14 items-center justify-center rounded-full text-white/80">
+        <HeartOff size={24} />
+      </span>
+      <h3 className="text-xl font-semibold text-white">
+        아직 찜한 게임이 없어요
+      </h3>
+      <p className="text-mypage-muted mt-3 max-w-md text-sm/6">
+        마음에 드는 게임을 찜해두면 이곳에서 다시 빠르게 확인할 수 있습니다.
+      </p>
+    </div>
+  );
+}
+
+export default FavoriteGamesEmptyState;

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -1,0 +1,76 @@
+import { CircleUserRound } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import AuthButton from '../auth/AuthButton';
+
+type MyPageProfileSectionProps = {
+  nickname: string;
+  isProfileLoading?: boolean;
+  isLoggingOut: boolean;
+  isPasswordPanelOpen: boolean;
+  onPasswordToggle: () => void;
+  onLogout: () => void;
+  children?: ReactNode;
+};
+
+function MyPageProfileSection({
+  nickname,
+  isProfileLoading = false,
+  isLoggingOut,
+  isPasswordPanelOpen,
+  onPasswordToggle,
+  onLogout,
+  children,
+}: MyPageProfileSectionProps) {
+  return (
+    <section className="border-mypage-panel bg-mypage-panel shadow-mypage-float rounded-[28px] border px-5 py-8 text-center backdrop-blur-xl sm:px-8 sm:py-10">
+      <h1 className="text-[clamp(2rem,4.8vw,2.75rem)] font-semibold text-white">
+        마이페이지
+      </h1>
+
+      <div className="mt-8 flex justify-center">
+        <div className="border-mypage-panel bg-mypage-card flex h-28 w-28 items-center justify-center rounded-full border">
+          <CircleUserRound size={42} className="text-white/85" />
+        </div>
+      </div>
+
+      {isProfileLoading ? (
+        <div className="mt-5 flex flex-col items-center gap-3">
+          <div className="h-8 w-32 animate-pulse rounded-full bg-white/8" />
+          <div className="h-4 w-full max-w-sm animate-pulse rounded-full bg-white/6" />
+        </div>
+      ) : (
+        <>
+          <p className="mt-5 text-2xl font-semibold text-white">{nickname}</p>
+          <p className="text-mypage-muted mt-2 text-sm/6">
+            계정 정보와 찜한 게임 목록을 한곳에서 관리할 수 있습니다.
+          </p>
+        </>
+      )}
+
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:justify-center">
+        <AuthButton
+          type="button"
+          variant="secondary"
+          className="w-full sm:w-auto sm:min-w-36"
+          onClick={onPasswordToggle}
+        >
+          {isPasswordPanelOpen ? '비밀번호 변경 닫기' : '비밀번호 변경'}
+        </AuthButton>
+        <AuthButton
+          type="button"
+          variant="secondary"
+          className="w-full sm:w-auto sm:min-w-28"
+          onClick={onLogout}
+          disabled={isLoggingOut}
+        >
+          {isLoggingOut ? '로그아웃 중...' : '로그아웃'}
+        </AuthButton>
+      </div>
+
+      {children}
+    </section>
+  );
+}
+
+export default MyPageProfileSection;

--- a/src/components/mypage/PasswordChangePanel.tsx
+++ b/src/components/mypage/PasswordChangePanel.tsx
@@ -1,0 +1,118 @@
+import type { FormEvent } from 'react';
+
+import AuthButton from '../auth/AuthButton';
+import AuthFormMessage from '../auth/AuthFormMessage';
+import AuthInputField from '../auth/AuthInputField';
+
+export type PasswordChangeValues = {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+};
+
+export type PasswordChangeFieldName = keyof PasswordChangeValues;
+
+type PasswordChangePanelProps = {
+  values: PasswordChangeValues;
+  errors: Partial<Record<PasswordChangeFieldName, string>>;
+  message?: string;
+  messageTone?: 'success' | 'error';
+  isPending: boolean;
+  onValueChange: (fieldName: PasswordChangeFieldName, value: string) => void;
+  onFieldBlur: (fieldName: PasswordChangeFieldName) => void;
+  onCancel: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+};
+
+function PasswordChangePanel({
+  values,
+  errors,
+  message,
+  messageTone = 'error',
+  isPending,
+  onValueChange,
+  onFieldBlur,
+  onCancel,
+  onSubmit,
+}: PasswordChangePanelProps) {
+  return (
+    <section className="bg-mypage-card border-mypage-panel mt-6 w-full rounded-[24px] border px-4 py-5 text-left sm:px-5 sm:py-6">
+      <div className="mb-5">
+        <h2 className="text-xl font-semibold text-white">비밀번호 변경</h2>
+        <p className="text-mypage-muted mt-2 text-sm/6">
+          현재 비밀번호를 확인한 뒤 새 비밀번호로 변경할 수 있습니다.
+        </p>
+      </div>
+
+      <form className="space-y-4" onSubmit={onSubmit}>
+        <AuthInputField
+          id="current-password"
+          name="current_password"
+          type="password"
+          label="현재 비밀번호"
+          placeholder="현재 비밀번호를 입력하세요"
+          value={values.currentPassword}
+          onChange={(event) =>
+            onValueChange('currentPassword', event.target.value)
+          }
+          onBlur={() => onFieldBlur('currentPassword')}
+          errorMessage={errors.currentPassword}
+          disabled={isPending}
+        />
+
+        <AuthInputField
+          id="new-password"
+          name="new_password"
+          type="password"
+          label="새 비밀번호"
+          placeholder="새 비밀번호를 입력하세요"
+          value={values.newPassword}
+          onChange={(event) => onValueChange('newPassword', event.target.value)}
+          onBlur={() => onFieldBlur('newPassword')}
+          errorMessage={errors.newPassword}
+          disabled={isPending}
+        />
+
+        <AuthInputField
+          id="new-password-confirm"
+          name="new_password_confirm"
+          type="password"
+          label="새 비밀번호 확인"
+          placeholder="새 비밀번호를 한번 더 입력하세요"
+          value={values.newPasswordConfirm}
+          onChange={(event) =>
+            onValueChange('newPasswordConfirm', event.target.value)
+          }
+          onBlur={() => onFieldBlur('newPasswordConfirm')}
+          errorMessage={errors.newPasswordConfirm}
+          disabled={isPending}
+        />
+
+        {message ? (
+          <AuthFormMessage tone={messageTone}>{message}</AuthFormMessage>
+        ) : null}
+
+        <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
+          <AuthButton
+            type="button"
+            variant="secondary"
+            className="w-full sm:w-auto sm:min-w-28"
+            onClick={onCancel}
+            disabled={isPending}
+          >
+            취소
+          </AuthButton>
+          <AuthButton
+            type="submit"
+            className="w-full sm:w-auto sm:min-w-32"
+            disabled={isPending}
+          >
+            {isPending ? '변경 중...' : '저장'}
+          </AuthButton>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+export default PasswordChangePanel;

--- a/src/components/mypage/ToastMessage.tsx
+++ b/src/components/mypage/ToastMessage.tsx
@@ -1,0 +1,40 @@
+import { AlertCircle, CheckCircle2, X } from 'lucide-react';
+
+type ToastMessageTone = 'success' | 'error';
+
+type ToastMessageProps = {
+  message: string;
+  tone?: ToastMessageTone;
+  onClose: () => void;
+};
+
+function ToastMessage({
+  message,
+  tone = 'success',
+  onClose,
+}: ToastMessageProps) {
+  const Icon = tone === 'success' ? CheckCircle2 : AlertCircle;
+
+  return (
+    <div className="bg-mypage-panel border-mypage-panel shadow-mypage-float fixed top-20 right-[clamp(1rem,5vw,20rem)] z-[70] flex w-[min(92vw,360px)] items-start gap-3 rounded-2xl border px-4 py-3 backdrop-blur-xl">
+      <span
+        className={`mt-0.5 shrink-0 ${
+          tone === 'success' ? 'text-emerald-400' : 'text-red-400'
+        }`}
+      >
+        <Icon size={18} />
+      </span>
+      <p className="flex-1 text-sm/6 font-medium text-white">{message}</p>
+      <button
+        type="button"
+        onClick={onClose}
+        className="text-mypage-muted transition hover:text-white"
+        aria-label="토스트 닫기"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}
+
+export default ToastMessage;

--- a/src/features/mypage/mockData.ts
+++ b/src/features/mypage/mockData.ts
@@ -1,0 +1,50 @@
+import type { FavoriteGamePreview, MyPageProfile } from './types';
+
+export const mockMyPageProfile: MyPageProfile = {
+  nickname: '데모유저',
+};
+
+export const mockFavoriteGames: FavoriteGamePreview[] = [
+  {
+    gameId: 901,
+    title: 'Eclipse Gate',
+    summary: '차원의 문 너머에서 펼쳐지는 탐험과 전투를 다시 즐겨보세요.',
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    gameId: 902,
+    title: 'Frozen Crown',
+    summary: '서늘한 설원과 거대한 성채가 인상적인 액션 어드벤처입니다.',
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1542751371-adc38448a05e?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    gameId: 903,
+    title: 'Crimson Trail',
+    summary: '붉게 물든 협곡을 따라 몰입감 있는 전투와 성장 루프를 경험하세요.',
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1511882150382-421056c89033?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    gameId: 904,
+    title: 'Astral Keep',
+    summary: '별빛 아래 펼쳐지는 성채 수비전과 전략적인 플레이가 특징입니다.',
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1493711662062-fa541adb3fc8?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    gameId: 905,
+    title: 'Moonlit Archive',
+    summary: '고요한 도서관 속 숨겨진 퍼즐과 서사를 차근차근 풀어보세요.',
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1518709268805-4e9042af2176?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    gameId: 906,
+    title: 'Neon Drift',
+    summary: '강렬한 분위기의 레이싱과 속도감을 원하는 날에 딱 어울립니다.',
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1486572788966-cfd3df1f5b42?auto=format&fit=crop&w=1200&q=80',
+  },
+];

--- a/src/features/mypage/types.ts
+++ b/src/features/mypage/types.ts
@@ -1,0 +1,10 @@
+export interface MyPageProfile {
+  nickname: string;
+}
+
+export interface FavoriteGamePreview {
+  gameId: number;
+  title: string;
+  summary: string;
+  thumbnailUrl: string | null;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,18 @@
   --color-auth-panel-border: rgba(255, 255, 255, 0.08);
   --shadow-auth-panel: rgba(0, 0, 0, 0.34);
   --shadow-login-primary: rgba(242, 15, 23, 0.42);
+  --color-mypage-panel: rgba(10, 10, 10, 0.92);
+  --color-mypage-panel-border: rgba(255, 255, 255, 0.08);
+  --color-mypage-divider: rgba(255, 255, 255, 0.1);
+  --color-mypage-card: rgba(255, 255, 255, 0.03);
+  --color-mypage-card-hover: rgba(255, 255, 255, 0.05);
+  --color-mypage-soft: #101010;
+  --color-mypage-muted: #a3a3a3;
+  --color-mypage-accent-soft: rgba(242, 15, 23, 0.14);
+  --color-mypage-overlay: rgba(0, 0, 0, 0.72);
+  --color-mypage-danger: #7c1515;
+  --color-mypage-danger-hover: #931919;
+  --shadow-mypage-float: rgba(0, 0, 0, 0.48);
   --color-surface-elevated: rgba(255, 255, 255, 0.04);
   --color-surface-border: rgba(255, 255, 255, 0.08);
   --color-surface-strong: rgba(255, 255, 255, 0.06);
@@ -190,28 +202,26 @@
     background-color: rgb(255 255 255 / 0.32);
   }
 
-  .game-detail-modal-scrollbar {
-    scrollbar-color: rgb(255 255 255 / 0.24) transparent;
+  .mypage-scrollbar {
+    scrollbar-color: rgb(255 255 255 / 0.2) transparent;
     scrollbar-width: thin;
   }
 
-  .game-detail-modal-scrollbar::-webkit-scrollbar {
+  .mypage-scrollbar::-webkit-scrollbar {
     width: 8px;
   }
 
-  .game-detail-modal-scrollbar::-webkit-scrollbar-track {
+  .mypage-scrollbar::-webkit-scrollbar-track {
     background: transparent;
   }
 
-  .game-detail-modal-scrollbar::-webkit-scrollbar-thumb {
-    border: 2px solid #111111;
+  .mypage-scrollbar::-webkit-scrollbar-thumb {
+    background-color: rgb(255 255 255 / 0.14);
     border-radius: 999px;
-    background-color: rgb(255 255 255 / 0.18);
-    background-clip: padding-box;
   }
 
-  .game-detail-modal-scrollbar::-webkit-scrollbar-thumb:hover {
-    background-color: rgb(255 255 255 / 0.34);
+  .mypage-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: rgb(255 255 255 / 0.26);
   }
 }
 
@@ -261,6 +271,38 @@
   background-color: var(--color-auth-panel);
 }
 
+@utility bg-mypage-panel {
+  background-color: var(--color-mypage-panel);
+}
+
+@utility bg-mypage-card {
+  background-color: var(--color-mypage-card);
+}
+
+@utility bg-mypage-card-hover {
+  background-color: var(--color-mypage-card-hover);
+}
+
+@utility bg-mypage-soft {
+  background-color: var(--color-mypage-soft);
+}
+
+@utility bg-mypage-accent-soft {
+  background-color: var(--color-mypage-accent-soft);
+}
+
+@utility bg-mypage-overlay {
+  background-color: var(--color-mypage-overlay);
+}
+
+@utility bg-mypage-danger {
+  background-color: var(--color-mypage-danger);
+}
+
+@utility bg-mypage-danger-hover {
+  background-color: var(--color-mypage-danger-hover);
+}
+
 @utility text-login-label {
   color: var(--color-login-label);
 }
@@ -279,6 +321,14 @@
 
 @utility text-login-kakao-label {
   color: var(--color-login-kakao-text);
+}
+
+@utility text-login-primary {
+  color: var(--color-login-primary);
+}
+
+@utility text-mypage-muted {
+  color: var(--color-mypage-muted);
 }
 
 @utility border-login-divider {
@@ -305,12 +355,30 @@
   border-color: var(--color-auth-panel-border);
 }
 
+@utility border-mypage-panel {
+  border-color: var(--color-mypage-panel-border);
+}
+
+@utility border-mypage-divider {
+  border-color: var(--color-mypage-divider);
+}
+
+@utility border-mypage-card {
+  border-color: var(--color-mypage-panel-border);
+}
+
 @utility shadow-auth-panel {
   box-shadow: 0 28px 60px -28px var(--shadow-auth-panel);
 }
 
 @utility shadow-login-primary {
   box-shadow: 0 10px 24px -10px var(--shadow-login-primary);
+}
+
+@utility shadow-mypage-float {
+  box-shadow:
+    0 24px 45px -22px var(--shadow-mypage-float),
+    0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
 @utility placeholder-login-muted {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,6 +14,7 @@ import RecommendationListPage from './pages/recommendation/RecommendationListPag
 import SurveyPage from './pages/survey/SurveyPage';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
+import MyPage from './pages/mypage/MyPage';
 import './index.css';
 
 const queryClient = new QueryClient();
@@ -50,6 +51,10 @@ const router = createBrowserRouter([
       {
         path: ROUTES.SIGNUP,
         element: <SignupPage />,
+      },
+      {
+        path: ROUTES.MY_PAGE,
+        element: <MyPage />,
       },
     ],
   },

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -1,0 +1,393 @@
+import type { FormEvent } from 'react';
+import { Heart, ShieldAlert } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router';
+
+import AuthButton from '../../components/auth/AuthButton';
+import Header from '../../components/common/Header';
+import ConfirmModal from '../../components/mypage/ConfirmModal';
+import FavoriteGameCard from '../../components/mypage/FavoriteGameCard';
+import FavoriteGamesEmptyState from '../../components/mypage/FavoriteGamesEmptyState';
+import MyPageProfileSection from '../../components/mypage/MyPageProfileSection';
+import PasswordChangePanel, {
+  type PasswordChangeFieldName,
+  type PasswordChangeValues,
+} from '../../components/mypage/PasswordChangePanel';
+import ToastMessage from '../../components/mypage/ToastMessage';
+import { ROUTES } from '../../constants/routes';
+import {
+  extractAuthApiErrorMessage,
+  extractAuthApiFieldErrors,
+} from '../../features/auth/api/auth';
+import {
+  useChangePasswordMutation,
+  useCurrentUserProfileQuery,
+  useDeleteAccountMutation,
+} from '../../features/auth/api/useAuthApi';
+import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
+import { mockFavoriteGames } from '../../features/mypage/mockData';
+import { clearAuthTokens, getAccessToken } from '../../utils/auth';
+
+type PasswordTouchedState = Record<PasswordChangeFieldName, boolean>;
+type PasswordFieldErrors = Partial<Record<PasswordChangeFieldName, string>>;
+type ToastState = {
+  tone: 'success' | 'error';
+  message: string;
+} | null;
+type PasswordPanelMessage = {
+  tone: 'success' | 'error';
+  message: string;
+} | null;
+
+const initialPasswordValues: PasswordChangeValues = {
+  currentPassword: '',
+  newPassword: '',
+  newPasswordConfirm: '',
+};
+
+const initialTouchedState: PasswordTouchedState = {
+  currentPassword: false,
+  newPassword: false,
+  newPasswordConfirm: false,
+};
+
+const getPasswordFieldErrors = (
+  values: PasswordChangeValues,
+  touchedState: PasswordTouchedState,
+) => {
+  const trimmedCurrentPassword = values.currentPassword.trim();
+  const trimmedNewPassword = values.newPassword.trim();
+  const trimmedNewPasswordConfirm = values.newPasswordConfirm.trim();
+
+  return {
+    currentPassword:
+      touchedState.currentPassword && !trimmedCurrentPassword
+        ? '현재 비밀번호를 입력해주세요.'
+        : '',
+    newPassword:
+      touchedState.newPassword && !trimmedNewPassword
+        ? '새 비밀번호를 입력해주세요.'
+        : touchedState.newPassword &&
+            trimmedNewPassword.length > 0 &&
+            trimmedNewPassword.length <= 8
+          ? '비밀번호가 8자 이하입니다.'
+          : '',
+    newPasswordConfirm:
+      touchedState.newPasswordConfirm && !trimmedNewPasswordConfirm
+        ? '새 비밀번호를 한번 더 입력해주세요.'
+        : touchedState.newPasswordConfirm &&
+            trimmedNewPassword.length > 0 &&
+            trimmedNewPasswordConfirm.length > 0 &&
+            trimmedNewPassword !== trimmedNewPasswordConfirm
+          ? '비밀번호와 일치하지 않습니다.'
+          : '',
+  } satisfies Record<PasswordChangeFieldName, string>;
+};
+
+const mapPasswordApiFieldErrors = (
+  fieldErrors: Record<string, string>,
+): PasswordFieldErrors => ({
+  currentPassword: fieldErrors.current_password,
+  newPassword: fieldErrors.new_password,
+  newPasswordConfirm: fieldErrors.new_password_confirm,
+});
+
+function MyPage() {
+  const navigate = useNavigate();
+  const hasAccessToken = Boolean(getAccessToken());
+  const { logout, isPending: isLogoutPending } = useLogoutAction();
+  const changePasswordMutation = useChangePasswordMutation();
+  const deleteAccountMutation = useDeleteAccountMutation();
+  const profileQuery = useCurrentUserProfileQuery(hasAccessToken);
+
+  const [isPasswordPanelOpen, setIsPasswordPanelOpen] = useState(false);
+  const [passwordValues, setPasswordValues] = useState<PasswordChangeValues>(
+    initialPasswordValues,
+  );
+  const [touchedState, setTouchedState] =
+    useState<PasswordTouchedState>(initialTouchedState);
+  const [apiFieldErrors, setApiFieldErrors] = useState<PasswordFieldErrors>({});
+  const [toast, setToast] = useState<ToastState>(null);
+  const [passwordPanelMessage, setPasswordPanelMessage] =
+    useState<PasswordPanelMessage>(null);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  const localFieldErrors = useMemo(
+    () => getPasswordFieldErrors(passwordValues, touchedState),
+    [passwordValues, touchedState],
+  );
+
+  const resolvedFieldErrors: Record<PasswordChangeFieldName, string> = {
+    currentPassword:
+      apiFieldErrors.currentPassword ?? localFieldErrors.currentPassword,
+    newPassword: apiFieldErrors.newPassword ?? localFieldErrors.newPassword,
+    newPasswordConfirm:
+      apiFieldErrors.newPasswordConfirm ?? localFieldErrors.newPasswordConfirm,
+  };
+
+  useEffect(() => {
+    if (!toast) {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setToast(null);
+    }, 3000);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [toast]);
+
+  useEffect(() => {
+    if (!isPasswordPanelOpen || passwordPanelMessage?.tone !== 'success') {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setIsPasswordPanelOpen(false);
+      setPasswordValues(initialPasswordValues);
+      setTouchedState(initialTouchedState);
+      setApiFieldErrors({});
+      setPasswordPanelMessage(null);
+    }, 2000);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [isPasswordPanelOpen, passwordPanelMessage]);
+
+  if (!hasAccessToken) {
+    return (
+      <Navigate
+        to={`/${ROUTES.LOGIN}`}
+        replace
+        state={{ noticeMessage: '로그인 후 마이페이지를 이용할 수 있습니다.' }}
+      />
+    );
+  }
+
+  const favoriteCount = mockFavoriteGames.length;
+
+  const resetPasswordPanel = () => {
+    setPasswordValues(initialPasswordValues);
+    setTouchedState(initialTouchedState);
+    setApiFieldErrors({});
+    setPasswordPanelMessage(null);
+  };
+
+  const closePasswordPanel = () => {
+    setIsPasswordPanelOpen(false);
+    resetPasswordPanel();
+  };
+
+  const handlePasswordValueChange = (
+    fieldName: PasswordChangeFieldName,
+    value: string,
+  ) => {
+    setPasswordValues((previous) => ({
+      ...previous,
+      [fieldName]: value,
+    }));
+
+    setApiFieldErrors((previous) => {
+      if (!previous[fieldName]) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        [fieldName]: '',
+      };
+    });
+
+    setPasswordPanelMessage(null);
+  };
+
+  const handlePasswordBlur = (fieldName: PasswordChangeFieldName) => {
+    setTouchedState((previous) => ({
+      ...previous,
+      [fieldName]: true,
+    }));
+  };
+
+  const handlePasswordSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const nextTouchedState = {
+      currentPassword: true,
+      newPassword: true,
+      newPasswordConfirm: true,
+    } satisfies PasswordTouchedState;
+
+    setTouchedState(nextTouchedState);
+    setApiFieldErrors({});
+    setPasswordPanelMessage(null);
+
+    const nextFieldErrors = getPasswordFieldErrors(
+      passwordValues,
+      nextTouchedState,
+    );
+    const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
+
+    if (hasLocalError) {
+      return;
+    }
+
+    try {
+      const response = await changePasswordMutation.mutateAsync({
+        current_password: passwordValues.currentPassword.trim(),
+        new_password: passwordValues.newPassword.trim(),
+        new_password_confirm: passwordValues.newPasswordConfirm.trim(),
+      });
+
+      setPasswordValues(initialPasswordValues);
+      setTouchedState(initialTouchedState);
+      setApiFieldErrors({});
+      setPasswordPanelMessage({
+        tone: 'success',
+        message: response.detail,
+      });
+    } catch (error) {
+      const nextApiFieldErrors = mapPasswordApiFieldErrors(
+        extractAuthApiFieldErrors(error),
+      );
+
+      if (Object.values(nextApiFieldErrors).some(Boolean)) {
+        setApiFieldErrors(nextApiFieldErrors);
+        return;
+      }
+
+      setPasswordPanelMessage({
+        tone: 'error',
+        message: extractAuthApiErrorMessage(error),
+      });
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    try {
+      const response = await deleteAccountMutation.mutateAsync();
+
+      clearAuthTokens();
+      navigate(`/${ROUTES.LOGIN}`, {
+        replace: true,
+        state: {
+          noticeMessage: response.detail,
+        },
+      });
+    } catch (error) {
+      setToast({
+        tone: 'error',
+        message: extractAuthApiErrorMessage(error),
+      });
+      setIsDeleteModalOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+      <div className="app-aurora pointer-events-none absolute inset-0 opacity-70" />
+      <Header fixed isLoggedIn />
+
+      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-[clamp(1rem,5vw,20rem)] pt-24 pb-14 sm:pt-28 sm:pb-16 lg:pt-32">
+        <MyPageProfileSection
+          nickname={profileQuery.data?.nickname ?? '회원'}
+          isProfileLoading={profileQuery.isLoading}
+          isLoggingOut={isLogoutPending}
+          isPasswordPanelOpen={isPasswordPanelOpen}
+          onPasswordToggle={() => setIsPasswordPanelOpen((current) => !current)}
+          onLogout={() => {
+            void logout();
+          }}
+        >
+          {isPasswordPanelOpen ? (
+            <PasswordChangePanel
+              values={passwordValues}
+              errors={resolvedFieldErrors}
+              message={passwordPanelMessage?.message}
+              messageTone={passwordPanelMessage?.tone ?? 'error'}
+              isPending={changePasswordMutation.isPending}
+              onValueChange={handlePasswordValueChange}
+              onFieldBlur={handlePasswordBlur}
+              onCancel={closePasswordPanel}
+              onSubmit={handlePasswordSubmit}
+            />
+          ) : null}
+        </MyPageProfileSection>
+
+        <section className="bg-mypage-panel border-mypage-panel shadow-mypage-float mt-8 rounded-[28px] border px-4 py-5 backdrop-blur-xl sm:mt-10 sm:px-6 sm:py-6">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <span className="bg-mypage-accent-soft text-login-primary inline-flex h-11 w-11 items-center justify-center rounded-full">
+                <Heart size={18} fill="currentColor" />
+              </span>
+              <div>
+                <h2 className="text-2xl font-semibold text-white">찜한 목록</h2>
+                <p className="text-mypage-muted mt-1 text-sm/6">
+                  내가 저장한 게임들을 한눈에 다시 확인할 수 있어요.
+                </p>
+              </div>
+            </div>
+            <p className="text-mypage-muted text-sm">
+              {favoriteCount > 0
+                ? `총 ${favoriteCount}개의 게임이 저장되어 있어요`
+                : '아직 저장된 게임이 없어요'}
+            </p>
+          </div>
+
+          <div className="mypage-scrollbar mt-5 max-h-[720px] overflow-y-auto pr-1">
+            {favoriteCount > 0 ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                {mockFavoriteGames.map((game) => (
+                  <FavoriteGameCard key={game.gameId} game={game} />
+                ))}
+              </div>
+            ) : (
+              <FavoriteGamesEmptyState />
+            )}
+          </div>
+        </section>
+
+        <section className="mt-8 flex flex-col items-center justify-center gap-3 pb-2 text-center">
+          <div className="text-mypage-muted flex items-center gap-2 text-sm/6">
+            <ShieldAlert size={16} />
+            <span>
+              더 이상 서비스를 이용하지 않으려면 회원탈퇴를 진행할 수 있습니다.
+            </span>
+          </div>
+          <AuthButton
+            type="button"
+            variant="secondary"
+            className="border-mypage-divider text-mypage-muted w-full max-w-44 hover:text-white"
+            onClick={() => setIsDeleteModalOpen(true)}
+          >
+            회원탈퇴
+          </AuthButton>
+        </section>
+      </main>
+
+      {toast ? (
+        <ToastMessage
+          message={toast.message}
+          tone={toast.tone}
+          onClose={() => setToast(null)}
+        />
+      ) : null}
+
+      <ConfirmModal
+        open={isDeleteModalOpen}
+        title="회원탈퇴 하시겠습니까?"
+        description="탈퇴를 진행하면 현재 로그인 세션이 종료되고, 로그인 화면으로 이동합니다."
+        confirmLabel="회원탈퇴"
+        isPending={deleteAccountMutation.isPending}
+        onClose={() => setIsDeleteModalOpen(false)}
+        onConfirm={() => {
+          void handleDeleteAccount();
+        }}
+      />
+    </div>
+  );
+}
+
+export default MyPage;


### PR DESCRIPTION
## 관련 이슈

- closes #53

## 변경 내용

- 마이페이지 라우트를 추가하고 `/my-page` 경로를 연결했습니다.
- 마이페이지 화면 UI를 구현했습니다.
- 프로필 섹션, 비밀번호 변경 패널, 찜한 목록 카드, 회원탈퇴 확인 모달, 토스트 메시지를 마이페이지 전용 컴포넌트로 분리했습니다.
- 로그인 상태가 아닐 경우 마이페이지 접근 시 로그인 페이지로 리다이렉트되도록 처리했습니다.
- 마이페이지 전용 mock 데이터와 타입을 추가했습니다.
- 마이페이지 전용 색상/패널/오버레이 스타일을 `index.css` 유틸리티로 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷
<img width="3432" height="1724" alt="image" src="https://github.com/user-attachments/assets/8ebff5d7-d4ec-4b6e-aacf-cac1a69d1f70" />



## 참고사항

- 이번 PR은 마이페이지 화면 및 라우팅 구현 범위만 포함합니다.
- 프로필 조회, 비밀번호 변경, 회원탈퇴 동작 자체는 auth API/mock PR을 기반으로 동작합니다.
- 찜한 목록은 현재 mock 데이터 기준으로 렌더링됩니다.
