### PR TITLE
[Refactor] 인증 아키텍처 고도화: Access Token 메모리화 및 쿠키 기반 Refresh 도입

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,35 +1,40 @@
 import axios from 'axios';
 
 import { apiBaseUrl } from '../lib/env';
-import { clearAuthTokens, getAccessToken } from '../utils/auth';
+import { useAuthStore } from '../store/useAuthStore';
+
+/**
+ * [Refactor] 인증 아키텍처 업데이트 (#94)
+ * - withCredentials: true 설정을 통해 쿠키(Refresh Token)를 자동으로 전송합니다.
+ * - 401 에러 발생 시 /accounts/token/refresh를 통해 Access Token을 자동 갱신합니다.
+ */
 
 const AUTH_EXCLUDED_PATHS = [
   '/api/v1/accounts/login',
   '/api/v1/accounts/signup',
   '/api/v1/accounts/check-id',
   '/api/v1/accounts/check-nickname',
+  '/api/v1/accounts/token/refresh', // 무한 루프 방지
 ];
 
 const shouldResetAuthSession = (requestUrl?: string) => {
-  if (!requestUrl) {
-    return true;
-  }
-
+  if (!requestUrl) return true;
   return !AUTH_EXCLUDED_PATHS.some((path) => requestUrl.includes(path));
 };
 
 export const api = axios.create({
   baseURL: apiBaseUrl,
   timeout: 7000,
-  withCredentials: true,
+  withCredentials: true, // 쿠키 기반 인증을 위해 필수
   headers: {
     'Content-Type': 'application/json',
   },
 });
 
+// 요청 인터셉터: 메모리에 있는 Access Token을 Authorization 헤더에 삽입
 api.interceptors.request.use(
   (config) => {
-    const token = getAccessToken();
+    const token = useAuthStore.getState().accessToken;
 
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
@@ -40,16 +45,49 @@ api.interceptors.request.use(
   (error) => Promise.reject(error),
 );
 
+// 응답 인터셉터: 401 에러 시 Silent Refresh 처리
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 401 에러이고, 재시도한 적이 없으며, 인증 제외 경로가 아닐 때
     if (
       error.response?.status === 401 &&
-      getAccessToken() &&
-      shouldResetAuthSession(error.config?.url)
+      !originalRequest._retry &&
+      shouldResetAuthSession(originalRequest.url)
     ) {
-      // Refresh cookie handling will be added when the backend refresh contract is fixed.
-      clearAuthTokens();
+      originalRequest._retry = true;
+
+      try {
+        // Refresh Token은 쿠키에 담겨 자동으로 전송됨
+        const response = await axios.post(
+          `${apiBaseUrl}/api/v1/accounts/token/refresh`,
+          {},
+          {
+            withCredentials: true,
+          },
+        );
+
+        const { access_token } = response.data;
+
+        // 새 토큰 저장
+        useAuthStore.getState().setAccessToken(access_token);
+
+        // 원래 요청 재시도
+        originalRequest.headers.Authorization = `Bearer ${access_token}`;
+        return api(originalRequest);
+      } catch (refreshError) {
+        // 리프레시 실패 시 (세션 만료) 로그아웃 처리
+        useAuthStore.getState().clearAuth();
+
+        // 브라우저 환경에서만 리다이렉트
+        if (typeof window !== 'undefined') {
+          window.location.href = '/login?expired=true';
+        }
+
+        return Promise.reject(refreshError);
+      }
     }
 
     console.error('API 에러 발생:', error.response?.data || error.message);

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -11,7 +11,14 @@ import {
   getSocialCallbackAccessToken,
   getSocialCallbackErrorMessage,
 } from '../features/auth/utils/socialAuth';
-import { clearAuthTokens, setAccessToken, setAuthAccount } from '../utils/auth';
+import { useAuthStore } from '../store/useAuthStore';
+
+/**
+ * [Refactor] 인증 아키텍처 업데이트 (#94)
+ * - 소셜 로그인 성공 후 백엔드에서 리다이렉트된 콜백을 처리합니다.
+ * - URL 파라미터에서 access_token을 추출하고, 유저 정보를 페칭합니다.
+ * - Refresh Token은 이미 백엔드에 의해 HttpOnly 쿠키로 설정된 상태여야 합니다.
+ */
 
 const DEFAULT_CALLBACK_ERROR_MESSAGE =
   '소셜 로그인 처리에 실패했습니다. 다시 시도해 주세요.';
@@ -19,6 +26,7 @@ const DEFAULT_CALLBACK_ERROR_MESSAGE =
 function AuthCallbackPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { setAuth, clearAuth } = useAuthStore();
   const [statusMessage, setStatusMessage] = useState(
     '소셜 로그인 정보를 확인하는 중입니다.',
   );
@@ -28,49 +36,50 @@ function AuthCallbackPage() {
 
     const handleAuthCallback = async () => {
       const searchParams = new URLSearchParams(location.search);
-      const callbackErrorMessage = getSocialCallbackErrorMessage(searchParams);
 
+      // 1. 에러 파라미터 확인
+      const callbackErrorMessage = getSocialCallbackErrorMessage(searchParams);
       if (callbackErrorMessage) {
         navigate(`/${ROUTES.LOGIN}`, {
           replace: true,
-          state: {
-            errorMessage: callbackErrorMessage,
-          },
+          state: { errorMessage: callbackErrorMessage },
         });
         return;
       }
 
+      // 2. Access Token 추출
       const accessToken = getSocialCallbackAccessToken(searchParams);
-
       if (!accessToken) {
         navigate(`/${ROUTES.LOGIN}`, {
           replace: true,
           state: {
             errorMessage:
-              '소셜 로그인 응답에 access token이 없어 로그인 상태를 저장할 수 없습니다.',
+              '인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.',
           },
         });
         return;
       }
 
       try {
-        setAccessToken(accessToken);
+        // 3. 임시로 토큰 설정 후 유저 프로필 조회
+        // (getCurrentUserProfile 내부의 axiosInstance가 이 토큰을 사용함)
+        useAuthStore.getState().setAccessToken(accessToken);
+
         const profile = await getCurrentUserProfile();
 
-        if (!isMounted) {
-          return;
-        }
+        if (!isMounted) return;
 
-        setAuthAccount(profile);
+        // 4. 최종 인증 상태 저장
+        setAuth(accessToken, profile);
+
+        // 5. 홈으로 이동
         navigate(ROUTES.HOME, { replace: true });
       } catch (error) {
-        clearAuthTokens();
+        if (!isMounted) return;
 
-        if (!isMounted) {
-          return;
-        }
-
+        clearAuth();
         setStatusMessage(DEFAULT_CALLBACK_ERROR_MESSAGE);
+
         navigate(`/${ROUTES.LOGIN}`, {
           replace: true,
           state: {
@@ -87,7 +96,7 @@ function AuthCallbackPage() {
     return () => {
       isMounted = false;
     };
-  }, [location.search, navigate]);
+  }, [location.search, navigate, setAuth, clearAuth]);
 
   return (
     <AuthLayout

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -17,7 +17,7 @@ import {
 } from '../features/auth/api/auth';
 import { useLoginMutation } from '../features/auth/api/useAuthApi';
 import type { LoginRequest } from '../features/auth/types/auth';
-import { setAccessToken, setAuthAccount } from '../utils/auth';
+import { useAuthStore } from '../store/useAuthStore';
 
 type LoginFieldName = keyof LoginRequest;
 type LoginFieldErrors = Partial<Record<LoginFieldName, string>>;
@@ -47,7 +47,9 @@ const getLoginFieldErrors = (
 function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const setAuth = useAuthStore((state) => state.setAuth);
   const loginMutation = useLoginMutation();
+
   const [formValues, setFormValues] = useState<LoginRequest>({
     login_id: '',
     password: '',
@@ -119,9 +121,10 @@ function LoginPage() {
     try {
       const response = await loginMutation.mutateAsync(payload);
 
-      setAccessToken(response.access_token);
+      // [Refactor] #94: Access Token 메모리 저장, Refresh Token은 HttpOnly 쿠키로 관리됨
       const profile = await getCurrentUserProfile();
-      setAuthAccount(profile);
+      setAuth(response.access_token, profile);
+
       navigate(ROUTES.HOME);
     } catch (error) {
       const nextApiFieldErrors = extractAuthApiFieldErrors(error);
@@ -153,7 +156,7 @@ function LoginPage() {
           onChange={(event) => handleChange('login_id', event.target.value)}
           onBlur={() =>
             setTouchedState((previous) => ({
-              ...previous,
+              previous,
               login_id: true,
             }))
           }
@@ -173,7 +176,7 @@ function LoginPage() {
           onChange={(event) => handleChange('password', event.target.value)}
           onBlur={() =>
             setTouchedState((previous) => ({
-              ...previous,
+              previous,
               password: true,
             }))
           }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -156,7 +156,7 @@ function LoginPage() {
           onChange={(event) => handleChange('login_id', event.target.value)}
           onBlur={() =>
             setTouchedState((previous) => ({
-              previous,
+              ...previous,
               login_id: true,
             }))
           }
@@ -176,7 +176,7 @@ function LoginPage() {
           onChange={(event) => handleChange('password', event.target.value)}
           onBlur={() =>
             setTouchedState((previous) => ({
-              previous,
+              ...previous,
               password: true,
             }))
           }

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,76 +1,75 @@
 import { create } from 'zustand';
-import { createJSONStorage, persist } from 'zustand/middleware';
 import type { CurrentUserProfileResponse } from '../features/auth/types/auth';
 
-const AUTH_STORAGE_KEY = 'auth-storage';
-const LEGACY_ACCESS_TOKEN_KEYS = ['accessToken', 'access_token'] as const;
-const LEGACY_REFRESH_TOKEN_KEYS = ['refreshToken', 'refresh_token'] as const;
-const LEGACY_PERSIST_KEYS = ['tokenStorage', 'infoStorage'] as const;
-
-const getLegacyAccessToken = () => {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  for (const key of LEGACY_ACCESS_TOKEN_KEYS) {
-    const token = window.localStorage.getItem(key);
-
-    if (token) {
-      return token;
-    }
-  }
-
-  return null;
-};
+/**
+ * [Refactor] 인증 아키텍처 업데이트 (#94)
+ * - Access Token: 보안 강화를 위해 클라이언트 메모리(State)에서만 관리 (XSS 방어)
+ * - Refresh Token: 브라우저 HttpOnly Cookie 기반 관리 (백엔드 주도)
+ * - persist 미들웨어를 제거하여 새로고침 시 세션 만료를 의도하거나,
+ *   Axios Interceptor를 통한 Silent Refresh로 세션을 유지합니다.
+ */
 
 interface AuthState {
   accessToken: string | null;
   account: CurrentUserProfileResponse | null;
+  isAuthenticated: boolean;
   setAccessToken: (token: string) => void;
   setAccount: (account: CurrentUserProfileResponse | null) => void;
-  clearAuthTokens: () => void;
+  setAuth: (token: string, account: CurrentUserProfileResponse) => void;
+  clearAuth: () => void;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      accessToken: getLegacyAccessToken(),
-      account: null,
-      setAccessToken: (token) => set({ accessToken: token }),
-      setAccount: (account) => set({ account }),
-      clearAuthTokens: () => set({ accessToken: null, account: null }),
+export const useAuthStore = create<AuthState>((set) => ({
+  accessToken: null,
+  account: null,
+  isAuthenticated: false,
+
+  setAccessToken: (token) =>
+    set({
+      accessToken: token,
+      isAuthenticated: !!token,
     }),
-    {
-      name: AUTH_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({
-        accessToken: state.accessToken,
-        account: state.account,
-      }),
-    },
-  ),
-);
 
+  setAccount: (account) => set({ account }),
+
+  setAuth: (token, account) =>
+    set({
+      accessToken: token,
+      account: account,
+      isAuthenticated: true,
+    }),
+
+  clearAuth: () => {
+    set({
+      accessToken: null,
+      account: null,
+      isAuthenticated: false,
+    });
+
+    // 기존 localStorage 기반 레거시 데이터 완전 삭제
+    clearLegacyAuthStorage();
+  },
+}));
+
+/**
+ * 기존 localStorage에 저장되던 모든 인증 관련 레거시 키를 삭제합니다.
+ */
 export const clearLegacyAuthStorage = () => {
-  if (typeof window === 'undefined') {
-    return;
-  }
+  if (typeof window === 'undefined') return;
 
-  for (const key of LEGACY_ACCESS_TOKEN_KEYS) {
-    window.localStorage.removeItem(key);
-  }
+  const LEGACY_KEYS = [
+    'auth-storage', // Zustand persist key
+    'accessToken',
+    'access_token',
+    'refreshToken',
+    'refresh_token',
+    'tokenStorage',
+    'infoStorage',
+  ];
 
-  for (const key of LEGACY_REFRESH_TOKEN_KEYS) {
-    window.localStorage.removeItem(key);
-  }
-
-  for (const key of LEGACY_PERSIST_KEYS) {
-    window.localStorage.removeItem(key);
-  }
+  LEGACY_KEYS.forEach((key) => window.localStorage.removeItem(key));
 };
 
-export const getLegacyAccessTokenFromStorage = getLegacyAccessToken;
-export const clearAuthPersistedStorage = () => {
-  useAuthStore.persist.clearStorage();
-  clearLegacyAuthStorage();
-};
+// 하위 호환성을 위한 export (점진적 교체용)
+export const clearAuthTokens = () => useAuthStore.getState().clearAuth();
+export const clearAuthPersistedStorage = clearLegacyAuthStorage;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,15 +1,13 @@
-import {
-  clearAuthPersistedStorage,
-  clearLegacyAuthStorage,
-  getLegacyAccessTokenFromStorage,
-  useAuthStore,
-} from '../store/useAuthStore';
+import { useAuthStore } from '../store/useAuthStore';
 import type { CurrentUserProfileResponse } from '../features/auth/types/auth';
 
+/**
+ * [Refactor] 인증 아키텍처 업데이트 (#94)
+ * - 유틸리티 함수들을 새로운 Zustand 스토어 액션으로 연결합니다.
+ */
+
 export const getAccessToken = () => {
-  return (
-    useAuthStore.getState().accessToken ?? getLegacyAccessTokenFromStorage()
-  );
+  return useAuthStore.getState().accessToken;
 };
 
 export const getAuthAccount = () => {
@@ -18,16 +16,15 @@ export const getAuthAccount = () => {
 
 export const setAccessToken = (token: string) => {
   useAuthStore.getState().setAccessToken(token);
-  clearLegacyAuthStorage();
 };
 
 export const setAuthAccount = (account: CurrentUserProfileResponse | null) => {
   useAuthStore.getState().setAccount(account);
 };
 
-export const clearAccessToken = () => {
-  useAuthStore.getState().clearAuthTokens();
-  clearAuthPersistedStorage();
+export const clearAuthTokens = () => {
+  useAuthStore.getState().clearAuth();
 };
 
-export const clearAuthTokens = clearAccessToken;
+// 하위 호환성을 위한 별칭
+export const clearAccessToken = clearAuthTokens;


### PR DESCRIPTION
## 관련 이슈

- closes #94 

## 변경 내용

-인증 아키텍처 전환: 보안 강화를 위해 Access Token을 클라이언트 메모리(Zustand State) 관리 방식으로 변경하고, Refresh Token은 백엔드 주도형 HttpOnly 쿠키 기반으로 전환했습니다.
-Zustand 스토어 리팩토링: persist 미들웨어를 제거하여 XSS 공격으로부터 안전하게 설계하였으며, 로그아웃 시 localStorage 내 레거시 데이터를 강제 삭제하는 클린업 로직을 추가했습니다.
-Silent Refresh 구현: Axios 인터셉터를 고도화하여 401 Unauthorized 에러 발생 시 자동으로 /token/refresh API를 호출, 세션을 끊김 없이 유지하도록 구현했습니다.
-소셜 로그인 콜백 최적화: 백엔드 리다이렉트 후 URL에서 access_token을 추출하여 즉시 유저 프로필을 페칭하는 백엔드 주도형 플로우를 적용했습니다.
-TypeScript 안정성 확보: LoginPage.tsx 등 관련 컴포넌트의 상태 업데이트 로직 및 타입을 최신 스토어 구조에 맞게 수정했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-본 작업은 백엔드에서 /api/v1/accounts/token/refresh 엔드포인트가 준비되고, 쿠키 설정 시 HttpOnly; Secure; SameSite=Lax 옵션이 적용되어야 정상적으로 동작합니다.
-기존 localStorage 기반 인증 정보는 첫 로그아웃 또는 세션 만료 시 자동으로 정리됩니다.
