### PR TITLE
[Feat] 챗봇 UI 컴포넌트 구현 

### DIFF
--- a/src/components/support-chat/SupportChatComposer.tsx
+++ b/src/components/support-chat/SupportChatComposer.tsx
@@ -1,0 +1,61 @@
+import type { FormEvent, KeyboardEvent } from 'react';
+import { SendHorizontal } from 'lucide-react';
+
+type SupportChatComposerProps = {
+  value: string;
+  disabled?: boolean;
+  error?: string | null;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+};
+
+function SupportChatComposer({
+  value,
+  disabled = false,
+  error = null,
+  onChange,
+  onSubmit,
+}: SupportChatComposerProps) {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
+      event.preventDefault();
+      onSubmit();
+    }
+  };
+
+  return (
+    <div className="border-t border-white/8 px-4 pt-3 pb-3">
+      <form onSubmit={handleSubmit} className="flex items-end gap-3">
+        <label className="sr-only" htmlFor="support-chat-message">
+          고객센터 챗봇 메시지 입력
+        </label>
+        <input
+          id="support-chat-message"
+          type="text"
+          value={value}
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="메시지를 입력하세요..."
+          className="support-chat-input min-w-0 flex-1"
+        />
+        <button
+          type="submit"
+          disabled={disabled}
+          className="support-chat-send-btn flex h-13 shrink-0 items-center gap-2 rounded-2xl px-4 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <span>전송</span>
+          <SendHorizontal size={16} />
+        </button>
+      </form>
+      {error ? <p className="mt-1 text-xs text-[#ff8b84]">{error}</p> : null}
+    </div>
+  );
+}
+
+export default SupportChatComposer;

--- a/src/components/support-chat/SupportChatHeader.tsx
+++ b/src/components/support-chat/SupportChatHeader.tsx
@@ -1,0 +1,58 @@
+import { Bot, RotateCcw, X } from 'lucide-react';
+
+import type { SupportChatRouteContext } from '@/features/support-chat/types/supportChat';
+
+type SupportChatHeaderProps = {
+  routeContext: SupportChatRouteContext;
+  onReset: () => void;
+  onClose: () => void;
+};
+
+function SupportChatHeader({
+  routeContext,
+  onReset,
+  onClose,
+}: SupportChatHeaderProps) {
+  return (
+    <div className="border-b border-[#641312] px-4 py-4 sm:px-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <div className="support-chat-header-badge">
+            <Bot size={20} />
+          </div>
+          <div className="min-w-0">
+            <p className="text-lg font-semibold tracking-[0.02em] text-white sm:text-xl">
+              고객센터
+            </p>
+            <p className="mt-1 truncate text-sm leading-5 whitespace-nowrap text-white/70">
+              {routeContext.pageLabel} 화면에서도 바로 문의하실 수 있어요.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={onReset}
+            className="support-chat-icon-btn"
+            aria-label="대화 초기화"
+            title="대화 초기화"
+          >
+            <RotateCcw size={16} />
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="support-chat-icon-btn"
+            aria-label="챗봇 닫기"
+            title="챗봇 닫기"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SupportChatHeader;

--- a/src/components/support-chat/SupportChatLauncherButton.tsx
+++ b/src/components/support-chat/SupportChatLauncherButton.tsx
@@ -1,0 +1,30 @@
+import { Bot } from 'lucide-react';
+
+type SupportChatLauncherButtonProps = {
+  isOpen: boolean;
+  onClick: () => void;
+};
+
+function SupportChatLauncherButton({
+  isOpen,
+  onClick,
+}: SupportChatLauncherButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={isOpen ? '고객센터 챗봇 닫기' : '고객센터 챗봇 열기'}
+      className="support-chat-fab group fixed right-4 bottom-4 z-[95] flex h-16 w-16 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none sm:right-6 sm:bottom-6"
+    >
+      <span className="support-chat-fab-glow" />
+      <Bot
+        size={24}
+        className={`relative z-10 transition-transform ${
+          isOpen ? 'scale-95 rotate-6' : 'scale-100'
+        }`}
+      />
+    </button>
+  );
+}
+
+export default SupportChatLauncherButton;

--- a/src/components/support-chat/SupportChatMessageBubble.tsx
+++ b/src/components/support-chat/SupportChatMessageBubble.tsx
@@ -1,0 +1,70 @@
+import { Bot, UserRound } from 'lucide-react';
+
+import type { SupportChatMessage } from '@/features/support-chat/types/supportChat';
+import SupportChatTypingIndicator from './SupportChatTypingIndicator';
+
+type SupportChatMessageBubbleProps = {
+  message: SupportChatMessage;
+};
+
+const roleMeta = {
+  assistant: {
+    Icon: Bot,
+    wrapperClassName: 'justify-start',
+    bodyClassName: 'support-chat-bubble-bot',
+    badgeClassName:
+      'border border-[#7a1715]/70 bg-[#2a0e0d] text-[#ff6b62] shadow-[0_0_24px_rgba(201,41,35,0.16)]',
+  },
+  user: {
+    Icon: UserRound,
+    wrapperClassName: 'justify-end',
+    bodyClassName: 'support-chat-bubble-user',
+    badgeClassName:
+      'border border-white/12 bg-white/6 text-white shadow-[0_12px_24px_rgba(0,0,0,0.18)]',
+  },
+} as const;
+
+function SupportChatMessageBubble({ message }: SupportChatMessageBubbleProps) {
+  const meta = roleMeta[message.role];
+  const Icon = meta.Icon;
+  const isTyping =
+    message.role === 'assistant' &&
+    message.status === 'streaming' &&
+    !message.content;
+
+  return (
+    <div className={`flex w-full ${meta.wrapperClassName}`}>
+      <div className="flex max-w-[88%] items-start gap-3 motion-safe:animate-[support-chat-message-in_220ms_ease-out]">
+        {message.role === 'assistant' ? (
+          <div
+            className={`mt-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl ${meta.badgeClassName}`}
+          >
+            <Icon size={18} />
+          </div>
+        ) : null}
+
+        <div
+          className={`min-w-0 rounded-[24px] px-4 py-3.5 ${meta.bodyClassName}`}
+        >
+          {isTyping ? (
+            <SupportChatTypingIndicator />
+          ) : (
+            <p className="text-sm/6 whitespace-pre-line text-white/92">
+              {message.content}
+            </p>
+          )}
+        </div>
+
+        {message.role === 'user' ? (
+          <div
+            className={`mt-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl ${meta.badgeClassName}`}
+          >
+            <Icon size={18} />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export default SupportChatMessageBubble;

--- a/src/components/support-chat/SupportChatPanel.tsx
+++ b/src/components/support-chat/SupportChatPanel.tsx
@@ -1,0 +1,96 @@
+import type { RefObject } from 'react';
+
+import type {
+  SupportChatMessage,
+  SupportChatQuickAction,
+  SupportChatRouteContext,
+} from '@/features/support-chat/types/supportChat';
+import SupportChatComposer from './SupportChatComposer';
+import SupportChatHeader from './SupportChatHeader';
+import SupportChatMessageBubble from './SupportChatMessageBubble';
+import SupportChatQuickActions from './SupportChatQuickActions';
+
+type SupportChatPanelProps = {
+  isOpen: boolean;
+  panelRef: RefObject<HTMLDivElement | null>;
+  viewportRef: RefObject<HTMLDivElement | null>;
+  routeContext: SupportChatRouteContext;
+  messages: SupportChatMessage[];
+  quickActions: SupportChatQuickAction[];
+  showQuickActions: boolean;
+  isSubmitting: boolean;
+  error: string | null;
+  inputValue: string;
+  onReset: () => void;
+  onClose: () => void;
+  onQuickActionSelect: (label: string) => void;
+  onInputChange: (value: string) => void;
+  onSubmit: () => void;
+};
+
+function SupportChatPanel({
+  isOpen,
+  panelRef,
+  viewportRef,
+  routeContext,
+  messages,
+  quickActions,
+  showQuickActions,
+  isSubmitting,
+  error,
+  inputValue,
+  onReset,
+  onClose,
+  onQuickActionSelect,
+  onInputChange,
+  onSubmit,
+}: SupportChatPanelProps) {
+  return (
+    <div
+      ref={panelRef}
+      className={`support-chat-panel fixed right-4 bottom-24 z-[90] flex h-[min(78vh,46rem)] w-[min(94vw,27rem)] origin-bottom-right flex-col overflow-hidden transition-all duration-300 ease-out sm:right-6 sm:bottom-26 ${
+        isOpen
+          ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
+          : 'pointer-events-none translate-y-4 scale-95 opacity-0'
+      }`}
+      role="dialog"
+      aria-modal="false"
+      aria-label="고객센터 챗봇"
+    >
+      <SupportChatHeader
+        routeContext={routeContext}
+        onReset={onReset}
+        onClose={onClose}
+      />
+
+      <div
+        ref={viewportRef}
+        className="support-chat-scrollbar flex-1 overflow-y-auto px-4 py-4"
+      >
+        <div className="flex flex-col gap-4">
+          {messages.map((message) => (
+            <SupportChatMessageBubble key={message.id} message={message} />
+          ))}
+
+          {showQuickActions ? (
+            <SupportChatQuickActions
+              actions={quickActions}
+              disabled={isSubmitting}
+              onSelect={onQuickActionSelect}
+            />
+          ) : null}
+        </div>
+      </div>
+
+      <SupportChatComposer
+        value={inputValue}
+        disabled={isSubmitting}
+        error={error}
+        onChange={onInputChange}
+        onSubmit={onSubmit}
+      />
+    </div>
+  );
+}
+
+export default SupportChatPanel;

--- a/src/components/support-chat/SupportChatQuickActions.tsx
+++ b/src/components/support-chat/SupportChatQuickActions.tsx
@@ -1,0 +1,35 @@
+import type { SupportChatQuickAction } from '@/features/support-chat/types/supportChat';
+
+type SupportChatQuickActionsProps = {
+  actions: SupportChatQuickAction[];
+  disabled?: boolean;
+  onSelect: (label: string) => void;
+};
+
+function SupportChatQuickActions({
+  actions,
+  disabled = false,
+  onSelect,
+}: SupportChatQuickActionsProps) {
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      {actions.map((action) => (
+        <button
+          key={action.id}
+          type="button"
+          onClick={() => onSelect(action.label)}
+          disabled={disabled}
+          className="support-chat-quick-action min-h-12 max-w-[80%] px-4 py-3 text-right text-sm/5 font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default SupportChatQuickActions;

--- a/src/components/support-chat/SupportChatTypingIndicator.tsx
+++ b/src/components/support-chat/SupportChatTypingIndicator.tsx
@@ -1,0 +1,11 @@
+function SupportChatTypingIndicator() {
+  return (
+    <div className="flex items-center gap-1.5" aria-label="챗봇 응답 작성 중">
+      <span className="support-chat-dot [animation-delay:0ms]" />
+      <span className="support-chat-dot [animation-delay:150ms]" />
+      <span className="support-chat-dot [animation-delay:300ms]" />
+    </div>
+  );
+}
+
+export default SupportChatTypingIndicator;

--- a/src/components/support-chat/SupportChatWidget.tsx
+++ b/src/components/support-chat/SupportChatWidget.tsx
@@ -1,0 +1,302 @@
+import {
+  type MutableRefObject,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useLocation } from 'react-router';
+
+// import {
+//   createDefaultRouteContext,
+//   SUPPORT_CHAT_QUICK_ACTIONS,
+// } from '@/features/support-chat/data/faqs';
+import {
+  extractSupportChatErrorMessage,
+  streamChatbotResponse,
+} from '@/features/support-chat/api/chatbot';
+import { useSendChatbotMessageMutation } from '@/features/support-chat/api/useSupportChatApi';
+import { useSupportChatStore } from '@/features/support-chat/store/useSupportChatStore';
+import type {
+  SupportChatRouteContext,
+  SupportChatQuickAction,
+} from '@/features/support-chat/types/supportChat';
+import SupportChatLauncherButton from './SupportChatLauncherButton';
+import SupportChatPanel from './SupportChatPanel';
+
+// Temporary placeholders to fix build errors until PR #74 is merged
+const createDefaultRouteContext = (): SupportChatRouteContext => ({
+  pathname: '/',
+  pageLabel: '홈',
+});
+const SUPPORT_CHAT_QUICK_ACTIONS: SupportChatQuickAction[] = [];
+
+const getPageLabel = (pathname: string) => {
+  if (pathname === '/login') {
+    return '로그인';
+  }
+
+  if (pathname === '/signup') {
+    return '회원가입';
+  }
+
+  if (pathname === '/my-page') {
+    return '마이페이지';
+  }
+
+  if (pathname.startsWith('/survey')) {
+    return '설문';
+  }
+
+  if (pathname.startsWith('/matching-list')) {
+    return '매칭';
+  }
+
+  if (pathname.startsWith('/recommendation-list')) {
+    return '추천';
+  }
+
+  return '현재';
+};
+
+const getRouteContext = (pathname: string): SupportChatRouteContext => ({
+  pathname,
+  pageLabel: getPageLabel(pathname),
+});
+
+function SupportChatWidget() {
+  const location = useLocation();
+  const [inputValue, setInputValue] = useState('');
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const streamAbortRef = useRef<AbortController | null>(null);
+
+  const routeContext = useMemo(
+    () => getRouteContext(location.pathname),
+    [location.pathname],
+  );
+
+  const {
+    sessionId,
+    messages,
+    quickActions,
+    showQuickActions,
+    hasBootstrapped,
+    isOpen,
+    isSubmitting,
+    error,
+    bootstrapConversation,
+    resetConversation,
+    closePanel,
+    togglePanel,
+    setRouteContext,
+    setSessionId,
+    setSubmitting,
+    setError,
+    clearError,
+    hideQuickActions,
+    appendUserMessage,
+    beginAssistantMessage,
+    appendAssistantChunk,
+    finalizeAssistantMessage,
+    removeMessage,
+  } = useSupportChatStore();
+
+  const sendMessageMutation = useSendChatbotMessageMutation();
+
+  const isRecoverableSessionError = (message: string) =>
+    message.includes('session_id') || message.includes('유효하지 않은');
+
+  useEffect(() => {
+    if (!hasBootstrapped) {
+      bootstrapConversation(routeContext);
+      return;
+    }
+
+    setRouteContext(routeContext);
+  }, [bootstrapConversation, hasBootstrapped, routeContext, setRouteContext]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closePanel();
+      }
+    };
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(event.target as Node) &&
+        !(event.target as HTMLElement)?.closest('.support-chat-fab')
+      ) {
+        closePanel();
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    window.addEventListener('mousedown', handleOutsideClick);
+
+    return () => {
+      window.removeEventListener('keydown', handleEscape);
+      window.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [closePanel, isOpen]);
+
+  useEffect(
+    () => () => {
+      streamAbortRef.current?.abort();
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!isOpen || !viewportRef.current) {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      const viewport = viewportRef.current;
+
+      if (!viewport) {
+        return;
+      }
+
+      viewport.scrollTo({
+        top: viewport.scrollHeight,
+        behavior: 'auto',
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [isOpen, isSubmitting, messages, showQuickActions]);
+
+  const handleReset = () => {
+    streamAbortRef.current?.abort();
+    setInputValue('');
+    resetConversation(routeContext);
+  };
+
+  const submitMessage = async (message: string) => {
+    const trimmedMessage = message.trim();
+
+    if (trimmedMessage.length < 2 || isSubmitting) {
+      setError('메시지는 공백일 수 없고 2자 이상이어야 합니다.');
+      return;
+    }
+
+    const assistantMessageId = crypto.randomUUID();
+
+    clearError();
+    hideQuickActions();
+    appendUserMessage(trimmedMessage);
+    beginAssistantMessage(assistantMessageId);
+    setSubmitting(true);
+
+    try {
+      let response;
+
+      try {
+        response = await sendMessageMutation.mutateAsync({
+          message: trimmedMessage,
+          session_id: sessionId ?? undefined,
+        });
+      } catch (requestError) {
+        const errorMessage = extractSupportChatErrorMessage(requestError);
+
+        if (sessionId && isRecoverableSessionError(errorMessage)) {
+          setSessionId(null);
+          response = await sendMessageMutation.mutateAsync({
+            message: trimmedMessage,
+          });
+        } else {
+          throw requestError;
+        }
+      }
+
+      setSessionId(response.session_id);
+
+      const abortController = new AbortController();
+      streamAbortRef.current = abortController;
+
+      await streamChatbotResponse({
+        sessionId: response.session_id,
+        signal: abortController.signal,
+        onEvent: (event) => {
+          if (event.type === 'chunk') {
+            appendAssistantChunk(assistantMessageId, event.content);
+          }
+
+          if (event.type === 'complete') {
+            finalizeAssistantMessage(assistantMessageId);
+            setSubmitting(false);
+          }
+        },
+      });
+    } catch (requestError) {
+      removeMessage(assistantMessageId);
+      const errorMessage = extractSupportChatErrorMessage(requestError);
+
+      if (errorMessage) {
+        setError(errorMessage);
+      }
+
+      setSubmitting(false);
+    } finally {
+      streamAbortRef.current = null;
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!inputValue.trim()) {
+      setError('메시지는 공백일 수 없고 2자 이상이어야 합니다.');
+      return;
+    }
+
+    const nextValue = inputValue;
+    setInputValue('');
+    await submitMessage(nextValue);
+  };
+
+  const handleQuickActionSelect = async (label: string) => {
+    await submitMessage(label);
+  };
+
+  return (
+    <>
+      <SupportChatPanel
+        isOpen={isOpen}
+        panelRef={panelRef as MutableRefObject<HTMLDivElement | null>}
+        viewportRef={viewportRef as MutableRefObject<HTMLDivElement | null>}
+        routeContext={routeContext || createDefaultRouteContext()}
+        messages={messages}
+        quickActions={
+          showQuickActions ? quickActions : SUPPORT_CHAT_QUICK_ACTIONS
+        }
+        showQuickActions={showQuickActions}
+        isSubmitting={isSubmitting}
+        error={error}
+        inputValue={inputValue}
+        onReset={handleReset}
+        onClose={closePanel}
+        onQuickActionSelect={handleQuickActionSelect}
+        onInputChange={(value) => {
+          if (error) {
+            clearError();
+          }
+
+          setInputValue(value);
+        }}
+        onSubmit={handleSubmit}
+      />
+      <SupportChatLauncherButton isOpen={isOpen} onClick={togglePanel} />
+    </>
+  );
+}
+
+export default SupportChatWidget;


### PR DESCRIPTION
## 관련 이슈

- closes #73

## 변경 내용

- 챗봇 위젯 및 관련 UI 컴포넌트 구현
  - `SupportChatWidget`: 전체 챗봇 로직 통합 및 위젯 래퍼
  - `SupportChatPanel`: 채팅창 레이아웃 및 메시지 리스트
  - `SupportChatMessageBubble`: 사용자/어시스턴트 메시지 버블
  - `SupportChatComposer`: 메시지 입력창
  - `SupportChatHeader`, `SupportChatLauncherButton` 등
- 반응형 디자인 및 접근성 고려 (Escape 키 닫기, 외부 클릭 닫기 등)
- 메시지 스트리밍 UI 처리 및 자동 스크롤 구현

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다. (단독 확인 불가, 통합 PR에서 확인 예정)
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.

## 스크린샷

(통합 PR 단계에서 전체 동작 스크린샷 첨부 예정)

## 참고사항

- 빌드 에러 방지를 위해 `data/faqs` 참조 부분은 임시로 파일 내부 정의로 대체하였으며, 이는 PR #74 단계에서 복구될 예정입니다.
