### PR TITLE
[Feat] 게임 상세 모달 좋아요 API 연동

### DIFF
--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -1,7 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { ExternalLink, Heart, PlayCircle, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { getGameDetail } from '../gameApi';
+import { useAuthStore } from '../../../store/useAuthStore';
+import { getGameDetail, likeGame, unlikeGame } from '../gameApi';
 import type { GameDetail, GameListItem } from '../types';
 
 type GameDetailModalProps = {
@@ -24,42 +26,102 @@ const formatDetailRating = (rating: number | null) =>
 const formatNullableText = (value: string | null | undefined) =>
   value?.trim() ? value : 'N/A';
 
-const getLikeCountAdjustment = ({
-  isLiked,
-  sourceLiked,
-}: {
-  isLiked: boolean;
-  sourceLiked: boolean;
-}) => {
-  if (isLiked === sourceLiked) {
-    return 0;
+const LOGIN_REQUIRED_MESSAGE = '로그인 후 찜하기를 사용할 수 있어요.';
+const LIKE_ERROR_MESSAGE =
+  '찜하기 상태를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+const DETAIL_NOT_FOUND_TITLE = '게임 상세 정보 없음';
+const DETAIL_NOT_FOUND_MESSAGE = '해당 게임 상세 정보를 찾을 수 없습니다.';
+
+const getLikeErrorMessage = (error: unknown) => {
+  if (error instanceof AxiosError) {
+    if (error.response?.status === 401) {
+      return LOGIN_REQUIRED_MESSAGE;
+    }
+
+    if (error.response?.status === 404) {
+      return DETAIL_NOT_FOUND_MESSAGE;
+    }
   }
 
-  return isLiked ? 1 : -1;
+  return LIKE_ERROR_MESSAGE;
 };
 
 const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
-  const [likedOverride, setLikedOverride] = useState<boolean | null>(null);
-  const [failedImageUrls, setFailedImageUrls] = useState<string[]>([]);
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const queryClient = useQueryClient();
+  const [likeState, setLikeState] = useState<{
+    gameId: number;
+    isLiked: boolean | null;
+    likeCount: number;
+  } | null>(null);
+  const [likeFeedback, setLikeFeedback] = useState<{
+    gameId: number;
+    message: string;
+  } | null>(null);
+  const [failedImageUrlsByGameId, setFailedImageUrlsByGameId] = useState<
+    Record<number, string[]>
+  >({});
 
   const detailQuery = useQuery({
     queryKey: ['games', 'detail', game.gameId],
     queryFn: () => getGameDetail(game.gameId),
     staleTime: 60_000,
+    retry: false,
+  });
+
+  const likeMutation = useMutation({
+    mutationFn: (nextLiked: boolean) =>
+      nextLiked ? likeGame(game.gameId) : unlikeGame(game.gameId),
+    onMutate: () => {
+      setLikeFeedback(null);
+    },
+    onSuccess: (response) => {
+      const nextLikeState = {
+        gameId: response.gameId,
+        isLiked: response.isLiked,
+        likeCount: response.likeCount,
+      };
+
+      setLikeState(nextLikeState);
+      queryClient.setQueryData<GameDetail>(
+        ['games', 'detail', game.gameId],
+        (currentDetail) =>
+          currentDetail
+            ? {
+                ...currentDetail,
+                isLiked: response.isLiked,
+                likeCount: response.likeCount,
+              }
+            : currentDetail,
+      );
+    },
+    onError: (error) => {
+      setLikeFeedback({
+        gameId: game.gameId,
+        message: getLikeErrorMessage(error),
+      });
+    },
   });
 
   const detail = detailQuery.data;
   const title = detail?.title ?? game.name;
   const genres = detail?.genres.length ? detail.genres : game.genres;
   const genreLabel = genres.length > 0 ? genres.join(', ') : 'N/A';
-  const sourceLiked = Boolean(detail?.isLiked ?? game.isLiked);
-  const isLiked = likedOverride ?? sourceLiked;
-  const likeLabel = isLiked ? '찜 해제' : '찜하기';
-  const likeCountAdjustment = getLikeCountAdjustment({
-    isLiked,
-    sourceLiked,
-  });
-  const likeCount = Math.max(0, (detail?.likeCount ?? 0) + likeCountAdjustment);
+  const activeLikeState = likeState?.gameId === game.gameId ? likeState : null;
+  const activeLikeFeedback =
+    likeFeedback?.gameId === game.gameId ? likeFeedback.message : null;
+  const currentLiked =
+    activeLikeState?.isLiked ??
+    detail?.isLiked ??
+    (typeof game.isLiked === 'boolean' ? game.isLiked : null);
+  const isLiked = currentLiked === true;
+  const likeLabel = isLiked ? '찜하기 취소' : '찜하기';
+  const likeCount = Math.max(
+    0,
+    activeLikeState?.likeCount ?? detail?.likeCount ?? 0,
+  );
+  const hasAccessToken = Boolean(accessToken);
+  const failedImageUrls = failedImageUrlsByGameId[game.gameId] ?? [];
   const imageCandidates = [detail?.coverImageUrl, game.thumbnailUrl].filter(
     (url): url is string => Boolean(url),
   );
@@ -78,8 +140,21 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
     label,
     url: detail?.externalLinks[key],
   })).filter((link): link is { label: string; url: string } =>
-    Boolean(link.url && link.url !== 'N/A'),
+    Boolean(link.url?.trim() && link.url.trim() !== 'N/A'),
   );
+
+  const handleToggleLike = () => {
+    if (!hasAccessToken) {
+      setLikeFeedback({
+        gameId: game.gameId,
+        message: LOGIN_REQUIRED_MESSAGE,
+      });
+      return;
+    }
+
+    likeMutation.mutate(!isLiked);
+  };
+
   useEffect(() => {
     const previousBodyOverflow = document.body.style.overflow;
     const previousBodyPaddingRight = document.body.style.paddingRight;
@@ -132,136 +207,164 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
           <X aria-hidden="true" className="h-5 w-5" />
         </button>
 
-        <div className="grid gap-5 px-5 pt-5 pb-6 sm:grid-cols-[216px_minmax(0,1fr)] sm:px-7 sm:pt-7">
-          <div className="relative isolate aspect-4/5 w-[min(56vw,13.5rem)] max-w-full overflow-hidden rounded-lg border border-white/10 bg-[#1a1a1a] sm:w-54">
-            {imageUrl ? (
-              <img
-                src={imageUrl}
-                alt={`${title} 커버 이미지`}
-                className="relative z-0 h-full w-full object-cover"
-                onError={() => {
-                  setFailedImageUrls((current) =>
-                    current.includes(imageUrl)
-                      ? current
-                      : [...current, imageUrl],
-                  );
-                }}
-              />
-            ) : (
-              <div className="relative z-0 flex h-full w-full items-center justify-center text-xs text-white/45">
-                이미지 N/A
-              </div>
-            )}
-          </div>
-
-          <div className="min-w-0 sm:pr-12">
-            <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3 pr-10 sm:items-center sm:pr-0">
-              <h2
-                id="game-detail-modal-title"
-                className="min-w-0 truncate text-2xl leading-tight font-bold sm:text-3xl"
-                title={title}
-              >
-                {title}
-              </h2>
-              <button
-                type="button"
-                aria-label={likeLabel}
-                aria-pressed={isLiked}
-                title={likeLabel}
-                onClick={() =>
-                  setLikedOverride((current) => !(current ?? sourceLiked))
-                }
-                className={`inline-flex h-10 shrink-0 cursor-pointer items-center gap-2 rounded-md border px-3 text-sm font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12] ${
-                  isLiked
-                    ? 'border-[#ff4b55]/60 bg-[#251010] text-white hover:border-[#ff4b55]/90 hover:bg-[#2d1113]'
-                    : 'border-white/15 bg-white/4 text-white/78 hover:border-[#ff4b55]/60 hover:bg-white/8 hover:text-white'
-                }`}
-              >
-                <Heart
-                  aria-hidden="true"
-                  className={`h-4.5 w-4.5 transition ${
-                    isLiked
-                      ? 'fill-current text-[#ff4b55]'
-                      : 'fill-transparent text-[#ff4b55]'
-                  }`}
-                />
-                <span>찜하기</span>
-              </button>
-            </div>
-            <p className="mt-3 text-sm text-white/65">{genreLabel}</p>
-            <p className="mt-2 text-sm text-white/70">
-              평점{' '}
-              <span className="font-semibold text-[#ff4b55]">
-                {formatDetailRating(game.rating)}
-              </span>
-              <span className="mx-2 text-white/24">|</span>
-              좋아요{' '}
-              <span className="font-semibold text-white/86">
-                {likeCount.toLocaleString('ko-KR')}
-              </span>
-            </p>
-            <p className="mt-5 line-clamp-5 text-sm leading-6 text-white/60 sm:line-clamp-6">
-              {detailQuery.isLoading
-                ? '상세 정보를 불러오는 중입니다.'
-                : formatNullableText(detail?.description)}
+        {detailQuery.isError ? (
+          <div className="flex min-h-[24rem] flex-col items-center justify-center px-6 py-16 text-center sm:px-10">
+            <h2
+              id="game-detail-modal-title"
+              className="text-2xl font-bold text-white sm:text-3xl"
+            >
+              {DETAIL_NOT_FOUND_TITLE}
+            </h2>
+            <p className="mt-4 max-w-md text-sm leading-6 text-white/60 sm:text-base">
+              {DETAIL_NOT_FOUND_MESSAGE}
             </p>
           </div>
-        </div>
+        ) : (
+          <>
+            <div className="grid gap-5 px-5 pt-5 pb-6 sm:grid-cols-[216px_minmax(0,1fr)] sm:px-7 sm:pt-7">
+              <div className="relative isolate aspect-4/5 w-[min(56vw,13.5rem)] max-w-full overflow-hidden rounded-lg border border-white/10 bg-[#1a1a1a] sm:w-54">
+                {imageUrl ? (
+                  <img
+                    src={imageUrl}
+                    alt={`${title} 커버 이미지`}
+                    className="relative z-0 h-full w-full object-cover"
+                    onError={() => {
+                      setFailedImageUrlsByGameId((current) => {
+                        const currentUrls = current[game.gameId] ?? [];
 
-        <div className="px-5 pb-6 sm:px-7 sm:pb-7">
-          <div className="flex aspect-video min-h-44 items-center justify-center overflow-hidden rounded-lg border border-[#5a1115]/70 bg-[#2a1711] shadow-[inset_0_0_42px_rgba(255,75,85,0.08)] sm:min-h-72">
-            <div className="px-4 text-center">
-              <PlayCircle
-                aria-hidden="true"
-                className="mx-auto h-12 w-12 text-white/55 sm:h-16 sm:w-16"
-              />
-              <p className="mt-4 text-sm font-semibold text-white/75 sm:text-base">
-                프로모션 동영상 영역
-              </p>
-              <p className="mt-2 text-xs text-white/45 sm:text-sm">
-                영상 URL 정책이 확정되면 이 영역에 iframe을 연결합니다.
-              </p>
-            </div>
-          </div>
+                        if (currentUrls.includes(imageUrl)) {
+                          return current;
+                        }
 
-          <dl className="mt-6 divide-y divide-white/10 border-y border-white/10">
-            {detailRows.map((row) => (
-              <div
-                key={row.label}
-                className="grid gap-1 py-4 text-sm sm:grid-cols-[140px_minmax(0,1fr)] sm:gap-4"
-              >
-                <dt className="text-white/65">{row.label}</dt>
-                <dd className="text-white/80">{row.value}</dd>
-              </div>
-            ))}
-            <div className="grid items-center gap-3 py-4 text-sm sm:grid-cols-[140px_minmax(0,1fr)] sm:gap-4">
-              <dt className="text-white/65">외부 링크</dt>
-              <dd className="text-white/80">
-                {externalLinks.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    {externalLinks.map((link) => (
-                      <a
-                        key={link.label}
-                        href={link.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="inline-flex min-h-10 items-center gap-2 rounded-md border border-white/12 bg-white/4 px-3 text-sm font-semibold text-white/78 transition hover:border-[#ff4b55]/50 hover:bg-white/8 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]"
-                      >
-                        <span>{link.label}</span>
-                        <ExternalLink
-                          aria-hidden="true"
-                          className="h-3.5 w-3.5"
-                        />
-                      </a>
-                    ))}
-                  </div>
+                        return {
+                          ...current,
+                          [game.gameId]: [...currentUrls, imageUrl],
+                        };
+                      });
+                    }}
+                  />
                 ) : (
-                  'N/A'
+                  <div className="relative z-0 flex h-full w-full items-center justify-center text-xs text-white/45">
+                    이미지 N/A
+                  </div>
                 )}
-              </dd>
+              </div>
+
+              <div className="min-w-0 sm:pr-12">
+                <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3 pr-10 sm:items-center sm:pr-0">
+                  <h2
+                    id="game-detail-modal-title"
+                    className="min-w-0 truncate text-2xl leading-tight font-bold sm:text-3xl"
+                    title={title}
+                  >
+                    {title}
+                  </h2>
+                  <button
+                    type="button"
+                    aria-label={likeLabel}
+                    aria-pressed={isLiked}
+                    aria-disabled={!hasAccessToken}
+                    title={likeLabel}
+                    disabled={likeMutation.isPending}
+                    onClick={handleToggleLike}
+                    className={`inline-flex h-10 shrink-0 cursor-pointer items-center gap-2 rounded-md border px-3 text-sm font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12] disabled:cursor-wait disabled:opacity-70 ${
+                      isLiked
+                        ? 'border-[#ff4b55]/60 bg-[#251010] text-white hover:border-[#ff4b55]/90 hover:bg-[#2d1113]'
+                        : 'border-white/15 bg-white/4 text-white/78 hover:border-[#ff4b55]/60 hover:bg-white/8 hover:text-white'
+                    }`}
+                  >
+                    <Heart
+                      aria-hidden="true"
+                      className={`h-4.5 w-4.5 transition ${
+                        isLiked
+                          ? 'fill-current text-[#ff4b55]'
+                          : 'fill-transparent text-[#ff4b55]'
+                      }`}
+                    />
+                    <span>찜하기</span>
+                  </button>
+                </div>
+                <p className="mt-3 text-sm text-white/65">{genreLabel}</p>
+                <p className="mt-2 text-sm text-white/70">
+                  평점{' '}
+                  <span className="font-semibold text-[#ff4b55]">
+                    {formatDetailRating(game.rating)}
+                  </span>
+                  <span className="mx-2 text-white/24">|</span>
+                  좋아요{' '}
+                  <span className="font-semibold text-white/86">
+                    {likeCount.toLocaleString('ko-KR')}
+                  </span>
+                </p>
+                {activeLikeFeedback ? (
+                  <p role="status" className="mt-3 text-xs text-[#ffb4b8]">
+                    {activeLikeFeedback}
+                  </p>
+                ) : null}
+                <p className="mt-5 line-clamp-5 text-sm leading-6 text-white/60 sm:line-clamp-6">
+                  {detailQuery.isLoading
+                    ? '상세 정보를 불러오는 중입니다.'
+                    : formatNullableText(detail?.description)}
+                </p>
+              </div>
             </div>
-          </dl>
-        </div>
+
+            <div className="px-5 pb-6 sm:px-7 sm:pb-7">
+              <div className="flex aspect-video min-h-44 items-center justify-center overflow-hidden rounded-lg border border-[#5a1115]/70 bg-[#2a1711] shadow-[inset_0_0_42px_rgba(255,75,85,0.08)] sm:min-h-72">
+                <div className="px-4 text-center">
+                  <PlayCircle
+                    aria-hidden="true"
+                    className="mx-auto h-12 w-12 text-white/55 sm:h-16 sm:w-16"
+                  />
+                  <p className="mt-4 text-sm font-semibold text-white/75 sm:text-base">
+                    프로모션 동영상 영역
+                  </p>
+                  <p className="mt-2 text-xs text-white/45 sm:text-sm">
+                    영상 URL 정책이 확정되면 이 영역에 iframe을 연결합니다.
+                  </p>
+                </div>
+              </div>
+
+              <dl className="mt-6 divide-y divide-white/10 border-y border-white/10">
+                {detailRows.map((row) => (
+                  <div
+                    key={row.label}
+                    className="grid gap-1 py-4 text-sm sm:grid-cols-[140px_minmax(0,1fr)] sm:gap-4"
+                  >
+                    <dt className="text-white/65">{row.label}</dt>
+                    <dd className="text-white/80">{row.value}</dd>
+                  </div>
+                ))}
+                <div className="grid items-center gap-3 py-4 text-sm sm:grid-cols-[140px_minmax(0,1fr)] sm:gap-4">
+                  <dt className="text-white/65">외부 링크</dt>
+                  <dd className="text-white/80">
+                    {externalLinks.length > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {externalLinks.map((link) => (
+                          <a
+                            key={link.label}
+                            href={link.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex min-h-10 items-center gap-2 rounded-md border border-white/12 bg-white/4 px-3 text-sm font-semibold text-white/78 transition hover:border-[#ff4b55]/50 hover:bg-white/8 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]"
+                          >
+                            <span>{link.label}</span>
+                            <ExternalLink
+                              aria-hidden="true"
+                              className="h-3.5 w-3.5"
+                            />
+                          </a>
+                        ))}
+                      </div>
+                    ) : (
+                      'N/A'
+                    )}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </>
+        )}
       </section>
     </div>
   );

--- a/src/features/games/gameApi.ts
+++ b/src/features/games/gameApi.ts
@@ -1,12 +1,16 @@
+import { AxiosError } from 'axios';
+
 import { api } from '../../api/axios';
 import { getGameGenreId, matchesGenreFilter } from './genres';
 import { mockTopGames } from './mockGames';
 import type {
   GameDetail,
+  GameLikeResponse,
   GameListItem,
   GameListResponse,
   GetTopGamesParams,
   RawGameDetailResponse,
+  RawGameLikeResponse,
   RawGameListItem,
   SearchGamesParams,
 } from './types';
@@ -28,6 +32,18 @@ const getMockDetail = async (gameId: number) => {
   return getMockGameDetail(gameId);
 };
 
+const updateMockLikeStatus = async (gameId: number, isLiked: boolean) => {
+  const { updateMockGameLikeStatus } = await import('./mockGameDetails');
+
+  return updateMockGameLikeStatus(gameId, isLiked);
+};
+
+const normalizeNullableString = (value: string | null | undefined) => {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue && trimmedValue !== 'N/A' ? trimmedValue : null;
+};
+
 const normalizeGameListItem = (game: RawGameListItem): GameListItem => ({
   gameId: game.game_id,
   name: game.name || 'N/A',
@@ -44,8 +60,9 @@ const normalizeGameDetail = (game: RawGameDetailResponse): GameDetail => ({
   releaseDate: game.release_date || null,
   developer: game.developer || null,
   publisher: game.publisher || null,
-  promoVideoUrl: game.media?.promo_video_url || null,
-  coverImageUrl: game.media?.cover_image_url || null,
+  promoVideoUrl: normalizeNullableString(game.media?.promo_video_url),
+  promoEmbedUrl: normalizeNullableString(game.media?.promo_embed_url),
+  coverImageUrl: normalizeNullableString(game.media?.cover_image_url),
   description: game.description || null,
   platforms:
     game.platforms
@@ -53,13 +70,24 @@ const normalizeGameDetail = (game: RawGameDetailResponse): GameDetail => ({
       .filter((name): name is string => Boolean(name))
       .map((name) => ({ name })) ?? [],
   externalLinks: {
-    officialSite: game.external_links?.official_site || null,
-    steam: game.external_links?.steam || null,
-    epicStore: game.external_links?.epic_store || null,
+    officialSite: normalizeNullableString(game.external_links?.official_site),
+    steam: normalizeNullableString(game.external_links?.steam),
+    epicStore: normalizeNullableString(game.external_links?.epic_store),
   },
   likeCount: game.like_count ?? 0,
   isLiked: typeof game.is_liked === 'boolean' ? game.is_liked : null,
 });
+
+const normalizeGameLikeResponse = (
+  response: RawGameLikeResponse,
+): GameLikeResponse => ({
+  gameId: response.game_id,
+  isLiked: response.is_liked,
+  likeCount: response.like_count ?? 0,
+});
+
+const isNotFoundError = (error: unknown) =>
+  error instanceof AxiosError && error.response?.status === 404;
 
 const filterGames = (
   games: GameListItem[],
@@ -146,7 +174,35 @@ export const getGameDetail = async (gameId: number): Promise<GameDetail> => {
     );
 
     return normalizeGameDetail(response.data);
-  } catch {
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      throw error;
+    }
+
     return getMockDetail(gameId);
   }
+};
+
+export const likeGame = async (gameId: number): Promise<GameLikeResponse> => {
+  if (!hasApiBaseUrl) {
+    return updateMockLikeStatus(gameId, true);
+  }
+
+  const response = await api.post<RawGameLikeResponse>(
+    `/api/v1/games/${gameId}/like`,
+  );
+
+  return normalizeGameLikeResponse(response.data);
+};
+
+export const unlikeGame = async (gameId: number): Promise<GameLikeResponse> => {
+  if (!hasApiBaseUrl) {
+    return updateMockLikeStatus(gameId, false);
+  }
+
+  const response = await api.delete<RawGameLikeResponse>(
+    `/api/v1/games/${gameId}/like`,
+  );
+
+  return normalizeGameLikeResponse(response.data);
 };

--- a/src/features/games/mockGameDetails.ts
+++ b/src/features/games/mockGameDetails.ts
@@ -23,6 +23,7 @@ const createMockGameDetail = ({
   promoVideoUrl = `https://www.youtube.com/results?search_query=${encodeURIComponent(
     `${title} 공식 트레일러`,
   )}`,
+  promoEmbedUrl = null,
 }: {
   gameId: number;
   title: string;
@@ -37,6 +38,7 @@ const createMockGameDetail = ({
   officialSite?: string | null;
   epicStore?: string | null;
   promoVideoUrl?: string | null;
+  promoEmbedUrl?: string | null;
 }): GameDetail => ({
   gameId,
   title,
@@ -45,6 +47,7 @@ const createMockGameDetail = ({
   developer,
   publisher,
   promoVideoUrl,
+  promoEmbedUrl,
   coverImageUrl: steamCoverUrl(gameId),
   description,
   platforms: platforms.map((name) => ({ name })),
@@ -378,6 +381,7 @@ export const getMockGameDetail = (gameId: number): GameDetail => {
     developer: null,
     publisher: null,
     promoVideoUrl: null,
+    promoEmbedUrl: null,
     coverImageUrl: game?.thumbnailUrl ?? null,
     description: null,
     platforms: [],
@@ -388,5 +392,22 @@ export const getMockGameDetail = (gameId: number): GameDetail => {
     },
     likeCount: 0,
     isLiked: game?.isLiked ?? null,
+  };
+};
+
+export const updateMockGameLikeStatus = (gameId: number, isLiked: boolean) => {
+  const detail = mockGameDetails[gameId] ?? getMockGameDetail(gameId);
+  const currentLiked = detail.isLiked === true;
+  const likeCountAdjustment = currentLiked === isLiked ? 0 : isLiked ? 1 : -1;
+  const likeCount = Math.max(0, detail.likeCount + likeCountAdjustment);
+
+  detail.isLiked = isLiked;
+  detail.likeCount = likeCount;
+  mockGameDetails[gameId] = detail;
+
+  return {
+    gameId,
+    isLiked,
+    likeCount,
   };
 };

--- a/src/features/games/types.ts
+++ b/src/features/games/types.ts
@@ -32,6 +32,7 @@ export type GameDetail = {
   developer: string | null;
   publisher: string | null;
   promoVideoUrl: string | null;
+  promoEmbedUrl: string | null;
   coverImageUrl: string | null;
   description: string | null;
   platforms: Array<{ name: string }>;
@@ -53,6 +54,7 @@ export type RawGameDetailResponse = {
   publisher: string | null;
   media: {
     promo_video_url?: string | null;
+    promo_embed_url?: string | null;
     cover_image_url?: string | null;
   } | null;
   description: string | null;
@@ -64,6 +66,18 @@ export type RawGameDetailResponse = {
   } | null;
   like_count: number | null;
   is_liked: boolean | null;
+};
+
+export type GameLikeResponse = {
+  gameId: number;
+  isLiked: boolean;
+  likeCount: number;
+};
+
+export type RawGameLikeResponse = {
+  game_id: number;
+  is_liked: boolean;
+  like_count: number | null;
 };
 
 export type GetTopGamesParams = {


### PR DESCRIPTION
## 관련 이슈

- closes #80

## 변경 내용

- 게임 상세 응답 타입에 `promoEmbedUrl`을 추가했습니다.
- 상세 응답 정규화에서 `promo_embed_url`, URL `null`/`"N/A"`, `like_count: null` 정책을 반영했습니다.
- `POST /api/v1/games/{game_id}/like`, `DELETE /api/v1/games/{game_id}/like` API 함수를 추가했습니다.
- 상세 모달 찜하기 버튼을 실제 좋아요 API mutation으로 연결했습니다.
- 좋아요 응답의 `is_liked`, `like_count`로 상세 모달 UI를 갱신하도록 했습니다.
- 비로그인 상태에서는 좋아요 API를 호출하지 않고 안내 문구를 표시하도록 했습니다.
- 상세 조회 404 시 모달 내부 빈 상태를 표시하도록 했습니다.
- mock 환경에서도 좋아요 상태와 좋아요 수가 변경되도록 했습니다.
- 영상 영역은 기존 placeholder 상태를 유지했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- 인증 구조 변경 전까지 로그인 여부는 현재 `useAuthStore.accessToken` 기준으로 판단합니다.
- `promo_embed_url`은 타입과 정규화에만 반영했고, 실제 iframe 렌더링은 후속 작업으로 분리했습니다.
- `npm run build`에서 Vite chunk size warning이 발생하지만 빌드는 성공했습니다.