### PR TITLE
[Feat] 토큰 저장 정책 정리

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,11 +1,27 @@
 import axios from 'axios';
 
 import { apiBaseUrl } from '../lib/env';
-import { getAccessToken } from '../utils/auth';
+import { clearAuthTokens, getAccessToken } from '../utils/auth';
+
+const AUTH_EXCLUDED_PATHS = [
+  '/api/v1/accounts/login',
+  '/api/v1/accounts/signup',
+  '/api/v1/accounts/check-id',
+  '/api/v1/accounts/check-nickname',
+];
+
+const shouldResetAuthSession = (requestUrl?: string) => {
+  if (!requestUrl) {
+    return true;
+  }
+
+  return !AUTH_EXCLUDED_PATHS.some((path) => requestUrl.includes(path));
+};
 
 export const api = axios.create({
   baseURL: apiBaseUrl,
   timeout: 7000,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -27,6 +43,15 @@ api.interceptors.request.use(
 api.interceptors.response.use(
   (response) => response,
   (error) => {
+    if (
+      error.response?.status === 401 &&
+      getAccessToken() &&
+      shouldResetAuthSession(error.config?.url)
+    ) {
+      // Refresh cookie handling will be added when the backend refresh contract is fixed.
+      clearAuthTokens();
+    }
+
     console.error('API 에러 발생:', error.response?.data || error.message);
     return Promise.reject(error);
   },

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -7,7 +7,7 @@ export interface LoginRequest {
 
 export interface LoginResponse {
   access_token: string;
-  refresh_token: string;
+  refresh_token?: string | null;
 }
 
 export interface LogoutResponse {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -17,7 +17,7 @@ import {
 } from '../features/auth/api/auth';
 import { useLoginMutation } from '../features/auth/api/useAuthApi';
 import type { LoginRequest } from '../features/auth/types/auth';
-import { setAuthAccount, setAuthTokens } from '../utils/auth';
+import { setAccessToken, setAuthAccount } from '../utils/auth';
 
 type LoginFieldName = keyof LoginRequest;
 type LoginFieldErrors = Partial<Record<LoginFieldName, string>>;
@@ -116,7 +116,7 @@ function LoginPage() {
     try {
       const response = await loginMutation.mutateAsync(payload);
 
-      setAuthTokens(response.access_token, response.refresh_token);
+      setAccessToken(response.access_token);
       const profile = await getCurrentUserProfile();
       setAuthAccount(profile);
       navigate(ROUTES.HOME);

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -24,7 +24,7 @@ import {
   useSignupMutation,
 } from '../features/auth/api/useAuthApi';
 import type { AuthGender, SignupRequest } from '../features/auth/types/auth';
-import { setAuthAccount, setAuthTokens } from '../utils/auth';
+import { setAccessToken, setAuthAccount } from '../utils/auth';
 
 type SignupFormValues = Omit<SignupRequest, 'gender'> & {
   gender: AuthGender | '';
@@ -412,7 +412,7 @@ function SignupPage() {
         password: payload.password,
       });
 
-      setAuthTokens(loginResponse.access_token, loginResponse.refresh_token);
+      setAccessToken(loginResponse.access_token);
       const profile = await getCurrentUserProfile();
       setAuthAccount(profile);
       navigate(ROUTES.HOME);

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -23,27 +23,9 @@ const getLegacyAccessToken = () => {
   return null;
 };
 
-const getLegacyRefreshToken = () => {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  for (const key of LEGACY_REFRESH_TOKEN_KEYS) {
-    const token = window.localStorage.getItem(key);
-
-    if (token) {
-      return token;
-    }
-  }
-
-  return null;
-};
-
 interface AuthState {
   accessToken: string | null;
-  refreshToken: string | null;
   account: CurrentUserProfileResponse | null;
-  setAuthTokens: (accessToken: string, refreshToken: string) => void;
   setAccessToken: (token: string) => void;
   setAccount: (account: CurrentUserProfileResponse | null) => void;
   clearAuthTokens: () => void;
@@ -53,21 +35,16 @@ export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       accessToken: getLegacyAccessToken(),
-      refreshToken: getLegacyRefreshToken(),
       account: null,
-      setAuthTokens: (accessToken, refreshToken) =>
-        set({ accessToken, refreshToken }),
       setAccessToken: (token) => set({ accessToken: token }),
       setAccount: (account) => set({ account }),
-      clearAuthTokens: () =>
-        set({ accessToken: null, refreshToken: null, account: null }),
+      clearAuthTokens: () => set({ accessToken: null, account: null }),
     }),
     {
       name: AUTH_STORAGE_KEY,
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         accessToken: state.accessToken,
-        refreshToken: state.refreshToken,
         account: state.account,
       }),
     },
@@ -93,7 +70,6 @@ export const clearLegacyAuthStorage = () => {
 };
 
 export const getLegacyAccessTokenFromStorage = getLegacyAccessToken;
-export const getLegacyRefreshTokenFromStorage = getLegacyRefreshToken;
 export const clearAuthPersistedStorage = () => {
   useAuthStore.persist.clearStorage();
   clearLegacyAuthStorage();

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -2,7 +2,6 @@ import {
   clearAuthPersistedStorage,
   clearLegacyAuthStorage,
   getLegacyAccessTokenFromStorage,
-  getLegacyRefreshTokenFromStorage,
   useAuthStore,
 } from '../store/useAuthStore';
 import type { CurrentUserProfileResponse } from '../features/auth/types/auth';
@@ -13,19 +12,8 @@ export const getAccessToken = () => {
   );
 };
 
-export const getRefreshToken = () => {
-  return (
-    useAuthStore.getState().refreshToken ?? getLegacyRefreshTokenFromStorage()
-  );
-};
-
 export const getAuthAccount = () => {
   return useAuthStore.getState().account;
-};
-
-export const setAuthTokens = (accessToken: string, refreshToken: string) => {
-  useAuthStore.getState().setAuthTokens(accessToken, refreshToken);
-  clearLegacyAuthStorage();
 };
 
 export const setAccessToken = (token: string) => {


### PR DESCRIPTION
## 관련 이슈

- closes #87

## 변경 내용

- auth store와 유틸에서 `refresh token` 프론트 저장 의존성을 제거하고 `access token` 중심 구조로 정리했습니다.
- 로그인/회원가입 이후 인증 상태 저장 로직을 `setAccessToken` 기준으로 변경해, 백엔드가 refresh token을 HttpOnly Cookie로 전환해도 프론트 수정 범위를 줄이도록 정리했습니다.
- 로그인 응답 타입에서 `refresh_token`을 optional로 완화해 쿠키 기반 인증 정책과의 호환성을 확보했습니다.
- Axios 인스턴스에 `withCredentials: true`를 적용하고, 인증 API 일부를 제외한 `401` 응답에서 로컬 인증 상태를 정리하는 임시 정책을 추가했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 없어서 첨부하지 않았습니다.

## 참고사항

- 백엔드의 refresh token 저장 정책과 refresh API 계약이 아직 확정되지 않아, 이번 PR에서는 `refresh token을 프론트 persist에 저장하지 않는 방향`으로 먼저 정리했습니다.
- 현재 `401` 응답 시 refresh 재발급 재시도는 구현하지 않았고, 인증 세션을 정리하는 임시 정책만 반영했습니다.
- 이후 백엔드 계약이 확정되면 refresh 재시도 interceptor 또는 cookie 기반 세션 복구 흐름을 별도 작업으로 연결해야 합니다.
