### PR TITLE
[Feat] 챗봇 타입 정의 및 API 통신 로직 구현

### DIFF
--- a/src/features/support-chat/api/chatbot.ts
+++ b/src/features/support-chat/api/chatbot.ts
@@ -1,0 +1,208 @@
+import { apiBaseUrl } from '@/lib/env';
+import type {
+  ChatbotErrorResponse,
+  ChatbotMessageRequest,
+  ChatbotMessageResponse,
+  ChatbotStreamEvent,
+} from '../types/supportChat';
+
+const CHATBOT_BASE_PATH = '/api/v1/chatbot';
+
+const createApiUrl = (
+  path: string,
+  params?: Record<string, string | number | undefined>,
+) => {
+  const base =
+    apiBaseUrl ||
+    (typeof window !== 'undefined'
+      ? window.location.origin
+      : 'http://localhost');
+  const url = new URL(path, base);
+
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  if (apiBaseUrl) {
+    return url.toString();
+  }
+
+  return `${url.pathname}${url.search}`;
+};
+
+const getDefaultChatbotErrorMessage = (
+  status: number | null,
+  fallback = '챗봇 요청을 처리하는 중 오류가 발생했습니다.',
+) => {
+  if (status === 400) {
+    return '메시지는 공백일 수 없고 2자 이상이어야 합니다.';
+  }
+
+  if (status === 404) {
+    return '만료되었거나 유효하지 않은 대화 세션입니다.';
+  }
+
+  return fallback;
+};
+
+const extractChatbotErrorMessage = async (response: Response) => {
+  try {
+    const data = (await response.json()) as ChatbotErrorResponse;
+
+    return (
+      data.error_detail ||
+      getDefaultChatbotErrorMessage(response.status, data.error_detail)
+    );
+  } catch {
+    return getDefaultChatbotErrorMessage(response.status);
+  }
+};
+
+export const sendChatbotMessage = async (payload: ChatbotMessageRequest) => {
+  const response = await fetch(createApiUrl(`${CHATBOT_BASE_PATH}/messages`), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(await extractChatbotErrorMessage(response));
+  }
+
+  return (await response.json()) as ChatbotMessageResponse;
+};
+
+const parseSseEvent = (chunk: string): ChatbotStreamEvent | null => {
+  let eventName = 'message';
+  const dataLines: string[] = [];
+
+  for (const line of chunk.split('\n')) {
+    if (line.startsWith('event:')) {
+      eventName = line.replace('event:', '').trim();
+      continue;
+    }
+
+    if (line.startsWith('data:')) {
+      dataLines.push(line.replace('data:', '').trim());
+    }
+  }
+
+  if (dataLines.length === 0) {
+    return null;
+  }
+
+  const parsed = JSON.parse(dataLines.join('\n')) as {
+    session_id?: number;
+    content?: string;
+  };
+
+  if (eventName === 'start' && typeof parsed.session_id === 'number') {
+    return {
+      type: 'start',
+      sessionId: parsed.session_id,
+    };
+  }
+
+  if (eventName === 'chunk' && typeof parsed.content === 'string') {
+    return {
+      type: 'chunk',
+      content: parsed.content,
+    };
+  }
+
+  if (eventName === 'complete' && typeof parsed.session_id === 'number') {
+    return {
+      type: 'complete',
+      sessionId: parsed.session_id,
+    };
+  }
+
+  return null;
+};
+
+export const streamChatbotResponse = async ({
+  sessionId,
+  signal,
+  onEvent,
+}: {
+  sessionId: number;
+  signal?: AbortSignal;
+  onEvent: (event: ChatbotStreamEvent) => void;
+}) => {
+  const response = await fetch(
+    createApiUrl(`${CHATBOT_BASE_PATH}/stream`, { session_id: sessionId }),
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'text/event-stream',
+      },
+      signal,
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(await extractChatbotErrorMessage(response));
+  }
+
+  if (!response.body) {
+    throw new Error('챗봇 응답 스트림을 불러오지 못했습니다.');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n');
+
+    while (buffer.includes('\n\n')) {
+      const separatorIndex = buffer.indexOf('\n\n');
+      const eventBlock = buffer.slice(0, separatorIndex).trim();
+      buffer = buffer.slice(separatorIndex + 2);
+
+      if (!eventBlock) {
+        continue;
+      }
+
+      const parsedEvent = parseSseEvent(eventBlock);
+
+      if (parsedEvent) {
+        onEvent(parsedEvent);
+      }
+    }
+  }
+
+  const tail = buffer.trim();
+
+  if (tail) {
+    const parsedEvent = parseSseEvent(tail);
+
+    if (parsedEvent) {
+      onEvent(parsedEvent);
+    }
+  }
+};
+
+export const extractSupportChatErrorMessage = (error: unknown) => {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return '';
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return '챗봇 요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+};

--- a/src/features/support-chat/api/useSupportChatApi.ts
+++ b/src/features/support-chat/api/useSupportChatApi.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { sendChatbotMessage } from './chatbot';
+
+export const useSendChatbotMessageMutation = () =>
+  useMutation({
+    mutationKey: ['support-chat', 'messages'],
+    mutationFn: sendChatbotMessage,
+  });

--- a/src/features/support-chat/store/useSupportChatStore.ts
+++ b/src/features/support-chat/store/useSupportChatStore.ts
@@ -1,0 +1,183 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+// import {
+//   createDefaultRouteContext,
+//   SUPPORT_CHAT_QUICK_ACTIONS,
+//   SUPPORT_CHAT_WELCOME_MESSAGE,
+// } from '../data/faqs';
+import type {
+  SupportChatMessage,
+  SupportChatQuickAction,
+  SupportChatRouteContext,
+} from '../types/supportChat';
+
+// Temporary placeholders to fix build errors until PR #74 is merged
+const createDefaultRouteContext = (): SupportChatRouteContext => ({
+  pathname: '/',
+  pageLabel: '홈',
+});
+const SUPPORT_CHAT_QUICK_ACTIONS: SupportChatQuickAction[] = [];
+const SUPPORT_CHAT_WELCOME_MESSAGE = '안녕하세요! 무엇을 도와드릴까요?';
+
+type SupportChatStoreState = {
+  sessionId: number | null;
+  messages: SupportChatMessage[];
+  quickActions: SupportChatQuickAction[];
+  showQuickActions: boolean;
+  hasBootstrapped: boolean;
+  isOpen: boolean;
+  isSubmitting: boolean;
+  error: string | null;
+  routeContext: SupportChatRouteContext;
+  bootstrapConversation: (routeContext?: SupportChatRouteContext) => void;
+  resetConversation: (routeContext?: SupportChatRouteContext) => void;
+  openPanel: () => void;
+  closePanel: () => void;
+  togglePanel: () => void;
+  setRouteContext: (routeContext: SupportChatRouteContext) => void;
+  setSessionId: (sessionId: number | null) => void;
+  setSubmitting: (isSubmitting: boolean) => void;
+  setError: (error: string | null) => void;
+  clearError: () => void;
+  hideQuickActions: () => void;
+  appendUserMessage: (content: string) => void;
+  beginAssistantMessage: (messageId: string) => void;
+  appendAssistantChunk: (messageId: string, chunk: string) => void;
+  finalizeAssistantMessage: (messageId: string) => void;
+  removeMessage: (messageId: string) => void;
+};
+
+const STORAGE_KEY = 'support-chat-storage';
+
+const createMessage = (
+  role: SupportChatMessage['role'],
+  content: string,
+  status: SupportChatMessage['status'] = 'complete',
+  messageId: string = crypto.randomUUID(),
+): SupportChatMessage => ({
+  id: messageId,
+  role,
+  content,
+  createdAt: new Date().toISOString(),
+  status,
+});
+
+const createInitialMessages = () => [
+  createMessage('assistant', SUPPORT_CHAT_WELCOME_MESSAGE),
+];
+
+const initialState = {
+  sessionId: null as number | null,
+  messages: createInitialMessages(),
+  quickActions: SUPPORT_CHAT_QUICK_ACTIONS,
+  showQuickActions: true,
+  hasBootstrapped: true,
+  isOpen: false,
+  isSubmitting: false,
+  error: null as string | null,
+  routeContext: createDefaultRouteContext(),
+};
+
+export const useSupportChatStore = create<SupportChatStoreState>()(
+  persist(
+    (set, get) => ({
+      ...initialState,
+      bootstrapConversation: (routeContext = get().routeContext) => {
+        const state = get();
+
+        if (state.hasBootstrapped && state.messages.length > 0) {
+          if (routeContext.pathname !== state.routeContext.pathname) {
+            set({ routeContext });
+          }
+
+          return;
+        }
+
+        set({
+          ...initialState,
+          routeContext,
+        });
+      },
+      resetConversation: (routeContext = get().routeContext) =>
+        set({
+          ...initialState,
+          isOpen: true,
+          routeContext,
+        }),
+      openPanel: () => set({ isOpen: true }),
+      closePanel: () => set({ isOpen: false }),
+      togglePanel: () => set((state) => ({ isOpen: !state.isOpen })),
+      setRouteContext: (routeContext) => set({ routeContext }),
+      setSessionId: (sessionId) => set({ sessionId }),
+      setSubmitting: (isSubmitting) => set({ isSubmitting }),
+      setError: (error) => set({ error }),
+      clearError: () => set({ error: null }),
+      hideQuickActions: () => set({ showQuickActions: false }),
+      appendUserMessage: (content) =>
+        set((state) => ({
+          messages: [...state.messages, createMessage('user', content)],
+        })),
+      beginAssistantMessage: (messageId) =>
+        set((state) => ({
+          messages: [
+            ...state.messages,
+            createMessage('assistant', '', 'streaming', messageId),
+          ],
+        })),
+      appendAssistantChunk: (messageId, chunk) =>
+        set((state) => ({
+          messages: state.messages.map((message) =>
+            message.id === messageId
+              ? {
+                  ...message,
+                  content: `${message.content}${chunk}`,
+                }
+              : message,
+          ),
+        })),
+      finalizeAssistantMessage: (messageId) =>
+        set((state) => ({
+          messages: state.messages.map((message) =>
+            message.id === messageId
+              ? {
+                  ...message,
+                  status: 'complete',
+                }
+              : message,
+          ),
+        })),
+      removeMessage: (messageId) =>
+        set((state) => ({
+          messages: state.messages.filter(
+            (message) => message.id !== messageId,
+          ),
+        })),
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (state) => ({
+        sessionId: state.sessionId,
+        messages: state.messages,
+        quickActions: state.quickActions,
+        showQuickActions: state.showQuickActions,
+        hasBootstrapped: state.hasBootstrapped,
+        routeContext: state.routeContext,
+      }),
+      merge: (persistedState, currentState) => {
+        const mergedState = {
+          ...currentState,
+          ...(persistedState as Partial<typeof currentState>),
+        };
+
+        return {
+          ...mergedState,
+          isOpen: false,
+          isSubmitting: false,
+          error: null,
+        };
+      },
+    },
+  ),
+);

--- a/src/features/support-chat/types/supportChat.ts
+++ b/src/features/support-chat/types/supportChat.ts
@@ -1,0 +1,54 @@
+export type SupportChatMessageRole = 'assistant' | 'user';
+
+export type SupportChatMessageStatus = 'streaming' | 'complete';
+
+export type SupportChatMessage = {
+  id: string;
+  role: SupportChatMessageRole;
+  content: string;
+  createdAt: string;
+  status: SupportChatMessageStatus;
+};
+
+export type SupportChatQuickAction = {
+  id: string;
+  label: string;
+};
+
+export type SupportChatRouteContext = {
+  pathname: string;
+  pageLabel: string;
+};
+
+export type ChatbotMessageRequest = {
+  message: string;
+  session_id?: number;
+};
+
+export type ChatbotMessageResponse = {
+  session_id: number;
+};
+
+export type ChatbotErrorResponse = {
+  error_detail: string;
+};
+
+export type ChatbotStreamStartEvent = {
+  type: 'start';
+  sessionId: number;
+};
+
+export type ChatbotStreamChunkEvent = {
+  type: 'chunk';
+  content: string;
+};
+
+export type ChatbotStreamCompleteEvent = {
+  type: 'complete';
+  sessionId: number;
+};
+
+export type ChatbotStreamEvent =
+  | ChatbotStreamStartEvent
+  | ChatbotStreamChunkEvent
+  | ChatbotStreamCompleteEvent;


### PR DESCRIPTION
## 관련 이슈

- closes #72 

## 변경 내용

- 챗봇 고객센터 기능을 위한 핵심 도메인 모델 및 타입 정의 추가 (`supportChat.ts`)
- 챗봇 메시지 전송 및 스트리밍 응답 처리를 위한 API 핸들러 구현 (`chatbot.ts`, `useSupportChatApi.ts`)
- Zustand를 이용한 챗봇 대화 상태 관리 스토어 구축 (`useSupportChatStore.ts`)
- 빌드 안정성을 위해 미구현된 데이터 참조 부분 임시 처리 및 자체 타입 정의 포함

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다. (UI 미포함)
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

(UI 변경 사항이 없는 백엔드 통신 및 상태 관리 로직 작업입니다.)

## 참고사항

- 현재 PR은 챗봇의 기반이 되는 로직만 포함하고 있습니다.
- 빌드 에러 방지를 위해 `data/faqs` 참조 부분은 임시로 파일 내부 정의로 대체하였으며, 이는 이후 PR #74(Mock 데이터 추가) 단계에서 실제 파일 참조로 업데이트될 예정입니다.
