### PR TITLE
[Refactor] 로그인 페이지 뷰포트 최적화 및 반응형 레이아웃 구현

### DIFF
--- a/src/components/auth/AuthSocialLoginGroup.tsx
+++ b/src/components/auth/AuthSocialLoginGroup.tsx
@@ -9,7 +9,29 @@ import {
 
 type AuthSocialLoginGroupProps = {
   className?: string;
+  size?: 'default' | 'compact';
 };
+
+const GROUP_SIZE_CLASS_NAMES = {
+  default: 'space-y-3 sm:space-y-3.5',
+  compact: 'space-y-[clamp(0.625rem,1.8dvh,0.875rem)]',
+} as const;
+
+const BUTTON_SIZE_CLASS_NAMES = {
+  default: {
+    google: 'h-14 sm:h-[61px]',
+    kakao: 'h-14 sm:h-[59px]',
+    naver: 'h-14 sm:h-[59px]',
+    label: '',
+  },
+  compact: {
+    google: 'h-[clamp(3rem,6.5dvh,3.5rem)]',
+    kakao: 'h-[clamp(3rem,6.5dvh,3.5rem)]',
+    naver: 'h-[clamp(3rem,6.5dvh,3.5rem)]',
+    label:
+      'text-[clamp(0.95rem,2dvh,1.05rem)] leading-none sm:text-[clamp(0.95rem,2dvh,1.05rem)]',
+  },
+} as const;
 
 const GoogleIcon = () => (
   <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
@@ -50,10 +72,14 @@ const NaverIcon = () => (
   </svg>
 );
 
-function AuthSocialLoginGroup({ className = '' }: AuthSocialLoginGroupProps) {
+function AuthSocialLoginGroup({
+  className = '',
+  size = 'default',
+}: AuthSocialLoginGroupProps) {
   const [redirectingProvider, setRedirectingProvider] =
     useState<SocialAuthProvider | null>(null);
   const [errorMessage, setErrorMessage] = useState('');
+  const buttonSizeClassName = BUTTON_SIZE_CLASS_NAMES[size];
 
   const handleSocialLogin = (provider: SocialAuthProvider) => {
     try {
@@ -70,28 +96,28 @@ function AuthSocialLoginGroup({ className = '' }: AuthSocialLoginGroupProps) {
   };
 
   return (
-    <div className={`space-y-3 ${className} sm:space-y-3.5`}>
+    <div className={`${GROUP_SIZE_CLASS_NAMES[size]} ${className}`}>
       <SocialLoginButton
         label="Google로 로그인하기"
         icon={<GoogleIcon />}
-        className="bg-login-google border-login-google h-14 border sm:h-[61px]"
-        labelClassName="text-white"
+        className={`bg-login-google border-login-google border ${buttonSizeClassName.google}`}
+        labelClassName={`text-white ${buttonSizeClassName.label}`}
         onClick={() => handleSocialLogin('google')}
         disabled={Boolean(redirectingProvider)}
       />
       <SocialLoginButton
         label="카카오로 로그인하기"
         icon={<KakaoIcon />}
-        className="bg-login-kakao h-14 sm:h-[59px]"
-        labelClassName="text-login-kakao-label"
+        className={`bg-login-kakao ${buttonSizeClassName.kakao}`}
+        labelClassName={`text-login-kakao-label ${buttonSizeClassName.label}`}
         onClick={() => handleSocialLogin('kakao')}
         disabled={Boolean(redirectingProvider)}
       />
       <SocialLoginButton
         label="네이버로 로그인하기"
         icon={<NaverIcon />}
-        className="bg-login-naver h-14 sm:h-[59px]"
-        labelClassName="text-white"
+        className={`bg-login-naver ${buttonSizeClassName.naver}`}
+        labelClassName={`text-white ${buttonSizeClassName.label}`}
         onClick={() => handleSocialLogin('naver')}
         disabled={Boolean(redirectingProvider)}
       />

--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -7,7 +7,9 @@ type AuthLayoutProps = {
   withPanel?: boolean;
   titleClassName?: string;
   subtitleClassName?: string;
+  mainClassName?: string;
   panelClassName?: string;
+  contentClassName?: string;
   children: ReactNode;
 };
 
@@ -17,7 +19,9 @@ function AuthLayout({
   withPanel = false,
   titleClassName = '',
   subtitleClassName = '',
+  mainClassName = '',
   panelClassName = '',
+  contentClassName = '',
   children,
 }: AuthLayoutProps) {
   const content = (
@@ -42,15 +46,21 @@ function AuthLayout({
     <div className="bg-login-page flex min-h-dvh flex-col text-white">
       <Header fixed={false} />
 
-      <main className="flex flex-1 items-center justify-center px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+      <main
+        className={`flex flex-1 items-center justify-center px-4 py-6 sm:px-6 sm:py-8 lg:px-8 ${mainClassName}`}
+      >
         {withPanel ? (
           <section
             className={`bg-auth-panel border-auth-panel shadow-auth-panel w-full max-w-[520px] rounded-[28px] border px-4 py-5 backdrop-blur-sm sm:rounded-3xl sm:px-8 sm:py-8 ${panelClassName}`}
           >
-            <div className="mx-auto w-full max-w-[440px]">{content}</div>
+            <div className={`mx-auto w-full max-w-[440px] ${contentClassName}`}>
+              {content}
+            </div>
           </section>
         ) : (
-          <section className="w-full max-w-[440px]">{content}</section>
+          <section className={`w-full max-w-[440px] ${contentClassName}`}>
+            {content}
+          </section>
         )}
       </main>
     </div>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -27,6 +27,23 @@ type LoginLocationState = {
   errorMessage?: string;
 };
 
+const LOGIN_MAIN_CLASS_NAME = 'min-h-0 py-3 sm:py-4';
+const LOGIN_PANEL_CLASS_NAME =
+  'max-w-[500px] max-h-[calc(100dvh-4rem-1.5rem)] overflow-y-auto overscroll-contain recommendation-scroll px-[clamp(1rem,3vw,1.75rem)] py-[clamp(1.25rem,3.6dvh,2rem)] sm:max-h-[calc(100dvh-4rem-2rem)] sm:px-[clamp(1.25rem,3vw,2rem)] sm:py-[clamp(1.5rem,4dvh,2.25rem)]';
+const LOGIN_CONTENT_CLASS_NAME = 'max-w-[420px]';
+const LOGIN_TITLE_CLASS_NAME = 'text-[clamp(2.25rem,5dvh,3rem)]';
+const LOGIN_SOCIAL_GROUP_CLASS_NAME = 'mt-[clamp(1rem,2.5dvh,1.75rem)]';
+const LOGIN_DIVIDER_CLASS_NAME = 'my-[clamp(0.875rem,2.4dvh,1.5rem)]';
+const LOGIN_FORM_CLASS_NAME = 'space-y-[clamp(0.75rem,2.2dvh,1rem)]';
+const LOGIN_FIELD_CLASS_NAME =
+  'h-[clamp(3rem,6.5dvh,3.5rem)] px-[clamp(0.875rem,2vw,1rem)] text-[clamp(0.95rem,2dvh,1rem)]';
+const LOGIN_PRIMARY_BUTTON_CLASS_NAME =
+  'mt-[clamp(0.75rem,2dvh,1rem)] h-[clamp(3rem,6.5dvh,3.5rem)] text-[clamp(1rem,2.2dvh,1.125rem)] leading-none';
+const LOGIN_SECONDARY_BUTTON_CLASS_NAME =
+  'mt-[clamp(0.75rem,2dvh,1.25rem)] h-[clamp(3rem,6.5dvh,3.5rem)] text-[clamp(1rem,2.2dvh,1.125rem)] leading-none';
+const LOGIN_SIGNUP_SECTION_CLASS_NAME =
+  'border-login-divider mt-[clamp(1rem,2.5dvh,1.75rem)] border-t pt-[clamp(0.875rem,2.2dvh,1.5rem)]';
+
 const getLoginFieldErrors = (
   values: LoginRequest,
   touchedState: LoginTouchedState,
@@ -139,12 +156,22 @@ function LoginPage() {
   };
 
   return (
-    <AuthLayout title="Log In" withPanel panelClassName="max-w-[500px]">
-      <AuthSocialLoginGroup className="mt-6 sm:mt-7" />
+    <AuthLayout
+      title="Log In"
+      withPanel
+      titleClassName={LOGIN_TITLE_CLASS_NAME}
+      mainClassName={LOGIN_MAIN_CLASS_NAME}
+      panelClassName={LOGIN_PANEL_CLASS_NAME}
+      contentClassName={LOGIN_CONTENT_CLASS_NAME}
+    >
+      <AuthSocialLoginGroup
+        className={LOGIN_SOCIAL_GROUP_CLASS_NAME}
+        size="compact"
+      />
 
-      <AuthDivider className="my-5 sm:my-6" />
+      <AuthDivider className={LOGIN_DIVIDER_CLASS_NAME} />
 
-      <form className="space-y-3.5 sm:space-y-4" onSubmit={handleSubmit}>
+      <form className={LOGIN_FORM_CLASS_NAME} onSubmit={handleSubmit}>
         <AuthInputField
           id="login-id"
           name="login_id"
@@ -162,7 +189,8 @@ function LoginPage() {
           }
           errorMessage={resolvedFieldErrors.login_id}
           disabled={loginMutation.isPending}
-          containerClassName="pt-1"
+          containerClassName="pt-[clamp(0.125rem,0.7dvh,0.25rem)]"
+          className={LOGIN_FIELD_CLASS_NAME}
         />
 
         <AuthInputField
@@ -182,6 +210,7 @@ function LoginPage() {
           }
           errorMessage={resolvedFieldErrors.password}
           disabled={loginMutation.isPending}
+          className={LOGIN_FIELD_CLASS_NAME}
         />
 
         {noticeMessage ? (
@@ -193,7 +222,7 @@ function LoginPage() {
         <div className="flex justify-end">
           <button
             type="button"
-            className="text-login-muted text-sm font-medium transition-colors hover:text-white/80"
+            className="text-login-muted text-[clamp(0.75rem,1.7dvh,0.875rem)] font-medium transition-colors hover:text-white/80"
           >
             아이디/비밀번호를 잊어버리셨나요?
           </button>
@@ -201,20 +230,20 @@ function LoginPage() {
 
         <AuthButton
           type="submit"
-          className="mt-3.5 w-full sm:mt-4"
+          className={`w-full ${LOGIN_PRIMARY_BUTTON_CLASS_NAME}`}
           disabled={loginMutation.isPending}
         >
           {loginMutation.isPending ? '로그인 중...' : '로그인'}
         </AuthButton>
       </form>
 
-      <div className="border-login-divider mt-6 border-t pt-5 sm:mt-7 sm:pt-6">
-        <p className="text-login-helper text-center text-sm/5 font-normal">
+      <div className={LOGIN_SIGNUP_SECTION_CLASS_NAME}>
+        <p className="text-login-helper text-center text-[clamp(0.75rem,1.8dvh,0.875rem)] leading-5 font-normal">
           아직 PGTI 회원이 아니신가요?
         </p>
         <AuthLinkButton
           to={`/${ROUTES.SIGNUP}`}
-          className="mt-4 w-full sm:mt-5"
+          className={`w-full ${LOGIN_SECONDARY_BUTTON_CLASS_NAME}`}
         >
           회원가입
         </AuthLinkButton>


### PR DESCRIPTION
## 관련 이슈

- closes #117

## 변경 내용

-뷰포트 최적화: 로그인 컨테이너의 크기를 vh, vw 및 max-w 단위를 사용하여 다양한 디바이스 화면에 대응하도록 수정했습니다.

-반응형 레이아웃: 모바일 환경에서 주소창 등으로 인해 UI가 잘리는 현상을 방지하기 위해 min-h-screen 등을 활용한 레이아웃 보완을 진행했습니다.

-중앙 정렬 개선: Flexbox를 활용하여 모든 해상도에서 로그인 폼이 화면 중앙에 안정적으로 위치하도록 개선했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3234" height="1610" alt="image" src="https://github.com/user-attachments/assets/14611062-f1ef-464a-ba92-a6d9299ae892" />

## 참고사항

-배포 환경(Vercel)에서의 뷰포트 작동 여부를 Preview 배포를 통해 확인했습니다.
