### PR TITLE
[Fix] 게임 상세 지원 플랫폼 항목 제거

### DIFF
--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -127,14 +127,10 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
   );
   const imageUrl =
     imageCandidates.find((url) => !failedImageUrls.includes(url)) ?? null;
-  const platformLabel = detail?.platforms.length
-    ? detail.platforms.map((platform) => platform.name).join(', ')
-    : 'N/A';
   const detailRows = [
     { label: '게임 출시일', value: formatNullableText(detail?.releaseDate) },
     { label: '게임 개발사', value: formatNullableText(detail?.developer) },
     { label: '게임 배급사', value: formatNullableText(detail?.publisher) },
-    { label: '지원 플랫폼', value: platformLabel },
   ];
   const externalLinks = EXTERNAL_LINK_LABELS.map(({ key, label }) => ({
     label,
@@ -217,7 +213,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
         role="dialog"
         aria-modal="true"
         aria-labelledby="game-detail-modal-title"
-        className="game-detail-modal-scrollbar relative max-h-[calc(100dvh-2rem)] w-full max-w-4xl overflow-y-auto overscroll-contain rounded-lg border border-[#5a1115]/80 bg-[#111111] text-white shadow-[0_0_48px_rgba(210,11,18,0.22)] sm:max-h-[calc(100dvh-3rem)]"
+        className="game-detail-modal-scrollbar bg-auth-panel relative max-h-[calc(100dvh-2rem)] w-full max-w-4xl overflow-y-auto overscroll-contain rounded-lg border border-[#5a1115]/80 text-white shadow-[0_0_48px_rgba(210,11,18,0.22)] sm:max-h-[calc(100dvh-3rem)]"
         onMouseDown={(event) => event.stopPropagation()}
       >
         <button
@@ -230,7 +226,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
         </button>
 
         {detailQuery.isError ? (
-          <div className="flex min-h-[24rem] flex-col items-center justify-center px-6 py-16 text-center sm:px-10">
+          <div className="flex min-h-96 flex-col items-center justify-center px-6 py-16 text-center sm:px-10">
             <h2
               id="game-detail-modal-title"
               className="text-2xl font-bold text-white sm:text-3xl"

--- a/src/features/games/gameApi.ts
+++ b/src/features/games/gameApi.ts
@@ -64,11 +64,6 @@ const normalizeGameDetail = (game: RawGameDetailResponse): GameDetail => ({
   promoEmbedUrl: normalizeNullableString(game.media?.promo_embed_url),
   coverImageUrl: normalizeNullableString(game.media?.cover_image_url),
   description: game.description || null,
-  platforms:
-    game.platforms
-      ?.map((platform) => platform.name?.trim())
-      .filter((name): name is string => Boolean(name))
-      .map((name) => ({ name })) ?? [],
   externalLinks: {
     officialSite: normalizeNullableString(game.external_links?.official_site),
     steam: normalizeNullableString(game.external_links?.steam),

--- a/src/features/games/mockGameDetails.ts
+++ b/src/features/games/mockGameDetails.ts
@@ -15,7 +15,6 @@ const createMockGameDetail = ({
   developer,
   publisher,
   description,
-  platforms,
   likeCount,
   isLiked = false,
   officialSite = null,
@@ -32,7 +31,6 @@ const createMockGameDetail = ({
   developer: string;
   publisher: string;
   description: string;
-  platforms: string[];
   likeCount: number;
   isLiked?: boolean;
   officialSite?: string | null;
@@ -50,7 +48,6 @@ const createMockGameDetail = ({
   promoEmbedUrl,
   coverImageUrl: steamCoverUrl(gameId),
   description,
-  platforms: platforms.map((name) => ({ name })),
   externalLinks: {
     officialSite,
     steam: steamStoreUrl(gameId),
@@ -70,7 +67,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Bandai Namco Entertainment',
     description:
       '황금률이 무너진 틈새의 땅을 배경으로, 플레이어는 빛바랜 자가 되어 엘든 링의 힘을 되찾기 위한 여정을 떠납니다. 방대한 오픈 월드와 던전, 강력한 보스전, 자유도 높은 빌드 구성이 핵심입니다.',
-    platforms: ['PC', 'PS4', 'PS5', 'Xbox One', 'Xbox Series X|S'],
     likeCount: 1250,
     officialSite: 'https://www.eldenring.com/',
   }),
@@ -83,7 +79,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Game Science',
     description:
       '서유기에서 영감을 받은 액션 RPG입니다. 천명자는 신화 속 존재와 맞서며 잊힌 진실을 좇고, 빠른 전투와 변신 능력, 보스 공략을 중심으로 모험을 진행합니다.',
-    platforms: ['PC', 'PS5', 'Xbox Series X|S'],
     likeCount: 980,
     officialSite: 'https://www.heishenhua.com/',
   }),
@@ -96,7 +91,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Atlus',
     description:
       '왕의 죽음 이후 혼란에 빠진 판타지 세계에서 주인공 일행이 새로운 왕을 정하는 선거에 뛰어듭니다. 턴제 전투, 아키타입 성장, 동료와의 유대가 결합된 RPG입니다.',
-    platforms: ['PC', 'PS4', 'PS5', 'Xbox Series X|S'],
     likeCount: 740,
     officialSite: 'https://metaphor.atlus.com/',
   }),
@@ -109,7 +103,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Electronic Arts',
     description:
       '테다스 세계를 위협하는 고대의 신들에 맞서 동료를 모으고 베일가드를 이끄는 판타지 RPG입니다. 선택과 관계, 파티 기반 전투가 이야기의 중심을 이룹니다.',
-    platforms: ['PC', 'PS5', 'Xbox Series X|S'],
     likeCount: 510,
     officialSite:
       'https://www.ea.com/games/dragon-age/dragon-age-the-veilguard',
@@ -123,7 +116,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Larian Studios',
     description:
       '던전 앤 드래곤 5판 규칙을 기반으로 한 파티 RPG입니다. 플레이어의 선택과 주사위 판정이 전투, 대화, 탐험 결과를 크게 바꾸며 다양한 방식으로 이야기를 풀어갈 수 있습니다.',
-    platforms: ['PC', 'macOS', 'PS5', 'Xbox Series X|S'],
     likeCount: 1430,
     officialSite: 'https://baldursgate3.game/',
   }),
@@ -136,14 +128,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'CD Projekt',
     description:
       '괴물 사냥꾼 게롤트가 시리를 찾아 전쟁과 음모가 뒤섞인 대륙을 누비는 오픈 월드 RPG입니다. 선택에 따라 달라지는 퀘스트와 풍부한 서사가 강점입니다.',
-    platforms: [
-      'PC',
-      'PS4',
-      'PS5',
-      'Xbox One',
-      'Xbox Series X|S',
-      'Nintendo Switch',
-    ],
     likeCount: 1320,
     officialSite: 'https://www.thewitcher.com/witcher3',
   }),
@@ -156,7 +140,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'CD Projekt',
     description:
       '거대 기업과 갱단이 지배하는 나이트 시티에서 용병 V가 생존과 자유를 위해 싸우는 오픈 월드 RPG입니다. 사이버웨어, 총격전, 해킹, 선택형 서사가 결합되어 있습니다.',
-    platforms: ['PC', 'PS4', 'PS5', 'Xbox One', 'Xbox Series X|S'],
     likeCount: 1180,
     officialSite: 'https://www.cyberpunk.net/',
   }),
@@ -169,7 +152,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Capcom',
     description:
       '신대륙을 조사하는 헌터가 거대한 몬스터를 추적하고 사냥하는 액션 게임입니다. 장비 제작, 협동 플레이, 몬스터별 패턴 공략이 핵심 재미입니다.',
-    platforms: ['PC', 'PS4', 'Xbox One'],
     likeCount: 920,
     officialSite: 'https://www.monsterhunter.com/world/',
   }),
@@ -182,7 +164,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Activision',
     description:
       '전국 시대풍 세계에서 외팔이 늑대가 주군을 구하기 위해 싸우는 액션 어드벤처입니다. 자세를 무너뜨리는 검극, 잠입, 의수 도구 활용이 전투의 중심입니다.',
-    platforms: ['PC', 'PS4', 'Xbox One'],
     likeCount: 870,
     officialSite: 'https://www.sekirothegame.com/',
   }),
@@ -195,7 +176,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Capcom',
     description:
       '요원 레온 S. 케네디가 납치된 대통령의 딸을 구하기 위해 폐쇄적인 마을로 향하는 서바이벌 호러 액션입니다. 원작의 긴장감을 현대적인 조작과 연출로 재구성했습니다.',
-    platforms: ['PC', 'PS4', 'PS5', 'Xbox Series X|S'],
     likeCount: 690,
     officialSite: 'https://www.residentevil.com/re4/',
   }),
@@ -208,7 +188,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'PlayStation Publishing',
     description:
       '슈퍼 지구를 위해 외계 세력과 싸우는 협동 슈팅 게임입니다. 분대 전술, 스트라타젬 호출, 아군 오사까지 포함한 혼란스러운 전장이 특징입니다.',
-    platforms: ['PC', 'PS5'],
     likeCount: 830,
     officialSite: 'https://www.playstation.com/games/helldivers-2/',
   }),
@@ -221,7 +200,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Pocketpair',
     description:
       '팰을 수집하고 함께 전투, 건축, 생산을 이어가는 오픈 월드 생존 게임입니다. 기지 운영과 탐험, 협동 플레이가 결합되어 있습니다.',
-    platforms: ['PC', 'Xbox One', 'Xbox Series X|S'],
     likeCount: 760,
     officialSite: 'https://www.pocketpair.jp/palworld',
   }),
@@ -234,7 +212,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Supergiant Games',
     description:
       '저승의 공주 멜리노에가 시간의 티탄 크로노스에 맞서는 로그라이크 액션 게임입니다. 반복 도전 속에서 무기, 은혜, 주문을 조합해 새로운 빌드를 완성합니다.',
-    platforms: ['PC'],
     likeCount: 650,
     officialSite: 'https://www.supergiantgames.com/games/hades-ii/',
   }),
@@ -247,7 +224,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Team Cherry',
     description:
       '몰락한 왕국 할로우네스트를 탐험하는 메트로배니아 액션 게임입니다. 정교한 플랫폼, 보스전, 탐험을 통해 세계의 비밀을 천천히 밝혀갑니다.',
-    platforms: ['PC', 'macOS', 'Linux', 'PS4', 'Xbox One', 'Nintendo Switch'],
     likeCount: 1040,
     officialSite: 'https://www.hollowknight.com/',
   }),
@@ -260,7 +236,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Neowiz Games',
     description:
       '피노키오를 어둡게 재해석한 소울라이크 액션 RPG입니다. 기계 인형이 폭주한 크라트에서 진실과 거짓을 오가며 전투와 선택을 이어갑니다.',
-    platforms: ['PC', 'PS4', 'PS5', 'Xbox One', 'Xbox Series X|S'],
     likeCount: 590,
     officialSite: 'https://www.liesofp.com/',
   }),
@@ -273,7 +248,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'MINTROCKET',
     description:
       '낮에는 블루홀을 탐험해 해산물을 잡고, 밤에는 초밥집을 운영하는 어드벤처 경영 게임입니다. 탐험, 채집, 매장 운영이 가볍고 유쾌하게 이어집니다.',
-    platforms: ['PC', 'macOS', 'PS4', 'PS5', 'Nintendo Switch'],
     likeCount: 710,
     officialSite: 'https://mintrocketgames.com/en/DaveTheDiver',
   }),
@@ -286,16 +260,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Mega Crit',
     description:
       '카드 덱을 구성하며 첨탑을 오르는 로그라이크 덱빌딩 게임입니다. 매 전투와 이벤트에서 얻는 카드, 유물, 선택이 새로운 전략을 만듭니다.',
-    platforms: [
-      'PC',
-      'macOS',
-      'Linux',
-      'PS4',
-      'Xbox One',
-      'Nintendo Switch',
-      'iOS',
-      'Android',
-    ],
     likeCount: 860,
     officialSite: 'https://www.megacrit.com/',
   }),
@@ -308,17 +272,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Playstack',
     description:
       '포커 족보를 기반으로 점수를 폭발적으로 키우는 로그라이크 덱빌딩 게임입니다. 조커와 카드 강화 조합을 통해 매 판 다른 점수 엔진을 완성합니다.',
-    platforms: [
-      'PC',
-      'macOS',
-      'PS4',
-      'PS5',
-      'Xbox One',
-      'Xbox Series X|S',
-      'Nintendo Switch',
-      'iOS',
-      'Android',
-    ],
     likeCount: 790,
     officialSite: 'https://www.playbalatro.com/',
   }),
@@ -331,7 +284,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Coffee Stain Publishing',
     description:
       '우주 드워프 광부들이 절차적으로 생성되는 동굴에서 자원을 채굴하고 외계 생물과 싸우는 협동 FPS입니다. 직업별 장비와 팀워크가 중요합니다.',
-    platforms: ['PC', 'PS4', 'PS5', 'Xbox One', 'Xbox Series X|S'],
     likeCount: 680,
     officialSite: 'https://www.deeprockgalactic.com/',
   }),
@@ -344,16 +296,6 @@ export const mockGameDetails: Record<number, GameDetail> = {
     publisher: 'Re-Logic',
     description:
       '2D 샌드박스 세계에서 채집, 건축, 탐험, 보스전을 자유롭게 즐기는 어드벤처 게임입니다. 장비 성장과 월드 변화가 긴 플레이 흐름을 만듭니다.',
-    platforms: [
-      'PC',
-      'macOS',
-      'Linux',
-      'PS4',
-      'Xbox One',
-      'Nintendo Switch',
-      'iOS',
-      'Android',
-    ],
     likeCount: 1120,
     officialSite: 'https://terraria.org/',
   }),
@@ -379,7 +321,6 @@ export const getMockGameDetail = (gameId: number): GameDetail => {
     promoEmbedUrl: null,
     coverImageUrl: game?.thumbnailUrl ?? null,
     description: null,
-    platforms: [],
     externalLinks: {
       officialSite: null,
       steam: game ? steamStoreUrl(game.gameId) : null,

--- a/src/features/games/types.ts
+++ b/src/features/games/types.ts
@@ -35,7 +35,6 @@ export type GameDetail = {
   promoEmbedUrl: string | null;
   coverImageUrl: string | null;
   description: string | null;
-  platforms: Array<{ name: string }>;
   externalLinks: {
     officialSite?: string | null;
     steam?: string | null;
@@ -58,7 +57,6 @@ export type RawGameDetailResponse = {
     cover_image_url?: string | null;
   } | null;
   description: string | null;
-  platforms: Array<{ name: string | null }> | null;
   external_links: {
     official_site?: string | null;
     steam?: string | null;


### PR DESCRIPTION
## 관련 이슈

- closes #121

## 변경 내용

- 게임 상세 모달에서 `지원 플랫폼` 행을 제거했습니다.
- 게임 상세 타입에서 `platforms` 필드를 제거했습니다.
- 상세 응답 정규화 로직에서 `platforms` 처리를 제거했습니다.
- mock 상세 데이터의 `platforms` 값을 제거했습니다.
- 상세 모달의 Tailwind canonical class / prettier 경고를 함께 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 기획 변경에 따라 게임 상세에서 `지원 플랫폼`은 더 이상 노출하지 않습니다.
- 백엔드 응답에 관련 필드가 남아 있더라도 프론트에서는 사용하지 않습니다.
- `npm run build`는 통과했고, 기존과 동일하게 Vite chunk size warning만 출력됩니다.
