### PR TITLE
[Feat] 헤더 로그아웃 마감

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,13 +1,15 @@
 import { Link } from 'react-router';
 import { ROUTES } from '../../constants/routes';
+import { useAuthStore } from '../../store/useAuthStore';
 import HeaderProfileMenu from './HeaderProfileMenu';
 
 type HeaderProps = {
-  isLoggedIn?: boolean;
   fixed?: boolean;
 };
 
-const Header = ({ isLoggedIn = false, fixed = true }: HeaderProps) => {
+const Header = ({ fixed = true }: HeaderProps) => {
+  const isLoggedIn = useAuthStore((state) => Boolean(state.accessToken));
+
   return (
     <header
       className={`header-shell h-16 w-full lg:h-18 ${

--- a/src/components/common/HeaderProfileMenu.tsx
+++ b/src/components/common/HeaderProfileMenu.tsx
@@ -5,6 +5,8 @@ import profileImg from '../../assets/프로필 이미지.png';
 import { ROUTES } from '../../constants/routes';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
 
+const PROFILE_MENU_ID = 'header-profile-menu';
+
 function HeaderProfileMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -42,24 +44,34 @@ function HeaderProfileMenu() {
   }, [isOpen]);
 
   return (
-    <div ref={containerRef} className="relative">
+    <div
+      ref={containerRef}
+      className="relative"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setIsOpen(false);
+        }
+      }}
+    >
       <button
         type="button"
-        aria-label="프로필 메뉴 열기"
+        aria-label={isOpen ? '프로필 메뉴 닫기' : '프로필 메뉴 열기'}
         aria-haspopup="menu"
         aria-expanded={isOpen}
+        aria-controls={PROFILE_MENU_ID}
         onClick={() => setIsOpen((current) => !current)}
         className="hover:border-header-accent h-10 w-10 cursor-pointer overflow-hidden rounded-full border-2 border-transparent transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
       >
         <img
           src={profileImg}
-          alt="Profile"
+          alt="프로필 이미지"
           className="h-full w-full object-cover"
         />
       </button>
 
       {isOpen ? (
         <div
+          id={PROFILE_MENU_ID}
           role="menu"
           aria-label="프로필 메뉴"
           className="bg-mypage-panel border-mypage-panel shadow-mypage-float absolute top-[calc(100%+0.85rem)] right-0 z-50 w-40 overflow-hidden rounded-2xl border p-2 backdrop-blur-xl"

--- a/src/features/auth/hooks/useLogoutAction.ts
+++ b/src/features/auth/hooks/useLogoutAction.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 
 import { ROUTES } from '../../../constants/routes';
@@ -6,24 +7,20 @@ import { useLogoutMutation } from '../api/useAuthApi';
 
 function useLogoutAction() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const logoutMutation = useLogoutMutation();
 
-  const logout = async (
-    noticeMessage = '로그아웃 되었습니다. 다시 로그인해 주세요.',
-  ) => {
+  const logout = async () => {
     try {
       await logoutMutation.mutateAsync();
     } catch {
-      // Even if the API call fails, clear the local session so the user can recover.
+      // Invalid or expired tokens should not keep the UI in a logged-in state.
     }
 
     clearAuthTokens();
-    navigate(`/${ROUTES.LOGIN}`, {
-      replace: true,
-      state: {
-        noticeMessage,
-      },
-    });
+    await queryClient.cancelQueries({ queryKey: ['auth'] });
+    queryClient.removeQueries({ queryKey: ['auth'] });
+    navigate(ROUTES.HOME, { replace: true });
   };
 
   return {

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -18,7 +18,6 @@ import GameDetailModal from '../../features/games/components/GameDetailModal';
 import { getTopGames, searchGames } from '../../features/games/gameApi';
 import { GAME_GENRE_FILTERS } from '../../features/games/genres';
 import { useDebouncedValue } from '../../features/games/hooks/useDebouncedValue';
-import { getAccessToken } from '../../utils/auth';
 import type { GameListItem } from '../../features/games/types';
 import type { GameGenreFilter } from '../../features/games/genres';
 import 'swiper/swiper.css';
@@ -28,7 +27,6 @@ const GENRE_FILTER_MENU_ID = 'game-genre-filter-menu';
 const CTA_PENDING_MESSAGE = '준비 중입니다.';
 
 const MainPage = () => {
-  const hasAccessToken = Boolean(getAccessToken());
   const [searchText, setSearchText] = useState('');
   const [selectedGenre, setSelectedGenre] = useState<GameGenreFilter>('전체');
   const [selectedGame, setSelectedGame] = useState<GameListItem | null>(null);
@@ -59,7 +57,7 @@ const MainPage = () => {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
-      <Header fixed isLoggedIn={hasAccessToken} />
+      <Header fixed />
       <main className="min-h-screen pt-24 pb-10 text-white sm:pt-28 sm:pb-14 lg:pt-32">
         <section className="w-full">
           <div className="flex flex-col gap-4 px-[clamp(1rem,5vw,20rem)] sm:flex-row sm:items-center sm:justify-between">

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -129,7 +129,7 @@ function MatchingGenreDetailPage() {
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.12),transparent_24%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
-      <Header fixed isLoggedIn={hasAccessToken} />
+      <Header fixed />
 
       <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1180px] px-4 pt-24 pb-14 sm:px-6 sm:pt-28 md:px-8 md:pt-32 md:pb-18">
         {!genre || !isValidGenreSlug ? (

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -4,15 +4,12 @@ import { Link } from 'react-router';
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
 import { MATCHING_GENRES } from '../../features/matching/genres';
-import { getAccessToken } from '../../utils/auth';
 
 function MatchingListPage() {
-  const hasAccessToken = Boolean(getAccessToken());
-
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.18),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
-      <Header fixed isLoggedIn={hasAccessToken} />
+      <Header fixed />
 
       <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1180px] px-4 pt-24 pb-14 sm:px-6 sm:pt-28 md:px-8 md:pt-32 md:pb-18">
         <section className="mx-auto max-w-[920px]">

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -328,7 +328,7 @@ function MyPage() {
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <div className="app-aurora pointer-events-none absolute inset-0 opacity-70" />
-      <Header fixed isLoggedIn />
+      <Header fixed />
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-[clamp(1rem,5vw,20rem)] pt-24 pb-14 sm:pt-28 sm:pb-16 lg:pt-32">
         <MyPageProfileSection

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -251,7 +251,7 @@ function RecommendationListPage() {
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <RecommendationBackdrop items={recommendationItems} />
-      <Header fixed isLoggedIn={hasAccessToken} />
+      <Header fixed />
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1200px] flex-col px-3 pt-24 pb-10 sm:px-4 sm:pt-28 sm:pb-12 md:px-8 md:pt-32 md:pb-16">
         <section className="mx-auto w-full max-w-[980px]">

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -11,7 +11,7 @@ function SurveyPage() {
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <div className="app-aurora pointer-events-none absolute inset-0 opacity-90" />
-      <Header fixed isLoggedIn={hasAccessToken} />
+      <Header fixed />
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-3 pt-24 pb-10 sm:px-4 sm:pt-28 sm:pb-12 md:px-8 md:pt-32 md:pb-16">
         <section className="mb-8 flex flex-col gap-5">


### PR DESCRIPTION
## 관련 이슈

- closes #85

## 변경 내용

- `Header`가 auth store를 직접 구독하도록 변경해 로그인 상태가 즉시 반영되도록 수정했습니다.
- 로그아웃 시 `POST /api/v1/accounts/logout` 호출 후 로컬 인증 상태와 auth query cache를 정리하고 메인 페이지(`/`)로 이동하도록 변경했습니다.
- 헤더 프로필 메뉴에 접근성 속성(`aria-expanded`, `aria-controls`, 동적 aria-label`)과 blur 기반 닫힘 동작을 추가했습니다.
- 헤더를 사용하는 주요 페이지에서 `isLoggedIn` prop 전달을 제거하고 공통 인증 상태 판단을 `Header` 내부로 일원화했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3322" height="844" alt="image" src="https://github.com/user-attachments/assets/60ef2b75-d717-43aa-943b-113a9dac4aa5" />

## 참고사항

- 로그아웃 API가 실패하더라도 만료/무효 토큰으로 인해 UI가 로그인 상태에 남지 않도록 로컬 인증 상태는 정리하도록 처리했습니다.
- 브라우저에서 추가 확인이 필요한 항목은 프로필 메뉴 열기/닫기, 로그아웃 후 메인 이동, 헤더 비로그인 UI 반영입니다.
