### PR TITLE
[Feat] 매칭 제출 완료 상태 및 결과 연결

### DIFF
--- a/src/features/matching/api/matching.ts
+++ b/src/features/matching/api/matching.ts
@@ -1,5 +1,11 @@
 import { api } from '../../../api/axios';
-import type { MatchingCandidatesResponse } from '../types';
+import type {
+  MatchResultQuery,
+  MatchResultResponse,
+  MatchingCandidatesResponse,
+  SubmitMatchResponsesRequest,
+  SubmitMatchResponsesResponse,
+} from '../types';
 
 const MATCHING_BASE_PATH = '/api/v1/match';
 
@@ -10,6 +16,28 @@ export const getMatchCandidates = async (genreId: number) => {
       params: {
         genre_id: genreId,
       },
+    },
+  );
+
+  return response.data;
+};
+
+export const submitMatchResponses = async (
+  payload: SubmitMatchResponsesRequest,
+) => {
+  const response = await api.post<SubmitMatchResponsesResponse>(
+    `${MATCHING_BASE_PATH}/responses`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const getMatchResponseResults = async (query: MatchResultQuery) => {
+  const response = await api.get<MatchResultResponse>(
+    `${MATCHING_BASE_PATH}/responses/result`,
+    {
+      params: query,
     },
   );
 

--- a/src/features/matching/api/useMatchingApi.ts
+++ b/src/features/matching/api/useMatchingApi.ts
@@ -1,6 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
 
-import { getMatchCandidates } from './matching';
+import {
+  getMatchCandidates,
+  getMatchResponseResults,
+  submitMatchResponses,
+} from './matching';
 
 export const useMatchCandidatesQuery = (
   genreId: number | null,
@@ -11,4 +15,26 @@ export const useMatchCandidatesQuery = (
     enabled: genreId !== null && enabled,
     queryFn: () => getMatchCandidates(genreId!),
     staleTime: 60_000,
+  });
+
+export const useSubmitMatchResponsesMutation = () =>
+  useMutation({
+    mutationFn: submitMatchResponses,
+  });
+
+export const useMatchResultsInfinite = (
+  sort: 'rating_desc' | 'created_at' = 'rating_desc',
+  enabled = true,
+) =>
+  useInfiniteQuery({
+    queryKey: ['match-results', sort],
+    initialPageParam: null as string | null,
+    enabled,
+    queryFn: ({ pageParam }) =>
+      getMatchResponseResults({
+        sort,
+        cursor: pageParam ?? undefined,
+        page_size: 4,
+      }),
+    getNextPageParam: (lastPage) => lastPage.next,
   });

--- a/src/features/matching/mocks/data.ts
+++ b/src/features/matching/mocks/data.ts
@@ -367,3 +367,11 @@ export const matchingMockCandidatesByGenreId: Record<
     ),
   ],
 };
+
+export const matchingMockCandidates = Object.values(
+  matchingMockCandidatesByGenreId,
+).flat();
+
+export const matchingMockCandidateMapById = new Map(
+  matchingMockCandidates.map((candidate) => [candidate.game_id, candidate]),
+);

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -1,6 +1,9 @@
 import { delay, http, HttpResponse } from 'msw';
 
-import { matchingMockCandidatesByGenreId } from './data';
+import {
+  matchingMockCandidateMapById,
+  matchingMockCandidatesByGenreId,
+} from './data';
 
 const getErrorResponse = (status: number, message: string) =>
   HttpResponse.json(
@@ -9,6 +12,25 @@ const getErrorResponse = (status: number, message: string) =>
     },
     { status },
   );
+
+type StoredMatchResult = {
+  game_id: number;
+  rating: number;
+  is_liked: boolean;
+  created_at_order: number;
+};
+
+let storedMatchResults: StoredMatchResult[] = [];
+
+const getSortedMatchResults = (sort: string) => {
+  const entries = [...storedMatchResults];
+
+  if (sort === 'created_at') {
+    return entries.sort((a, b) => a.created_at_order - b.created_at_order);
+  }
+
+  return entries.sort((a, b) => b.rating - a.rating);
+};
 
 export const matchingHandlers = [
   http.get('/api/v1/match/candidates', async ({ request }) => {
@@ -33,6 +55,92 @@ export const matchingHandlers = [
       count: candidates.length,
       next: null,
       results: candidates,
+    });
+  }),
+  http.post('/api/v1/match/responses', async ({ request }) => {
+    const body = (await request.json()) as {
+      match_result?: Array<{
+        game_id?: number;
+        rating?: number;
+        is_liked?: boolean;
+      }>;
+    };
+
+    if (!Array.isArray(body.match_result) || body.match_result.length === 0) {
+      return getErrorResponse(400, '평가할 match_result가 필요합니다.');
+    }
+
+    for (const result of body.match_result) {
+      if (
+        typeof result.game_id !== 'number' ||
+        !matchingMockCandidateMapById.has(result.game_id)
+      ) {
+        return getErrorResponse(404, '해당 게임을 찾을 수 없습니다.');
+      }
+
+      if (
+        typeof result.rating !== 'number' ||
+        !Number.isInteger(result.rating) ||
+        result.rating < 1 ||
+        result.rating > 5
+      ) {
+        return getErrorResponse(400, '1~5 사이 정수여야 합니다.');
+      }
+    }
+
+    storedMatchResults = body.match_result.map((result, index) => ({
+      game_id: result.game_id!,
+      rating: result.rating!,
+      is_liked: Boolean(result.is_liked),
+      created_at_order: index,
+    }));
+
+    await delay(500);
+
+    return HttpResponse.json({
+      user_id: 1,
+      match_result: storedMatchResults.map((result) => ({
+        game_id: result.game_id,
+        rating: result.rating,
+        is_liked: result.is_liked,
+      })),
+    });
+  }),
+  http.get('/api/v1/match/responses/result', async ({ request }) => {
+    const url = new URL(request.url);
+    const sort = url.searchParams.get('sort') ?? 'rating_desc';
+
+    if (!['rating_desc', 'created_at'].includes(sort)) {
+      return getErrorResponse(
+        400,
+        '유효하지 않은 sort 값입니다. (rating_desc, created_at)',
+      );
+    }
+
+    if (storedMatchResults.length === 0) {
+      return getErrorResponse(404, '매칭 추천 결과를 찾을 수 없습니다.');
+    }
+
+    const results = getSortedMatchResults(sort).map((result) => {
+      const candidate = matchingMockCandidateMapById.get(result.game_id)!;
+
+      return {
+        game_id: candidate.game_id,
+        title: candidate.title,
+        genres: candidate.genres,
+        thumbnail_url: candidate.thumbnail_url,
+        rating: result.rating,
+        is_liked: result.is_liked,
+      };
+    });
+
+    await delay(450);
+
+    return HttpResponse.json({
+      user_id: 1,
+      count: results.length,
+      next: null,
+      results,
     });
   }),
 ];

--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -45,3 +45,42 @@ export type MatchingEvaluationsByGameId = Record<
   number,
   MatchingEvaluationValue
 >;
+
+export interface MatchResponseItem {
+  game_id: number;
+  rating: MatchingRatingValue;
+  is_liked: boolean;
+}
+
+export interface SubmitMatchResponsesRequest {
+  match_result: MatchResponseItem[];
+}
+
+export interface SubmitMatchResponsesResponse {
+  user_id: number;
+  match_result: MatchResponseItem[];
+}
+
+export type MatchResultSort = 'rating_desc' | 'created_at';
+
+export interface MatchResultQuery {
+  sort?: MatchResultSort;
+  cursor?: string;
+  page_size?: number;
+}
+
+export interface MatchResultItem {
+  game_id: number;
+  title: string;
+  genres: string[];
+  thumbnail_url: string | null;
+  rating: number;
+  is_liked: boolean;
+}
+
+export interface MatchResultResponse {
+  user_id: number;
+  count: number;
+  next: string | null;
+  results: MatchResultItem[];
+}

--- a/src/features/survey/api/useSurveyApi.ts
+++ b/src/features/survey/api/useSurveyApi.ts
@@ -22,11 +22,14 @@ export const useResetSurveyMutation = () =>
     mutationFn: resetSurveySession,
   });
 
-export const useSurveyResultsInfinite = (sessionId: string | null) =>
+export const useSurveyResultsInfinite = (
+  sessionId: string | null,
+  enabled = true,
+) =>
   useInfiniteQuery({
     queryKey: ['survey-results', sessionId],
     initialPageParam: null as string | null,
-    enabled: Boolean(sessionId),
+    enabled: Boolean(sessionId) && enabled,
     queryFn: ({ pageParam }) =>
       getSurveyResults({
         session_id: sessionId!,

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -1,10 +1,13 @@
 import { ChevronLeft, ChevronRight, Heart } from 'lucide-react';
 import { useEffect, useMemo } from 'react';
-import { Link, useParams } from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
-import { useMatchCandidatesQuery } from '../../features/matching/api/useMatchingApi';
+import {
+  useMatchCandidatesQuery,
+  useSubmitMatchResponsesMutation,
+} from '../../features/matching/api/useMatchingApi';
 import MatchingGuideCards from '../../features/matching/components/MatchingGuideCards';
 import MatchingMediaPanel from '../../features/matching/components/MatchingMediaPanel';
 import MatchingRatingStars from '../../features/matching/components/MatchingRatingStars';
@@ -19,6 +22,7 @@ import { getAccessToken } from '../../utils/auth';
 
 function MatchingGenreDetailPage() {
   const { genreSlug } = useParams();
+  const navigate = useNavigate();
   const hasAccessToken = Boolean(getAccessToken());
   const isMockMode = isMockServiceWorkerEnabled();
   const canAccessPage = isMockMode || hasAccessToken;
@@ -29,6 +33,8 @@ function MatchingGenreDetailPage() {
     genre?.genreId ?? null,
     canAccessPage,
   );
+  const submitMatchResponsesMutation = useSubmitMatchResponsesMutation();
+  const resetSubmitMatchResponsesMutation = submitMatchResponsesMutation.reset;
   const candidates = useMemo(
     () => matchCandidatesQuery.data?.results ?? [],
     [matchCandidatesQuery.data?.results],
@@ -47,6 +53,7 @@ function MatchingGenreDetailPage() {
   const toggleLiked = useMatchingStore((state) => state.toggleLiked);
   const goNext = useMatchingStore((state) => state.goNext);
   const goPrevious = useMatchingStore((state) => state.goPrevious);
+  const resetFlow = useMatchingStore((state) => state.resetFlow);
 
   useEffect(() => {
     if (!genre || candidates.length === 0) {
@@ -54,7 +61,8 @@ function MatchingGenreDetailPage() {
     }
 
     initializeFlow(genre, candidates);
-  }, [genre, candidates, initializeFlow]);
+    resetSubmitMatchResponsesMutation();
+  }, [genre, candidates, initializeFlow, resetSubmitMatchResponsesMutation]);
 
   const displayCandidates =
     selectedGenreSlug === genre?.slug &&
@@ -75,6 +83,48 @@ function MatchingGenreDetailPage() {
   const isLastCard = totalSteps > 0 && safeIndex === totalSteps - 1;
   const hasSelectedRating = currentEvaluation?.rating !== null;
   const canGoPrevious = safeIndex > 0;
+  const allCandidatesRated =
+    displayCandidates.length > 0 &&
+    displayCandidates.every(
+      (candidate) => evaluationsByGameId[candidate.game_id]?.rating !== null,
+    );
+  const likedCount = displayCandidates.filter(
+    (candidate) => evaluationsByGameId[candidate.game_id]?.isLiked,
+  ).length;
+  const ratedCount = displayCandidates.filter(
+    (candidate) => evaluationsByGameId[candidate.game_id]?.rating !== null,
+  ).length;
+  const submitErrorMessage = submitMatchResponsesMutation.error
+    ? extractApiErrorMessage(submitMatchResponsesMutation.error)
+    : null;
+  const isCompleted = submitMatchResponsesMutation.isSuccess;
+
+  const handleRestart = () => {
+    resetFlow();
+    submitMatchResponsesMutation.reset();
+
+    if (genre && candidates.length > 0) {
+      initializeFlow(genre, candidates);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!allCandidatesRated || displayCandidates.length === 0) {
+      return;
+    }
+
+    try {
+      await submitMatchResponsesMutation.mutateAsync({
+        match_result: displayCandidates.map((candidate) => ({
+          game_id: candidate.game_id,
+          rating: evaluationsByGameId[candidate.game_id]!.rating!,
+          is_liked: evaluationsByGameId[candidate.game_id]!.isLiked,
+        })),
+      });
+    } catch {
+      return;
+    }
+  };
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
@@ -163,6 +213,87 @@ function MatchingGenreDetailPage() {
               다른 장르 보기
             </Link>
           </section>
+        ) : isCompleted ? (
+          <section className="mx-auto max-w-[920px]">
+            <div className="survey-panel px-6 py-8 sm:px-8 sm:py-10">
+              <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
+                Matching Complete
+              </p>
+              <h1 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl">
+                매칭 평가가 모두 저장되었어요.
+              </h1>
+              <p className="mt-4 max-w-[56ch] text-sm leading-7 break-keep text-white/60 sm:text-base">
+                {genre.title} 장르에서 남긴 평가를 바탕으로 추천 결과를 확인할
+                수 있어요. 다른 장르를 둘러보거나, 같은 장르를 다시 평가해도
+                괜찮습니다.
+              </p>
+
+              <div className="mt-8 grid gap-4 sm:grid-cols-3">
+                <div className="rounded-[24px] border border-white/8 bg-white/[0.03] px-5 py-5">
+                  <p className="text-[11px] font-medium tracking-[0.22em] text-white/34 uppercase">
+                    Rated
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white">
+                    {ratedCount}
+                  </p>
+                  <p className="mt-2 text-sm text-white/52">
+                    평가를 완료한 게임 수
+                  </p>
+                </div>
+
+                <div className="rounded-[24px] border border-white/8 bg-white/[0.03] px-5 py-5">
+                  <p className="text-[11px] font-medium tracking-[0.22em] text-white/34 uppercase">
+                    Liked
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white">
+                    {likedCount}
+                  </p>
+                  <p className="mt-2 text-sm text-white/52">
+                    좋아요 표시한 게임 수
+                  </p>
+                </div>
+
+                <div className="rounded-[24px] border border-white/8 bg-white/[0.03] px-5 py-5">
+                  <p className="text-[11px] font-medium tracking-[0.22em] text-white/34 uppercase">
+                    Genre
+                  </p>
+                  <p className="mt-3 text-2xl font-semibold tracking-[-0.03em] text-white">
+                    {genre.title}
+                  </p>
+                  <p className="mt-2 text-sm text-white/52">
+                    이번에 완료한 장르 매칭
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-8 flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  onClick={() =>
+                    navigate(`/${ROUTES.RECOMMENDATION_LIST}?source=match`)
+                  }
+                  className="inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212]"
+                >
+                  추천 결과 보기
+                  <ChevronRight size={16} />
+                </button>
+                <button
+                  type="button"
+                  onClick={handleRestart}
+                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
+                >
+                  같은 장르 다시하기
+                </button>
+                <Link
+                  to={`/${ROUTES.MATCHING_LIST}`}
+                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
+                >
+                  <ChevronLeft size={16} />
+                  다른 장르 보기
+                </Link>
+              </div>
+            </div>
+          </section>
         ) : (
           <section className="mx-auto max-w-[980px]">
             <div className="text-center">
@@ -193,12 +324,12 @@ function MatchingGenreDetailPage() {
 
               {currentCandidate && currentEvaluation ? (
                 <article className="survey-panel flex flex-col px-6 py-7 sm:px-8 sm:py-8">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0 flex-1">
                       <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
                         Candidate {safeIndex + 1}
                       </p>
-                      <h2 className="mt-3 text-2xl font-semibold tracking-[-0.02em] text-white sm:text-[30px]">
+                      <h2 className="mt-3 text-2xl font-semibold tracking-[-0.02em] break-keep text-white sm:text-[30px]">
                         {currentCandidate.title}
                       </h2>
                     </div>
@@ -211,7 +342,7 @@ function MatchingGenreDetailPage() {
                           ? '좋아요 해제'
                           : '좋아요 추가'
                       }
-                      className={`inline-flex h-12 w-12 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
+                      className={`mt-0.5 inline-flex h-12 w-12 shrink-0 items-center justify-center self-start rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
                         currentEvaluation.isLiked
                           ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
                           : 'border-white/10 bg-white/[0.03] text-white/54 hover:border-white/20 hover:text-white/80'
@@ -256,13 +387,19 @@ function MatchingGenreDetailPage() {
                     <p className="text-sm leading-7 break-keep text-white/64">
                       {isLastCard
                         ? currentEvaluation.rating === null
-                          ? '마지막 카드입니다. 별점을 남겨두면 다음 단계에서 제출과 완료 흐름을 연결할 수 있어요.'
-                          : '마지막 카드까지 평가를 남겼어요. 제출과 완료는 다음 단계에서 이어집니다.'
+                          ? '마지막 카드입니다. 별점을 선택하면 모든 평가를 한 번에 제출할 수 있어요.'
+                          : '마지막 카드까지 평가를 남겼어요. 제출하면 추천 결과를 바로 확인할 수 있어요.'
                         : currentEvaluation.rating === null
                           ? '현재 카드의 별점을 먼저 선택해 주세요.'
                           : '별점과 좋아요는 바로 저장되고, 이전 카드로 돌아가 수정할 수도 있어요.'}
                     </p>
                   </div>
+
+                  {submitErrorMessage ? (
+                    <p className="mt-4 text-sm leading-6 break-keep text-[#ffc2c2]">
+                      {submitErrorMessage}
+                    </p>
+                  ) : null}
 
                   <div className="mt-auto flex flex-wrap items-center justify-between gap-3 pt-8">
                     <button
@@ -276,9 +413,27 @@ function MatchingGenreDetailPage() {
                     </button>
 
                     {isLastCard ? (
-                      <p className="text-right text-sm leading-6 break-keep text-white/48 sm:max-w-[22ch]">
-                        다음 단계에서 제출과 완료 화면이 연결될 예정입니다.
-                      </p>
+                      <div className="flex flex-col items-end gap-3">
+                        <p className="text-right text-sm leading-6 break-keep text-white/48 sm:max-w-[30ch]">
+                          5개 게임의 평가가 모두 준비되면 제출할 수 있어요.
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => void handleSubmit()}
+                          disabled={
+                            !allCandidatesRated ||
+                            submitMatchResponsesMutation.isPending
+                          }
+                          className="inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212] disabled:cursor-not-allowed disabled:bg-[#5c1a1a] disabled:text-white/44"
+                        >
+                          {submitMatchResponsesMutation.isPending
+                            ? '제출 중...'
+                            : '제출하기'}
+                          {!submitMatchResponsesMutation.isPending ? (
+                            <ChevronRight size={16} />
+                          ) : null}
+                        </button>
+                      </div>
                     ) : (
                       <button
                         type="button"

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -3,6 +3,8 @@ import { Link, useSearchParams } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
+import { useMatchResultsInfinite } from '../../features/matching/api/useMatchingApi';
+import type { MatchResultItem } from '../../features/matching/types';
 import { useSurveyResultsInfinite } from '../../features/survey/api/useSurveyApi';
 import { extractApiErrorMessage } from '../../features/survey/api/survey';
 import type { SurveyResultItem } from '../../features/survey/types/survey';
@@ -41,7 +43,30 @@ const getDisplayPrice = (gameId: number) =>
 
 const FALLBACK_HIGHLIGHTS = ['몰입감', '스토리', '액션', '전략'];
 
-const getRecommendationHighlights = (items: SurveyResultItem[]) => {
+type RecommendationDisplayItem = {
+  game_id: number;
+  title: string;
+  genres: string[];
+  thumbnail_url: string | null;
+  rating: number | null;
+  is_liked: boolean;
+};
+
+const normalizeResultItem = (
+  item: SurveyResultItem | MatchResultItem,
+): RecommendationDisplayItem =>
+  'title' in item
+    ? item
+    : {
+        game_id: item.game_id,
+        title: item.name,
+        genres: item.genres,
+        thumbnail_url: item.thumbnail_url,
+        rating: item.rating,
+        is_liked: item.is_liked,
+      };
+
+const getRecommendationHighlights = (items: RecommendationDisplayItem[]) => {
   const genreCounts = new Map<string, number>();
 
   items.forEach((item) => {
@@ -65,7 +90,7 @@ const getRecommendationHighlights = (items: SurveyResultItem[]) => {
 };
 
 type RecommendationRowProps = {
-  item: SurveyResultItem;
+  item: RecommendationDisplayItem;
 };
 
 function RecommendationRow({ item }: RecommendationRowProps) {
@@ -75,7 +100,7 @@ function RecommendationRow({ item }: RecommendationRowProps) {
         {item.thumbnail_url ? (
           <img
             src={item.thumbnail_url}
-            alt={item.name}
+            alt={item.title}
             className="h-[94px] w-full object-cover transition-transform duration-300 group-hover:scale-[1.02] sm:h-[88px]"
           />
         ) : (
@@ -88,7 +113,7 @@ function RecommendationRow({ item }: RecommendationRowProps) {
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
           <h2 className="truncate text-[22px] font-semibold tracking-[-0.02em] text-white sm:text-[26px]">
-            {item.name}
+            {item.title}
           </h2>
 
           <div className="inline-flex items-center gap-1.5 rounded-full border border-[#702525]/40 bg-[#190a0a]/55 px-2.5 py-1 text-[12px] font-semibold text-white/88">
@@ -126,7 +151,7 @@ function RecommendationRow({ item }: RecommendationRowProps) {
 
         <button
           type="button"
-          aria-label={`${item.name} 상세 보기 준비 중`}
+          aria-label={`${item.title} 상세 보기 준비 중`}
           className="flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-white/42 transition group-hover:border-white/8 group-hover:bg-white/[0.03] group-hover:text-white/82"
         >
           <ChevronRight size={18} />
@@ -137,7 +162,7 @@ function RecommendationRow({ item }: RecommendationRowProps) {
 }
 
 type RecommendationBackdropProps = {
-  items: SurveyResultItem[];
+  items: RecommendationDisplayItem[];
 };
 
 function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
@@ -145,7 +170,7 @@ function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
     items.length > 0
       ? [...items, ...items].slice(0, 12).map((item, index) => ({
           id: `${item.game_id}-${index}`,
-          title: item.name,
+          title: item.title,
           thumbnail: item.thumbnail_url,
         }))
       : FALLBACK_BACKDROP_ITEMS;
@@ -180,10 +205,21 @@ function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
 function RecommendationListPage() {
   const [searchParams] = useSearchParams();
   const sessionId = searchParams.get('session_id');
+  const source = searchParams.get('source');
+  const isMatchSource = source === 'match';
   const isMockMode = isMockServiceWorkerEnabled();
   const hasAccessToken = Boolean(getAccessToken());
   const canAccessPage = isMockMode || hasAccessToken;
 
+  const surveyResultsQuery = useSurveyResultsInfinite(
+    sessionId,
+    !isMatchSource && canAccessPage,
+  );
+  const matchResultsQuery = useMatchResultsInfinite(
+    'rating_desc',
+    isMatchSource && canAccessPage,
+  );
+  const activeQuery = isMatchSource ? matchResultsQuery : surveyResultsQuery;
   const {
     data,
     error,
@@ -191,12 +227,26 @@ function RecommendationListPage() {
     isFetchingNextPage,
     fetchNextPage,
     hasNextPage,
-  } = useSurveyResultsInfinite(sessionId);
+  } = activeQuery;
 
-  const recommendationItems = data?.pages.flatMap((page) => page.results) ?? [];
+  const surveyItems =
+    surveyResultsQuery.data?.pages.flatMap((page) => page.results) ?? [];
+  const matchItems =
+    matchResultsQuery.data?.pages.flatMap((page) => page.results) ?? [];
+  const recommendationItems = (isMatchSource ? matchItems : surveyItems).map(
+    normalizeResultItem,
+  );
   const totalCount = data?.pages[0]?.count ?? 0;
   const recommendationHighlights =
     getRecommendationHighlights(recommendationItems);
+  const errorMessage = error ? extractApiErrorMessage(error) : null;
+  const shouldShowMatchEntryCta =
+    isMatchSource &&
+    !isLoading &&
+    Boolean(
+      errorMessage?.includes('매칭 추천 결과를 찾을 수 없습니다') ||
+      recommendationItems.length === 0,
+    );
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
@@ -215,8 +265,9 @@ function RecommendationListPage() {
                 게임 추천 리스트
               </h1>
               <p className="mt-4 max-w-[620px] text-sm leading-7 break-keep text-white/58 sm:text-base">
-                설문에서 드러난 취향을 바탕으로, 지금 바로 플레이하고 싶어질
-                만한 게임들을 차분하게 정리해뒀어요.
+                {isMatchSource
+                  ? '매칭 평가에서 남긴 별점과 좋아요를 바탕으로, 바로 확인해볼 만한 결과를 정리했어요.'
+                  : '설문에서 드러난 취향을 바탕으로, 지금 바로 플레이하고 싶어질 만한 게임들을 차분하게 정리해뒀어요.'}
               </p>
               <div className="mt-5 flex flex-wrap gap-2.5">
                 {recommendationHighlights.map((highlight) => (
@@ -238,7 +289,9 @@ function RecommendationListPage() {
                 {totalCount > 0 ? totalCount : '...'}
               </p>
               <p className="mt-2 text-sm leading-6 break-keep text-white/52">
-                현재 설문 응답을 기준으로 정리된 추천 결과예요.
+                {isMatchSource
+                  ? '현재 매칭 평가를 기준으로 정리된 추천 결과예요.'
+                  : '현재 설문 응답을 기준으로 정리된 추천 결과예요.'}
               </p>
             </aside>
           </div>
@@ -250,10 +303,10 @@ function RecommendationListPage() {
               </h2>
               <p className="mt-4 text-base leading-7 break-keep text-white/60">
                 실제 API 모드에서는 인증 토큰이 필요합니다. 개발 중에는 MSW를
-                켜두면 설문부터 추천 결과까지 전체 흐름을 확인할 수 있습니다.
+                켜두면 추천 결과 흐름을 확인할 수 있습니다.
               </p>
             </section>
-          ) : !sessionId ? (
+          ) : !sessionId && !isMatchSource ? (
             <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
               <h2 className="text-2xl font-bold text-white">
                 먼저 설문을 완료해 주세요.
@@ -268,6 +321,22 @@ function RecommendationListPage() {
                 설문 페이지로 이동
               </Link>
             </section>
+          ) : shouldShowMatchEntryCta ? (
+            <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
+              <h2 className="text-2xl font-bold text-white">
+                먼저 매칭 평가를 완료해 주세요.
+              </h2>
+              <p className="mt-4 text-base leading-7 break-keep text-white/60">
+                장르별 매칭에서 5개 게임 평가를 제출하면 추천 결과를 이
+                페이지에서 바로 확인할 수 있어요.
+              </p>
+              <Link
+                to={`/${ROUTES.MATCHING_LIST}`}
+                className="mt-6 inline-flex rounded-2xl bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3 text-sm font-semibold text-white transition hover:brightness-105"
+              >
+                매칭 페이지로 이동
+              </Link>
+            </section>
           ) : (
             <section className="overflow-hidden rounded-[32px] border border-white/8 bg-[linear-gradient(180deg,rgba(16,16,18,0.92),rgba(9,9,10,0.98))] shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-2xl">
               <div className="px-4 py-5 sm:px-6 lg:px-7 lg:py-6">
@@ -277,8 +346,9 @@ function RecommendationListPage() {
                       Refined For You
                     </p>
                     <p className="mt-3 text-sm leading-6 break-keep text-white/56">
-                      마음에 드는 게임을 비교해보고, 더보기로 결과를 이어서
-                      확인해보세요.
+                      {isMatchSource
+                        ? '평가를 바탕으로 정리된 결과를 비교해보고 마음에 드는 게임을 골라보세요.'
+                        : '마음에 드는 게임을 비교해보고, 더보기로 결과를 이어서 확인해보세요.'}
                     </p>
                   </div>
 
@@ -296,11 +366,13 @@ function RecommendationListPage() {
                 </div>
               ) : error ? (
                 <div className="px-4 py-12 text-[#ffc2c2] sm:px-6 lg:px-7">
-                  {extractApiErrorMessage(error)}
+                  {errorMessage}
                 </div>
               ) : recommendationItems.length === 0 ? (
                 <div className="px-4 py-12 text-white/55 sm:px-6 lg:px-7">
-                  추천 결과가 아직 없습니다.
+                  {isMatchSource
+                    ? '매칭 추천 결과가 아직 없습니다.'
+                    : '추천 결과가 아직 없습니다.'}
                 </div>
               ) : (
                 <>


### PR DESCRIPTION
## 관련 이슈

- closes #69 

## 변경 내용

- 매칭 상세 페이지 마지막 카드에서 평가 결과 제출 기능 추가
- `POST /api/v1/match/responses` API 연동 및 MSW mock 응답 추가
- 제출 성공 후 완료 상태 화면 추가
- 완료 상태에서 아래 동선 제공
  - 추천 결과 보기
  - 같은 장르 다시하기
  - 다른 장르 보기
- 추천 리스트 페이지를 설문/매칭 공용 화면으로 확장
  - 설문: `session_id` 기반 조회
  - 매칭: `source=match` 기반 조회
- `GET /api/v1/match/responses/result` API 및 MSW 결과 조회 추가
- 매칭 결과가 없을 때 추천 페이지에서 매칭 유도 CTA 노출
- 제출 에러 메시지 처리 추가
- 매칭 상세 페이지 상단 찜 버튼이 제목 길이에 영향을 받지 않고 우측 상단에 고정되도록 레이아웃 수정

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="1715" height="893" alt="스크린샷 2026-04-16 오후 8 39 44" src="https://github.com/user-attachments/assets/52aecc15-ce6b-44b7-b3db-2aaa0d38acaa" />
<img width="1722" height="823" alt="스크린샷 2026-04-16 오후 8 39 59" src="https://github.com/user-attachments/assets/d6b9ef21-2fc3-4169-9626-5c5df10472f2" />


## 참고사항

- 빌드 시 chunk size warning은 남아 있지만 기능 오류는 아닙니다.
