### PR TITLE
[Feat] 소셜 로그인 구조 및 실제 이동 연결

### DIFF
--- a/src/components/auth/AuthSocialLoginGroup.tsx
+++ b/src/components/auth/AuthSocialLoginGroup.tsx
@@ -1,4 +1,11 @@
+import { useState } from 'react';
+
+import AuthFormMessage from './AuthFormMessage';
 import SocialLoginButton from '../login/SocialLoginButton';
+import {
+  getSocialLoginStartUrl,
+  type SocialAuthProvider,
+} from '../../features/auth/utils/socialAuth';
 
 type AuthSocialLoginGroupProps = {
   className?: string;
@@ -44,6 +51,24 @@ const NaverIcon = () => (
 );
 
 function AuthSocialLoginGroup({ className = '' }: AuthSocialLoginGroupProps) {
+  const [redirectingProvider, setRedirectingProvider] =
+    useState<SocialAuthProvider | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSocialLogin = (provider: SocialAuthProvider) => {
+    try {
+      const redirectUrl = getSocialLoginStartUrl(provider);
+      setRedirectingProvider(provider);
+      setErrorMessage('');
+      window.location.assign(redirectUrl);
+    } catch {
+      setRedirectingProvider(null);
+      setErrorMessage(
+        '소셜 로그인 시작 주소를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      );
+    }
+  };
+
   return (
     <div className={`space-y-3 ${className} sm:space-y-3.5`}>
       <SocialLoginButton
@@ -51,19 +76,26 @@ function AuthSocialLoginGroup({ className = '' }: AuthSocialLoginGroupProps) {
         icon={<GoogleIcon />}
         className="bg-login-google border-login-google h-14 border sm:h-[61px]"
         labelClassName="text-white"
+        onClick={() => handleSocialLogin('google')}
+        disabled={Boolean(redirectingProvider)}
       />
       <SocialLoginButton
         label="카카오로 로그인하기"
         icon={<KakaoIcon />}
         className="bg-login-kakao h-14 sm:h-[59px]"
         labelClassName="text-login-kakao-label"
+        onClick={() => handleSocialLogin('kakao')}
+        disabled={Boolean(redirectingProvider)}
       />
       <SocialLoginButton
         label="네이버로 로그인하기"
         icon={<NaverIcon />}
         className="bg-login-naver h-14 sm:h-[59px]"
         labelClassName="text-white"
+        onClick={() => handleSocialLogin('naver')}
+        disabled={Boolean(redirectingProvider)}
       />
+      {errorMessage ? <AuthFormMessage>{errorMessage}</AuthFormMessage> : null}
     </div>
   );
 }

--- a/src/components/login/SocialLoginButton.tsx
+++ b/src/components/login/SocialLoginButton.tsx
@@ -5,6 +5,8 @@ type SocialLoginButtonProps = {
   icon: ReactNode;
   className: string;
   labelClassName?: string;
+  onClick: () => void;
+  disabled?: boolean;
 };
 
 function SocialLoginButton({
@@ -12,11 +14,15 @@ function SocialLoginButton({
   icon,
   className,
   labelClassName = '',
+  onClick,
+  disabled = false,
 }: SocialLoginButtonProps) {
   return (
     <button
       type="button"
-      className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-all duration-200 hover:-translate-y-0.5 hover:brightness-105 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none active:translate-y-0 ${className}`}
+      onClick={onClick}
+      disabled={disabled}
+      className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-all duration-200 hover:-translate-y-0.5 hover:brightness-105 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-70 ${className}`}
     >
       {icon}
       <span

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -4,6 +4,7 @@ export const ROUTES = {
   MATCHING_LIST: 'matching-list',
   MATCHING_GENRE_DETAIL: 'matching-list/:genreSlug',
   RECOMMENDATION_LIST: 'recommendation-list',
+  AUTH_CALLBACK: 'auth/callback',
   LOGIN: 'login',
   SIGNUP: 'signup',
   MY_PAGE: 'my-page',

--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -1,0 +1,64 @@
+import { apiBaseUrl } from '@/lib/env';
+import { ROUTES } from '@/constants/routes';
+import { AUTH_BASE_PATH } from '../constants/auth';
+
+export type SocialAuthProvider = 'google' | 'kakao' | 'naver';
+
+const SOCIAL_AUTH_START_URL_ENV_KEYS: Record<SocialAuthProvider, string> = {
+  google: 'VITE_SOCIAL_LOGIN_GOOGLE_URL',
+  kakao: 'VITE_SOCIAL_LOGIN_KAKAO_URL',
+  naver: 'VITE_SOCIAL_LOGIN_NAVER_URL',
+};
+
+const SOCIAL_AUTH_DEFAULT_PATHS: Record<SocialAuthProvider, string> = {
+  google: `${AUTH_BASE_PATH}/oauth/google/login`,
+  kakao: `${AUTH_BASE_PATH}/oauth/kakao/login`,
+  naver: `${AUTH_BASE_PATH}/oauth/naver/login`,
+};
+
+const getSocialLoginStartUrlFromEnv = (provider: SocialAuthProvider) => {
+  const env = import.meta.env as Record<string, string | undefined>;
+  const value = env[SOCIAL_AUTH_START_URL_ENV_KEYS[provider]]?.trim();
+
+  return value || null;
+};
+
+const getSocialCallbackUrl = () => {
+  if (typeof window === 'undefined') {
+    return `/${ROUTES.AUTH_CALLBACK}`;
+  }
+
+  return new URL(`/${ROUTES.AUTH_CALLBACK}`, window.location.origin).toString();
+};
+
+export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
+  const configuredUrl = getSocialLoginStartUrlFromEnv(provider);
+
+  if (configuredUrl) {
+    return configuredUrl;
+  }
+
+  const basePath = SOCIAL_AUTH_DEFAULT_PATHS[provider];
+  const callbackUrl = getSocialCallbackUrl();
+
+  if (apiBaseUrl) {
+    const url = new URL(basePath, apiBaseUrl);
+    url.searchParams.set('redirect_uri', callbackUrl);
+    return url.toString();
+  }
+
+  const searchParams = new URLSearchParams({
+    redirect_uri: callbackUrl,
+  });
+
+  return `${basePath}?${searchParams.toString()}`;
+};
+
+export const getSocialCallbackErrorMessage = (searchParams: URLSearchParams) =>
+  searchParams.get('error_description') ||
+  searchParams.get('error_detail') ||
+  searchParams.get('detail') ||
+  searchParams.get('error');
+
+export const getSocialCallbackAccessToken = (searchParams: URLSearchParams) =>
+  searchParams.get('access_token') || searchParams.get('token');

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,6 +14,7 @@ import SurveyPage from './pages/survey/SurveyPage';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
 import MyPage from './pages/mypage/MyPage';
+import AuthCallbackPage from './pages/AuthCallbackPage';
 import './index.css';
 
 const queryClient = new QueryClient();
@@ -46,6 +47,10 @@ const router = createBrowserRouter([
       {
         path: ROUTES.LOGIN,
         element: <LoginPage />,
+      },
+      {
+        path: ROUTES.AUTH_CALLBACK,
+        element: <AuthCallbackPage />,
       },
       {
         path: ROUTES.SIGNUP,

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
+import AuthLayout from '../components/layout/AuthLayout';
+import { ROUTES } from '../constants/routes';
+import {
+  extractAuthApiErrorMessage,
+  getCurrentUserProfile,
+} from '../features/auth/api/auth';
+import {
+  getSocialCallbackAccessToken,
+  getSocialCallbackErrorMessage,
+} from '../features/auth/utils/socialAuth';
+import { clearAuthTokens, setAccessToken, setAuthAccount } from '../utils/auth';
+
+const DEFAULT_CALLBACK_ERROR_MESSAGE =
+  '소셜 로그인 처리에 실패했습니다. 다시 시도해 주세요.';
+
+function AuthCallbackPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [statusMessage, setStatusMessage] = useState(
+    '소셜 로그인 정보를 확인하는 중입니다.',
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const handleAuthCallback = async () => {
+      const searchParams = new URLSearchParams(location.search);
+      const callbackErrorMessage = getSocialCallbackErrorMessage(searchParams);
+
+      if (callbackErrorMessage) {
+        navigate(`/${ROUTES.LOGIN}`, {
+          replace: true,
+          state: {
+            errorMessage: callbackErrorMessage,
+          },
+        });
+        return;
+      }
+
+      const accessToken = getSocialCallbackAccessToken(searchParams);
+
+      if (!accessToken) {
+        navigate(`/${ROUTES.LOGIN}`, {
+          replace: true,
+          state: {
+            errorMessage:
+              '소셜 로그인 응답에 access token이 없어 로그인 상태를 저장할 수 없습니다.',
+          },
+        });
+        return;
+      }
+
+      try {
+        setAccessToken(accessToken);
+        const profile = await getCurrentUserProfile();
+
+        if (!isMounted) {
+          return;
+        }
+
+        setAuthAccount(profile);
+        navigate(ROUTES.HOME, { replace: true });
+      } catch (error) {
+        clearAuthTokens();
+
+        if (!isMounted) {
+          return;
+        }
+
+        setStatusMessage(DEFAULT_CALLBACK_ERROR_MESSAGE);
+        navigate(`/${ROUTES.LOGIN}`, {
+          replace: true,
+          state: {
+            errorMessage:
+              extractAuthApiErrorMessage(error) ||
+              DEFAULT_CALLBACK_ERROR_MESSAGE,
+          },
+        });
+      }
+    };
+
+    void handleAuthCallback();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [location.search, navigate]);
+
+  return (
+    <AuthLayout
+      title="소셜 로그인"
+      subtitle="로그인 정보를 확인하고 있습니다."
+      withPanel
+      panelClassName="max-w-[500px]"
+    >
+      <div className="mt-8 rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-center text-sm/6 text-white/75">
+        {statusMessage}
+      </div>
+    </AuthLayout>
+  );
+}
+
+export default AuthCallbackPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -24,6 +24,7 @@ type LoginFieldErrors = Partial<Record<LoginFieldName, string>>;
 type LoginTouchedState = Record<LoginFieldName, boolean>;
 type LoginLocationState = {
   noticeMessage?: string;
+  errorMessage?: string;
 };
 
 const getLoginFieldErrors = (
@@ -56,8 +57,10 @@ function LoginPage() {
     password: false,
   });
   const [apiFieldErrors, setApiFieldErrors] = useState<LoginFieldErrors>({});
-  const [formMessage, setFormMessage] = useState('');
   const locationState = location.state as LoginLocationState | null;
+  const [formMessage, setFormMessage] = useState(
+    locationState?.errorMessage ?? '',
+  );
   const [noticeMessage, setNoticeMessage] = useState(
     locationState?.noticeMessage ?? '',
   );


### PR DESCRIPTION
## 관련 이슈

- closes #86

## 변경 내용

- Google/Kakao/Naver 소셜 로그인 버튼에 provider별 시작 URL 분기 로직을 추가했습니다.
- 소셜 로그인 시작 URL은 환경변수 우선으로 사용하고, 값이 없을 경우 `/api/v1/accounts/oauth/{provider}/login?redirect_uri=...` 경로를 기본값으로 사용하도록 구성했습니다.
- `/auth/callback` 라우트를 추가하고, callback 응답의 `access_token` 또는 `token` 값을 읽어 로그인 상태 저장 후 메인 페이지로 이동하도록 연결했습니다.
- callback 실패 시 로그인 페이지로 돌아가 에러 메시지를 표시하도록 처리했습니다.
- 로그인 페이지에서 callback 에러 메시지를 location state로 받아 사용자에게 안내할 수 있도록 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 크지 않아 첨부하지 않았습니다.

## 참고사항

- provider별 시작 URL 계약이 저장소에는 아직 없어서, 환경변수 미설정 시 `/api/v1/accounts/oauth/{provider}/login` 경로를 기본 가정으로 사용했습니다.
- callback 처리도 백엔드 계약이 확정되지 않아 `access_token` 또는 `token` 쿼리 파라미터를 받는 방식으로 우선 연결했습니다.
- 백엔드가 다른 redirect/token 전달 방식을 사용하면 `src/features/auth/utils/socialAuth.ts`와 `src/pages/AuthCallbackPage.tsx` 중심으로 수정하면 됩니다.
