### PR TITLE
[Feat] 추천 결과 리스트 UI 및 조회 방식 개선

### DIFF
--- a/src/features/matching/api/useMatchingApi.ts
+++ b/src/features/matching/api/useMatchingApi.ts
@@ -34,7 +34,18 @@ export const useMatchResultsInfinite = (
       getMatchResponseResults({
         sort,
         cursor: pageParam ?? undefined,
-        page_size: 4,
+        page_size: 5,
       }),
-    getNextPageParam: (lastPage) => lastPage.next,
+    getNextPageParam: (lastPage, allPages) => {
+      const loadedCount = allPages.reduce(
+        (count, page) => count + page.results.length,
+        0,
+      );
+
+      if (loadedCount >= 15) {
+        return undefined;
+      }
+
+      return lastPage.next;
+    },
   });

--- a/src/features/survey/api/useSurveyApi.ts
+++ b/src/features/survey/api/useSurveyApi.ts
@@ -34,7 +34,18 @@ export const useSurveyResultsInfinite = (
       getSurveyResults({
         session_id: sessionId!,
         cursor: pageParam ?? undefined,
-        page_size: 4,
+        page_size: 5,
       }),
-    getNextPageParam: (lastPage) => lastPage.next,
+    getNextPageParam: (lastPage, allPages) => {
+      const loadedCount = allPages.reduce(
+        (count, page) => count + page.results.length,
+        0,
+      );
+
+      if (loadedCount >= 15) {
+        return undefined;
+      }
+
+      return lastPage.next;
+    },
   });

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -41,9 +41,6 @@ const FALLBACK_BACKDROP_ITEMS = [
   },
 ];
 
-const getDisplayPrice = (gameId: number) =>
-  gameId % 4 === 0 ? '가격: 무료' : '가격: 정보 준비 중';
-
 const FALLBACK_HIGHLIGHTS = ['몰입감', '스토리', '액션', '전략'];
 
 type RecommendationDisplayItem = {
@@ -106,7 +103,12 @@ type RecommendationRowProps = {
 function RecommendationRow({ item, onOpenDetail }: RecommendationRowProps) {
   return (
     <article className="group grid gap-4 px-4 py-5 transition-colors duration-200 hover:bg-white/[0.025] sm:grid-cols-[118px_minmax(0,1fr)] sm:items-center sm:px-6 sm:py-6 lg:grid-cols-[118px_minmax(0,1fr)_auto] lg:gap-6 lg:px-7">
-      <div className="overflow-hidden rounded-[20px] border border-white/6 bg-[#111111] shadow-[0_14px_32px_rgba(0,0,0,0.18)]">
+      <button
+        type="button"
+        onClick={() => onOpenDetail(item)}
+        aria-label={`${item.title} 상세 보기`}
+        className="overflow-hidden rounded-[20px] border border-white/6 bg-[#111111] text-left shadow-[0_14px_32px_rgba(0,0,0,0.18)] transition hover:border-white/12 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]"
+      >
         {item.thumbnail_url ? (
           <img
             src={item.thumbnail_url}
@@ -118,7 +120,7 @@ function RecommendationRow({ item, onOpenDetail }: RecommendationRowProps) {
             이미지 준비 중
           </div>
         )}
-      </div>
+      </button>
 
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
@@ -137,16 +139,7 @@ function RecommendationRow({ item, onOpenDetail }: RecommendationRowProps) {
         </p>
       </div>
 
-      <div className="flex flex-wrap items-center justify-between gap-3 sm:justify-end lg:min-w-[240px] lg:flex-nowrap">
-        <div className="min-w-[110px] lg:text-right">
-          <p className="text-[11px] font-medium tracking-[0.18em] text-white/28 uppercase">
-            Price
-          </p>
-          <p className="mt-1 text-sm text-white/62">
-            {getDisplayPrice(item.game_id)}
-          </p>
-        </div>
-
+      <div className="flex items-center justify-end gap-3 lg:min-w-[96px]">
         <button
           type="button"
           className={`flex h-9 w-9 items-center justify-center rounded-full border transition ${
@@ -249,6 +242,11 @@ function RecommendationListPage() {
     normalizeResultItem,
   );
   const totalCount = data?.pages[0]?.count ?? 0;
+  const visibleResultLimit = 15;
+  const cappedTotalCount =
+    totalCount > 0
+      ? Math.min(totalCount, visibleResultLimit)
+      : Math.min(recommendationItems.length, visibleResultLimit);
   const recommendationHighlights =
     getRecommendationHighlights(recommendationItems);
   const errorMessage = error ? extractApiErrorMessage(error) : null;
@@ -301,7 +299,7 @@ function RecommendationListPage() {
                 Summary
               </p>
               <p className="mt-5 text-[34px] font-semibold tracking-[-0.04em] text-white">
-                {totalCount > 0 ? totalCount : '...'}
+                {cappedTotalCount > 0 ? cappedTotalCount : '...'}
               </p>
               <p className="mt-2 text-sm leading-6 break-keep text-white/52">
                 {isMatchSource
@@ -368,8 +366,8 @@ function RecommendationListPage() {
                   </div>
 
                   <div className="inline-flex w-fit items-center rounded-full border border-white/8 bg-white/[0.03] px-4 py-2 text-xs text-white/48">
-                    {totalCount > 0
-                      ? `${totalCount}개의 추천 결과`
+                    {cappedTotalCount > 0
+                      ? `${cappedTotalCount}개의 추천 결과`
                       : '추천 결과를 정리하고 있어요'}
                   </div>
                 </div>


### PR DESCRIPTION
## 관련 이슈

- closes #112 

## 변경 내용

- 추천 결과 리스트 조회 단위를 5개 기준으로 변경
- 더보기 클릭 시 5개씩 추가 조회되도록 수정
- 추천 결과는 최대 15개까지만 불러오도록 제한
- 추천 리스트 row에서 가격 영역 제거
- 게임 썸네일 이미지를 클릭해도 상세 모달이 열리도록 수정
- 기존 우측 상세 버튼과 동일한 상세 진입 동선을 이미지 영역에도 연결
- 추천 결과 개수 요약도 최대 15개 기준으로 표시되도록 정리

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 상세 모달은 기존 공용 `GameDetailModal`을 그대로 재사용합니다.
