### PR TITLE
[Docs] 추천 결과 더보기 정책 API 계약 문서 정리

### DIFF
--- a/docs/ai/api-contract.md
+++ b/docs/ai/api-contract.md
@@ -115,13 +115,18 @@ GET    /api/v1/survey/result
 
 추천 결과 리스트 화면은 아래 필드를 기준으로 동작합니다.
 
+- 설문 추천 결과와 매칭 추천 결과는 같은 리스트 화면에서 동일한 UX로 노출합니다.
+- 로딩 방식은 **무한 스크롤이 아니라 `더보기` 버튼 방식**으로 고정합니다.
+- 프론트 기본 조회 단위는 `5개`이며, `next`가 있으면 `더보기` 클릭 시 다음 결과를 추가 조회합니다.
+- `next === null`이면 더보기 버튼을 노출하지 않고 추가 조회를 종료합니다.
+
 - `game_id`: 상세 모달 연결 키
 - `title`: 게임명 표기 기준
 - `genres`: 태그/하이라이트 계산
 - `thumbnail_url`: 리스트 썸네일
 - `rating`: 평점 표시
 - `is_liked`: 현재 찜 상태 표시
-- `count`, `next`: 더보기/무한 조회 기준
+- `count`, `next`: 더보기 버튼 기반 추가 조회 기준
 
 ### 5. Adapter Rules
 
@@ -142,6 +147,7 @@ MSW mock은 실제 API 경로와 응답 구조를 최대한 동일하게 맞춥�
 
 - 설문 시작/답변/초기화 경로는 실제 `chatbot` 경로와 동일하게 유지
 - 추천 결과 item은 mock에서도 `title` 기준으로 반환
+- 추천 결과 mock도 `더보기` 버튼 정책과 동일하게 `5개 단위 + next 기반` 구조를 유지
 - 프론트 adapter는 방어적으로 legacy fallback을 유지하지만, mock 응답은 최신 계약을 우선 기준으로 사용
 
 ### 7. Recommendation Detail Modal Integration


### PR DESCRIPTION
## 관련 이슈

- closes #124 

## 변경 내용

- `docs/ai/api-contract.md`에서 추천 결과 로딩 방식을 `더보기 버튼` 기준으로 명확히 정리했습니다.
- 설문 추천 결과와 매칭 추천 결과가 같은 리스트 화면과 동일한 UX를 사용한다고 명시했습니다.
- 프론트 기본 조회 단위를 `5개`로 명시했습니다.
- `next`가 있으면 더보기 클릭 시 다음 결과를 추가 조회하고, `next === null`이면 더보기 종료라고 명시했습니다.
- mock도 `5개 단위 + next 기반` 구조를 유지한다고 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- 문서 변경만 포함합니다.
- 추천 결과 로딩 방식은 `더보기 버튼` 기준으로 정리했습니다.
- 실제 mock/API 구현 정리는 별도 작업에서 맞춥니다.
