### PR TITLE
[Feat] 설문 입력창 포커스 유지 개선

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -32,6 +32,8 @@ function SurveyChatPanel() {
   const navigate = useNavigate();
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const formRef = useRef<HTMLFormElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const shouldRestoreFocusRef = useRef(false);
   const [inputValue, setInputValue] = useState('');
 
   const {
@@ -71,6 +73,31 @@ function SurveyChatPanel() {
       behavior: 'smooth',
     });
   }, [messages, error]);
+
+  const restoreTextareaFocus = useCallback(() => {
+    requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+
+      if (!textarea || textarea.disabled) {
+        return;
+      }
+
+      textarea.focus();
+      const cursorPosition = textarea.value.length;
+      textarea.setSelectionRange(cursorPosition, cursorPosition);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (
+      !isSubmitting &&
+      !recommendationReady &&
+      shouldRestoreFocusRef.current
+    ) {
+      shouldRestoreFocusRef.current = false;
+      restoreTextareaFocus();
+    }
+  }, [isSubmitting, recommendationReady, restoreTextareaFocus]);
 
   const bootstrapSurvey = useCallback(
     async (force = false) => {
@@ -177,11 +204,14 @@ function SurveyChatPanel() {
       return;
     }
 
+    shouldRestoreFocusRef.current = true;
     setInputValue('');
     await submitMessage({ content: nextMessage, appendUserMessage: true });
   };
 
   const handleRetry = async () => {
+    shouldRestoreFocusRef.current = true;
+
     if (!lastSubmittedMessage) {
       await bootstrapSurvey(true);
       return;
@@ -230,12 +260,14 @@ function SurveyChatPanel() {
     clearError();
 
     if (!sessionId) {
+      shouldRestoreFocusRef.current = true;
       setInputValue('');
       resetSurveyState();
       await bootstrapSurvey();
       return;
     }
 
+    shouldRestoreFocusRef.current = true;
     setSubmitting(true);
 
     try {
@@ -404,6 +436,7 @@ function SurveyChatPanel() {
                     : '지금 떠오르는 취향이나 최근 즐긴 게임 이야기를 적어보세요.'}
                 </span>
                 <textarea
+                  ref={textareaRef}
                   value={inputValue}
                   onChange={(event) => setInputValue(event.target.value)}
                   onKeyDown={handleTextareaKeyDown}


### PR DESCRIPTION
## 관련 이슈

- closes #116 

## 변경 내용

- 설문 전송 후 textarea 포커스가 유지되도록 수정
- `다시 시도` 이후 입력창 포커스가 다시 돌아오도록 처리
- `설문 초기화` 이후에도 입력창이 다시 활성화되면 자동으로 포커스를 복원하도록 수정
- 포커스 복원 시 커서가 입력창 끝으로 자연스럽게 이동하도록 정리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 전송 이후 매번 마우스로 입력창을 다시 클릭해야 하던 불편을 줄이기 위한 수정입니다.