### PR TITLE
[Feat] 개발 및 테스트용 로그인 목데이터 생성

### DIFF
--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -13,53 +13,9 @@ import type {
   LogoutResponse,
   SignupRequest,
 } from '../types/auth';
+import { createMockUserMap, type MockUserRecord } from './mockUsers';
 
-type MockUserRecord = {
-  id: number;
-  loginId: string;
-  password: string;
-  name: string;
-  nickname: string;
-  gender: AuthGender;
-  suspended?: boolean;
-};
-
-const mockUsers = new Map<string, MockUserRecord>([
-  [
-    'pgti-demo',
-    {
-      id: 1,
-      loginId: 'pgti-demo',
-      password: 'demo1234',
-      name: 'PGTI 데모',
-      nickname: '데모유저',
-      gender: 'M',
-    },
-  ],
-  [
-    'already-used',
-    {
-      id: 2,
-      loginId: 'already-used',
-      password: 'demo1234',
-      name: '기존 사용자',
-      nickname: '중복닉네임',
-      gender: 'W',
-    },
-  ],
-  [
-    'suspended-user',
-    {
-      id: 3,
-      loginId: 'suspended-user',
-      password: 'demo1234',
-      name: '정지 사용자',
-      nickname: '정지계정',
-      gender: 'M',
-      suspended: true,
-    },
-  ],
-]);
+const mockUsers = createMockUserMap();
 
 const validGenders: AuthGender[] = ['M', 'W'];
 
@@ -234,6 +190,7 @@ const signupHandlers = [
       name,
       nickname,
       gender,
+      note: '회원가입 mock으로 생성된 계정',
     };
 
     mockUsers.set(loginId, createdUser);

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -94,15 +94,6 @@ const loginHandlers = [
       );
     }
 
-    if (user.suspended) {
-      return HttpResponse.json(
-        {
-          error_detail: '정지된 계정입니다.',
-        },
-        { status: 403 },
-      );
-    }
-
     await delay(500);
 
     return HttpResponse.json({

--- a/src/features/auth/mocks/mockUsers.ts
+++ b/src/features/auth/mocks/mockUsers.ts
@@ -8,12 +8,11 @@ export type MockUserRecord = {
   nickname: string;
   gender: AuthGender;
   note: string;
-  suspended?: boolean;
 };
 
 export type MockLoginAccount = Pick<
   MockUserRecord,
-  'loginId' | 'password' | 'name' | 'nickname' | 'gender' | 'note' | 'suspended'
+  'loginId' | 'password' | 'name' | 'nickname' | 'gender' | 'note'
 >;
 
 export const mockAuthSeedUsers: MockUserRecord[] = [
@@ -38,14 +37,13 @@ export const mockAuthSeedUsers: MockUserRecord[] = [
 ];
 
 export const mockLoginAccounts: MockLoginAccount[] = mockAuthSeedUsers.map(
-  ({ loginId, password, name, nickname, gender, note, suspended }) => ({
+  ({ loginId, password, name, nickname, gender, note }) => ({
     loginId,
     password,
     name,
     nickname,
     gender,
     note,
-    suspended,
   }),
 );
 

--- a/src/features/auth/mocks/mockUsers.ts
+++ b/src/features/auth/mocks/mockUsers.ts
@@ -1,0 +1,55 @@
+import type { AuthGender } from '../types/auth';
+
+export type MockUserRecord = {
+  id: number;
+  loginId: string;
+  password: string;
+  name: string;
+  nickname: string;
+  gender: AuthGender;
+  note: string;
+  suspended?: boolean;
+};
+
+export type MockLoginAccount = Pick<
+  MockUserRecord,
+  'loginId' | 'password' | 'name' | 'nickname' | 'gender' | 'note' | 'suspended'
+>;
+
+export const mockAuthSeedUsers: MockUserRecord[] = [
+  {
+    id: 1,
+    loginId: 'pgti-demo',
+    password: 'demo12345',
+    name: 'PGTI 데모',
+    nickname: '데모유저',
+    gender: 'M',
+    note: '기본 로그인, 추천, 설문, 마이페이지 확인용 계정',
+  },
+  {
+    id: 2,
+    loginId: 'pgti-tester',
+    password: 'tester12345',
+    name: 'PGTI 테스터',
+    nickname: '테스트유저',
+    gender: 'W',
+    note: '중복 확인, 계정 전환, 비교 테스트용 계정',
+  },
+];
+
+export const mockLoginAccounts: MockLoginAccount[] = mockAuthSeedUsers.map(
+  ({ loginId, password, name, nickname, gender, note, suspended }) => ({
+    loginId,
+    password,
+    name,
+    nickname,
+    gender,
+    note,
+    suspended,
+  }),
+);
+
+export const createMockUserMap = () =>
+  new Map<string, MockUserRecord>(
+    mockAuthSeedUsers.map((user) => [user.loginId, { ...user }]),
+  );

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,4 +1,6 @@
 export const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
 
-export const isMockServiceWorkerEnabled = () =>
+export const mockServiceWorkerEnabled =
   import.meta.env.DEV && import.meta.env.VITE_USE_MSW !== 'false';
+
+export const isMockServiceWorkerEnabled = () => mockServiceWorkerEnabled;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import type { FormEvent } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+import { KeyRound, X } from 'lucide-react';
 
 import AuthButton from '../components/auth/AuthButton';
 import AuthDivider from '../components/auth/AuthDivider';
@@ -41,9 +42,6 @@ const LOGIN_MAIN_CLASS_NAME = 'min-h-0 py-1 sm:py-1.5';
 const LOGIN_PANEL_CLASS_NAME =
   'max-w-[452px] px-[clamp(0.75rem,1.7vw,1.25rem)] py-[clamp(0.75rem,1.6dvh,1rem)] sm:px-[clamp(0.875rem,2vw,1.5rem)] sm:py-[clamp(0.875rem,1.9dvh,1.25rem)]';
 const LOGIN_CONTENT_CLASS_NAME = 'max-w-[360px]';
-const LOGIN_PANEL_WITH_MOCKS_CLASS_NAME =
-  'max-w-[760px] px-[clamp(0.75rem,1.8vw,1.5rem)] py-[clamp(0.75rem,1.6dvh,1.25rem)] sm:px-[clamp(0.875rem,2.2vw,1.75rem)] sm:py-[clamp(0.875rem,1.9dvh,1.5rem)]';
-const LOGIN_CONTENT_WITH_MOCKS_CLASS_NAME = 'max-w-[700px]';
 const LOGIN_TITLE_CLASS_NAME = 'text-[clamp(1.75rem,3.6dvh,2.375rem)]';
 const LOGIN_SOCIAL_GROUP_CLASS_NAME = 'mt-[clamp(0.5rem,1.2dvh,0.875rem)]';
 const LOGIN_DIVIDER_CLASS_NAME =
@@ -57,10 +55,10 @@ const LOGIN_SECONDARY_BUTTON_CLASS_NAME =
   'mt-[clamp(0.5rem,1.2dvh,0.75rem)] h-[clamp(2.5rem,4.8dvh,2.75rem)] text-[clamp(0.9rem,1.55dvh,1rem)] leading-none';
 const LOGIN_SIGNUP_SECTION_CLASS_NAME =
   'border-login-divider mt-[clamp(0.625rem,1.4dvh,0.875rem)] border-t pt-[clamp(0.5rem,1.2dvh,0.75rem)]';
-const LOGIN_CONTENT_GRID_CLASS_NAME =
-  'grid gap-4 lg:grid-cols-[minmax(0,1fr)_240px] lg:items-start';
+const LOGIN_MOCK_FAB_CLASS_NAME =
+  'support-chat-fab group fixed left-4 bottom-4 z-[95] flex h-14 w-14 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none sm:left-6 sm:bottom-6';
 const LOGIN_MOCK_PANEL_CLASS_NAME =
-  'bg-login-field/55 border-login-outline mt-[clamp(0.5rem,1.2dvh,0.875rem)] rounded-2xl border px-4 py-4 lg:mt-[clamp(0.5rem,1.2dvh,0.875rem)]';
+  'support-chat-panel fixed left-4 bottom-22 z-[90] flex w-[min(92vw,22rem)] origin-bottom-left flex-col overflow-hidden transition-all duration-300 ease-out sm:left-6 sm:bottom-24';
 
 const getLoginFieldErrors = (
   values: LoginRequest,
@@ -85,6 +83,8 @@ function LoginPage() {
   const setAuth = useAuthStore((state) => state.setAuth);
   const loginMutation = useLoginMutation();
   const [mockAccounts, setMockAccounts] = useState<DevMockLoginAccount[]>([]);
+  const [isMockPanelOpen, setIsMockPanelOpen] = useState(false);
+  const mockPanelRef = useRef<HTMLDivElement | null>(null);
 
   const [formValues, setFormValues] = useState<LoginRequest>({
     login_id: '',
@@ -137,6 +137,44 @@ function LoginPage() {
     };
   }, []);
 
+  useEffect(() => {
+    if (showMockAccounts) {
+      return;
+    }
+
+    setIsMockPanelOpen(false);
+  }, [showMockAccounts]);
+
+  useEffect(() => {
+    if (!isMockPanelOpen) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsMockPanelOpen(false);
+      }
+    };
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (
+        mockPanelRef.current &&
+        !mockPanelRef.current.contains(event.target as Node) &&
+        !(event.target as HTMLElement)?.closest('.dev-login-fab')
+      ) {
+        setIsMockPanelOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    window.addEventListener('mousedown', handleOutsideClick);
+
+    return () => {
+      window.removeEventListener('keydown', handleEscape);
+      window.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [isMockPanelOpen]);
+
   const handleChange = (fieldName: LoginFieldName, value: string) => {
     setFormValues((previous) => ({
       ...previous,
@@ -170,6 +208,7 @@ function LoginPage() {
     setApiFieldErrors({});
     setFormMessage('');
     setNoticeMessage('');
+    setIsMockPanelOpen(false);
   };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -218,168 +257,204 @@ function LoginPage() {
   };
 
   return (
-    <AuthLayout
-      title="Log In"
-      withPanel
-      titleClassName={LOGIN_TITLE_CLASS_NAME}
-      mainClassName={LOGIN_MAIN_CLASS_NAME}
-      panelClassName={
-        showMockAccounts
-          ? LOGIN_PANEL_WITH_MOCKS_CLASS_NAME
-          : LOGIN_PANEL_CLASS_NAME
-      }
-      contentClassName={
-        showMockAccounts
-          ? LOGIN_CONTENT_WITH_MOCKS_CLASS_NAME
-          : LOGIN_CONTENT_CLASS_NAME
-      }
-    >
-      <div className={showMockAccounts ? LOGIN_CONTENT_GRID_CLASS_NAME : ''}>
-        <div>
-          <AuthSocialLoginGroup
-            className={LOGIN_SOCIAL_GROUP_CLASS_NAME}
-            size="compact"
+    <>
+      <AuthLayout
+        title="Log In"
+        withPanel
+        titleClassName={LOGIN_TITLE_CLASS_NAME}
+        mainClassName={LOGIN_MAIN_CLASS_NAME}
+        panelClassName={LOGIN_PANEL_CLASS_NAME}
+        contentClassName={LOGIN_CONTENT_CLASS_NAME}
+      >
+        <AuthSocialLoginGroup
+          className={LOGIN_SOCIAL_GROUP_CLASS_NAME}
+          size="compact"
+        />
+
+        <AuthDivider className={LOGIN_DIVIDER_CLASS_NAME} />
+
+        <form className={LOGIN_FORM_CLASS_NAME} onSubmit={handleSubmit}>
+          <AuthInputField
+            id="login-id"
+            name="login_id"
+            label="아이디"
+            type="text"
+            autoComplete="username"
+            placeholder="ID"
+            value={formValues.login_id}
+            onChange={(event) => handleChange('login_id', event.target.value)}
+            onBlur={() =>
+              setTouchedState((previous) => ({
+                ...previous,
+                login_id: true,
+              }))
+            }
+            errorMessage={resolvedFieldErrors.login_id}
+            disabled={loginMutation.isPending}
+            containerClassName="pt-[clamp(0.125rem,0.3dvh,0.1875rem)]"
+            className={LOGIN_FIELD_CLASS_NAME}
           />
 
-          <AuthDivider className={LOGIN_DIVIDER_CLASS_NAME} />
+          <AuthInputField
+            id="login-password"
+            name="password"
+            label="비밀번호"
+            type="password"
+            autoComplete="current-password"
+            placeholder="PASSWORD"
+            value={formValues.password}
+            onChange={(event) => handleChange('password', event.target.value)}
+            onBlur={() =>
+              setTouchedState((previous) => ({
+                ...previous,
+                password: true,
+              }))
+            }
+            errorMessage={resolvedFieldErrors.password}
+            disabled={loginMutation.isPending}
+            className={LOGIN_FIELD_CLASS_NAME}
+          />
 
-          <form className={LOGIN_FORM_CLASS_NAME} onSubmit={handleSubmit}>
-            <AuthInputField
-              id="login-id"
-              name="login_id"
-              label="아이디"
-              type="text"
-              autoComplete="username"
-              placeholder="ID"
-              value={formValues.login_id}
-              onChange={(event) => handleChange('login_id', event.target.value)}
-              onBlur={() =>
-                setTouchedState((previous) => ({
-                  ...previous,
-                  login_id: true,
-                }))
-              }
-              errorMessage={resolvedFieldErrors.login_id}
-              disabled={loginMutation.isPending}
-              containerClassName="pt-[clamp(0.125rem,0.3dvh,0.1875rem)]"
-              className={LOGIN_FIELD_CLASS_NAME}
-            />
+          {noticeMessage ? (
+            <AuthFormMessage tone="success">{noticeMessage}</AuthFormMessage>
+          ) : null}
 
-            <AuthInputField
-              id="login-password"
-              name="password"
-              label="비밀번호"
-              type="password"
-              autoComplete="current-password"
-              placeholder="PASSWORD"
-              value={formValues.password}
-              onChange={(event) => handleChange('password', event.target.value)}
-              onBlur={() =>
-                setTouchedState((previous) => ({
-                  ...previous,
-                  password: true,
-                }))
-              }
-              errorMessage={resolvedFieldErrors.password}
-              disabled={loginMutation.isPending}
-              className={LOGIN_FIELD_CLASS_NAME}
-            />
+          {formMessage ? (
+            <AuthFormMessage>{formMessage}</AuthFormMessage>
+          ) : null}
 
-            {noticeMessage ? (
-              <AuthFormMessage tone="success">{noticeMessage}</AuthFormMessage>
-            ) : null}
+          <div className="flex justify-end">
+            <button
+              type="button"
+              className="text-login-muted text-[clamp(0.675rem,1.1dvh,0.75rem)] font-medium transition-colors hover:text-white/80"
+            >
+              아이디/비밀번호를 잊어버리셨나요?
+            </button>
+          </div>
 
-            {formMessage ? (
-              <AuthFormMessage>{formMessage}</AuthFormMessage>
-            ) : null}
+          <AuthButton
+            type="submit"
+            className={`w-full ${LOGIN_PRIMARY_BUTTON_CLASS_NAME}`}
+            disabled={loginMutation.isPending}
+          >
+            {loginMutation.isPending ? '로그인 중...' : '로그인'}
+          </AuthButton>
+        </form>
 
-            <div className="flex justify-end">
+        <div className={LOGIN_SIGNUP_SECTION_CLASS_NAME}>
+          <p className="text-login-helper text-center text-[clamp(0.675rem,1.15dvh,0.75rem)] leading-[1.1rem] font-normal">
+            아직 PGTI 회원이 아니신가요?
+          </p>
+          <AuthLinkButton
+            to={`/${ROUTES.SIGNUP}`}
+            className={`w-full ${LOGIN_SECONDARY_BUTTON_CLASS_NAME}`}
+          >
+            회원가입
+          </AuthLinkButton>
+        </div>
+      </AuthLayout>
+
+      {showMockAccounts ? (
+        <>
+          <div
+            ref={mockPanelRef}
+            className={`${LOGIN_MOCK_PANEL_CLASS_NAME} ${
+              isMockPanelOpen
+                ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
+                : 'pointer-events-none translate-y-4 scale-95 opacity-0'
+            }`}
+            role="dialog"
+            aria-modal="false"
+            aria-label="개발용 로그인 계정"
+          >
+            <div className="border-login-outline flex items-center justify-between border-b px-4 py-3">
+              <div>
+                <p className="text-sm font-semibold text-white">
+                  개발용 로그인 계정
+                </p>
+                <p className="text-login-helper mt-1 text-xs/5">
+                  dev + MSW에서만 표시됩니다.
+                </p>
+              </div>
               <button
                 type="button"
-                className="text-login-muted text-[clamp(0.675rem,1.1dvh,0.75rem)] font-medium transition-colors hover:text-white/80"
+                onClick={() => setIsMockPanelOpen(false)}
+                className="support-chat-icon-btn"
+                aria-label="개발용 로그인 계정 패널 닫기"
               >
-                아이디/비밀번호를 잊어버리셨나요?
+                <X size={16} />
               </button>
             </div>
 
-            <AuthButton
-              type="submit"
-              className={`w-full ${LOGIN_PRIMARY_BUTTON_CLASS_NAME}`}
-              disabled={loginMutation.isPending}
-            >
-              {loginMutation.isPending ? '로그인 중...' : '로그인'}
-            </AuthButton>
-          </form>
-
-          <div className={LOGIN_SIGNUP_SECTION_CLASS_NAME}>
-            <p className="text-login-helper text-center text-[clamp(0.675rem,1.15dvh,0.75rem)] leading-[1.1rem] font-normal">
-              아직 PGTI 회원이 아니신가요?
-            </p>
-            <AuthLinkButton
-              to={`/${ROUTES.SIGNUP}`}
-              className={`w-full ${LOGIN_SECONDARY_BUTTON_CLASS_NAME}`}
-            >
-              회원가입
-            </AuthLinkButton>
+            <div className="support-chat-scrollbar max-h-[min(60vh,28rem)] overflow-y-auto px-4 py-4">
+              <ul className="space-y-2.5">
+                {mockAccounts.map((account) => (
+                  <li
+                    key={account.loginId}
+                    className="border-login-outline rounded-2xl border bg-black/20 p-3"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-white">
+                          {account.name}
+                        </p>
+                        <p className="text-login-helper mt-1 text-xs/5">
+                          {account.note}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleApplyMockAccount(account)}
+                        className="border-login-outline shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:border-white/25 hover:bg-white/5"
+                      >
+                        입력하기
+                      </button>
+                    </div>
+                    <dl className="mt-3 space-y-1.5 text-xs/5">
+                      <div className="flex items-center justify-between gap-3">
+                        <dt className="text-login-helper">아이디</dt>
+                        <dd className="font-mono text-white">
+                          {account.loginId}
+                        </dd>
+                      </div>
+                      <div className="flex items-center justify-between gap-3">
+                        <dt className="text-login-helper">비밀번호</dt>
+                        <dd className="font-mono text-white">
+                          {account.password}
+                        </dd>
+                      </div>
+                      <div className="flex items-center justify-between gap-3">
+                        <dt className="text-login-helper">닉네임</dt>
+                        <dd className="text-white">{account.nickname}</dd>
+                      </div>
+                    </dl>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
-        </div>
 
-        {showMockAccounts ? (
-          <aside className={LOGIN_MOCK_PANEL_CLASS_NAME}>
-            <p className="text-sm font-semibold text-white">
-              개발용 로그인 계정
-            </p>
-            <p className="text-login-helper mt-1 text-xs/5">
-              개발 환경에서 MSW를 사용할 때만 표시됩니다.
-            </p>
-            <ul className="mt-3 space-y-2.5">
-              {mockAccounts.map((account) => (
-                <li
-                  key={account.loginId}
-                  className="border-login-outline rounded-2xl border bg-black/20 p-3"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <p className="text-sm font-semibold text-white">
-                        {account.name}
-                      </p>
-                      <p className="text-login-helper mt-1 text-xs/5">
-                        {account.note}
-                      </p>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => handleApplyMockAccount(account)}
-                      className="border-login-outline shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:border-white/25 hover:bg-white/5"
-                    >
-                      입력하기
-                    </button>
-                  </div>
-                  <dl className="mt-3 space-y-1.5 text-xs/5">
-                    <div className="flex items-center justify-between gap-3">
-                      <dt className="text-login-helper">아이디</dt>
-                      <dd className="font-mono text-white">
-                        {account.loginId}
-                      </dd>
-                    </div>
-                    <div className="flex items-center justify-between gap-3">
-                      <dt className="text-login-helper">비밀번호</dt>
-                      <dd className="font-mono text-white">
-                        {account.password}
-                      </dd>
-                    </div>
-                    <div className="flex items-center justify-between gap-3">
-                      <dt className="text-login-helper">닉네임</dt>
-                      <dd className="text-white">{account.nickname}</dd>
-                    </div>
-                  </dl>
-                </li>
-              ))}
-            </ul>
-          </aside>
-        ) : null}
-      </div>
-    </AuthLayout>
+          <button
+            type="button"
+            onClick={() => setIsMockPanelOpen((previous) => !previous)}
+            className={`${LOGIN_MOCK_FAB_CLASS_NAME} dev-login-fab`}
+            aria-label={
+              isMockPanelOpen
+                ? '개발용 로그인 계정 패널 닫기'
+                : '개발용 로그인 계정 패널 열기'
+            }
+          >
+            <span className="support-chat-fab-glow" />
+            <KeyRound
+              size={22}
+              className={`relative z-10 transition-transform ${
+                isMockPanelOpen ? 'scale-95 -rotate-6' : 'scale-100'
+              }`}
+            />
+          </button>
+        </>
+      ) : null}
+    </>
   );
 }
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import type { FormEvent } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import AuthButton from '../components/auth/AuthButton';
@@ -17,6 +17,7 @@ import {
 } from '../features/auth/api/auth';
 import { useLoginMutation } from '../features/auth/api/useAuthApi';
 import type { LoginRequest } from '../features/auth/types/auth';
+import { mockServiceWorkerEnabled } from '../lib/env';
 import { useAuthStore } from '../store/useAuthStore';
 
 type LoginFieldName = keyof LoginRequest;
@@ -27,10 +28,22 @@ type LoginLocationState = {
   errorMessage?: string;
 };
 
+type DevMockLoginAccount = {
+  loginId: string;
+  password: string;
+  name: string;
+  nickname: string;
+  gender: string;
+  note: string;
+};
+
 const LOGIN_MAIN_CLASS_NAME = 'min-h-0 py-1 sm:py-1.5';
 const LOGIN_PANEL_CLASS_NAME =
   'max-w-[452px] px-[clamp(0.75rem,1.7vw,1.25rem)] py-[clamp(0.75rem,1.6dvh,1rem)] sm:px-[clamp(0.875rem,2vw,1.5rem)] sm:py-[clamp(0.875rem,1.9dvh,1.25rem)]';
 const LOGIN_CONTENT_CLASS_NAME = 'max-w-[360px]';
+const LOGIN_PANEL_WITH_MOCKS_CLASS_NAME =
+  'max-w-[760px] px-[clamp(0.75rem,1.8vw,1.5rem)] py-[clamp(0.75rem,1.6dvh,1.25rem)] sm:px-[clamp(0.875rem,2.2vw,1.75rem)] sm:py-[clamp(0.875rem,1.9dvh,1.5rem)]';
+const LOGIN_CONTENT_WITH_MOCKS_CLASS_NAME = 'max-w-[700px]';
 const LOGIN_TITLE_CLASS_NAME = 'text-[clamp(1.75rem,3.6dvh,2.375rem)]';
 const LOGIN_SOCIAL_GROUP_CLASS_NAME = 'mt-[clamp(0.5rem,1.2dvh,0.875rem)]';
 const LOGIN_DIVIDER_CLASS_NAME =
@@ -44,6 +57,10 @@ const LOGIN_SECONDARY_BUTTON_CLASS_NAME =
   'mt-[clamp(0.5rem,1.2dvh,0.75rem)] h-[clamp(2.5rem,4.8dvh,2.75rem)] text-[clamp(0.9rem,1.55dvh,1rem)] leading-none';
 const LOGIN_SIGNUP_SECTION_CLASS_NAME =
   'border-login-divider mt-[clamp(0.625rem,1.4dvh,0.875rem)] border-t pt-[clamp(0.5rem,1.2dvh,0.75rem)]';
+const LOGIN_CONTENT_GRID_CLASS_NAME =
+  'grid gap-4 lg:grid-cols-[minmax(0,1fr)_240px] lg:items-start';
+const LOGIN_MOCK_PANEL_CLASS_NAME =
+  'bg-login-field/55 border-login-outline mt-[clamp(0.5rem,1.2dvh,0.875rem)] rounded-2xl border px-4 py-4 lg:mt-[clamp(0.5rem,1.2dvh,0.875rem)]';
 
 const getLoginFieldErrors = (
   values: LoginRequest,
@@ -67,6 +84,7 @@ function LoginPage() {
   const location = useLocation();
   const setAuth = useAuthStore((state) => state.setAuth);
   const loginMutation = useLoginMutation();
+  const [mockAccounts, setMockAccounts] = useState<DevMockLoginAccount[]>([]);
 
   const [formValues, setFormValues] = useState<LoginRequest>({
     login_id: '',
@@ -89,6 +107,35 @@ function LoginPage() {
     login_id: apiFieldErrors.login_id ?? fieldErrors.login_id,
     password: apiFieldErrors.password ?? fieldErrors.password,
   };
+  const showMockAccounts = mockServiceWorkerEnabled && mockAccounts.length > 0;
+
+  useEffect(() => {
+    if (!mockServiceWorkerEnabled) {
+      return;
+    }
+
+    let isMounted = true;
+
+    void import('../features/auth/mocks/mockUsers')
+      .then(({ mockLoginAccounts }) => {
+        if (!isMounted) {
+          return;
+        }
+
+        setMockAccounts(mockLoginAccounts);
+      })
+      .catch(() => {
+        if (!isMounted) {
+          return;
+        }
+
+        setMockAccounts([]);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   const handleChange = (fieldName: LoginFieldName, value: string) => {
     setFormValues((previous) => ({
@@ -107,6 +154,20 @@ function LoginPage() {
       };
     });
 
+    setFormMessage('');
+    setNoticeMessage('');
+  };
+
+  const handleApplyMockAccount = (account: DevMockLoginAccount) => {
+    setFormValues({
+      login_id: account.loginId,
+      password: account.password,
+    });
+    setTouchedState({
+      login_id: false,
+      password: false,
+    });
+    setApiFieldErrors({});
     setFormMessage('');
     setNoticeMessage('');
   };
@@ -162,92 +223,161 @@ function LoginPage() {
       withPanel
       titleClassName={LOGIN_TITLE_CLASS_NAME}
       mainClassName={LOGIN_MAIN_CLASS_NAME}
-      panelClassName={LOGIN_PANEL_CLASS_NAME}
-      contentClassName={LOGIN_CONTENT_CLASS_NAME}
+      panelClassName={
+        showMockAccounts
+          ? LOGIN_PANEL_WITH_MOCKS_CLASS_NAME
+          : LOGIN_PANEL_CLASS_NAME
+      }
+      contentClassName={
+        showMockAccounts
+          ? LOGIN_CONTENT_WITH_MOCKS_CLASS_NAME
+          : LOGIN_CONTENT_CLASS_NAME
+      }
     >
-      <AuthSocialLoginGroup
-        className={LOGIN_SOCIAL_GROUP_CLASS_NAME}
-        size="compact"
-      />
+      <div className={showMockAccounts ? LOGIN_CONTENT_GRID_CLASS_NAME : ''}>
+        <div>
+          <AuthSocialLoginGroup
+            className={LOGIN_SOCIAL_GROUP_CLASS_NAME}
+            size="compact"
+          />
 
-      <AuthDivider className={LOGIN_DIVIDER_CLASS_NAME} />
+          <AuthDivider className={LOGIN_DIVIDER_CLASS_NAME} />
 
-      <form className={LOGIN_FORM_CLASS_NAME} onSubmit={handleSubmit}>
-        <AuthInputField
-          id="login-id"
-          name="login_id"
-          label="아이디"
-          type="text"
-          autoComplete="username"
-          placeholder="ID"
-          value={formValues.login_id}
-          onChange={(event) => handleChange('login_id', event.target.value)}
-          onBlur={() =>
-            setTouchedState((previous) => ({
-              ...previous,
-              login_id: true,
-            }))
-          }
-          errorMessage={resolvedFieldErrors.login_id}
-          disabled={loginMutation.isPending}
-          containerClassName="pt-[clamp(0.125rem,0.3dvh,0.1875rem)]"
-          className={LOGIN_FIELD_CLASS_NAME}
-        />
+          <form className={LOGIN_FORM_CLASS_NAME} onSubmit={handleSubmit}>
+            <AuthInputField
+              id="login-id"
+              name="login_id"
+              label="아이디"
+              type="text"
+              autoComplete="username"
+              placeholder="ID"
+              value={formValues.login_id}
+              onChange={(event) => handleChange('login_id', event.target.value)}
+              onBlur={() =>
+                setTouchedState((previous) => ({
+                  ...previous,
+                  login_id: true,
+                }))
+              }
+              errorMessage={resolvedFieldErrors.login_id}
+              disabled={loginMutation.isPending}
+              containerClassName="pt-[clamp(0.125rem,0.3dvh,0.1875rem)]"
+              className={LOGIN_FIELD_CLASS_NAME}
+            />
 
-        <AuthInputField
-          id="login-password"
-          name="password"
-          label="비밀번호"
-          type="password"
-          autoComplete="current-password"
-          placeholder="PASSWORD"
-          value={formValues.password}
-          onChange={(event) => handleChange('password', event.target.value)}
-          onBlur={() =>
-            setTouchedState((previous) => ({
-              ...previous,
-              password: true,
-            }))
-          }
-          errorMessage={resolvedFieldErrors.password}
-          disabled={loginMutation.isPending}
-          className={LOGIN_FIELD_CLASS_NAME}
-        />
+            <AuthInputField
+              id="login-password"
+              name="password"
+              label="비밀번호"
+              type="password"
+              autoComplete="current-password"
+              placeholder="PASSWORD"
+              value={formValues.password}
+              onChange={(event) => handleChange('password', event.target.value)}
+              onBlur={() =>
+                setTouchedState((previous) => ({
+                  ...previous,
+                  password: true,
+                }))
+              }
+              errorMessage={resolvedFieldErrors.password}
+              disabled={loginMutation.isPending}
+              className={LOGIN_FIELD_CLASS_NAME}
+            />
 
-        {noticeMessage ? (
-          <AuthFormMessage tone="success">{noticeMessage}</AuthFormMessage>
-        ) : null}
+            {noticeMessage ? (
+              <AuthFormMessage tone="success">{noticeMessage}</AuthFormMessage>
+            ) : null}
 
-        {formMessage ? <AuthFormMessage>{formMessage}</AuthFormMessage> : null}
+            {formMessage ? (
+              <AuthFormMessage>{formMessage}</AuthFormMessage>
+            ) : null}
 
-        <div className="flex justify-end">
-          <button
-            type="button"
-            className="text-login-muted text-[clamp(0.675rem,1.1dvh,0.75rem)] font-medium transition-colors hover:text-white/80"
-          >
-            아이디/비밀번호를 잊어버리셨나요?
-          </button>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                className="text-login-muted text-[clamp(0.675rem,1.1dvh,0.75rem)] font-medium transition-colors hover:text-white/80"
+              >
+                아이디/비밀번호를 잊어버리셨나요?
+              </button>
+            </div>
+
+            <AuthButton
+              type="submit"
+              className={`w-full ${LOGIN_PRIMARY_BUTTON_CLASS_NAME}`}
+              disabled={loginMutation.isPending}
+            >
+              {loginMutation.isPending ? '로그인 중...' : '로그인'}
+            </AuthButton>
+          </form>
+
+          <div className={LOGIN_SIGNUP_SECTION_CLASS_NAME}>
+            <p className="text-login-helper text-center text-[clamp(0.675rem,1.15dvh,0.75rem)] leading-[1.1rem] font-normal">
+              아직 PGTI 회원이 아니신가요?
+            </p>
+            <AuthLinkButton
+              to={`/${ROUTES.SIGNUP}`}
+              className={`w-full ${LOGIN_SECONDARY_BUTTON_CLASS_NAME}`}
+            >
+              회원가입
+            </AuthLinkButton>
+          </div>
         </div>
 
-        <AuthButton
-          type="submit"
-          className={`w-full ${LOGIN_PRIMARY_BUTTON_CLASS_NAME}`}
-          disabled={loginMutation.isPending}
-        >
-          {loginMutation.isPending ? '로그인 중...' : '로그인'}
-        </AuthButton>
-      </form>
-
-      <div className={LOGIN_SIGNUP_SECTION_CLASS_NAME}>
-        <p className="text-login-helper text-center text-[clamp(0.675rem,1.15dvh,0.75rem)] leading-[1.1rem] font-normal">
-          아직 PGTI 회원이 아니신가요?
-        </p>
-        <AuthLinkButton
-          to={`/${ROUTES.SIGNUP}`}
-          className={`w-full ${LOGIN_SECONDARY_BUTTON_CLASS_NAME}`}
-        >
-          회원가입
-        </AuthLinkButton>
+        {showMockAccounts ? (
+          <aside className={LOGIN_MOCK_PANEL_CLASS_NAME}>
+            <p className="text-sm font-semibold text-white">
+              개발용 로그인 계정
+            </p>
+            <p className="text-login-helper mt-1 text-xs/5">
+              개발 환경에서 MSW를 사용할 때만 표시됩니다.
+            </p>
+            <ul className="mt-3 space-y-2.5">
+              {mockAccounts.map((account) => (
+                <li
+                  key={account.loginId}
+                  className="border-login-outline rounded-2xl border bg-black/20 p-3"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-white">
+                        {account.name}
+                      </p>
+                      <p className="text-login-helper mt-1 text-xs/5">
+                        {account.note}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleApplyMockAccount(account)}
+                      className="border-login-outline shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:border-white/25 hover:bg-white/5"
+                    >
+                      입력하기
+                    </button>
+                  </div>
+                  <dl className="mt-3 space-y-1.5 text-xs/5">
+                    <div className="flex items-center justify-between gap-3">
+                      <dt className="text-login-helper">아이디</dt>
+                      <dd className="font-mono text-white">
+                        {account.loginId}
+                      </dd>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <dt className="text-login-helper">비밀번호</dt>
+                      <dd className="font-mono text-white">
+                        {account.password}
+                      </dd>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <dt className="text-login-helper">닉네임</dt>
+                      <dd className="text-white">{account.nickname}</dd>
+                    </div>
+                  </dl>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        ) : null}
       </div>
     </AuthLayout>
   );


### PR DESCRIPTION
## 관련 이슈

- closes #120

## 변경 내용

-MSW 기반 목데이터 생성: 백엔드 API 미완성 상태에서도 로그인을 테스트할 수 있도록 MSW 핸들러 및 사용자 목데이터(PGTI 데모, 테스터)를 구축했습니다.

-개발 모드 전용 UI 구현: process.env.NODE_ENV === 'development' 및 MSW 활성화 상태일 때만 노출되는 '개발용 로그인 계정' 가이드 섹션을 로그인 페이지 우측에 추가했습니다.

-배포 환경 자동 분기: 프로덕션(배포) 환경에서는 사용자 혼란을 방지하기 위해 가이드 섹션이 보이지 않도록 클린한 UI로 자동 전환되게 설정했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="2146" height="1534" alt="image" src="https://github.com/user-attachments/assets/ec97cbd2-cb7a-4a0c-b1bc-da212390f29d" />
<img width="1136" height="1080" alt="image" src="https://github.com/user-attachments/assets/c8ee950e-e61b-4f8c-97e2-23ee263de35c" />


## 참고사항

-현재 제공된 테스트 계정 정보는 pgti-demo / demo12345, pgti-tester / tester12345 입니다.

-우측 가이드의 '입력하기' 버튼 클릭 시 해당 계정 정보가 입력창에 자동으로 채워지는 편의 기능이 포함되어 있습니다.
