### PR TITLE
[Feat] MSW 핸들러 및 목 데이터 추가

### DIFF
--- a/src/components/support-chat/SupportChatWidget.tsx
+++ b/src/components/support-chat/SupportChatWidget.tsx
@@ -7,29 +7,19 @@ import {
 } from 'react';
 import { useLocation } from 'react-router';
 
-// import {
-//   createDefaultRouteContext,
-//   SUPPORT_CHAT_QUICK_ACTIONS,
-// } from '@/features/support-chat/data/faqs';
+import {
+  createDefaultRouteContext,
+  SUPPORT_CHAT_QUICK_ACTIONS,
+} from '@/features/support-chat/data/faqs';
 import {
   extractSupportChatErrorMessage,
   streamChatbotResponse,
 } from '@/features/support-chat/api/chatbot';
 import { useSendChatbotMessageMutation } from '@/features/support-chat/api/useSupportChatApi';
 import { useSupportChatStore } from '@/features/support-chat/store/useSupportChatStore';
-import type {
-  SupportChatRouteContext,
-  SupportChatQuickAction,
-} from '@/features/support-chat/types/supportChat';
+import type { SupportChatRouteContext } from '@/features/support-chat/types/supportChat';
 import SupportChatLauncherButton from './SupportChatLauncherButton';
 import SupportChatPanel from './SupportChatPanel';
-
-// Temporary placeholders to fix build errors until PR #74 is merged
-const createDefaultRouteContext = (): SupportChatRouteContext => ({
-  pathname: '/',
-  pageLabel: '홈',
-});
-const SUPPORT_CHAT_QUICK_ACTIONS: SupportChatQuickAction[] = [];
 
 const getPageLabel = (pathname: string) => {
   if (pathname === '/login') {

--- a/src/features/support-chat/data/faqs.ts
+++ b/src/features/support-chat/data/faqs.ts
@@ -1,0 +1,89 @@
+import type {
+  SupportChatQuickAction,
+  SupportChatRouteContext,
+} from '../types/supportChat';
+
+type SupportFaqEntry = {
+  id: string;
+  label: string;
+  keywords: string[];
+  answer: string;
+};
+
+export const SUPPORT_CHAT_WELCOME_MESSAGE =
+  '안녕하세요! 고객센터 챗봇입니다.\n궁금한 내용을 입력하시거나 아래 예시 질문을 눌러 바로 도움을 받아보세요.';
+
+export const SUPPORT_CHAT_QUICK_ACTIONS: SupportChatQuickAction[] = [
+  { id: 'account-help', label: '아이디 비밀번호 변경 어떻게 해요' },
+  { id: 'search-help', label: '게임을 검색했는데 안 나와요' },
+  { id: 'discount-help', label: '할인 여부 확인하고 싶어요' },
+  { id: 'delete-account-help', label: '계정 삭제 하고 싶은데 어떻게 하나요' },
+  { id: 'find-id-help', label: '아이디를 찾고 싶어요' },
+];
+
+const SUPPORT_FAQ_ENTRIES: SupportFaqEntry[] = [
+  {
+    id: 'account-change',
+    label: '아이디 비밀번호 변경 어떻게 해요',
+    keywords: ['아이디', '비밀번호', '변경', '수정', '로그인 정보'],
+    answer:
+      '아이디 확인이나 비밀번호 변경이 필요하시면 로그인 화면 또는 마이페이지를 이용해 주세요.\n비밀번호 변경은 마이페이지에서 진행할 수 있고, 아이디 찾기는 본인 확인 절차가 준비되면 안내에 따라 확인하실 수 있습니다.',
+  },
+  {
+    id: 'search',
+    label: '게임을 검색했는데 안 나와요',
+    keywords: ['게임', '검색', '안 나와', '결과 없음', '찾을 수 없'],
+    answer:
+      '검색 결과가 보이지 않는 경우 띄어쓰기나 영문 표기를 조금 다르게 입력해 보시는 것을 먼저 권장드려요.\n그래도 찾으시는 게임이 없다면 메인 페이지 검색이나 추천 목록 갱신 후 다시 확인해 주세요.',
+  },
+  {
+    id: 'discount',
+    label: '할인 여부 확인하고 싶어요',
+    keywords: ['할인', '세일', '가격', '특가'],
+    answer:
+      '현재 서비스에서는 할인 여부를 직접 결제하지는 않지만, 게임 상세 정보와 외부 링크를 통해 관련 정보를 확인하실 수 있도록 준비 중입니다.\n원하시는 게임이 있다면 상세 페이지에서 링크 정보를 먼저 확인해 주세요.',
+  },
+  {
+    id: 'delete-account',
+    label: '계정 삭제 하고 싶은데 어떻게 하나요',
+    keywords: ['계정 삭제', '회원 탈퇴', '탈퇴', '계정 제거'],
+    answer:
+      '회원탈퇴는 마이페이지 하단의 회원탈퇴 버튼에서 진행하실 수 있습니다.\n탈퇴 전에는 계정 정보와 저장된 로그인 상태가 함께 정리되므로, 필요한 정보가 있다면 먼저 확인해 주세요.',
+  },
+  {
+    id: 'find-id',
+    label: '아이디를 찾고 싶어요',
+    keywords: ['아이디', '찾고', '분실', '모르겠'],
+    answer:
+      '아이디 찾기는 본인 인증 기반 안내가 준비되는 대로 로그인 화면과 고객센터 안내를 통해 제공될 예정입니다.\n현재는 가입 시 사용한 이름과 닉네임 정보를 먼저 확인해 주세요.',
+  },
+];
+
+const normalizeQuestion = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '')
+    .replace(/[?!.,]/g, '');
+
+export const findSupportFaqEntry = (message: string) => {
+  const normalizedMessage = normalizeQuestion(message);
+
+  return (
+    SUPPORT_FAQ_ENTRIES.find((entry) =>
+      entry.keywords.some((keyword) =>
+        normalizedMessage.includes(normalizeQuestion(keyword)),
+      ),
+    ) ?? null
+  );
+};
+
+export const buildSupportChatFallbackMessage = (
+  routeContext: SupportChatRouteContext,
+) =>
+  `${routeContext.pageLabel} 화면과 관련된 문의를 도와드릴 수 있어요.\n현재 챗봇은 고객센터 FAQ 기반으로 동작하고 있습니다. 아래 예시 질문을 눌러주시거나, 문의 내용을 조금 더 구체적으로 적어주시면 비슷한 도움말을 안내해 드릴게요.`;
+
+export const createDefaultRouteContext = (): SupportChatRouteContext => ({
+  pathname: '/',
+  pageLabel: '현재',
+});

--- a/src/features/support-chat/mocks/handlers.ts
+++ b/src/features/support-chat/mocks/handlers.ts
@@ -1,0 +1,137 @@
+import { delay, http, HttpResponse } from 'msw';
+
+import {
+  buildSupportChatFallbackMessage,
+  createDefaultRouteContext,
+  findSupportFaqEntry,
+} from '../data/faqs';
+import type {
+  ChatbotMessageRequest,
+  ChatbotMessageResponse,
+} from '../types/supportChat';
+
+const CHATBOT_BASE_PATH = '/api/v1/chatbot';
+
+type MockChatSession = {
+  id: number;
+  lastReply: string;
+};
+
+const chatSessions = new Map<number, MockChatSession>();
+let nextSessionId = 1;
+
+const toJsonError = (status: number, message: string) =>
+  HttpResponse.json(
+    {
+      error_detail: message,
+    },
+    { status },
+  );
+
+const splitMessageIntoChunks = (message: string) => {
+  const chunks: string[] = [];
+  let cursor = 0;
+
+  while (cursor < message.length) {
+    const size = Math.min(message.length - cursor, cursor % 3 === 0 ? 10 : 14);
+    chunks.push(message.slice(cursor, cursor + size));
+    cursor += size;
+  }
+
+  return chunks;
+};
+
+const createStreamResponse = (sessionId: number, reply: string) => {
+  const encoder = new TextEncoder();
+  const chunks = splitMessageIntoChunks(reply);
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const pushEvent = async (eventName: string, data: object) => {
+        controller.enqueue(
+          encoder.encode(
+            `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`,
+          ),
+        );
+      };
+
+      void (async () => {
+        await pushEvent('start', { session_id: sessionId });
+
+        for (const chunk of chunks) {
+          await delay(140);
+          await pushEvent('chunk', { content: chunk });
+        }
+
+        await delay(100);
+        await pushEvent('complete', { session_id: sessionId });
+        controller.close();
+      })().catch((error) => {
+        controller.error(error);
+      });
+    },
+  });
+
+  return new HttpResponse(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+};
+
+export const supportChatHandlers = [
+  http.post(`${CHATBOT_BASE_PATH}/messages`, async ({ request }) => {
+    const body = (await request.json()) as ChatbotMessageRequest;
+    const message = body.message.trim();
+
+    if (message.length < 2) {
+      return toJsonError(400, '메시지는 공백일 수 없고 2자 이상이어야 합니다.');
+    }
+
+    let sessionId = body.session_id;
+
+    if (sessionId !== undefined && !chatSessions.has(sessionId)) {
+      return toJsonError(404, '만료되었거나 유효하지 않은 session_id 입니다.');
+    }
+
+    if (sessionId === undefined) {
+      sessionId = nextSessionId;
+      nextSessionId += 1;
+    }
+
+    const matchedEntry = findSupportFaqEntry(message);
+    const reply =
+      matchedEntry?.answer ??
+      buildSupportChatFallbackMessage(createDefaultRouteContext());
+
+    chatSessions.set(sessionId, {
+      id: sessionId,
+      lastReply: reply,
+    });
+
+    await delay(180);
+
+    return HttpResponse.json({
+      session_id: sessionId,
+    } satisfies ChatbotMessageResponse);
+  }),
+
+  http.get(`${CHATBOT_BASE_PATH}/stream`, async ({ request }) => {
+    const url = new URL(request.url);
+    const sessionId = Number(url.searchParams.get('session_id'));
+
+    if (Number.isNaN(sessionId) || sessionId <= 0) {
+      return toJsonError(400, '잘못된 session_id 입니다.');
+    }
+
+    const session = chatSessions.get(sessionId);
+
+    if (!session) {
+      return toJsonError(404, '스트리밍 대상 세션을 찾을 수 없습니다.');
+    }
+
+    return createStreamResponse(sessionId, session.lastReply);
+  }),
+];

--- a/src/features/support-chat/store/useSupportChatStore.ts
+++ b/src/features/support-chat/store/useSupportChatStore.ts
@@ -1,24 +1,16 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
-// import {
-//   createDefaultRouteContext,
-//   SUPPORT_CHAT_QUICK_ACTIONS,
-//   SUPPORT_CHAT_WELCOME_MESSAGE,
-// } from '../data/faqs';
+import {
+  createDefaultRouteContext,
+  SUPPORT_CHAT_QUICK_ACTIONS,
+  SUPPORT_CHAT_WELCOME_MESSAGE,
+} from '../data/faqs';
 import type {
   SupportChatMessage,
   SupportChatQuickAction,
   SupportChatRouteContext,
 } from '../types/supportChat';
-
-// Temporary placeholders to fix build errors until PR #74 is merged
-const createDefaultRouteContext = (): SupportChatRouteContext => ({
-  pathname: '/',
-  pageLabel: '홈',
-});
-const SUPPORT_CHAT_QUICK_ACTIONS: SupportChatQuickAction[] = [];
-const SUPPORT_CHAT_WELCOME_MESSAGE = '안녕하세요! 무엇을 도와드릴까요?';
 
 type SupportChatStoreState = {
   sessionId: number | null;


### PR DESCRIPTION
## 관련 이슈

- closes #74

## 변경 내용

- 챗봇 응답 시뮬레이션을 위한 MSW 핸들러 구현 (`src/features/support-chat/mocks/handlers.ts`)
- 자주 묻는 질문(FAQ) 및 초기 환영 메시지 데이터 추가 (`src/features/support-chat/data/faqs.ts`)
- 이전 PR(#72, #73)에서 빌드 에러 방지를 위해 작성했던 임시 코드 및 주석 완벽 제거
- Store 및 Widget 컴포넌트에 실제 FAQ 데이터 및 API 연동 로직 복구 완료

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다. (코드 상의 데이터 연결 확인)
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] MSW를 통해 백엔드 API 명세에 맞춘 스트리밍 응답 구현이 완료되었습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

(백엔드 로직 및 데이터 연결 작업으로, 최종 UI 노출은 다음 PR(#75) 통합 단계에서 확인 가능합니다.)

## 참고사항

- 이제 챗봇의 모든 도메인 로직과 데이터가 연결되어 독립적으로 동작 가능한 상태입니다.
- 마지막 PR(#75)에서 `App.tsx`에 위젯을 최종 등록하면 전체 프로젝트에 반영됩니다.
