### PR TITLE
[Feat] 설문 화면 사용자 문구 정리

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -286,7 +286,7 @@ function SurveyChatPanel() {
           <div className="max-w-2xl">
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#6c2323] bg-[#1a0a0a] px-3 py-1 text-xs font-semibold tracking-[0.2em] text-[#ff8f8f] uppercase">
               <Sparkles size={14} />
-              {isMockServiceWorkerEnabled() ? 'MSW Mock Mode' : 'Live API'}
+              {isMockServiceWorkerEnabled() ? '체험 모드' : '개인화 설문'}
             </div>
             <h2 className="text-2xl font-bold text-white md:text-3xl">
               AI 취향 설문
@@ -297,7 +297,7 @@ function SurveyChatPanel() {
             </p>
             {isMockServiceWorkerEnabled() ? (
               <p className="mt-3 text-sm leading-6 text-[#ffb0b0]">
-                현재 질문/응답은 실제 AI가 아니라 MSW mock 데이터로 동작합니다.
+                체험 모드에서 설문 흐름을 먼저 확인할 수 있어요.
               </p>
             ) : null}
           </div>

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -16,7 +16,7 @@ function SurveyPage() {
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-3 pt-24 pb-10 sm:px-4 sm:pt-28 sm:pb-12 md:px-8 md:pt-32 md:pb-16">
         <section className="mb-8 flex flex-col gap-5">
           <div className="inline-flex w-fit items-center rounded-full border border-[#5e1717] bg-[#150707] px-4 py-1.5 text-xs font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
-            Survey Experience
+            개인화 설문
           </div>
           <div className="max-w-3xl">
             <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl md:text-5xl">
@@ -37,9 +37,8 @@ function SurveyPage() {
               로그인 후 설문을 시작할 수 있어요.
             </h2>
             <p className="mt-4 text-base leading-7 text-white/60">
-              실제 API 모드에서는 인증된 사용자만 설문 세션을 생성할 수
-              있습니다. 개발 중에는 `VITE_USE_MSW`를 활성화하면 로그인 없이도
-              설문 체험이 가능합니다.
+              로그인하면 취향을 바탕으로 질문을 이어가고, 설문이 끝난 뒤 바로
+              추천 결과까지 확인할 수 있어요.
             </p>
           </section>
         )}


### PR DESCRIPTION
## 관련 이슈

- closes #96 

## 변경 내용

- 설문 화면의 개발자용 문구를 사용자-facing 문구로 정리
- 상단 배지를 `개인화 설문`으로 변경
- `MSW Mock Mode`, `Live API` 등 내부 구현명을 화면에서 제거
- 체험 환경에서는 `체험 모드` 안내 문구로 자연스럽게 노출되도록 수정
- 비로그인 안내 문구에서 환경 변수명과 내부 구현 표현 제거

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
