### PR TITLE
[Feat]: 매칭 평가 인터렉션 플로우 구현

### DIFF
--- a/src/features/matching/components/MatchingGuideCards.tsx
+++ b/src/features/matching/components/MatchingGuideCards.tsx
@@ -1,0 +1,47 @@
+import { Hand, Heart, Star } from 'lucide-react';
+
+const guideCards = [
+  {
+    title: '카드를 넘겨보세요',
+    description:
+      '현재 게임의 분위기와 취향이 맞는지 보면서 차례대로 평가를 진행해요.',
+    icon: Hand,
+  },
+  {
+    title: '별점을 남겨보세요',
+    description:
+      '마음에 드는 정도를 별점으로 표현하면 다음 단계 추천 정확도가 높아져요.',
+    icon: Star,
+  },
+  {
+    title: '게임을 모아보세요',
+    description:
+      '좋아 보이는 게임은 하트로 표시해두고 나중에 다시 살펴볼 수 있어요.',
+    icon: Heart,
+  },
+];
+
+function MatchingGuideCards() {
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      {guideCards.map(({ title, description, icon: Icon }) => (
+        <article
+          key={title}
+          className="rounded-[24px] border border-white/8 bg-white/[0.025] px-5 py-6 shadow-[0_18px_34px_rgba(0,0,0,0.16)]"
+        >
+          <div className="flex h-11 w-11 items-center justify-center rounded-full border border-[#9c1b1b]/35 bg-[#150909] text-[#e34141]">
+            <Icon size={20} />
+          </div>
+          <h2 className="mt-5 text-lg font-semibold tracking-[-0.02em] text-white">
+            {title}
+          </h2>
+          <p className="mt-3 text-sm leading-6 break-keep text-white/58">
+            {description}
+          </p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export default MatchingGuideCards;

--- a/src/features/matching/components/MatchingMediaPanel.tsx
+++ b/src/features/matching/components/MatchingMediaPanel.tsx
@@ -1,0 +1,141 @@
+import { PlayCircle } from 'lucide-react';
+
+import type { MatchingCandidateItem } from '../types';
+
+type MatchingMediaPanelProps = {
+  candidate: MatchingCandidateItem;
+  genreTitle: string;
+  stepLabel: string;
+};
+
+const getYoutubeEmbedUrl = (trailerUrl: string | null) => {
+  if (!trailerUrl) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trailerUrl);
+    const hostname = url.hostname.replace('www.', '');
+
+    if (hostname === 'youtu.be') {
+      const videoId = url.pathname.replace('/', '');
+
+      return videoId
+        ? `https://www.youtube.com/embed/${videoId}?rel=0&modestbranding=1`
+        : null;
+    }
+
+    if (hostname === 'youtube.com' || hostname === 'm.youtube.com') {
+      const videoId = url.searchParams.get('v');
+
+      return videoId
+        ? `https://www.youtube.com/embed/${videoId}?rel=0&modestbranding=1`
+        : null;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+};
+
+function MatchingMediaPanel({
+  candidate,
+  genreTitle,
+  stepLabel,
+}: MatchingMediaPanelProps) {
+  const embedUrl = getYoutubeEmbedUrl(candidate.trailer_url);
+  const imageUrl = candidate.thumbnail_url;
+  const candidateSummary = `${genreTitle} 흐름에서 ${candidate.title}은 ${candidate.genres.join(
+    ' · ',
+  )} 감각을 대표하는 후보예요. 영상과 이미지를 보고 취향에 얼마나 맞는지 편하게 판단해보세요.`;
+
+  return (
+    <article className="flex h-full flex-col overflow-hidden rounded-[28px] border border-white/8 bg-[#0d0d0f] shadow-[0_26px_52px_rgba(0,0,0,0.28)]">
+      <div className="relative shrink-0">
+        {embedUrl ? (
+          <iframe
+            src={embedUrl}
+            title={`${candidate.title} 트레일러`}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+            className="aspect-[16/9] w-full border-0"
+          />
+        ) : imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={candidate.title}
+            className="aspect-[16/9] w-full object-cover"
+          />
+        ) : (
+          <div className="flex aspect-[16/9] w-full items-center justify-center bg-[#111113] text-sm text-white/45">
+            미디어가 준비되지 않았습니다.
+          </div>
+        )}
+        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(8,8,10,0.12),rgba(8,8,10,0.78))]" />
+        <div className="absolute right-0 bottom-0 left-0 p-6 sm:p-8">
+          <div className="flex flex-wrap items-center gap-2 text-[11px] font-medium tracking-[0.2em] uppercase">
+            <span className="rounded-full border border-white/12 bg-black/24 px-3 py-1.5 text-white/70">
+              {genreTitle}
+            </span>
+            {candidate.trailer_url ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-[#972020]/30 bg-[#180a0a] px-3 py-1.5 text-[#f07272]">
+                <PlayCircle size={12} />
+                Trailer
+              </span>
+            ) : null}
+          </div>
+          <h2 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-[40px]">
+            {candidate.title}
+          </h2>
+          <p className="mt-3 text-sm leading-7 break-keep text-white/68 sm:text-base">
+            {candidate.genres.join(' · ')}
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col border-t border-white/8 bg-[linear-gradient(180deg,rgba(18,18,20,0.94),rgba(11,11,12,0.98))] px-6 py-6 sm:px-8 sm:py-7">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
+            이 카드에서 볼 포인트
+          </p>
+          <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1.5 text-xs font-medium text-white/52">
+            {stepLabel}
+          </span>
+        </div>
+
+        <p className="mt-4 text-sm leading-7 break-keep text-white/62">
+          {candidateSummary}
+        </p>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-4 py-4">
+            <p className="text-[11px] font-medium tracking-[0.18em] text-white/34 uppercase">
+              평균 평점
+            </p>
+            <p className="mt-2 text-xl font-semibold text-white">
+              {candidate.rating?.toFixed(1) ?? 'N/A'}
+            </p>
+          </div>
+          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-4 py-4">
+            <p className="text-[11px] font-medium tracking-[0.18em] text-white/34 uppercase">
+              미디어
+            </p>
+            <p className="mt-2 text-sm font-medium text-white/78">
+              {candidate.trailer_url ? '트레일러 제공' : '이미지 미리보기'}
+            </p>
+          </div>
+          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-4 py-4">
+            <p className="text-[11px] font-medium tracking-[0.18em] text-white/34 uppercase">
+              장르 감각
+            </p>
+            <p className="mt-2 text-sm font-medium text-white/78">
+              {candidate.genres[0] ?? genreTitle}
+            </p>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default MatchingMediaPanel;

--- a/src/features/matching/components/MatchingRatingStars.tsx
+++ b/src/features/matching/components/MatchingRatingStars.tsx
@@ -1,0 +1,43 @@
+import { Star } from 'lucide-react';
+
+import type { MatchingRatingValue } from '../types';
+
+type MatchingRatingStarsProps = {
+  value: MatchingRatingValue | null;
+  onRate: (rating: MatchingRatingValue) => void;
+};
+
+const ratingValues: MatchingRatingValue[] = [1, 2, 3, 4, 5];
+
+function MatchingRatingStars({ value, onRate }: MatchingRatingStarsProps) {
+  return (
+    <div className="flex items-center gap-1.5">
+      {ratingValues.map((ratingValue) => {
+        const isActive = value !== null && ratingValue <= value;
+
+        return (
+          <button
+            key={ratingValue}
+            type="button"
+            onClick={() => onRate(ratingValue)}
+            aria-label={`${ratingValue}점 선택`}
+            aria-pressed={value === ratingValue}
+            className={`flex h-11 w-11 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
+              isActive
+                ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
+                : 'border-white/10 bg-white/[0.03] text-white/34 hover:border-white/18 hover:text-white/72'
+            }`}
+          >
+            <Star
+              size={20}
+              fill={isActive ? 'currentColor' : 'none'}
+              className={isActive ? '' : 'stroke-[1.9px]'}
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default MatchingRatingStars;

--- a/src/features/matching/store/useMatchingStore.ts
+++ b/src/features/matching/store/useMatchingStore.ts
@@ -1,0 +1,138 @@
+import { create } from 'zustand';
+
+import type {
+  MatchingCandidateItem,
+  MatchingEvaluationsByGameId,
+  MatchingEvaluationValue,
+  MatchingGenreCard,
+  MatchingGenreSlug,
+  MatchingRatingValue,
+} from '../types';
+
+interface MatchingStoreState {
+  selectedGenreSlug: MatchingGenreSlug | null;
+  selectedGenreId: number | null;
+  candidates: MatchingCandidateItem[];
+  currentIndex: number;
+  evaluationsByGameId: MatchingEvaluationsByGameId;
+  initializeFlow: (
+    genre: MatchingGenreCard,
+    candidates: MatchingCandidateItem[],
+  ) => void;
+  setRating: (gameId: number, rating: MatchingRatingValue) => void;
+  toggleLiked: (gameId: number) => void;
+  goNext: () => void;
+  goPrevious: () => void;
+  resetFlow: () => void;
+}
+
+const initialState = {
+  selectedGenreSlug: null as MatchingGenreSlug | null,
+  selectedGenreId: null as number | null,
+  candidates: [] as MatchingCandidateItem[],
+  currentIndex: 0,
+  evaluationsByGameId: {} as MatchingEvaluationsByGameId,
+};
+
+const createEvaluationMap = (
+  candidates: MatchingCandidateItem[],
+  previousEvaluations: MatchingEvaluationsByGameId = {},
+  preserveExisting = false,
+): MatchingEvaluationsByGameId =>
+  Object.fromEntries(
+    candidates.map((candidate) => {
+      const previous = preserveExisting
+        ? previousEvaluations[candidate.game_id]
+        : undefined;
+
+      const nextValue: MatchingEvaluationValue = previous
+        ? previous
+        : {
+            rating: null,
+            isLiked: candidate.is_liked,
+          };
+
+      return [candidate.game_id, nextValue];
+    }),
+  );
+
+const hasSameCandidateOrder = (
+  previousCandidates: MatchingCandidateItem[],
+  nextCandidates: MatchingCandidateItem[],
+) =>
+  previousCandidates.length === nextCandidates.length &&
+  previousCandidates.every(
+    (candidate, index) => candidate.game_id === nextCandidates[index]?.game_id,
+  );
+
+export const useMatchingStore = create<MatchingStoreState>((set) => ({
+  ...initialState,
+  initializeFlow: (genre, candidates) =>
+    set((state) => {
+      const isSameGenre =
+        state.selectedGenreSlug === genre.slug &&
+        state.selectedGenreId === genre.genreId;
+      const isSameCandidateOrder = hasSameCandidateOrder(
+        state.candidates,
+        candidates,
+      );
+
+      if (isSameGenre && isSameCandidateOrder) {
+        return state;
+      }
+
+      return {
+        selectedGenreSlug: genre.slug,
+        selectedGenreId: genre.genreId,
+        candidates,
+        currentIndex: 0,
+        evaluationsByGameId: createEvaluationMap(
+          candidates,
+          state.evaluationsByGameId,
+          isSameGenre,
+        ),
+      };
+    }),
+  setRating: (gameId, rating) =>
+    set((state) => ({
+      evaluationsByGameId: {
+        ...state.evaluationsByGameId,
+        [gameId]: {
+          ...(state.evaluationsByGameId[gameId] ?? {
+            rating: null,
+            isLiked: false,
+          }),
+          rating,
+        },
+      },
+    })),
+  toggleLiked: (gameId) =>
+    set((state) => {
+      const currentValue = state.evaluationsByGameId[gameId] ?? {
+        rating: null,
+        isLiked: false,
+      };
+
+      return {
+        evaluationsByGameId: {
+          ...state.evaluationsByGameId,
+          [gameId]: {
+            ...currentValue,
+            isLiked: !currentValue.isLiked,
+          },
+        },
+      };
+    }),
+  goNext: () =>
+    set((state) => ({
+      currentIndex:
+        state.currentIndex < state.candidates.length - 1
+          ? state.currentIndex + 1
+          : state.currentIndex,
+    })),
+  goPrevious: () =>
+    set((state) => ({
+      currentIndex: state.currentIndex > 0 ? state.currentIndex - 1 : 0,
+    })),
+  resetFlow: () => ({ ...initialState }),
+}));

--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -33,3 +33,15 @@ export interface MatchingCandidatesResponse {
   next: string | null;
   results: MatchingCandidateItem[];
 }
+
+export type MatchingRatingValue = 1 | 2 | 3 | 4 | 5;
+
+export interface MatchingEvaluationValue {
+  rating: MatchingRatingValue | null;
+  isLiked: boolean;
+}
+
+export type MatchingEvaluationsByGameId = Record<
+  number,
+  MatchingEvaluationValue
+>;

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -1,13 +1,18 @@
-import { ChevronLeft, Sparkles } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Heart } from 'lucide-react';
+import { useEffect, useMemo } from 'react';
 import { Link, useParams } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
 import { useMatchCandidatesQuery } from '../../features/matching/api/useMatchingApi';
+import MatchingGuideCards from '../../features/matching/components/MatchingGuideCards';
+import MatchingMediaPanel from '../../features/matching/components/MatchingMediaPanel';
+import MatchingRatingStars from '../../features/matching/components/MatchingRatingStars';
 import {
   getMatchingGenreBySlug,
   isMatchingGenreSlug,
 } from '../../features/matching/genres';
+import { useMatchingStore } from '../../features/matching/store/useMatchingStore';
 import { extractApiErrorMessage } from '../../features/survey/api/survey';
 import { isMockServiceWorkerEnabled } from '../../lib/env';
 import { getAccessToken } from '../../utils/auth';
@@ -24,7 +29,52 @@ function MatchingGenreDetailPage() {
     genre?.genreId ?? null,
     canAccessPage,
   );
-  const candidates = matchCandidatesQuery.data?.results ?? [];
+  const candidates = useMemo(
+    () => matchCandidatesQuery.data?.results ?? [],
+    [matchCandidatesQuery.data?.results],
+  );
+  const selectedGenreSlug = useMatchingStore(
+    (state) => state.selectedGenreSlug,
+  );
+  const selectedGenreId = useMatchingStore((state) => state.selectedGenreId);
+  const flowCandidates = useMatchingStore((state) => state.candidates);
+  const currentIndex = useMatchingStore((state) => state.currentIndex);
+  const evaluationsByGameId = useMatchingStore(
+    (state) => state.evaluationsByGameId,
+  );
+  const initializeFlow = useMatchingStore((state) => state.initializeFlow);
+  const setRating = useMatchingStore((state) => state.setRating);
+  const toggleLiked = useMatchingStore((state) => state.toggleLiked);
+  const goNext = useMatchingStore((state) => state.goNext);
+  const goPrevious = useMatchingStore((state) => state.goPrevious);
+
+  useEffect(() => {
+    if (!genre || candidates.length === 0) {
+      return;
+    }
+
+    initializeFlow(genre, candidates);
+  }, [genre, candidates, initializeFlow]);
+
+  const displayCandidates =
+    selectedGenreSlug === genre?.slug &&
+    selectedGenreId === genre?.genreId &&
+    flowCandidates.length > 0
+      ? flowCandidates
+      : candidates;
+  const totalSteps = displayCandidates.length;
+  const safeIndex =
+    totalSteps > 0 ? Math.min(currentIndex, totalSteps - 1) : currentIndex;
+  const currentCandidate = displayCandidates[safeIndex];
+  const currentEvaluation = currentCandidate
+    ? (evaluationsByGameId[currentCandidate.game_id] ?? {
+        rating: null,
+        isLiked: currentCandidate.is_liked,
+      })
+    : null;
+  const isLastCard = totalSteps > 0 && safeIndex === totalSteps - 1;
+  const hasSelectedRating = currentEvaluation?.rating !== null;
+  const canGoPrevious = safeIndex > 0;
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
@@ -117,110 +167,135 @@ function MatchingGenreDetailPage() {
           <section className="mx-auto max-w-[980px]">
             <div className="text-center">
               <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
-                Matching Candidates
+                {safeIndex + 1} / {totalSteps} 단계
               </p>
               <h1 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[44px]">
-                {genre.title} 후보 게임이 준비되었어요
+                매칭 과정을 따라가세요
               </h1>
               <p className="mt-4 text-sm leading-7 break-keep text-white/58 sm:text-base">
-                최신 명세 기준으로 후보 조회 계약과 MSW 연동이 먼저 연결된
-                상태입니다. 다음 단계에서는 이 5개 게임을 실제로 평가하는
-                인터랙션 화면이 붙게 됩니다.
+                5개의 게임을 차례대로 평가하고, 마음에 드는 게임은 하트로
+                표시해둘 수 있어요.
               </p>
             </div>
 
-            <div className="mt-8 grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
-              <article className="overflow-hidden rounded-[28px] border border-white/8 bg-[#0d0d0f] shadow-[0_26px_52px_rgba(0,0,0,0.28)]">
-                <div className="relative">
-                  <img
-                    src={genre.thumbnailUrl}
-                    alt={genre.title}
-                    className="aspect-[16/9] w-full object-cover"
-                  />
-                  <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(8,8,10,0.14),rgba(8,8,10,0.76))]" />
-                  <div className="absolute right-0 bottom-0 left-0 p-6 sm:p-8">
-                    <p className="text-[11px] font-medium tracking-[0.22em] text-white/64 uppercase">
-                      {genre.subtitle}
-                    </p>
-                    <h2 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-[40px]">
-                      {genre.title}
-                    </h2>
-                    <p className="mt-4 max-w-[56ch] text-sm leading-7 break-keep text-white/70 sm:text-base">
-                      {genre.description}
-                    </p>
-                  </div>
-                </div>
-              </article>
-
-              <article className="survey-panel px-6 py-8 sm:px-8 sm:py-9">
-                <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-xs font-semibold tracking-[0.18em] text-white/52 uppercase">
-                  <Sparkles size={14} />
-                  Candidates Ready
-                </div>
-                <h2 className="mt-5 text-2xl font-semibold tracking-[-0.02em] text-white sm:text-[30px]">
-                  총 {matchCandidatesQuery.data?.count ?? candidates.length}개의
-                  평가 대상
-                </h2>
-                <p className="mt-3 text-base leading-7 break-keep text-white/60">
-                  지금은 후보 조회 단계까지만 연결된 상태예요. 다음 단계에서
-                  별점과 좋아요를 남기며 실제 매칭을 진행하게 됩니다.
-                </p>
-                <div className="mt-6 rounded-[22px] border border-white/8 bg-white/[0.03] px-5 py-5">
-                  <p className="text-sm leading-7 break-keep text-white/68">
-                    `GET /api/v1/match/candidates?genre_id={genre.genreId}`
-                    계약과 MSW 데이터가 연결되어, 장르별 5개 후보를 안정적으로
-                    불러올 수 있어요.
-                  </p>
-                </div>
-              </article>
+            <div className="mt-10">
+              <MatchingGuideCards />
             </div>
 
-            <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-              {candidates.map((candidate) => (
-                <article
-                  key={candidate.game_id}
-                  className="overflow-hidden rounded-[24px] border border-white/8 bg-[linear-gradient(180deg,rgba(16,16,18,0.9),rgba(10,10,11,0.96))] shadow-[0_18px_34px_rgba(0,0,0,0.2)]"
-                >
-                  {candidate.thumbnail_url ? (
-                    <img
-                      src={candidate.thumbnail_url}
-                      alt={candidate.title}
-                      className="aspect-[16/9] w-full object-cover"
-                    />
-                  ) : (
-                    <div className="aspect-[16/9] w-full bg-[#151517]" />
-                  )}
-                  <div className="px-5 py-5">
-                    <p className="text-[11px] font-medium tracking-[0.2em] text-white/34 uppercase">
-                      Candidate {candidate.game_id}
+            <div className="mt-8 grid gap-5 lg:grid-cols-[1.1fr_0.9fr]">
+              {currentCandidate ? (
+                <MatchingMediaPanel
+                  candidate={currentCandidate}
+                  genreTitle={genre.title}
+                  stepLabel={`${safeIndex + 1} / ${totalSteps} 단계`}
+                />
+              ) : null}
+
+              {currentCandidate && currentEvaluation ? (
+                <article className="survey-panel flex flex-col px-6 py-7 sm:px-8 sm:py-8">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
+                        Candidate {safeIndex + 1}
+                      </p>
+                      <h2 className="mt-3 text-2xl font-semibold tracking-[-0.02em] text-white sm:text-[30px]">
+                        {currentCandidate.title}
+                      </h2>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => toggleLiked(currentCandidate.game_id)}
+                      aria-pressed={currentEvaluation.isLiked}
+                      aria-label={
+                        currentEvaluation.isLiked
+                          ? '좋아요 해제'
+                          : '좋아요 추가'
+                      }
+                      className={`inline-flex h-12 w-12 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
+                        currentEvaluation.isLiked
+                          ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
+                          : 'border-white/10 bg-white/[0.03] text-white/54 hover:border-white/20 hover:text-white/80'
+                      }`}
+                    >
+                      <Heart
+                        size={20}
+                        fill={
+                          currentEvaluation.isLiked ? 'currentColor' : 'none'
+                        }
+                      />
+                    </button>
+                  </div>
+
+                  <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-white/46">
+                    <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
+                      장르 {currentCandidate.genres.join(' · ')}
+                    </span>
+                    <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
+                      평균 평점 {currentCandidate.rating?.toFixed(1) ?? 'N/A'}
+                    </span>
+                  </div>
+
+                  <div className="mt-8">
+                    <p className="text-sm font-semibold text-white">
+                      이 게임은 얼마나 끌리나요?
                     </p>
-                    <h3 className="mt-3 text-xl font-semibold tracking-[-0.02em] text-white">
-                      {candidate.title}
-                    </h3>
-                    <p className="mt-2 text-sm leading-6 break-keep text-white/56">
-                      {candidate.genres.join(' · ')}
+                    <p className="mt-2 text-sm leading-6 break-keep text-white/55">
+                      별점을 남기면 다음 카드로 넘어갈 수 있어요.
                     </p>
-                    <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-white/44">
-                      <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
-                        평점 {candidate.rating?.toFixed(1) ?? 'N/A'}
-                      </span>
-                      <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
-                        좋아요 {candidate.is_liked ? 'ON' : 'OFF'}
-                      </span>
+                    <div className="mt-5">
+                      <MatchingRatingStars
+                        value={currentEvaluation.rating}
+                        onRate={(rating) =>
+                          setRating(currentCandidate.game_id, rating)
+                        }
+                      />
                     </div>
                   </div>
+
+                  <div className="mt-8 rounded-[22px] border border-white/8 bg-white/[0.03] px-5 py-5">
+                    <p className="text-sm leading-7 break-keep text-white/64">
+                      {isLastCard
+                        ? currentEvaluation.rating === null
+                          ? '마지막 카드입니다. 별점을 남겨두면 다음 단계에서 제출과 완료 흐름을 연결할 수 있어요.'
+                          : '마지막 카드까지 평가를 남겼어요. 제출과 완료는 다음 단계에서 이어집니다.'
+                        : currentEvaluation.rating === null
+                          ? '현재 카드의 별점을 먼저 선택해 주세요.'
+                          : '별점과 좋아요는 바로 저장되고, 이전 카드로 돌아가 수정할 수도 있어요.'}
+                    </p>
+                  </div>
+
+                  <div className="mt-auto flex flex-wrap items-center justify-between gap-3 pt-8">
+                    <button
+                      type="button"
+                      onClick={goPrevious}
+                      disabled={!canGoPrevious}
+                      className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/[0.02] disabled:text-white/28"
+                    >
+                      <ChevronLeft size={16} />
+                      이전
+                    </button>
+
+                    {isLastCard ? (
+                      <p className="text-right text-sm leading-6 break-keep text-white/48 sm:max-w-[22ch]">
+                        다음 단계에서 제출과 완료 화면이 연결될 예정입니다.
+                      </p>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={goNext}
+                        disabled={!hasSelectedRating}
+                        className="inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212] disabled:cursor-not-allowed disabled:bg-[#5c1a1a] disabled:text-white/44"
+                      >
+                        다음
+                        <ChevronRight size={16} />
+                      </button>
+                    )}
+                  </div>
                 </article>
-              ))}
+              ) : null}
             </div>
 
             <div className="mt-8 flex flex-wrap justify-center gap-3">
-              <button
-                type="button"
-                onClick={() => void matchCandidatesQuery.refetch()}
-                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
-              >
-                후보 다시 불러오기
-              </button>
               <Link
                 to={`/${ROUTES.MATCHING_LIST}`}
                 className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"


### PR DESCRIPTION
## 관련 이슈

- closed #66 

## 변경 내용
- 장르별 매칭 상세 페이지를 후보 조회 화면에서 실제 평가 플로우 화면으로 전환
- Zustand 기반 매칭 평가 상태 관리 추가
- 5개 후보 게임 순차 평가 인터랙션 구현
- 별점/좋아요 입력값 즉시 저장
- 이전 버튼으로 이전 카드 수정 가능
- 별점 미선택 시 다음 버튼 비활성화
- 마지막 5번째 카드에서 다음 버튼 숨김 및 다음 단계 안내 문구 표시
- 트레일러/이미지 영역을 미디어 + 하단 정보 패널 구조로 개선

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 제출 API 연결 및 완료 화면은 다음 단계에서 구현 예정
