### PR TITLE
[Feat] 챗봇 위젯 통합 및 메인 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,13 @@
 import { Outlet } from 'react-router';
+import SupportChatWidget from './components/support-chat/SupportChatWidget';
 
 function App() {
-  return <Outlet />;
+  return (
+    <>
+      <Outlet />
+      <SupportChatWidget />
+    </>
+  );
 }
 
 export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,15 @@
   --color-auth-panel-border: rgba(255, 255, 255, 0.08);
   --shadow-auth-panel: rgba(0, 0, 0, 0.34);
   --shadow-login-primary: rgba(242, 15, 23, 0.42);
+  --color-support-chat-panel: rgba(8, 8, 9, 0.92);
+  --color-support-chat-panel-border: rgba(153, 25, 20, 0.8);
+  --color-support-chat-panel-soft-border: rgba(255, 255, 255, 0.08);
+  --color-support-chat-user: rgba(115, 12, 12, 0.96);
+  --color-support-chat-user-border: rgba(184, 31, 27, 0.6);
+  --color-support-chat-accent: #df3b33;
+  --color-support-chat-accent-hover: #f04b42;
+  --shadow-support-chat-panel: rgba(0, 0, 0, 0.5);
+  --shadow-support-chat-glow: rgba(223, 59, 51, 0.26);
   --color-mypage-panel: rgba(10, 10, 10, 0.92);
   --color-mypage-panel-border: rgba(255, 255, 255, 0.08);
   --color-mypage-divider: rgba(255, 255, 255, 0.1);
@@ -224,6 +233,248 @@
     background-color: rgb(255 255 255 / 0.26);
   }
 
+  .support-chat-panel {
+    border: 1px solid var(--color-support-chat-panel-border);
+    background:
+      linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.04),
+        rgba(255, 255, 255, 0.015)
+      ),
+      var(--color-support-chat-panel);
+    box-shadow:
+      0 30px 60px var(--shadow-support-chat-panel),
+      0 0 0 1px rgba(255, 255, 255, 0.02),
+      0 0 36px var(--shadow-support-chat-glow);
+    backdrop-filter: blur(18px);
+    border-radius: 28px;
+  }
+
+  .support-chat-fab {
+    background:
+      radial-gradient(
+        circle at 30% 20%,
+        rgba(255, 255, 255, 0.24),
+        transparent 38%
+      ),
+      linear-gradient(180deg, #f04b42, #c81913);
+    box-shadow:
+      0 18px 36px rgba(0, 0, 0, 0.34),
+      0 0 28px rgba(223, 59, 51, 0.4);
+  }
+
+  .support-chat-fab-glow {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(
+      circle,
+      rgba(255, 255, 255, 0.16),
+      transparent 62%
+    );
+    opacity: 0.85;
+  }
+
+  .support-chat-header-badge {
+    display: flex;
+    height: 40px;
+    width: 40px;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    border-radius: 16px;
+    border: 1px solid rgba(223, 59, 51, 0.5);
+    background: rgba(223, 59, 51, 0.12);
+    color: #ff7f78;
+    box-shadow: 0 0 20px rgba(223, 59, 51, 0.16);
+  }
+
+  .support-chat-icon-btn {
+    display: inline-flex;
+    height: 36px;
+    width: 36px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 14px;
+    color: rgba(255, 255, 255, 0.66);
+    transition:
+      color 180ms ease,
+      background-color 180ms ease,
+      transform 180ms ease;
+  }
+
+  .support-chat-icon-btn:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: #ffffff;
+  }
+
+  .support-chat-icon-btn:focus-visible {
+    outline: 2px solid rgba(223, 59, 51, 0.46);
+    outline-offset: 2px;
+  }
+
+  .support-chat-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+  }
+
+  .support-chat-scrollbar::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .support-chat-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .support-chat-scrollbar::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.14);
+  }
+
+  .support-chat-bubble-bot {
+    border: 1px solid var(--color-support-chat-panel-soft-border);
+    background:
+      linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.05),
+        rgba(255, 255, 255, 0.03)
+      ),
+      rgba(14, 14, 15, 0.96);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.03),
+      0 18px 36px rgba(0, 0, 0, 0.22);
+  }
+
+  .support-chat-bubble-user {
+    border: 1px solid var(--color-support-chat-user-border);
+    background:
+      linear-gradient(135deg, rgba(152, 22, 18, 0.94), rgba(84, 9, 7, 0.98)),
+      var(--color-support-chat-user);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 18px 36px rgba(80, 6, 6, 0.28);
+  }
+
+  .support-chat-quick-action {
+    border-radius: 18px;
+    border: 1px solid rgba(157, 34, 29, 0.58);
+    background:
+      linear-gradient(180deg, rgba(95, 17, 15, 0.46), rgba(49, 10, 9, 0.6)),
+      rgba(30, 8, 8, 0.9);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.03),
+      0 14px 28px rgba(0, 0, 0, 0.18);
+    transition:
+      transform 180ms ease,
+      border-color 180ms ease,
+      background-color 180ms ease,
+      box-shadow 180ms ease;
+  }
+
+  .support-chat-quick-action:hover {
+    transform: translateX(-2px);
+    border-color: rgba(223, 59, 51, 0.8);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.04),
+      0 16px 30px rgba(56, 8, 8, 0.28);
+  }
+
+  .support-chat-input {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background:
+      linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.05),
+        rgba(255, 255, 255, 0.03)
+      ),
+      rgba(18, 18, 19, 0.96);
+    color: #ffffff;
+    border-radius: 18px;
+    height: 52px;
+    padding: 0 16px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    transition:
+      border-color 180ms ease,
+      box-shadow 180ms ease,
+      background-color 180ms ease;
+  }
+
+  .support-chat-input::placeholder {
+    color: rgba(255, 255, 255, 0.42);
+  }
+
+  .support-chat-input:hover {
+    border-color: rgba(255, 255, 255, 0.16);
+  }
+
+  .support-chat-input:focus {
+    border-color: rgba(223, 59, 51, 0.72);
+    box-shadow:
+      0 0 0 3px rgba(223, 59, 51, 0.14),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    outline: none;
+  }
+
+  .support-chat-send-btn {
+    background:
+      linear-gradient(
+        180deg,
+        var(--color-support-chat-accent-hover),
+        var(--color-support-chat-accent)
+      ),
+      var(--color-support-chat-accent);
+    box-shadow: 0 16px 28px rgba(223, 59, 51, 0.26);
+    transition:
+      transform 180ms ease,
+      box-shadow 180ms ease,
+      background-color 180ms ease;
+  }
+
+  .support-chat-send-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 30px rgba(223, 59, 51, 0.3);
+  }
+
+  .support-chat-send-btn:focus-visible {
+    outline: 2px solid rgba(223, 59, 51, 0.46);
+    outline-offset: 2px;
+  }
+
+  .support-chat-dot {
+    display: inline-block;
+    height: 8px;
+    width: 8px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.8);
+    animation: support-chat-dot 900ms ease-in-out infinite;
+  }
+
+  @keyframes support-chat-dot {
+    0%,
+    80%,
+    100% {
+      transform: translateY(0);
+      opacity: 0.4;
+    }
+
+    40% {
+      transform: translateY(-3px);
+      opacity: 1;
+    }
+  }
+
+  @keyframes support-chat-message-in {
+    0% {
+      transform: translateY(8px);
+      opacity: 0;
+    }
+
+    100% {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+
   .auth-input-autofill:-webkit-autofill,
   .auth-input-autofill:-webkit-autofill:hover,
   .auth-input-autofill:-webkit-autofill:focus,
@@ -242,6 +493,16 @@
 @media (max-width: 1024px) {
   .survey-grid {
     grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .support-chat-panel {
+    right: 0.5rem;
+    bottom: 5rem;
+    width: calc(100vw - 1rem);
+    height: min(76vh, 40rem);
+    border-radius: 24px;
   }
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import App from './App';
 import { ROUTES } from './constants/routes';
@@ -65,7 +64,6 @@ const renderApp = () => {
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
         <RouterProvider router={router} />
-        <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </React.StrictMode>,
   );

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,9 +1,11 @@
 import { authHandlers } from '../features/auth/mocks/handlers';
 import { matchingHandlers } from '../features/matching/mocks/handlers';
+import { supportChatHandlers } from '../features/support-chat/mocks/handlers';
 import { surveyHandlers } from '../features/survey/mocks/handlers';
 
 export const handlers = [
   ...authHandlers,
+  ...supportChatHandlers,
   ...surveyHandlers,
   ...matchingHandlers,
 ];


### PR DESCRIPTION
## 관련 이슈

- closes #75

## 변경 내용

- 챗봇 위젯(`SupportChatWidget`)을 `App.tsx` 전역 레이아웃에 등록하여 모든 서비스 페이지에서 접근 가능하도록 통합
- 전역 MSW 핸들러(`src/mocks/handlers.ts`)에 챗봇 관련 API 모킹 핸들러 등록
- `index.css`에 챗봇 UI 전용 스타일, 반응형 레이아웃, 애니메이션 효과 최종 반영
- 프로젝트 메인 엔트리(`main.tsx`)의 MSW 활성화 설정 및 스타일링 최종 점검 완료

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저 우측 하단에 챗봇 위젯 버튼이 정상적으로 노출되는지 확인
- [x] 위젯 클릭 시 채팅창 오픈 및 환영 메시지 출력 확인
- [x] 질문 입력 및 퀵 액션 버튼 클릭 시 스트리밍 응답 정상 작동 확인

## 요구사항 및 API 영향

- [x] 요구사항 정의서에 명시된 전역 고객센터 챗봇 기능 구현 완료
- [x] MSW를 이용한 프론트엔드 독립 테스트 환경 구축 완료

## 스크린샷
[화면 기록 2026-04-17 오후 2.49.15.mov.zip](https://github.com/user-attachments/files/26811008/2026-04-17.2.49.15.mov.zip)


## 참고사항

- 이번 PR을 끝으로 챗봇 고객센터 기능(PR #72 ~ #75)의 모든 단계별 통합이 완료되었습니다.
- 모든 도메인 로직, UI 컴포넌트, 목 데이터가 유기적으로 연결되어 정상 동작함을 확인했습니다.
