### PR TITLE
[Feat] 추천 결과 API 타입과 adapter 정리

### DIFF
--- a/src/features/survey/api/survey.ts
+++ b/src/features/survey/api/survey.ts
@@ -4,6 +4,8 @@ import { api } from '../../../api/axios';
 import type {
   SurveyApiChatRequest,
   SurveyApiResetResponse,
+  SurveyApiResultItem,
+  SurveyApiResultResponse,
   SurveyApiSessionResponse,
   SurveyChatRequest,
   SurveyChatResponse,
@@ -15,6 +17,7 @@ import type {
   SurveySessionStartRequest,
   SurveySessionStartResponse,
   SurveyProgress,
+  SurveyResultItem,
   SurveySessionStatus,
   SurveyApiProgress,
 } from '../types/survey';
@@ -101,6 +104,35 @@ export const normalizeSurveyResetResponse = (
   ...normalizeSurveySessionResponse(payload),
 });
 
+const normalizeSurveyResultItem = (
+  item: SurveyApiResultItem,
+): SurveyResultItem => ({
+  game_id: item.game_id,
+  title:
+    (typeof item.title === 'string' && item.title.trim()) ||
+    (typeof item.name === 'string' && item.name.trim()) ||
+    '제목 정보 준비 중',
+  genres: Array.isArray(item.genres) ? item.genres : [],
+  thumbnail_url: item.thumbnail_url ?? null,
+  rating: typeof item.rating === 'number' ? item.rating : null,
+  is_liked: Boolean(item.is_liked),
+});
+
+export const normalizeSurveyResultResponse = (
+  payload: SurveyApiResultResponse,
+): SurveyResultResponse => ({
+  session_id: payload.session_id,
+  user_id: payload.user_id,
+  count:
+    typeof payload.count === 'number'
+      ? payload.count
+      : (payload.results?.length ?? 0),
+  next: typeof payload.next === 'string' ? payload.next : null,
+  results: Array.isArray(payload.results)
+    ? payload.results.map(normalizeSurveyResultItem)
+    : [],
+});
+
 export const startSurveySession = async (
   payload: SurveySessionStartRequest,
 ): Promise<SurveySessionStartResponse> => {
@@ -135,14 +167,14 @@ export const resetSurveySession = async (payload: SurveyResetRequest) => {
 };
 
 export const getSurveyResults = async (query: SurveyResultQuery) => {
-  const response = await api.get<SurveyResultResponse>(
+  const response = await api.get<SurveyApiResultResponse>(
     `${SURVEY_BASE_PATH}/result`,
     {
       params: query,
     },
   );
 
-  return response.data;
+  return normalizeSurveyResultResponse(response.data);
 };
 
 export const extractApiErrorMessage = (error: unknown) => {

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -2,8 +2,8 @@ import { delay, http, HttpResponse } from 'msw';
 
 import type {
   SurveyApiChatRequest,
+  SurveyApiResultItem,
   SurveyResetRequest,
-  SurveyResultItem,
 } from '../types/survey';
 
 const MIN_STEPS = 3;
@@ -18,10 +18,10 @@ const surveyQuestions = [
   '플레이 타임은 짧고 강렬한 편이 좋으신가요, 아니면 오래 파고들며 성장하는 흐름이 좋으신가요?',
 ];
 
-const recommendations: SurveyResultItem[] = [
+const recommendations: SurveyApiResultItem[] = [
   {
     game_id: 501,
-    name: '호랑나비 어드벤처',
+    title: '호랑나비 어드벤처',
     genres: ['RPG', '어드벤처'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=800&q=80',
@@ -30,7 +30,7 @@ const recommendations: SurveyResultItem[] = [
   },
   {
     game_id: 502,
-    name: '이터널 오딧세이',
+    title: '이터널 오딧세이',
     genres: ['액션', 'RPG'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1542751371-adc38448a05e?auto=format&fit=crop&w=800&q=80',
@@ -39,7 +39,7 @@ const recommendations: SurveyResultItem[] = [
   },
   {
     game_id: 503,
-    name: '스타폴 택틱스',
+    title: '스타폴 택틱스',
     genres: ['전략', '시뮬레이션'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1493711662062-fa541adb3fc8?auto=format&fit=crop&w=800&q=80',
@@ -48,7 +48,7 @@ const recommendations: SurveyResultItem[] = [
   },
   {
     game_id: 504,
-    name: '크림슨 서킷',
+    title: '크림슨 서킷',
     genres: ['슈팅', '로그라이트'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1511882150382-421056c89033?auto=format&fit=crop&w=800&q=80',
@@ -57,7 +57,7 @@ const recommendations: SurveyResultItem[] = [
   },
   {
     game_id: 505,
-    name: '문라이트 캔버스',
+    title: '문라이트 캔버스',
     genres: ['비주얼 노벨', '퍼즐'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1518709268805-4e9042af2176?auto=format&fit=crop&w=800&q=80',
@@ -66,7 +66,7 @@ const recommendations: SurveyResultItem[] = [
   },
   {
     game_id: 506,
-    name: '드리프트 네온',
+    title: '드리프트 네온',
     genres: ['레이싱', '스포츠'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1486572788966-cfd3df1f5b42?auto=format&fit=crop&w=800&q=80',
@@ -75,7 +75,7 @@ const recommendations: SurveyResultItem[] = [
   },
   {
     game_id: 507,
-    name: '노던 랩소디',
+    title: '노던 랩소디',
     genres: ['어드벤처', '스토리'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1493711662062-fa541adb3fc8?auto=format&fit=crop&w=800&q=80',
@@ -84,7 +84,7 @@ const recommendations: SurveyResultItem[] = [
   },
   {
     game_id: 508,
-    name: '제로아워 레이드',
+    title: '제로아워 레이드',
     genres: ['FPS', '협동'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=800&q=80',

--- a/src/features/survey/types/survey.ts
+++ b/src/features/survey/types/survey.ts
@@ -89,17 +89,35 @@ export interface SurveyResultQuery {
   page_size?: number;
 }
 
-export interface SurveyResultItem {
+export interface SurveyApiResultItem {
   game_id: number;
-  name: string;
+  title?: string | null;
+  name?: string | null;
   genres: string[];
   thumbnail_url: string | null;
   rating: number | null;
   is_liked: boolean;
 }
 
+export interface SurveyResultItem {
+  game_id: number;
+  title: string;
+  genres: string[];
+  thumbnail_url: string | null;
+  rating: number | null;
+  is_liked: boolean;
+}
+
+export interface SurveyApiResultResponse {
+  session_id?: string;
+  user_id: number;
+  count?: number | null;
+  next?: string | null;
+  results: SurveyApiResultItem[];
+}
+
 export interface SurveyResultResponse {
-  session_id: string;
+  session_id?: string;
   user_id: number;
   count: number;
   next: string | null;

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -54,17 +54,14 @@ type RecommendationDisplayItem = {
 
 const normalizeResultItem = (
   item: SurveyResultItem | MatchResultItem,
-): RecommendationDisplayItem =>
-  'title' in item
-    ? item
-    : {
-        game_id: item.game_id,
-        title: item.name,
-        genres: item.genres,
-        thumbnail_url: item.thumbnail_url,
-        rating: item.rating,
-        is_liked: item.is_liked,
-      };
+): RecommendationDisplayItem => ({
+  game_id: item.game_id,
+  title: item.title,
+  genres: item.genres,
+  thumbnail_url: item.thumbnail_url,
+  rating: item.rating,
+  is_liked: item.is_liked,
+});
 
 const getRecommendationHighlights = (items: RecommendationDisplayItem[]) => {
   const genreCounts = new Map<string, number>();


### PR DESCRIPTION
## 관련 이슈

- closes #98 

## 변경 내용

- 설문 추천 결과 타입을 최신 API 명세 기준으로 정리
- 설문 추천 결과 raw 타입과 화면용 normalized 타입 분리
- 추천 결과 adapter를 추가해 `title` 기준으로 화면에 안정적으로 전달되도록 수정
- legacy `name` 필드는 adapter 내부 fallback으로만 처리하도록 정리
- 추천 결과 응답의 `count`, `next`를 API 기준으로 사용하고 최소 fallback 추가
- MSW 설문 추천 결과 응답을 최신 명세 형태(`title`)로 수정
- 추천 리스트 페이지의 `name/title` 임시 보정 로직 제거
- 설문/매칭 추천 결과가 동일한 display model 기준으로 렌더링되도록 정리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 추천 결과 API 타입/adapter 정리에 집중했습니다.
- 상세 모달 연결은 다음 PR에서 진행 예정입니다.
