### PR TITLE
[Feat] 추천 결과 리스트 상세 모달 연결

### DIFF
--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -1,8 +1,11 @@
 import { ChevronRight, Heart, Sparkles, Star } from 'lucide-react';
+import { useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
+import GameDetailModal from '../../features/games/components/GameDetailModal';
+import type { GameListItem } from '../../features/games/types';
 import { useMatchResultsInfinite } from '../../features/matching/api/useMatchingApi';
 import type { MatchResultItem } from '../../features/matching/types';
 import { useSurveyResultsInfinite } from '../../features/survey/api/useSurveyApi';
@@ -63,6 +66,15 @@ const normalizeResultItem = (
   is_liked: item.is_liked,
 });
 
+const toGameListItem = (item: RecommendationDisplayItem): GameListItem => ({
+  gameId: item.game_id,
+  name: item.title,
+  genres: item.genres,
+  thumbnailUrl: item.thumbnail_url,
+  rating: item.rating,
+  isLiked: item.is_liked,
+});
+
 const getRecommendationHighlights = (items: RecommendationDisplayItem[]) => {
   const genreCounts = new Map<string, number>();
 
@@ -88,9 +100,10 @@ const getRecommendationHighlights = (items: RecommendationDisplayItem[]) => {
 
 type RecommendationRowProps = {
   item: RecommendationDisplayItem;
+  onOpenDetail: (item: RecommendationDisplayItem) => void;
 };
 
-function RecommendationRow({ item }: RecommendationRowProps) {
+function RecommendationRow({ item, onOpenDetail }: RecommendationRowProps) {
   return (
     <article className="group grid gap-4 px-4 py-5 transition-colors duration-200 hover:bg-white/[0.025] sm:grid-cols-[118px_minmax(0,1fr)] sm:items-center sm:px-6 sm:py-6 lg:grid-cols-[118px_minmax(0,1fr)_auto] lg:gap-6 lg:px-7">
       <div className="overflow-hidden rounded-[20px] border border-white/6 bg-[#111111] shadow-[0_14px_32px_rgba(0,0,0,0.18)]">
@@ -148,7 +161,8 @@ function RecommendationRow({ item }: RecommendationRowProps) {
 
         <button
           type="button"
-          aria-label={`${item.title} 상세 보기 준비 중`}
+          onClick={() => onOpenDetail(item)}
+          aria-label={`${item.title} 상세 보기`}
           className="flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-white/42 transition group-hover:border-white/8 group-hover:bg-white/[0.03] group-hover:text-white/82"
         >
           <ChevronRight size={18} />
@@ -201,6 +215,7 @@ function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
 
 function RecommendationListPage() {
   const [searchParams] = useSearchParams();
+  const [selectedGame, setSelectedGame] = useState<GameListItem | null>(null);
   const sessionId = searchParams.get('session_id');
   const source = searchParams.get('source');
   const isMatchSource = source === 'match';
@@ -244,6 +259,9 @@ function RecommendationListPage() {
       errorMessage?.includes('매칭 추천 결과를 찾을 수 없습니다') ||
       recommendationItems.length === 0,
     );
+  const handleOpenDetail = (item: RecommendationDisplayItem) => {
+    setSelectedGame(toGameListItem(item));
+  };
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
@@ -376,7 +394,11 @@ function RecommendationListPage() {
                   <div className="recommendation-scroll max-h-[62vh] overflow-y-auto">
                     <div className="divide-y divide-white/8">
                       {recommendationItems.map((item) => (
-                        <RecommendationRow key={item.game_id} item={item} />
+                        <RecommendationRow
+                          key={item.game_id}
+                          item={item}
+                          onOpenDetail={handleOpenDetail}
+                        />
                       ))}
                     </div>
                   </div>
@@ -402,6 +424,14 @@ function RecommendationListPage() {
           )}
         </section>
       </main>
+
+      {selectedGame ? (
+        <GameDetailModal
+          key={selectedGame.gameId}
+          game={selectedGame}
+          onClose={() => setSelectedGame(null)}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## 관련 이슈

- closes #100 

## 변경 내용

- 추천 결과 리스트에서 게임 상세 모달을 열 수 있도록 연결
- 추천 결과 item을 `GameDetailModal`이 사용하는 `GameListItem` 형태로 매핑하도록 추가
- 상세 버튼 클릭 시 공용 `GameDetailModal`을 재사용해 상세 정보를 표시하도록 수정
- 모달은 추천 리스트 페이지 상태 안에서 열고 닫도록 처리
- 모달을 닫아도 추천 리스트 페이지와 스크롤 위치가 유지되도록 구성
- 상세 버튼의 접근성 문구를 `상세 보기 준비 중`에서 실제 동작 기준으로 수정

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 추천 결과 리스트에서 상세 모달을 여는 연결 작업에 집중했습니다.
- 추천 리스트 row의 좋아요 버튼 동작은 별도 범위로 유지했습니다.