### PR TITLE
[Docs] 게임 상세 API 계약 문서 갱신

### DIFF
--- a/docs/ai/api-contract.md
+++ b/docs/ai/api-contract.md
@@ -53,9 +53,10 @@ type GameDetail = {
   developer: string | null;
   publisher: string | null;
   promoVideoUrl: string | null;
+  promoEmbedUrl: string | null;
   coverImageUrl: string | null;
   description: string | null;
-  platforms: Array<{ name: string; iconUrl: string | null }>;
+  platforms: Array<{ name: string }>;
   externalLinks: {
     officialSite?: string | null;
     steam?: string | null;
@@ -66,15 +67,51 @@ type GameDetail = {
 };
 ```
 
-명세의 상세 응답에는 `create_date`와 예시의 `created_date`처럼 표기 차이가 있습니다.
-화면에서는 해당 값을 직접 사용하지 말고, 필요해지면 API 정규화 함수에서 처리합니다.
+백엔드 원본 응답에서 데이터가 없는 값은 `"N/A"` 문자열이 아니라 `null`로 받는 것을 기준으로 합니다.
+화면의 `N/A` 표기는 컴포넌트 또는 정규화 이후 표시 계층에서 처리합니다.
+
+`like_count`는 원본 응답에서 `null`일 수 있고, 프론트 정규화 이후에는 `0`으로 사용합니다.
+`is_liked`는 로그인 유저 기준 `true | false`, 비로그인 기준 `null`로 처리합니다.
+`promo_embed_url`은 iframe 연결을 위한 필드로 타입과 정규화까지만 반영하고, 실제 iframe 렌더링은 후속 작업에서 처리합니다.
+
+상세 조회가 `404 Not Found`를 반환하면 상세 모달 안에서 아래 빈 상태를 표시합니다.
+
+```text
+해당 게임 상세 정보를 찾을 수 없습니다.
+```
+
+## Like Response Shape
+
+좋아요 등록/취소 응답은 화면에서 아래 형태로 정규화해서 사용합니다.
+
+```ts
+type GameLikeResponse = {
+  gameId: number;
+  isLiked: boolean;
+  likeCount: number;
+};
+```
+
+백엔드 원본 응답은 아래 필드를 내려주는 것을 기준으로 합니다.
+
+```json
+{
+  "game_id": 501,
+  "is_liked": true,
+  "like_count": 1251
+}
+```
+
+상세 모달은 좋아요 등록/취소 이후 별도 재조회 없이 이 응답의 `is_liked`, `like_count`로 UI를 갱신합니다.
+비로그인 상태에서는 좋아요 API를 호출하지 않고 로그인 안내 문구를 표시합니다.
 
 ## Contract Notes and Uncertainties
 
 - `GET /api/v1/games/list/top100`과 `GET /api/v1/games/list`는 선택 장르가 있을 때 `genre_id`를 전달합니다.
 - `genre_id`는 1~14 범위를 사용하고, 전체 조회는 `genre_id`를 보내지 않습니다. 유효하지 않은 값은 `400 Bad Request`로 처리합니다.
 - 상세 응답 필드명은 `title`, 목록 응답 필드명은 `name`으로 다릅니다.
-- 좋아요 상태는 상세 응답의 `is_liked`와 별도 `like-status` API가 함께 존재합니다. 상세 조회 응답을 우선 사용하고, 백엔드 정책이 바뀌면 별도 조회로 전환합니다.
+- 좋아요 상태는 상세 응답의 `is_liked`를 우선 사용합니다. 별도 `like-status` API는 상태 재검증이 필요할 때만 사용합니다.
+- 상세 미디어 응답의 `promo_video_url`은 원본 영상 URL, `promo_embed_url`은 iframe용 URL로 구분합니다.
 
 정렬 기준은 새 요구사항 정의서 기준으로 평점순/최신순이며, API 명세의 `rating_desc`/`created_at`과 의미가 맞습니다.
 

--- a/docs/ai/task-template.md
+++ b/docs/ai/task-template.md
@@ -81,7 +81,7 @@
 
 ## Data and State
 
-- API 요청: genre_id=0 기준 전체 조회 준비
+- API 요청: 전체 조회는 genre_id 미전달, 장르 선택 시 genre_id=1~14 전달
 - 화면에서 사용할 타입: GameListItem
 - 로딩/에러/빈 상태: skeleton, 에러 메시지, 빈 목록 안내
 


### PR DESCRIPTION
## 관련 이슈

- closes #81

## 변경 내용

- 게임 상세 응답 타입에 `promoEmbedUrl`을 추가했습니다.
- `platforms` 타입을 현재 구현과 백엔드 명세 기준인 `Array<{ name: string }>`로 정리했습니다.
- 데이터 없음은 API `null`, 화면 표기는 프론트 `N/A` 기준으로 문서화했습니다.
- `like_count: null`은 프론트 정규화 후 `0`으로 사용한다고 명시했습니다.
- 로그인/비로그인 `is_liked` 기준을 문서화했습니다.
- 좋아요 등록/취소 응답 shape를 문서화했습니다.
- 상세 조회 404 시 모달 내부 빈 상태를 표시한다고 명시했습니다.
- `promo_embed_url`은 후속 iframe 연결용 필드라고 명시했습니다.
- `docs/ai/task-template.md`의 `genre_id=0` 예시를 제거하고, 전체 조회는 `genre_id` 미전달 기준으로 수정했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- 문서 변경만 포함합니다.
- 인증, 소셜 로그인, 설문, 추천 결과 API 계약 문서 갱신은 각 담당자 PR에서 처리합니다.
- 문서 PR이라 런타임 동작 변경은 없습니다.
- `git diff --check` 통과했습니다.
- `npm run build`에서 Vite chunk size warning이 발생하지만 빌드는 성공했습니다.