### PR TITLE
[Refactor] 중복확인 UX 개선

### DIFF
--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -413,9 +413,17 @@ function SignupPage() {
           action={
             <AuthInputActionButton
               onClick={handleCheckLoginIdDuplicate}
-              disabled={checkIdDuplicateMutation.isPending || isSubmitting}
+              disabled={
+                checkIdDuplicateMutation.isPending ||
+                isSubmitting ||
+                isLoginIdVerified
+              }
             >
-              {checkIdDuplicateMutation.isPending ? '확인 중...' : '중복확인'}
+              {checkIdDuplicateMutation.isPending
+                ? '확인 중...'
+                : isLoginIdVerified
+                  ? '확인완료'
+                  : '중복확인'}
             </AuthInputActionButton>
           }
         />
@@ -450,12 +458,16 @@ function SignupPage() {
             <AuthInputActionButton
               onClick={handleCheckNicknameDuplicate}
               disabled={
-                checkNicknameDuplicateMutation.isPending || isSubmitting
+                checkNicknameDuplicateMutation.isPending ||
+                isSubmitting ||
+                isNicknameVerified
               }
             >
               {checkNicknameDuplicateMutation.isPending
                 ? '확인 중...'
-                : '중복확인'}
+                : isNicknameVerified
+                  ? '확인완료'
+                  : '중복확인'}
             </AuthInputActionButton>
           }
         />


### PR DESCRIPTION
## 관련 이슈

- closes #54

## 변경 내용

- 회원가입 페이지의 아이디/닉네임 중복확인 UX를 개선했습니다.
- 중복확인 성공 시 버튼 문구가 `확인완료`로 변경되도록 처리했습니다.
- 이미 확인이 완료된 동일한 값에 대해서는 버튼이 비활성화되도록 처리했습니다.
- 입력값이 변경되면 중복확인 상태가 다시 초기화되도록 정리했습니다.
- 중복확인 상태와 버튼 표현이 더 명확하게 보이도록 화면 흐름을 다듬었습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="852" height="1552" alt="image" src="https://github.com/user-attachments/assets/81e1a018-1754-401f-b646-b2d431944afa" />

## 참고사항

- 이번 PR은 회원가입 페이지의 중복확인 UX 개선만 포함합니다.
- 중복확인 API 자체의 계약 변경은 없습니다.
