### PR TITLE
[Refactor] 로그인 페이지 뷰포트 최적화 및 레이아웃 수정

### DIFF
--- a/src/components/auth/AuthSocialLoginGroup.tsx
+++ b/src/components/auth/AuthSocialLoginGroup.tsx
@@ -14,7 +14,7 @@ type AuthSocialLoginGroupProps = {
 
 const GROUP_SIZE_CLASS_NAMES = {
   default: 'space-y-3 sm:space-y-3.5',
-  compact: 'space-y-[clamp(0.625rem,1.8dvh,0.875rem)]',
+  compact: 'space-y-[clamp(0.375rem,1dvh,0.625rem)]',
 } as const;
 
 const BUTTON_SIZE_CLASS_NAMES = {
@@ -25,16 +25,20 @@ const BUTTON_SIZE_CLASS_NAMES = {
     label: '',
   },
   compact: {
-    google: 'h-[clamp(3rem,6.5dvh,3.5rem)]',
-    kakao: 'h-[clamp(3rem,6.5dvh,3.5rem)]',
-    naver: 'h-[clamp(3rem,6.5dvh,3.5rem)]',
+    google: 'h-[clamp(2.5rem,4.8dvh,2.75rem)]',
+    kakao: 'h-[clamp(2.5rem,4.8dvh,2.75rem)]',
+    naver: 'h-[clamp(2.5rem,4.8dvh,2.75rem)]',
     label:
-      'text-[clamp(0.95rem,2dvh,1.05rem)] leading-none sm:text-[clamp(0.95rem,2dvh,1.05rem)]',
+      'text-[clamp(0.8125rem,1.45dvh,0.9rem)] leading-none sm:text-[clamp(0.8125rem,1.45dvh,0.9rem)]',
   },
 } as const;
 
-const GoogleIcon = () => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
+type SocialIconProps = {
+  className?: string;
+};
+
+const GoogleIcon = ({ className = 'h-5 w-5 shrink-0' }: SocialIconProps) => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className={className}>
     <path
       fill="#4285F4"
       d="M21.805 10.041H12.61v3.949h5.268c-.229 1.276-.955 2.356-2.036 3.083v2.526h3.304c1.937-1.783 3.056-4.41 3.056-7.548 0-.676-.061-1.315-.397-2.01Z"
@@ -54,8 +58,8 @@ const GoogleIcon = () => (
   </svg>
 );
 
-const KakaoIcon = () => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
+const KakaoIcon = ({ className = 'h-5 w-5 shrink-0' }: SocialIconProps) => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className={className}>
     <path
       fill="#181600"
       d="M12 4.2c-5.19 0-9.4 3.14-9.4 7.02 0 2.48 1.72 4.65 4.33 5.88l-1.08 3.96a.36.36 0 0 0 .55.4l4.57-3.1c.34.03.68.05 1.03.05 5.19 0 9.4-3.14 9.4-7.02S17.19 4.2 12 4.2Z"
@@ -63,8 +67,8 @@ const KakaoIcon = () => (
   </svg>
 );
 
-const NaverIcon = () => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 shrink-0">
+const NaverIcon = ({ className = 'h-5 w-5 shrink-0' }: SocialIconProps) => (
+  <svg aria-hidden="true" viewBox="0 0 24 24" className={className}>
     <path
       fill="currentColor"
       d="M6 5.5h4.57l2.94 4.19V5.5H18v13h-4.57l-2.94-4.19v4.19H6v-13Z"
@@ -80,6 +84,8 @@ function AuthSocialLoginGroup({
     useState<SocialAuthProvider | null>(null);
   const [errorMessage, setErrorMessage] = useState('');
   const buttonSizeClassName = BUTTON_SIZE_CLASS_NAMES[size];
+  const iconClassName =
+    size === 'compact' ? 'h-3.5 w-3.5 shrink-0' : 'h-5 w-5 shrink-0';
 
   const handleSocialLogin = (provider: SocialAuthProvider) => {
     try {
@@ -99,7 +105,7 @@ function AuthSocialLoginGroup({
     <div className={`${GROUP_SIZE_CLASS_NAMES[size]} ${className}`}>
       <SocialLoginButton
         label="Google로 로그인하기"
-        icon={<GoogleIcon />}
+        icon={<GoogleIcon className={iconClassName} />}
         className={`bg-login-google border-login-google border ${buttonSizeClassName.google}`}
         labelClassName={`text-white ${buttonSizeClassName.label}`}
         onClick={() => handleSocialLogin('google')}
@@ -107,7 +113,7 @@ function AuthSocialLoginGroup({
       />
       <SocialLoginButton
         label="카카오로 로그인하기"
-        icon={<KakaoIcon />}
+        icon={<KakaoIcon className={iconClassName} />}
         className={`bg-login-kakao ${buttonSizeClassName.kakao}`}
         labelClassName={`text-login-kakao-label ${buttonSizeClassName.label}`}
         onClick={() => handleSocialLogin('kakao')}
@@ -115,7 +121,7 @@ function AuthSocialLoginGroup({
       />
       <SocialLoginButton
         label="네이버로 로그인하기"
-        icon={<NaverIcon />}
+        icon={<NaverIcon className={iconClassName} />}
         className={`bg-login-naver ${buttonSizeClassName.naver}`}
         labelClassName={`text-white ${buttonSizeClassName.label}`}
         onClick={() => handleSocialLogin('naver')}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -27,22 +27,23 @@ type LoginLocationState = {
   errorMessage?: string;
 };
 
-const LOGIN_MAIN_CLASS_NAME = 'min-h-0 py-3 sm:py-4';
+const LOGIN_MAIN_CLASS_NAME = 'min-h-0 py-1 sm:py-1.5';
 const LOGIN_PANEL_CLASS_NAME =
-  'max-w-[500px] max-h-[calc(100dvh-4rem-1.5rem)] overflow-y-auto overscroll-contain recommendation-scroll px-[clamp(1rem,3vw,1.75rem)] py-[clamp(1.25rem,3.6dvh,2rem)] sm:max-h-[calc(100dvh-4rem-2rem)] sm:px-[clamp(1.25rem,3vw,2rem)] sm:py-[clamp(1.5rem,4dvh,2.25rem)]';
-const LOGIN_CONTENT_CLASS_NAME = 'max-w-[420px]';
-const LOGIN_TITLE_CLASS_NAME = 'text-[clamp(2.25rem,5dvh,3rem)]';
-const LOGIN_SOCIAL_GROUP_CLASS_NAME = 'mt-[clamp(1rem,2.5dvh,1.75rem)]';
-const LOGIN_DIVIDER_CLASS_NAME = 'my-[clamp(0.875rem,2.4dvh,1.5rem)]';
-const LOGIN_FORM_CLASS_NAME = 'space-y-[clamp(0.75rem,2.2dvh,1rem)]';
+  'max-w-[452px] px-[clamp(0.75rem,1.7vw,1.25rem)] py-[clamp(0.75rem,1.6dvh,1rem)] sm:px-[clamp(0.875rem,2vw,1.5rem)] sm:py-[clamp(0.875rem,1.9dvh,1.25rem)]';
+const LOGIN_CONTENT_CLASS_NAME = 'max-w-[360px]';
+const LOGIN_TITLE_CLASS_NAME = 'text-[clamp(1.75rem,3.6dvh,2.375rem)]';
+const LOGIN_SOCIAL_GROUP_CLASS_NAME = 'mt-[clamp(0.5rem,1.2dvh,0.875rem)]';
+const LOGIN_DIVIDER_CLASS_NAME =
+  'my-[clamp(0.5rem,1.2dvh,0.75rem)] gap-2.5 py-0';
+const LOGIN_FORM_CLASS_NAME = 'space-y-[clamp(0.5rem,1.25dvh,0.75rem)]';
 const LOGIN_FIELD_CLASS_NAME =
-  'h-[clamp(3rem,6.5dvh,3.5rem)] px-[clamp(0.875rem,2vw,1rem)] text-[clamp(0.95rem,2dvh,1rem)]';
+  'h-[clamp(2.5rem,4.8dvh,2.75rem)] rounded-[0.875rem] px-[clamp(0.75rem,1.5vw,0.9375rem)] text-[clamp(0.85rem,1.45dvh,0.9375rem)]';
 const LOGIN_PRIMARY_BUTTON_CLASS_NAME =
-  'mt-[clamp(0.75rem,2dvh,1rem)] h-[clamp(3rem,6.5dvh,3.5rem)] text-[clamp(1rem,2.2dvh,1.125rem)] leading-none';
+  'mt-[clamp(0.375rem,1dvh,0.625rem)] h-[clamp(2.5rem,4.8dvh,2.75rem)] text-[clamp(0.9rem,1.55dvh,1rem)] leading-none';
 const LOGIN_SECONDARY_BUTTON_CLASS_NAME =
-  'mt-[clamp(0.75rem,2dvh,1.25rem)] h-[clamp(3rem,6.5dvh,3.5rem)] text-[clamp(1rem,2.2dvh,1.125rem)] leading-none';
+  'mt-[clamp(0.5rem,1.2dvh,0.75rem)] h-[clamp(2.5rem,4.8dvh,2.75rem)] text-[clamp(0.9rem,1.55dvh,1rem)] leading-none';
 const LOGIN_SIGNUP_SECTION_CLASS_NAME =
-  'border-login-divider mt-[clamp(1rem,2.5dvh,1.75rem)] border-t pt-[clamp(0.875rem,2.2dvh,1.5rem)]';
+  'border-login-divider mt-[clamp(0.625rem,1.4dvh,0.875rem)] border-t pt-[clamp(0.5rem,1.2dvh,0.75rem)]';
 
 const getLoginFieldErrors = (
   values: LoginRequest,
@@ -189,7 +190,7 @@ function LoginPage() {
           }
           errorMessage={resolvedFieldErrors.login_id}
           disabled={loginMutation.isPending}
-          containerClassName="pt-[clamp(0.125rem,0.7dvh,0.25rem)]"
+          containerClassName="pt-[clamp(0.125rem,0.3dvh,0.1875rem)]"
           className={LOGIN_FIELD_CLASS_NAME}
         />
 
@@ -222,7 +223,7 @@ function LoginPage() {
         <div className="flex justify-end">
           <button
             type="button"
-            className="text-login-muted text-[clamp(0.75rem,1.7dvh,0.875rem)] font-medium transition-colors hover:text-white/80"
+            className="text-login-muted text-[clamp(0.675rem,1.1dvh,0.75rem)] font-medium transition-colors hover:text-white/80"
           >
             아이디/비밀번호를 잊어버리셨나요?
           </button>
@@ -238,7 +239,7 @@ function LoginPage() {
       </form>
 
       <div className={LOGIN_SIGNUP_SECTION_CLASS_NAME}>
-        <p className="text-login-helper text-center text-[clamp(0.75rem,1.8dvh,0.875rem)] leading-5 font-normal">
+        <p className="text-login-helper text-center text-[clamp(0.675rem,1.15dvh,0.75rem)] leading-[1.1rem] font-normal">
           아직 PGTI 회원이 아니신가요?
         </p>
         <AuthLinkButton


### PR DESCRIPTION
## 관련 이슈

- closes #117

## 변경 내용

-뷰포트 최적화: 로그인 컨테이너의 크기를 vh, vw 및 max-w 단위를 사용하여 다양한 디바이스 화면에 대응하도록 수정했습니다.

-반응형 레이아웃: 모바일 환경에서 주소창 등으로 인해 UI가 잘리는 현상을 방지하기 위해 min-h-screen 등을 활용한 레이아웃 보완을 진행했습니다.

-중앙 정렬 개선: Flexbox를 활용하여 모든 해상도에서 로그인 폼이 화면 중앙에 안정적으로 위치하도록 개선했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3234" height="1610" alt="image" src="https://github.com/user-attachments/assets/14611062-f1ef-464a-ba92-a6d9299ae892" />

## 참고사항

-배포 환경(Vercel)에서의 뷰포트 작동 여부를 Preview 배포를 통해 확인했습니다.
