### PR TITLE
[Refactor] 로그인·회원가입·마이페이지 UX 및 상태 관리 개선

### DIFF
--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -9,6 +9,7 @@ type AuthInputFieldProps = {
   helperMessage?: string;
   helperMessageTone?: AuthInputFieldMessageTone;
   action?: ReactNode;
+  toast?: ReactNode;
   containerClassName?: string;
 } & InputHTMLAttributes<HTMLInputElement>;
 
@@ -19,6 +20,7 @@ function AuthInputField({
   helperMessage,
   helperMessageTone = 'muted',
   action,
+  toast,
   containerClassName = '',
   className = '',
   ...inputProps
@@ -38,7 +40,7 @@ function AuthInputField({
       >
         {label}
       </label>
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
+      <div className="relative flex flex-col gap-3 sm:flex-row sm:items-stretch">
         <input
           id={id}
           {...inputProps}
@@ -50,6 +52,7 @@ function AuthInputField({
           }`}
         />
         {action}
+        {toast}
       </div>
       {resolvedMessage ? (
         <p className={`pl-1 text-sm/5 font-medium ${resolvedMessageClassName}`}>

--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -43,7 +43,7 @@ function AuthInputField({
           id={id}
           {...inputProps}
           aria-invalid={Boolean(errorMessage)}
-          className={`placeholder-login-muted bg-login-field h-14 min-w-0 flex-1 rounded-xl border px-4 text-base text-white transition outline-none focus-visible:ring-2 ${className} ${
+          className={`auth-input-autofill placeholder-login-muted bg-login-field h-14 min-w-0 flex-1 rounded-xl border px-4 text-base text-white transition outline-none focus-visible:ring-2 ${className} ${
             errorMessage
               ? 'border-red-500 hover:border-red-400 focus-visible:ring-red-500/20'
               : 'border-login-field hover:border-white/15 focus-visible:ring-white/20'

--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -39,10 +39,10 @@ function AuthLayout({
   );
 
   return (
-    <div className="bg-login-page flex min-h-screen flex-col text-white">
+    <div className="bg-login-page flex min-h-dvh flex-col text-white">
       <Header fixed={false} />
 
-      <main className="flex flex-1 items-start justify-center px-[clamp(1rem,5vw,20rem)] pt-6 pb-14 sm:pt-10 sm:pb-16">
+      <main className="flex flex-1 items-center justify-center px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
         {withPanel ? (
           <section
             className={`bg-auth-panel border-auth-panel shadow-auth-panel w-full max-w-[520px] rounded-[28px] border px-4 py-5 backdrop-blur-sm sm:rounded-3xl sm:px-8 sm:py-8 ${panelClassName}`}

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -5,40 +5,56 @@ import type { FavoriteGamePreview } from '../../features/mypage/types';
 type FavoriteGameCardProps = {
   game: FavoriteGamePreview;
   onClick?: (game: FavoriteGamePreview) => void;
+  onFavoriteClick?: (game: FavoriteGamePreview) => void;
 };
 
-function FavoriteGameCard({ game, onClick }: FavoriteGameCardProps) {
+function FavoriteGameCard({
+  game,
+  onClick,
+  onFavoriteClick,
+}: FavoriteGameCardProps) {
   return (
-    <button
-      type="button"
-      onClick={() => onClick?.(game)}
-      className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover flex h-full flex-col overflow-hidden rounded-[24px] border transition duration-200"
-    >
+    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover flex h-full flex-col overflow-hidden rounded-[24px] border transition duration-200">
       <div className="bg-mypage-soft relative aspect-[16/10] overflow-hidden">
-        {game.thumbnailUrl ? (
-          <img
-            src={game.thumbnailUrl}
-            alt={`${game.title} 썸네일`}
-            className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
-            loading="lazy"
-          />
-        ) : (
-          <div className="text-mypage-muted flex h-full items-center justify-center px-6 text-center text-sm">
-            이미지 준비 중
-          </div>
-        )}
+        <button
+          type="button"
+          onClick={() => onClick?.(game)}
+          className="block h-full w-full text-left"
+        >
+          {game.thumbnailUrl ? (
+            <img
+              src={game.thumbnailUrl}
+              alt={`${game.title} 썸네일`}
+              className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
+              loading="lazy"
+            />
+          ) : (
+            <div className="text-mypage-muted flex h-full items-center justify-center px-6 text-center text-sm">
+              이미지 준비 중
+            </div>
+          )}
+        </button>
         <div className="absolute inset-x-0 bottom-0 flex justify-end p-3">
-          <span className="bg-login-primary inline-flex h-10 w-10 items-center justify-center rounded-full text-white shadow-[0_12px_28px_rgba(242,15,23,0.25)]">
+          <button
+            type="button"
+            aria-label={`${game.title} 찜 삭제`}
+            onClick={() => onFavoriteClick?.(game)}
+            className="bg-login-primary inline-flex h-10 w-10 items-center justify-center rounded-full text-white shadow-[0_12px_28px_rgba(242,15,23,0.25)] transition hover:scale-105"
+          >
             <Heart size={16} fill="currentColor" />
-          </span>
+          </button>
         </div>
       </div>
 
-      <div className="flex flex-1 flex-col gap-2 px-4 py-4 sm:px-5">
+      <button
+        type="button"
+        onClick={() => onClick?.(game)}
+        className="flex flex-1 flex-col gap-2 px-4 py-4 text-left sm:px-5"
+      >
         <h3 className="text-lg/7 font-semibold text-white">{game.title}</h3>
         <p className="text-mypage-muted text-sm/6">{game.summary}</p>
-      </div>
-    </button>
+      </button>
+    </article>
   );
 }
 

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -1,16 +1,17 @@
 import { Heart } from 'lucide-react';
-import { Link } from 'react-router';
 
 import type { FavoriteGamePreview } from '../../features/mypage/types';
 
 type FavoriteGameCardProps = {
   game: FavoriteGamePreview;
+  onClick?: (game: FavoriteGamePreview) => void;
 };
 
-function FavoriteGameCard({ game }: FavoriteGameCardProps) {
+function FavoriteGameCard({ game, onClick }: FavoriteGameCardProps) {
   return (
-    <Link
-      to={`/games/${game.gameId}`}
+    <button
+      type="button"
+      onClick={() => onClick?.(game)}
       className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover flex h-full flex-col overflow-hidden rounded-[24px] border transition duration-200"
     >
       <div className="bg-mypage-soft relative aspect-[16/10] overflow-hidden">
@@ -37,7 +38,7 @@ function FavoriteGameCard({ game }: FavoriteGameCardProps) {
         <h3 className="text-lg/7 font-semibold text-white">{game.title}</h3>
         <p className="text-mypage-muted text-sm/6">{game.summary}</p>
       </div>
-    </Link>
+    </button>
   );
 }
 

--- a/src/components/mypage/ToastMessage.tsx
+++ b/src/components/mypage/ToastMessage.tsx
@@ -2,21 +2,33 @@ import { AlertCircle, CheckCircle2, X } from 'lucide-react';
 
 type ToastMessageTone = 'success' | 'error';
 
+type ToastMessageVariant = 'fixed' | 'absoluteCenter';
+
 type ToastMessageProps = {
   message: string;
   tone?: ToastMessageTone;
   onClose: () => void;
+  variant?: ToastMessageVariant;
+  className?: string;
 };
 
 function ToastMessage({
   message,
   tone = 'success',
   onClose,
+  variant = 'fixed',
+  className = '',
 }: ToastMessageProps) {
   const Icon = tone === 'success' ? CheckCircle2 : AlertCircle;
+  const positioningClass =
+    variant === 'absoluteCenter'
+      ? 'absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
+      : 'fixed top-20 right-[clamp(1rem,5vw,20rem)]';
 
   return (
-    <div className="bg-mypage-panel border-mypage-panel shadow-mypage-float fixed top-20 right-[clamp(1rem,5vw,20rem)] z-[70] flex w-[min(92vw,360px)] items-start gap-3 rounded-2xl border px-4 py-3 backdrop-blur-xl">
+    <div
+      className={`bg-mypage-panel border-mypage-panel shadow-mypage-float z-[70] flex w-[min(92vw,360px)] items-start gap-3 rounded-2xl border px-4 py-3 backdrop-blur-xl ${positioningClass} ${className}`}
+    >
       <span
         className={`mt-0.5 shrink-0 ${
           tone === 'success' ? 'text-emerald-400' : 'text-red-400'

--- a/src/components/mypage/ToastMessage.tsx
+++ b/src/components/mypage/ToastMessage.tsx
@@ -2,7 +2,7 @@ import { AlertCircle, CheckCircle2, X } from 'lucide-react';
 
 type ToastMessageTone = 'success' | 'error';
 
-type ToastMessageVariant = 'fixed' | 'absoluteCenter';
+type ToastMessageVariant = 'fixed' | 'fixedCenter' | 'absoluteCenter';
 
 type ToastMessageProps = {
   message: string;
@@ -23,7 +23,9 @@ function ToastMessage({
   const positioningClass =
     variant === 'absoluteCenter'
       ? 'absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
-      : 'fixed top-20 right-[clamp(1rem,5vw,20rem)]';
+      : variant === 'fixedCenter'
+        ? 'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
+        : 'fixed top-20 right-[clamp(1rem,5vw,20rem)]';
 
   return (
     <div

--- a/src/index.css
+++ b/src/index.css
@@ -223,6 +223,20 @@
   .mypage-scrollbar::-webkit-scrollbar-thumb:hover {
     background-color: rgb(255 255 255 / 0.26);
   }
+
+  .auth-input-autofill:-webkit-autofill,
+  .auth-input-autofill:-webkit-autofill:hover,
+  .auth-input-autofill:-webkit-autofill:focus,
+  .auth-input-autofill:-webkit-autofill:active {
+    -webkit-text-fill-color: #ffffff !important;
+    -webkit-box-shadow: 0 0 0 1000px var(--color-login-field) inset !important;
+    background-color: transparent !important;
+    background-clip: padding-box;
+    caret-color: #ffffff;
+    transition: background-color 9999s ease-in-out 0s;
+    box-shadow: 0 0 0 1000px var(--color-login-field) inset !important;
+    border-radius: inherit;
+  }
 }
 
 @media (max-width: 1024px) {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -11,12 +11,13 @@ import AuthInputField from '../components/auth/AuthInputField';
 import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
 import { ROUTES } from '../constants/routes';
 import {
+  getCurrentUserProfile,
   extractAuthApiErrorMessage,
   extractAuthApiFieldErrors,
 } from '../features/auth/api/auth';
 import { useLoginMutation } from '../features/auth/api/useAuthApi';
 import type { LoginRequest } from '../features/auth/types/auth';
-import { setAuthTokens } from '../utils/auth';
+import { setAuthAccount, setAuthTokens } from '../utils/auth';
 
 type LoginFieldName = keyof LoginRequest;
 type LoginFieldErrors = Partial<Record<LoginFieldName, string>>;
@@ -116,6 +117,8 @@ function LoginPage() {
       const response = await loginMutation.mutateAsync(payload);
 
       setAuthTokens(response.access_token, response.refresh_token);
+      const profile = await getCurrentUserProfile();
+      setAuthAccount(profile);
       navigate(ROUTES.HOME);
     } catch (error) {
       const nextApiFieldErrors = extractAuthApiFieldErrors(error);

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -133,12 +133,12 @@ function LoginPage() {
   };
 
   return (
-    <AuthLayout title="Log In">
-      <AuthSocialLoginGroup className="mt-8 sm:mt-10" />
+    <AuthLayout title="Log In" withPanel panelClassName="max-w-[500px]">
+      <AuthSocialLoginGroup className="mt-6 sm:mt-7" />
 
-      <AuthDivider className="my-6 sm:my-7" />
+      <AuthDivider className="my-5 sm:my-6" />
 
-      <form className="space-y-4" onSubmit={handleSubmit}>
+      <form className="space-y-3.5 sm:space-y-4" onSubmit={handleSubmit}>
         <AuthInputField
           id="login-id"
           name="login_id"
@@ -195,14 +195,14 @@ function LoginPage() {
 
         <AuthButton
           type="submit"
-          className="mt-4 w-full"
+          className="mt-3.5 w-full sm:mt-4"
           disabled={loginMutation.isPending}
         >
           {loginMutation.isPending ? '로그인 중...' : '로그인'}
         </AuthButton>
       </form>
 
-      <div className="border-login-divider mt-8 border-t pt-6 sm:mt-9 sm:pt-7">
+      <div className="border-login-divider mt-6 border-t pt-5 sm:mt-7 sm:pt-6">
         <p className="text-login-helper text-center text-sm/5 font-normal">
           아직 PGTI 회원이 아니신가요?
         </p>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,5 +1,5 @@
 import type { FormEvent } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import AuthButton from '../components/auth/AuthButton';
@@ -10,6 +10,7 @@ import AuthInputField from '../components/auth/AuthInputField';
 import AuthRadioGroup from '../components/auth/AuthRadioGroup';
 import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
 import AuthLayout from '../components/layout/AuthLayout';
+import ToastMessage from '../components/mypage/ToastMessage';
 import { ROUTES } from '../constants/routes';
 import {
   getCurrentUserProfile,
@@ -38,6 +39,12 @@ type DuplicateCheckState = {
   message: string;
   tone: 'success' | 'error' | null;
 };
+
+type DuplicateCheckToastState = {
+  message: string;
+  tone: 'success' | 'error';
+  anchor: 'login_id' | 'nickname';
+} | null;
 
 const signupGenderOptions = [
   { label: '남성', value: 'M' },
@@ -132,6 +139,8 @@ function SignupPage() {
     useState<DuplicateCheckState>(initialDuplicateCheckState);
   const [nicknameCheckState, setNicknameCheckState] =
     useState<DuplicateCheckState>(initialDuplicateCheckState);
+  const [duplicateCheckToast, setDuplicateCheckToast] =
+    useState<DuplicateCheckToastState>(null);
 
   const trimmedLoginId = formValues.login_id.trim();
   const trimmedNickname = formValues.nickname.trim();
@@ -169,6 +178,18 @@ function SignupPage() {
   };
 
   const isSubmitting = signupMutation.isPending || loginMutation.isPending;
+
+  useEffect(() => {
+    if (!duplicateCheckToast) {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setDuplicateCheckToast(null);
+    }, 2200);
+
+    return () => window.clearTimeout(timeout);
+  }, [duplicateCheckToast]);
 
   const clearApiFieldError = (fieldName: SignupFieldName) => {
     setApiFieldErrors((previous) => {
@@ -253,6 +274,11 @@ function SignupPage() {
         message: response.detail,
         tone: 'success',
       });
+      setDuplicateCheckToast({
+        message: response.detail,
+        tone: 'success',
+        anchor: 'login_id',
+      });
       clearApiFieldError('login_id');
     } catch (error) {
       const fieldErrors = extractAuthApiFieldErrors(error);
@@ -262,6 +288,11 @@ function SignupPage() {
         verifiedValue: null,
         message,
         tone: 'error',
+      });
+      setDuplicateCheckToast({
+        message,
+        tone: 'error',
+        anchor: 'login_id',
       });
     }
   };
@@ -287,6 +318,11 @@ function SignupPage() {
         message: response.detail,
         tone: 'success',
       });
+      setDuplicateCheckToast({
+        message: response.detail,
+        tone: 'success',
+        anchor: 'nickname',
+      });
       clearApiFieldError('nickname');
     } catch (error) {
       const fieldErrors = extractAuthApiFieldErrors(error);
@@ -296,6 +332,11 @@ function SignupPage() {
         verifiedValue: null,
         message,
         tone: 'error',
+      });
+      setDuplicateCheckToast({
+        message,
+        tone: 'error',
+        anchor: 'nickname',
       });
     }
   };
@@ -482,6 +523,16 @@ function SignupPage() {
                   : '중복확인'}
             </AuthInputActionButton>
           }
+          toast={
+            duplicateCheckToast?.anchor === 'login_id' ? (
+              <ToastMessage
+                message={duplicateCheckToast.message}
+                tone={duplicateCheckToast.tone}
+                onClose={() => setDuplicateCheckToast(null)}
+                variant="absoluteCenter"
+              />
+            ) : null
+          }
         />
 
         <AuthInputField
@@ -526,6 +577,16 @@ function SignupPage() {
                   ? '확인완료'
                   : '중복확인'}
             </AuthInputActionButton>
+          }
+          toast={
+            duplicateCheckToast?.anchor === 'nickname' ? (
+              <ToastMessage
+                message={duplicateCheckToast.message}
+                tone={duplicateCheckToast.tone}
+                onClose={() => setDuplicateCheckToast(null)}
+                variant="absoluteCenter"
+              />
+            ) : null
           }
         />
 

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -44,6 +44,11 @@ const signupGenderOptions = [
   { label: '여성', value: 'W' },
 ] as const;
 
+const NAME_MAX_LENGTH = 30;
+const LOGIN_ID_MAX_LENGTH = 15;
+const NICKNAME_MAX_LENGTH = 10;
+const NICKNAME_WHITESPACE_MESSAGE = '닉네임에는 띄어쓰기를 사용할 수 없습니다.';
+
 const initialDuplicateCheckState: DuplicateCheckState = {
   verifiedValue: null,
   message: '',
@@ -121,6 +126,8 @@ function SignupPage() {
   });
   const [apiFieldErrors, setApiFieldErrors] = useState<SignupFieldErrors>({});
   const [formMessage, setFormMessage] = useState('');
+  const [nicknameWhitespaceMessage, setNicknameWhitespaceMessage] =
+    useState('');
   const [loginIdCheckState, setLoginIdCheckState] =
     useState<DuplicateCheckState>(initialDuplicateCheckState);
   const [nicknameCheckState, setNicknameCheckState] =
@@ -152,6 +159,7 @@ function SignupPage() {
       localFieldErrors.login_id,
     nickname:
       apiFieldErrors.nickname ||
+      nicknameWhitespaceMessage ||
       (nicknameCheckState.tone === 'error' ? nicknameCheckState.message : '') ||
       localFieldErrors.nickname,
     password: apiFieldErrors.password ?? localFieldErrors.password,
@@ -176,9 +184,29 @@ function SignupPage() {
   };
 
   const handleFieldChange = (fieldName: SignupFieldName, value: string) => {
+    let nextValue = value;
+    let nextNicknameHasWhitespace = false;
+
+    if (fieldName === 'name') {
+      nextValue = value.slice(0, NAME_MAX_LENGTH);
+    }
+
+    if (fieldName === 'login_id') {
+      nextValue = value.slice(0, LOGIN_ID_MAX_LENGTH);
+    }
+
+    if (fieldName === 'nickname') {
+      nextNicknameHasWhitespace = /\s/.test(value);
+
+      nextValue = value.replace(/\s+/g, '').slice(0, NICKNAME_MAX_LENGTH);
+      setNicknameWhitespaceMessage(
+        nextNicknameHasWhitespace ? NICKNAME_WHITESPACE_MESSAGE : '',
+      );
+    }
+
     setFormValues((previous) => ({
       ...previous,
-      [fieldName]: value,
+      [fieldName]: nextValue,
     }));
 
     clearApiFieldError(fieldName);
@@ -186,7 +214,8 @@ function SignupPage() {
 
     if (fieldName === 'login_id') {
       setLoginIdCheckState((previous) =>
-        previous.verifiedValue === value.trim() && previous.tone === 'success'
+        previous.verifiedValue === nextValue.trim() &&
+        previous.tone === 'success'
           ? previous
           : initialDuplicateCheckState,
       );
@@ -194,7 +223,9 @@ function SignupPage() {
 
     if (fieldName === 'nickname') {
       setNicknameCheckState((previous) =>
-        previous.verifiedValue === value.trim() && previous.tone === 'success'
+        previous.verifiedValue === nextValue.trim() &&
+        previous.tone === 'success' &&
+        !nextNicknameHasWhitespace
           ? previous
           : initialDuplicateCheckState,
       );
@@ -386,6 +417,7 @@ function SignupPage() {
           type="text"
           autoComplete="off"
           placeholder="이름을 입력하세요"
+          maxLength={NAME_MAX_LENGTH}
           value={formValues.name}
           onChange={(event) => handleFieldChange('name', event.target.value)}
           onBlur={() =>
@@ -395,6 +427,11 @@ function SignupPage() {
             }))
           }
           errorMessage={resolvedFieldErrors.name}
+          helperMessage={
+            !resolvedFieldErrors.name
+              ? `이름은 ${NAME_MAX_LENGTH}자 이하로 입력해주세요.`
+              : ''
+          }
           disabled={isSubmitting}
           containerClassName="pt-1"
         />
@@ -406,6 +443,7 @@ function SignupPage() {
           type="text"
           autoComplete="new-password"
           placeholder="아이디를 입력하세요"
+          maxLength={LOGIN_ID_MAX_LENGTH}
           value={formValues.login_id}
           onChange={(event) =>
             handleFieldChange('login_id', event.target.value)
@@ -418,12 +456,15 @@ function SignupPage() {
           }
           errorMessage={resolvedFieldErrors.login_id}
           helperMessage={
-            !resolvedFieldErrors.login_id &&
-            loginIdCheckState.tone === 'success'
-              ? loginIdCheckState.message
+            !resolvedFieldErrors.login_id
+              ? loginIdCheckState.tone === 'success'
+                ? loginIdCheckState.message
+                : `아이디는 ${LOGIN_ID_MAX_LENGTH}자 이하로 입력해주세요.`
               : ''
           }
-          helperMessageTone="success"
+          helperMessageTone={
+            loginIdCheckState.tone === 'success' ? 'success' : 'muted'
+          }
           disabled={isSubmitting}
           action={
             <AuthInputActionButton
@@ -450,6 +491,7 @@ function SignupPage() {
           type="text"
           autoComplete="off"
           placeholder="닉네임을 입력하세요"
+          maxLength={NICKNAME_MAX_LENGTH}
           value={formValues.nickname}
           onChange={(event) =>
             handleFieldChange('nickname', event.target.value)

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -12,6 +12,7 @@ import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
 import AuthLayout from '../components/layout/AuthLayout';
 import { ROUTES } from '../constants/routes';
 import {
+  getCurrentUserProfile,
   extractAuthApiErrorMessage,
   extractAuthApiFieldErrors,
 } from '../features/auth/api/auth';
@@ -22,7 +23,7 @@ import {
   useSignupMutation,
 } from '../features/auth/api/useAuthApi';
 import type { AuthGender, SignupRequest } from '../features/auth/types/auth';
-import { setAuthTokens } from '../utils/auth';
+import { setAuthAccount, setAuthTokens } from '../utils/auth';
 
 type SignupFormValues = Omit<SignupRequest, 'gender'> & {
   gender: AuthGender | '';
@@ -340,6 +341,8 @@ function SignupPage() {
       });
 
       setAuthTokens(loginResponse.access_token, loginResponse.refresh_token);
+      const profile = await getCurrentUserProfile();
+      setAuthAccount(profile);
       navigate(ROUTES.HOME);
     } catch {
       navigate(`/${ROUTES.LOGIN}`, {

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -366,13 +366,25 @@ function SignupPage() {
 
       <AuthDivider className="my-5 sm:my-6" />
 
-      <form className="space-y-3.5 sm:space-y-4" onSubmit={handleSubmit}>
+      <form
+        className="space-y-3.5 sm:space-y-4"
+        autoComplete="off"
+        onSubmit={handleSubmit}
+      >
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -z-10 h-0 w-0 overflow-hidden opacity-0"
+        >
+          <input type="text" tabIndex={-1} autoComplete="username" />
+          <input type="password" tabIndex={-1} autoComplete="new-password" />
+        </div>
+
         <AuthInputField
           id="signup-name"
           name="name"
           label="이름"
           type="text"
-          autoComplete="name"
+          autoComplete="off"
           placeholder="이름을 입력하세요"
           value={formValues.name}
           onChange={(event) => handleFieldChange('name', event.target.value)}
@@ -392,7 +404,7 @@ function SignupPage() {
           name="login_id"
           label="아이디"
           type="text"
-          autoComplete="username"
+          autoComplete="new-password"
           placeholder="아이디를 입력하세요"
           value={formValues.login_id}
           onChange={(event) =>
@@ -436,7 +448,7 @@ function SignupPage() {
           name="nickname"
           label="닉네임"
           type="text"
-          autoComplete="nickname"
+          autoComplete="off"
           placeholder="닉네임을 입력하세요"
           value={formValues.nickname}
           onChange={(event) =>

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -302,6 +302,13 @@ function MyPage() {
     }
   };
 
+  const handleFavoriteGameCardClick = () => {
+    setToast({
+      tone: 'success',
+      message: '게임 상세 페이지는 현재 준비 중입니다.',
+    });
+  };
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <div className="app-aurora pointer-events-none absolute inset-0 opacity-70" />
@@ -359,7 +366,11 @@ function MyPage() {
             {favoriteCount > 0 ? (
               <div className="grid gap-4 md:grid-cols-2">
                 {mockFavoriteGames.map((game) => (
-                  <FavoriteGameCard key={game.gameId} game={game} />
+                  <FavoriteGameCard
+                    key={game.gameId}
+                    game={game}
+                    onClick={handleFavoriteGameCardClick}
+                  />
                 ))}
               </div>
             ) : (
@@ -391,6 +402,7 @@ function MyPage() {
           message={toast.message}
           tone={toast.tone}
           onClose={() => setToast(null)}
+          variant="fixedCenter"
         />
       ) : null}
 

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -26,7 +26,12 @@ import {
 } from '../../features/auth/api/useAuthApi';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
 import { mockFavoriteGames } from '../../features/mypage/mockData';
-import { clearAuthTokens, getAccessToken } from '../../utils/auth';
+import {
+  clearAuthTokens,
+  getAccessToken,
+  getAuthAccount,
+  setAuthAccount,
+} from '../../utils/auth';
 
 type PasswordTouchedState = Record<PasswordChangeFieldName, boolean>;
 type PasswordFieldErrors = Partial<Record<PasswordChangeFieldName, string>>;
@@ -99,6 +104,7 @@ function MyPage() {
   const changePasswordMutation = useChangePasswordMutation();
   const deleteAccountMutation = useDeleteAccountMutation();
   const profileQuery = useCurrentUserProfileQuery(hasAccessToken);
+  const storedAccount = getAuthAccount();
 
   const [isPasswordPanelOpen, setIsPasswordPanelOpen] = useState(false);
   const [passwordValues, setPasswordValues] = useState<PasswordChangeValues>(
@@ -138,6 +144,17 @@ function MyPage() {
       window.clearTimeout(timeout);
     };
   }, [toast]);
+
+  useEffect(() => {
+    if (profileQuery.data) {
+      setAuthAccount(profileQuery.data);
+      return;
+    }
+
+    if (profileQuery.isError) {
+      setAuthAccount(null);
+    }
+  }, [profileQuery.data, profileQuery.isError]);
 
   useEffect(() => {
     if (!isPasswordPanelOpen || passwordPanelMessage?.tone !== 'success') {
@@ -292,7 +309,9 @@ function MyPage() {
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-[clamp(1rem,5vw,20rem)] pt-24 pb-14 sm:pt-28 sm:pb-16 lg:pt-32">
         <MyPageProfileSection
-          nickname={profileQuery.data?.nickname ?? '회원'}
+          nickname={
+            profileQuery.data?.nickname ?? storedAccount?.nickname ?? '회원'
+          }
           isProfileLoading={profileQuery.isLoading}
           isLoggingOut={isLogoutPending}
           isPasswordPanelOpen={isPasswordPanelOpen}

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -30,9 +30,9 @@ import type { FavoriteGamePreview } from '../../features/mypage/types';
 import {
   clearAuthTokens,
   getAccessToken,
-  getAuthAccount,
   setAuthAccount,
 } from '../../utils/auth';
+import { useAuthStore } from '../../store/useAuthStore';
 
 type PasswordTouchedState = Record<PasswordChangeFieldName, boolean>;
 type PasswordFieldErrors = Partial<Record<PasswordChangeFieldName, string>>;
@@ -105,7 +105,7 @@ function MyPage() {
   const changePasswordMutation = useChangePasswordMutation();
   const deleteAccountMutation = useDeleteAccountMutation();
   const profileQuery = useCurrentUserProfileQuery(hasAccessToken);
-  const storedAccount = getAuthAccount();
+  const storedAccount = useAuthStore((state) => state.account);
 
   const [isPasswordPanelOpen, setIsPasswordPanelOpen] = useState(false);
   const [passwordValues, setPasswordValues] = useState<PasswordChangeValues>(
@@ -152,13 +152,8 @@ function MyPage() {
   useEffect(() => {
     if (profileQuery.data) {
       setAuthAccount(profileQuery.data);
-      return;
     }
-
-    if (profileQuery.isError) {
-      setAuthAccount(null);
-    }
-  }, [profileQuery.data, profileQuery.isError]);
+  }, [profileQuery.data]);
 
   useEffect(() => {
     if (!isPasswordPanelOpen || passwordPanelMessage?.tone !== 'success') {
@@ -189,6 +184,8 @@ function MyPage() {
   }
 
   const favoriteCount = favoriteGames.length;
+  const resolvedProfile = profileQuery.data ?? storedAccount;
+  const isProfileLoading = profileQuery.isLoading && !resolvedProfile;
 
   const resetPasswordPanel = () => {
     setPasswordValues(initialPasswordValues);
@@ -335,10 +332,8 @@ function MyPage() {
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-[clamp(1rem,5vw,20rem)] pt-24 pb-14 sm:pt-28 sm:pb-16 lg:pt-32">
         <MyPageProfileSection
-          nickname={
-            profileQuery.data?.nickname ?? storedAccount?.nickname ?? '회원'
-          }
-          isProfileLoading={profileQuery.isLoading}
+          nickname={resolvedProfile?.nickname ?? '회원'}
+          isProfileLoading={isProfileLoading}
           isLoggingOut={isLogoutPending}
           isPasswordPanelOpen={isPasswordPanelOpen}
           onPasswordToggle={() => setIsPasswordPanelOpen((current) => !current)}

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../features/auth/api/useAuthApi';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
 import { mockFavoriteGames } from '../../features/mypage/mockData';
+import type { FavoriteGamePreview } from '../../features/mypage/types';
 import {
   clearAuthTokens,
   getAccessToken,
@@ -117,6 +118,9 @@ function MyPage() {
   const [passwordPanelMessage, setPasswordPanelMessage] =
     useState<PasswordPanelMessage>(null);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [favoriteGames, setFavoriteGames] = useState(mockFavoriteGames);
+  const [selectedFavoriteGame, setSelectedFavoriteGame] =
+    useState<FavoriteGamePreview | null>(null);
 
   const localFieldErrors = useMemo(
     () => getPasswordFieldErrors(passwordValues, touchedState),
@@ -184,7 +188,7 @@ function MyPage() {
     );
   }
 
-  const favoriteCount = mockFavoriteGames.length;
+  const favoriteCount = favoriteGames.length;
 
   const resetPasswordPanel = () => {
     setPasswordValues(initialPasswordValues);
@@ -309,6 +313,21 @@ function MyPage() {
     });
   };
 
+  const handleFavoriteGameDeleteConfirm = () => {
+    if (!selectedFavoriteGame) {
+      return;
+    }
+
+    setFavoriteGames((current) =>
+      current.filter((game) => game.gameId !== selectedFavoriteGame.gameId),
+    );
+    setSelectedFavoriteGame(null);
+    setToast({
+      tone: 'success',
+      message: '찜한 게임이 목록에서 삭제되었습니다.',
+    });
+  };
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <div className="app-aurora pointer-events-none absolute inset-0 opacity-70" />
@@ -365,11 +384,12 @@ function MyPage() {
           <div className="mypage-scrollbar mt-5 max-h-[720px] overflow-y-auto pr-1">
             {favoriteCount > 0 ? (
               <div className="grid gap-4 md:grid-cols-2">
-                {mockFavoriteGames.map((game) => (
+                {favoriteGames.map((game) => (
                   <FavoriteGameCard
                     key={game.gameId}
                     game={game}
                     onClick={handleFavoriteGameCardClick}
+                    onFavoriteClick={setSelectedFavoriteGame}
                   />
                 ))}
               </div>
@@ -416,6 +436,15 @@ function MyPage() {
         onConfirm={() => {
           void handleDeleteAccount();
         }}
+      />
+      <ConfirmModal
+        open={Boolean(selectedFavoriteGame)}
+        title="찜한 게임을 삭제할까요?"
+        description={`'${selectedFavoriteGame?.title ?? ''}'을(를) 찜한 목록에서 삭제하시겠습니까?`}
+        confirmLabel="예"
+        cancelLabel="아니오"
+        onClose={() => setSelectedFavoriteGame(null)}
+        onConfirm={handleFavoriteGameDeleteConfirm}
       />
     </div>
   );

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -5,6 +5,7 @@ import type { CurrentUserProfileResponse } from '../features/auth/types/auth';
 const AUTH_STORAGE_KEY = 'auth-storage';
 const LEGACY_ACCESS_TOKEN_KEYS = ['accessToken', 'access_token'] as const;
 const LEGACY_REFRESH_TOKEN_KEYS = ['refreshToken', 'refresh_token'] as const;
+const LEGACY_PERSIST_KEYS = ['tokenStorage', 'infoStorage'] as const;
 
 const getLegacyAccessToken = () => {
   if (typeof window === 'undefined') {
@@ -85,7 +86,15 @@ export const clearLegacyAuthStorage = () => {
   for (const key of LEGACY_REFRESH_TOKEN_KEYS) {
     window.localStorage.removeItem(key);
   }
+
+  for (const key of LEGACY_PERSIST_KEYS) {
+    window.localStorage.removeItem(key);
+  }
 };
 
 export const getLegacyAccessTokenFromStorage = getLegacyAccessToken;
 export const getLegacyRefreshTokenFromStorage = getLegacyRefreshToken;
+export const clearAuthPersistedStorage = () => {
+  useAuthStore.persist.clearStorage();
+  clearLegacyAuthStorage();
+};

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
+import type { CurrentUserProfileResponse } from '../features/auth/types/auth';
 
 const AUTH_STORAGE_KEY = 'auth-storage';
 const LEGACY_ACCESS_TOKEN_KEYS = ['accessToken', 'access_token'] as const;
@@ -40,8 +41,10 @@ const getLegacyRefreshToken = () => {
 interface AuthState {
   accessToken: string | null;
   refreshToken: string | null;
+  account: CurrentUserProfileResponse | null;
   setAuthTokens: (accessToken: string, refreshToken: string) => void;
   setAccessToken: (token: string) => void;
+  setAccount: (account: CurrentUserProfileResponse | null) => void;
   clearAuthTokens: () => void;
 }
 
@@ -50,10 +53,13 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       accessToken: getLegacyAccessToken(),
       refreshToken: getLegacyRefreshToken(),
+      account: null,
       setAuthTokens: (accessToken, refreshToken) =>
         set({ accessToken, refreshToken }),
       setAccessToken: (token) => set({ accessToken: token }),
-      clearAuthTokens: () => set({ accessToken: null, refreshToken: null }),
+      setAccount: (account) => set({ account }),
+      clearAuthTokens: () =>
+        set({ accessToken: null, refreshToken: null, account: null }),
     }),
     {
       name: AUTH_STORAGE_KEY,
@@ -61,6 +67,7 @@ export const useAuthStore = create<AuthState>()(
       partialize: (state) => ({
         accessToken: state.accessToken,
         refreshToken: state.refreshToken,
+        account: state.account,
       }),
     },
   ),

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -4,6 +4,7 @@ import {
   getLegacyRefreshTokenFromStorage,
   useAuthStore,
 } from '../store/useAuthStore';
+import type { CurrentUserProfileResponse } from '../features/auth/types/auth';
 
 export const getAccessToken = () => {
   return (
@@ -17,6 +18,10 @@ export const getRefreshToken = () => {
   );
 };
 
+export const getAuthAccount = () => {
+  return useAuthStore.getState().account;
+};
+
 export const setAuthTokens = (accessToken: string, refreshToken: string) => {
   useAuthStore.getState().setAuthTokens(accessToken, refreshToken);
   clearLegacyAuthStorage();
@@ -25,6 +30,10 @@ export const setAuthTokens = (accessToken: string, refreshToken: string) => {
 export const setAccessToken = (token: string) => {
   useAuthStore.getState().setAccessToken(token);
   clearLegacyAuthStorage();
+};
+
+export const setAuthAccount = (account: CurrentUserProfileResponse | null) => {
+  useAuthStore.getState().setAccount(account);
 };
 
 export const clearAccessToken = () => {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,4 +1,5 @@
 import {
+  clearAuthPersistedStorage,
   clearLegacyAuthStorage,
   getLegacyAccessTokenFromStorage,
   getLegacyRefreshTokenFromStorage,
@@ -38,7 +39,7 @@ export const setAuthAccount = (account: CurrentUserProfileResponse | null) => {
 
 export const clearAccessToken = () => {
   useAuthStore.getState().clearAuthTokens();
-  clearLegacyAuthStorage();
+  clearAuthPersistedStorage();
 };
 
 export const clearAuthTokens = clearAccessToken;


### PR DESCRIPTION
## 관련 이슈

- closes #67

## 변경 내용

- zustand 기반으로 로그인 계정 정보를 함께 관리하도록 인증 상태 구조를 개선했습니다.
- 회원가입 폼의 자동완성 입력 동작과 자동완성 스타일 이슈를 완화했습니다.
- 회원가입 폼에 이름, 아이디, 닉네임 입력 제한과 안내 문구를 추가했습니다.
- 닉네임은 띄어쓰기를 제한하고, 아이디/닉네임 중복확인 결과를 더 명확한 UX로 정리했습니다.
- 아이디/닉네임 중복확인 결과가 토스트 알림으로도 표시되도록 개선했습니다.
- 마이페이지에서 저장된 계정 정보를 기반으로 프로필 초기 표시가 자연스럽게 유지되도록 수정했습니다.
- 마이페이지 찜한 목록 카드의 하트 버튼 인터랙션과 삭제 확인 흐름을 보강했습니다.
- 로그아웃/회원탈퇴 시 persisted 인증 저장소가 함께 정리되도록 수정했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

- UI 없음

## 참고사항

- 이번 PR은 인증 및 마이페이지 영역의 UX/상태 관리 리팩토링 범위만 포함합니다.
- 회원가입 자동완성 동작은 브라우저 기본 동작 특성상 완전 차단이 아닌 완화 방향으로 조정했습니다.
- 빌드 시 큰 청크 경고는 기존과 동일한 비차단 경고입니다.
