### PR TITLE
[Fix] 상세 모달 좋아요 안내 및 UI UX 개선

### DIFF
--- a/src/components/mypage/ToastMessage.tsx
+++ b/src/components/mypage/ToastMessage.tsx
@@ -38,7 +38,7 @@ function ToastMessage({
 
   return (
     <div
-      className={`bg-mypage-panel border-mypage-panel shadow-mypage-float z-[70] flex w-[min(92vw,360px)] items-start gap-3 rounded-2xl border px-4 py-3 backdrop-blur-xl ${positioningClass} ${className}`}
+      className={`bg-mypage-panel border-mypage-panel shadow-mypage-float z-[70] flex w-fit max-w-[min(92vw,360px)] items-start gap-3 rounded-2xl border px-4 py-3 backdrop-blur-xl ${positioningClass} ${className}`}
     >
       <span
         className={`mt-0.5 shrink-0 ${
@@ -47,11 +47,13 @@ function ToastMessage({
       >
         <Icon size={18} />
       </span>
-      <p className="flex-1 text-sm/6 font-medium text-white">{message}</p>
+      <p className="min-w-0 text-sm/6 font-medium break-words text-white">
+        {message}
+      </p>
       <button
         type="button"
         onClick={onClose}
-        className="text-mypage-muted transition hover:text-white"
+        className="text-mypage-muted shrink-0 self-center transition hover:text-white"
         aria-label="토스트 닫기"
       >
         <X size={16} />

--- a/src/components/mypage/ToastMessage.tsx
+++ b/src/components/mypage/ToastMessage.tsx
@@ -2,7 +2,11 @@ import { AlertCircle, CheckCircle2, X } from 'lucide-react';
 
 type ToastMessageTone = 'success' | 'error';
 
-type ToastMessageVariant = 'fixed' | 'fixedCenter' | 'absoluteCenter';
+type ToastMessageVariant =
+  | 'fixed'
+  | 'fixedCenter'
+  | 'absoluteCenter'
+  | 'absoluteTopCenter';
 
 type ToastMessageProps = {
   message: string;
@@ -20,12 +24,17 @@ function ToastMessage({
   className = '',
 }: ToastMessageProps) {
   const Icon = tone === 'success' ? CheckCircle2 : AlertCircle;
-  const positioningClass =
-    variant === 'absoluteCenter'
-      ? 'absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
-      : variant === 'fixedCenter'
-        ? 'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
-        : 'fixed top-20 right-[clamp(1rem,5vw,20rem)]';
+  let positioningClass = 'fixed top-20 right-[clamp(1rem,5vw,20rem)]';
+
+  if (variant === 'absoluteCenter') {
+    positioningClass =
+      'absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2';
+  } else if (variant === 'absoluteTopCenter') {
+    positioningClass = 'absolute left-1/2 top-4 -translate-x-1/2 sm:top-6';
+  } else if (variant === 'fixedCenter') {
+    positioningClass =
+      'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2';
+  }
 
   return (
     <div

--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { ExternalLink, Heart, PlayCircle, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import ToastMessage from '../../../components/mypage/ToastMessage';
 import { useAuthStore } from '../../../store/useAuthStore';
 import { getGameDetail, likeGame, unlikeGame } from '../gameApi';
 import type { GameDetail, GameListItem } from '../types';
@@ -31,6 +32,7 @@ const LIKE_ERROR_MESSAGE =
   '찜하기 상태를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.';
 const DETAIL_NOT_FOUND_TITLE = '게임 상세 정보 없음';
 const DETAIL_NOT_FOUND_MESSAGE = '해당 게임 상세 정보를 찾을 수 없습니다.';
+const TOAST_DURATION_MS = 3000;
 
 const getLikeErrorMessage = (error: unknown) => {
   if (error instanceof AxiosError) {
@@ -54,9 +56,9 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
     isLiked: boolean | null;
     likeCount: number;
   } | null>(null);
-  const [likeFeedback, setLikeFeedback] = useState<{
-    gameId: number;
+  const [toast, setToast] = useState<{
     message: string;
+    tone: 'error';
   } | null>(null);
   const [failedImageUrlsByGameId, setFailedImageUrlsByGameId] = useState<
     Record<number, string[]>
@@ -73,7 +75,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
     mutationFn: (nextLiked: boolean) =>
       nextLiked ? likeGame(game.gameId) : unlikeGame(game.gameId),
     onMutate: () => {
-      setLikeFeedback(null);
+      setToast(null);
     },
     onSuccess: (response) => {
       const nextLikeState = {
@@ -96,9 +98,9 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
       );
     },
     onError: (error) => {
-      setLikeFeedback({
-        gameId: game.gameId,
+      setToast({
         message: getLikeErrorMessage(error),
+        tone: 'error',
       });
     },
   });
@@ -108,8 +110,6 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
   const genres = detail?.genres.length ? detail.genres : game.genres;
   const genreLabel = genres.length > 0 ? genres.join(', ') : 'N/A';
   const activeLikeState = likeState?.gameId === game.gameId ? likeState : null;
-  const activeLikeFeedback =
-    likeFeedback?.gameId === game.gameId ? likeFeedback.message : null;
   const currentLiked =
     activeLikeState?.isLiked ??
     detail?.isLiked ??
@@ -145,15 +145,29 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
 
   const handleToggleLike = () => {
     if (!hasAccessToken) {
-      setLikeFeedback({
-        gameId: game.gameId,
+      setToast({
         message: LOGIN_REQUIRED_MESSAGE,
+        tone: 'error',
       });
       return;
     }
 
     likeMutation.mutate(!isLiked);
   };
+
+  useEffect(() => {
+    if (!toast) {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setToast(null);
+    }, TOAST_DURATION_MS);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [toast]);
 
   useEffect(() => {
     const previousBodyOverflow = document.body.style.overflow;
@@ -191,6 +205,14 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
         }
       }}
     >
+      {toast ? (
+        <ToastMessage
+          message={toast.message}
+          tone={toast.tone}
+          onClose={() => setToast(null)}
+          variant="absoluteTopCenter"
+        />
+      ) : null}
       <section
         role="dialog"
         aria-modal="true"
@@ -263,7 +285,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                     type="button"
                     aria-label={likeLabel}
                     aria-pressed={isLiked}
-                    aria-disabled={!hasAccessToken}
+                    aria-disabled={likeMutation.isPending}
                     title={likeLabel}
                     disabled={likeMutation.isPending}
                     onClick={handleToggleLike}
@@ -296,11 +318,6 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                     {likeCount.toLocaleString('ko-KR')}
                   </span>
                 </p>
-                {activeLikeFeedback ? (
-                  <p role="status" className="mt-3 text-xs text-[#ffb4b8]">
-                    {activeLikeFeedback}
-                  </p>
-                ) : null}
                 <p className="mt-5 line-clamp-5 text-sm leading-6 text-white/60 sm:line-clamp-6">
                   {detailQuery.isLoading
                     ? '상세 정보를 불러오는 중입니다.'

--- a/src/features/games/mockGameDetails.ts
+++ b/src/features/games/mockGameDetails.ts
@@ -72,7 +72,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '황금률이 무너진 틈새의 땅을 배경으로, 플레이어는 빛바랜 자가 되어 엘든 링의 힘을 되찾기 위한 여정을 떠납니다. 방대한 오픈 월드와 던전, 강력한 보스전, 자유도 높은 빌드 구성이 핵심입니다.',
     platforms: ['PC', 'PS4', 'PS5', 'Xbox One', 'Xbox Series X|S'],
     likeCount: 1250,
-    isLiked: true,
     officialSite: 'https://www.eldenring.com/',
   }),
   2358720: createMockGameDetail({
@@ -99,7 +98,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '왕의 죽음 이후 혼란에 빠진 판타지 세계에서 주인공 일행이 새로운 왕을 정하는 선거에 뛰어듭니다. 턴제 전투, 아키타입 성장, 동료와의 유대가 결합된 RPG입니다.',
     platforms: ['PC', 'PS4', 'PS5', 'Xbox Series X|S'],
     likeCount: 740,
-    isLiked: true,
     officialSite: 'https://metaphor.atlus.com/',
   }),
   1845910: createMockGameDetail({
@@ -127,7 +125,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '던전 앤 드래곤 5판 규칙을 기반으로 한 파티 RPG입니다. 플레이어의 선택과 주사위 판정이 전투, 대화, 탐험 결과를 크게 바꾸며 다양한 방식으로 이야기를 풀어갈 수 있습니다.',
     platforms: ['PC', 'macOS', 'PS5', 'Xbox Series X|S'],
     likeCount: 1430,
-    isLiked: true,
     officialSite: 'https://baldursgate3.game/',
   }),
   292030: createMockGameDetail({
@@ -187,7 +184,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '전국 시대풍 세계에서 외팔이 늑대가 주군을 구하기 위해 싸우는 액션 어드벤처입니다. 자세를 무너뜨리는 검극, 잠입, 의수 도구 활용이 전투의 중심입니다.',
     platforms: ['PC', 'PS4', 'Xbox One'],
     likeCount: 870,
-    isLiked: true,
     officialSite: 'https://www.sekirothegame.com/',
   }),
   2050650: createMockGameDetail({
@@ -253,7 +249,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '몰락한 왕국 할로우네스트를 탐험하는 메트로배니아 액션 게임입니다. 정교한 플랫폼, 보스전, 탐험을 통해 세계의 비밀을 천천히 밝혀갑니다.',
     platforms: ['PC', 'macOS', 'Linux', 'PS4', 'Xbox One', 'Nintendo Switch'],
     likeCount: 1040,
-    isLiked: true,
     officialSite: 'https://www.hollowknight.com/',
   }),
   1627720: createMockGameDetail({

--- a/src/index.css
+++ b/src/index.css
@@ -233,6 +233,32 @@
     background-color: rgb(255 255 255 / 0.26);
   }
 
+  .game-detail-modal-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: rgb(255 255 255 / 0.18) transparent;
+    scrollbar-gutter: stable;
+  }
+
+  .game-detail-modal-scrollbar::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  .game-detail-modal-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .game-detail-modal-scrollbar::-webkit-scrollbar-thumb {
+    min-height: 40px;
+    border: 2px solid transparent;
+    border-radius: 999px;
+    background-color: rgb(255 255 255 / 0.14);
+    background-clip: padding-box;
+  }
+
+  .game-detail-modal-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: rgb(255 255 255 / 0.24);
+  }
+
   .support-chat-panel {
     border: 1px solid var(--color-support-chat-panel-border);
     background:


### PR DESCRIPTION
## 관련 이슈

- closes #114

## 변경 내용

- 상세 모달에서 비로그인 상태로 찜하기를 누를 때 모달 인라인 문구 대신 토스트로 안내하도록 변경했습니다.
- 상세 모달 토스트를 상단 중앙에 표시하도록 조정했습니다.
- 토스트의 닫기 버튼 정렬과 메시지 간격을 자연스럽게 보정했습니다.
- 상세 모달 전용 스크롤바 스타일을 추가해 다크 톤에 맞게 정리했습니다.
- mock 상세 데이터에서 기본 찜 상태로 보이던 값을 제거했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷


https://github.com/user-attachments/assets/53dda341-b44f-4d80-8fea-b113c3f36439



## 참고사항

- 이번 PR은 상세 모달 UX 정리 범위만 포함합니다.
- 실제 로그인 mock 또는 인증 연동 이후 찜하기/취소하기 플로우 확장은 후속 작업으로 진행합니다.
- `git push` 과정에서 pre-push hook으로 `npm run build`가 한 번 더 실행됐고, 기존과 동일한 chunk size warning만 출력됐습니다.