### PR TITLE
[Chore] 디스코드 리뷰어 멘션 매핑 수정

### DIFF
--- a/.github/workflows/discord_notify.yml
+++ b/.github/workflows/discord_notify.yml
@@ -64,10 +64,10 @@ jobs:
             for login in $(echo "$REVIEWERS_JSON" | jq -r '.[] | .login'); do
               case "$login" in
                 "chen4023")
-                  MENTIONS="$MENTIONS <@950597490086924368>"
+                  MENTIONS="$MENTIONS <@683563560063991848>"
                   ;;
                 "sysysysyb")
-                  MENTIONS="$MENTIONS <@1419497006753124382>"
+                  MENTIONS="$MENTIONS <@950597490086924368>"
                   ;;
                 "ninanochichi")
                   MENTIONS="$MENTIONS <@1304754118199480381>"
@@ -87,8 +87,8 @@ jobs:
             # 만약 요청된 리뷰어가 없으면 현재 리뷰어로 대체
             if [ -z "$MENTIONS" ]; then
               case "$CURRENT_REVIEWER" in
-                "chen4023") MENTIONS="<@950597490086924368>" ;;
-                "sysysysyb") MENTIONS="<@1419497006753124382>" ;;
+                "chen4023") MENTIONS="<@683563560063991848>" ;;
+                "sysysysyb") MENTIONS="<@950597490086924368>" ;;
                 "ninanochichi") MENTIONS="<@1304754118199480381>" ;;
                 "hj-devlog") MENTIONS="<@452332808631746561>" ;;
                 "JinMyeong99") MENTIONS="<@1224946488845795370>" ;;
@@ -168,10 +168,10 @@ jobs:
           # PR 작성자 Discord ID 매핑
           case "${{ github.event.pull_request.user.login }}" in
             "chen4023")
-              AUTHOR_MENTION="<@950597490086924368>"
+              AUTHOR_MENTION="<@683563560063991848>"
               ;;
             "sysysysyb")
-              AUTHOR_MENTION="<@1419497006753124382>"
+              AUTHOR_MENTION="<@950597490086924368>"
               ;;
             "ninanochichi")
               AUTHOR_MENTION="<@1304754118199480381>"
@@ -221,10 +221,10 @@ jobs:
           # PR 작성자 Discord ID 매핑
           case "${{ github.event.pull_request.user.login }}" in
             "chen4023")
-              AUTHOR_MENTION="<@950597490086924368>"
+              AUTHOR_MENTION="<@683563560063991848>"
               ;;
             "sysysysyb")
-              AUTHOR_MENTION="<@1419497006753124382>"
+              AUTHOR_MENTION="<@950597490086924368>"
               ;;
             "ninanochichi")
               AUTHOR_MENTION="<@1304754118199480381>"


### PR DESCRIPTION
## 관련 이슈

- closes #108 

## 변경 내용

- GitHub reviewer login과 Discord 사용자 ID 매핑을 최신 기준으로 수정
- 리뷰 요청 알림에서 잘못된 Discord 멘션이 나가던 문제 수정
- 승인 알림과 변경 요청 알림에서도 동일한 매핑이 사용되도록 정리
- `chen4023`, `sysysysyb` 계정의 Discord ID가 뒤바뀌어 있던 부분 수정

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
