### PR TITLE
[Feat] 설문 API adapter와 mock 계약 정리 

### DIFF
--- a/src/features/survey/api/survey.ts
+++ b/src/features/survey/api/survey.ts
@@ -2,14 +2,21 @@ import { AxiosError } from 'axios';
 
 import { api } from '../../../api/axios';
 import type {
+  SurveyApiChatRequest,
+  SurveyApiResetResponse,
+  SurveyApiSessionResponse,
   SurveyChatRequest,
   SurveyChatResponse,
   SurveyResetRequest,
   SurveyResetResponse,
   SurveyResultQuery,
   SurveyResultResponse,
+  SurveyApiSessionStartRequest,
   SurveySessionStartRequest,
   SurveySessionStartResponse,
+  SurveyProgress,
+  SurveySessionStatus,
+  SurveyApiProgress,
 } from '../types/survey';
 
 interface ErrorResponseBody {
@@ -18,34 +25,113 @@ interface ErrorResponseBody {
 }
 
 const SURVEY_BASE_PATH = '/api/v1/survey';
+const SURVEY_CHATBOT_BASE_PATH = `${SURVEY_BASE_PATH}/chatbot`;
+
+const clampProgressRate = (value: number | null | undefined) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0;
+  }
+
+  if (value > 1) {
+    return Math.max(0, Math.min(value / 100, 1));
+  }
+
+  return Math.max(0, Math.min(value, 1));
+};
+
+const normalizeSurveyProgress = (
+  progress: SurveyApiProgress | null | undefined,
+  progressRate: number | null | undefined,
+): SurveyProgress => {
+  if (progress) {
+    return {
+      current_step:
+        typeof progress.current_step === 'number' ? progress.current_step : 0,
+      total_steps:
+        typeof progress.total_steps === 'number' ? progress.total_steps : 0,
+      completion_rate:
+        typeof progress.completion_rate === 'number'
+          ? clampProgressRate(progress.completion_rate)
+          : clampProgressRate(progressRate),
+    };
+  }
+
+  const completionRate = clampProgressRate(progressRate);
+
+  return {
+    current_step: Math.round(completionRate * 100),
+    total_steps: 100,
+    completion_rate: completionRate,
+  };
+};
+
+const normalizeSurveyStatus = (
+  status: SurveySessionStatus | null | undefined,
+  isCompleted: boolean,
+) => {
+  if (status) {
+    return status;
+  }
+
+  return isCompleted ? 'COMPLETED' : 'IN_PROGRESS';
+};
+
+export const normalizeSurveySessionResponse = (
+  payload: SurveyApiSessionResponse,
+): SurveySessionStartResponse => {
+  const isCompleted = Boolean(payload.is_completed);
+  const recommendationReady =
+    typeof payload.recommendation_ready === 'boolean'
+      ? payload.recommendation_ready
+      : isCompleted;
+
+  return {
+    session_id: payload.session_id,
+    assistant_message: payload.ai_question ?? payload.chatbot_reply ?? null,
+    progress: normalizeSurveyProgress(payload.progress, payload.progress_rate),
+    status: normalizeSurveyStatus(payload.status, isCompleted),
+    recommendation_ready: recommendationReady,
+  };
+};
+
+export const normalizeSurveyResetResponse = (
+  payload: SurveyApiResetResponse,
+): SurveyResetResponse => ({
+  message: payload.message,
+  ...normalizeSurveySessionResponse(payload),
+});
 
 export const startSurveySession = async (
   payload: SurveySessionStartRequest,
-) => {
-  const response = await api.post<SurveySessionStartResponse>(
-    `${SURVEY_BASE_PATH}/chat/sessions`,
-    payload,
+): Promise<SurveySessionStartResponse> => {
+  const response = await api.post<SurveyApiSessionResponse>(
+    `${SURVEY_CHATBOT_BASE_PATH}/sessions`,
+    payload satisfies SurveyApiSessionStartRequest,
   );
 
-  return response.data;
+  return normalizeSurveySessionResponse(response.data);
 };
 
-export const continueSurveyChat = async (payload: SurveyChatRequest) => {
-  const response = await api.post<SurveyChatResponse>(
-    `${SURVEY_BASE_PATH}/chat`,
-    payload,
+export const continueSurveyChat = async (
+  payload: SurveyChatRequest,
+): Promise<SurveyChatResponse> => {
+  const response = await api.post<SurveyApiSessionResponse>(
+    `${SURVEY_CHATBOT_BASE_PATH}/sessions/${payload.session_id}/messages`,
+    {
+      user_answer: payload.user_answer,
+    } satisfies SurveyApiChatRequest,
   );
 
-  return response.data;
+  return normalizeSurveySessionResponse(response.data);
 };
 
 export const resetSurveySession = async (payload: SurveyResetRequest) => {
-  const response = await api.post<SurveyResetResponse>(
+  const response = await api.post<SurveyApiResetResponse>(
     `${SURVEY_BASE_PATH}/sessions/reset`,
     payload,
   );
 
-  return response.data;
+  return normalizeSurveyResetResponse(response.data);
 };
 
 export const getSurveyResults = async (query: SurveyResultQuery) => {

--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -50,7 +50,6 @@ function SurveyChatPanel() {
     setLastSubmittedMessage,
     addUserMessage,
     hydrateInitialSession,
-    beginSession,
     applyChatResponse,
     resetSurveyState,
   } = useSurveyStore();
@@ -85,7 +84,9 @@ function SurveyChatPanel() {
       setSubmitting(true);
 
       try {
-        const response = await startSessionMutation.mutateAsync({});
+        const response = await startSessionMutation.mutateAsync({
+          is_reset: false,
+        });
         hydrateInitialSession(response);
       } catch (requestError) {
         setHasBootstrapped(false);
@@ -129,20 +130,30 @@ function SurveyChatPanel() {
     clearError();
     setLastSubmittedMessage(trimmed);
 
-    if (appendUserMessage) {
-      addUserMessage(trimmed);
-    }
-
     setSubmitting(true);
 
     try {
       if (!sessionId) {
-        const response = await startSessionMutation.mutateAsync({
-          message: trimmed,
+        const sessionResponse = await startSessionMutation.mutateAsync({
+          is_reset: false,
+        });
+        hydrateInitialSession(sessionResponse);
+
+        if (appendUserMessage) {
+          addUserMessage(trimmed);
+        }
+
+        const response = await continueSurveyMutation.mutateAsync({
+          session_id: sessionResponse.session_id,
+          user_answer: trimmed,
         });
 
-        beginSession(response);
+        applyChatResponse(response);
       } else {
+        if (appendUserMessage) {
+          addUserMessage(trimmed);
+        }
+
         const response = await continueSurveyMutation.mutateAsync({
           session_id: sessionId,
           user_answer: trimmed,
@@ -181,15 +192,21 @@ function SurveyChatPanel() {
       resetSurveyState();
       setHasBootstrapped(true);
       setLastSubmittedMessage(lastSubmittedMessage);
-      addUserMessage(lastSubmittedMessage);
       setSubmitting(true);
 
       try {
-        const response = await startSessionMutation.mutateAsync({
-          message: lastSubmittedMessage,
+        const sessionResponse = await startSessionMutation.mutateAsync({
+          is_reset: true,
+        });
+        hydrateInitialSession(sessionResponse);
+        addUserMessage(lastSubmittedMessage);
+
+        const response = await continueSurveyMutation.mutateAsync({
+          session_id: sessionResponse.session_id,
+          user_answer: lastSubmittedMessage,
         });
 
-        beginSession(response);
+        applyChatResponse(response);
       } catch (requestError) {
         setError(extractApiErrorMessage(requestError));
       } finally {
@@ -222,14 +239,12 @@ function SurveyChatPanel() {
     setSubmitting(true);
 
     try {
-      await resetSurveyMutation.mutateAsync({
+      const response = await resetSurveyMutation.mutateAsync({
         session_id: sessionId,
       });
 
       setInputValue('');
-      resetSurveyState();
-      setHasBootstrapped(false);
-      await bootstrapSurvey(true);
+      hydrateInitialSession(response);
     } catch (requestError) {
       const errorMessage = extractApiErrorMessage(requestError);
 

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -1,7 +1,7 @@
 import { delay, http, HttpResponse } from 'msw';
 
 import type {
-  SurveyChatRequest,
+  SurveyApiChatRequest,
   SurveyResetRequest,
   SurveyResultItem,
 } from '../types/survey';
@@ -169,11 +169,14 @@ const getErrorResponse = (status: number, message: string) =>
   );
 
 export const surveyHandlers = [
-  http.post('/api/v1/survey/chat/sessions', async () => {
+  http.post('/api/v1/survey/chatbot/sessions', async ({ request }) => {
+    await request.json().catch(() => ({}));
     const sessionId = createSessionId();
+    const totalQuestions = MAX_STEPS;
+
     surveySessions.set(sessionId, {
       askedQuestions: 1,
-      totalQuestions: DEFAULT_STEPS,
+      totalQuestions,
     });
 
     await delay(700);
@@ -182,58 +185,63 @@ export const surveyHandlers = [
       session_id: sessionId,
       ai_question: surveyQuestions[0],
       status: 'IN_PROGRESS',
-      progress: buildProgress(1, DEFAULT_STEPS),
-    });
-  }),
-
-  http.post('/api/v1/survey/chat', async ({ request }) => {
-    const body = (await request.json()) as SurveyChatRequest;
-
-    if (!body.session_id || !body.user_answer?.trim()) {
-      return getErrorResponse(400, '필수 입력 항목입니다.');
-    }
-
-    const session =
-      surveySessions.get(body.session_id) ??
-      ({
-        askedQuestions: 1,
-        totalQuestions: DEFAULT_STEPS,
-      } satisfies MockSurveySession);
-
-    if (session.askedQuestions === 1) {
-      session.totalQuestions = getQuestionCountFromAnswer(body.user_answer);
-    }
-
-    await delay(800);
-
-    if (session.askedQuestions >= session.totalQuestions) {
-      surveySessions.set(body.session_id, session);
-
-      return HttpResponse.json({
-        session_id: body.session_id,
-        ai_question: null,
-        progress: buildProgress(
-          session.totalQuestions,
-          session.totalQuestions,
-          true,
-        ),
-        status: 'COMPLETED',
-        recommendation_ready: true,
-      });
-    }
-
-    const nextQuestionIndex = session.askedQuestions;
-    session.askedQuestions += 1;
-    surveySessions.set(body.session_id, session);
-
-    return HttpResponse.json({
-      session_id: body.session_id,
-      ai_question: surveyQuestions[nextQuestionIndex],
-      progress: buildProgress(session.askedQuestions, session.totalQuestions),
-      status: 'IN_PROGRESS',
+      progress: buildProgress(1, totalQuestions),
       recommendation_ready: false,
     });
   }),
+
+  http.post(
+    '/api/v1/survey/chatbot/sessions/:sessionId/messages',
+    async ({ request, params }) => {
+      const body = (await request.json()) as SurveyApiChatRequest;
+      const sessionId = String(params.sessionId ?? '');
+
+      if (!sessionId || !body.user_answer?.trim()) {
+        return getErrorResponse(400, '필수 입력 항목입니다.');
+      }
+
+      const session =
+        surveySessions.get(sessionId) ??
+        ({
+          askedQuestions: 1,
+          totalQuestions: DEFAULT_STEPS,
+        } satisfies MockSurveySession);
+
+      if (session.askedQuestions === 1) {
+        session.totalQuestions = getQuestionCountFromAnswer(body.user_answer);
+      }
+
+      await delay(800);
+
+      if (session.askedQuestions >= session.totalQuestions) {
+        surveySessions.set(sessionId, session);
+
+        return HttpResponse.json({
+          session_id: sessionId,
+          ai_question: null,
+          progress: buildProgress(
+            session.totalQuestions,
+            session.totalQuestions,
+            true,
+          ),
+          status: 'COMPLETED',
+          recommendation_ready: true,
+        });
+      }
+
+      const nextQuestionIndex = session.askedQuestions;
+      session.askedQuestions += 1;
+      surveySessions.set(sessionId, session);
+
+      return HttpResponse.json({
+        session_id: sessionId,
+        ai_question: surveyQuestions[nextQuestionIndex],
+        progress: buildProgress(session.askedQuestions, session.totalQuestions),
+        status: 'IN_PROGRESS',
+        recommendation_ready: false,
+      });
+    },
+  ),
 
   http.get('/api/v1/survey/result', async ({ request }) => {
     const url = new URL(request.url);
@@ -273,11 +281,21 @@ export const surveyHandlers = [
 
     surveySessions.delete(body.session_id);
 
+    const nextSessionId = createSessionId();
+    surveySessions.set(nextSessionId, {
+      askedQuestions: 1,
+      totalQuestions: MAX_STEPS,
+    });
+
     await delay(350);
 
     return HttpResponse.json({
       message: '설문이 초기화되었습니다.',
-      reset: true,
+      session_id: nextSessionId,
+      status: 'IN_PROGRESS',
+      ai_question: surveyQuestions[0],
+      progress: buildProgress(1, MAX_STEPS),
+      recommendation_ready: false,
     });
   }),
 ];

--- a/src/features/survey/store/useSurveyStore.ts
+++ b/src/features/survey/store/useSurveyStore.ts
@@ -76,11 +76,13 @@ export const useSurveyStore = create<SurveyStoreState>((set) => ({
       isSubmitting: false,
       hasBootstrapped: true,
       error: null,
-      recommendationReady: false,
+      recommendationReady: payload.recommendation_ready,
       lastSubmittedMessage: null,
-      messages: payload.ai_question
-        ? [createMessage('assistant', payload.ai_question)]
-        : [],
+      messages: payload.assistant_message
+        ? [createMessage('assistant', payload.assistant_message)]
+        : payload.recommendation_ready
+          ? [createMessage('assistant', COMPLETION_GUIDE_MESSAGE)]
+          : [],
     })),
   beginSession: (payload) =>
     set((state) => ({
@@ -90,13 +92,24 @@ export const useSurveyStore = create<SurveyStoreState>((set) => ({
       hasBootstrapped: true,
       isSubmitting: false,
       error: null,
-      recommendationReady: false,
-      messages: payload.ai_question
+      recommendationReady: payload.recommendation_ready,
+      messages: payload.assistant_message
         ? state.messages.at(-1)?.role === 'assistant' &&
-          state.messages.at(-1)?.content === payload.ai_question
+          state.messages.at(-1)?.content === payload.assistant_message
           ? state.messages
-          : [...state.messages, createMessage('assistant', payload.ai_question)]
-        : state.messages,
+          : [
+              ...state.messages,
+              createMessage('assistant', payload.assistant_message),
+            ]
+        : payload.recommendation_ready
+          ? state.messages.at(-1)?.role === 'assistant' &&
+            state.messages.at(-1)?.content === COMPLETION_GUIDE_MESSAGE
+            ? state.messages
+            : [
+                ...state.messages,
+                createMessage('assistant', COMPLETION_GUIDE_MESSAGE),
+              ]
+          : state.messages,
     })),
   applyChatResponse: (payload) =>
     set((state) => ({
@@ -106,13 +119,13 @@ export const useSurveyStore = create<SurveyStoreState>((set) => ({
       isSubmitting: false,
       error: null,
       messages: (() => {
-        if (payload.ai_question) {
+        if (payload.assistant_message) {
           return state.messages.at(-1)?.role === 'assistant' &&
-            state.messages.at(-1)?.content === payload.ai_question
+            state.messages.at(-1)?.content === payload.assistant_message
             ? state.messages
             : [
                 ...state.messages,
-                createMessage('assistant', payload.ai_question),
+                createMessage('assistant', payload.assistant_message),
               ];
         }
 

--- a/src/features/survey/types/survey.ts
+++ b/src/features/survey/types/survey.ts
@@ -20,14 +20,36 @@ export interface SurveyProgress {
 }
 
 export interface SurveySessionStartRequest {
-  message?: string;
+  is_reset?: boolean;
 }
 
-export interface SurveySessionStartResponse {
+export interface SurveyApiSessionStartRequest {
+  is_reset?: boolean;
+}
+
+export interface SurveyApiChatRequest {
+  user_answer: string;
+}
+
+export interface SurveyApiProgress {
+  current_step?: number | null;
+  total_steps?: number | null;
+  completion_rate?: number | null;
+}
+
+export interface SurveyApiSessionResponse {
   session_id: string;
-  ai_question: string;
-  status: SurveySessionStatus;
-  progress?: SurveyProgress;
+  ai_question?: string | null;
+  progress?: SurveyApiProgress | null;
+  recommendation_ready?: boolean | null;
+  status?: SurveySessionStatus | null;
+  chatbot_reply?: string | null;
+  progress_rate?: number | null;
+  is_completed?: boolean | null;
+}
+
+export interface SurveyApiResetResponse extends SurveyApiSessionResponse {
+  message: string;
 }
 
 export interface SurveyChatRequest {
@@ -35,13 +57,17 @@ export interface SurveyChatRequest {
   user_answer: string;
 }
 
-export interface SurveyChatResponse {
+export interface SurveySessionResponse {
   session_id: string;
-  ai_question: string | null;
+  assistant_message: string | null;
   progress: SurveyProgress;
   status: SurveySessionStatus;
   recommendation_ready: boolean;
 }
+
+export type SurveySessionStartResponse = SurveySessionResponse;
+
+export type SurveyChatResponse = SurveySessionResponse;
 
 export interface SurveyResetRequest {
   session_id: string;
@@ -49,7 +75,11 @@ export interface SurveyResetRequest {
 
 export interface SurveyResetResponse {
   message: string;
-  reset: boolean;
+  session_id: string;
+  assistant_message: string | null;
+  progress: SurveyProgress;
+  status: SurveySessionStatus;
+  recommendation_ready: boolean;
 }
 
 export interface SurveyResultQuery {


### PR DESCRIPTION
## 관련 이슈

- closes #84 

## 변경 내용

- 설문 시작/대화 API 경로를 최신 명세 기준으로 정리
  - `POST /api/v1/survey/chatbot/sessions`
  - `POST /api/v1/survey/chatbot/sessions/{session_id}/messages`
- 설문 API raw 응답 타입과 화면용 normalized 타입을 분리
- `ai_question`, `progress`, `recommendation_ready` 기준으로 최신 응답 계약 반영
- 응답 필드 변동 가능성을 고려해 adapter에서 fallback 필드도 함께 흡수하도록 정리
- MSW mock handler를 최신 API 경로/응답 구조에 맞게 수정
- 설문 초기화 API 응답을 바로 hydrate하도록 변경
- 세션이 없는 상태에서 답변 전송 시 `세션 시작 -> 답변 전송` 흐름으로 정리
- store가 원본 API 필드명에 직접 의존하지 않고 normalized 응답만 사용하도록 정리
## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
