### PR TITLE
[Feat] 매칭 트레일러 UX 및 다시하기 흐름 개선

### DIFF
--- a/src/features/matching/components/MatchingMediaPanel.tsx
+++ b/src/features/matching/components/MatchingMediaPanel.tsx
@@ -1,5 +1,3 @@
-import { PlayCircle } from 'lucide-react';
-
 import type { MatchingCandidateItem } from '../types';
 
 type MatchingMediaPanelProps = {
@@ -21,7 +19,7 @@ const getYoutubeEmbedUrl = (trailerUrl: string | null) => {
       const videoId = url.pathname.replace('/', '');
 
       return videoId
-        ? `https://www.youtube.com/embed/${videoId}?rel=0&modestbranding=1`
+        ? `https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1&playsinline=1&rel=0&modestbranding=1`
         : null;
     }
 
@@ -29,7 +27,7 @@ const getYoutubeEmbedUrl = (trailerUrl: string | null) => {
       const videoId = url.searchParams.get('v');
 
       return videoId
-        ? `https://www.youtube.com/embed/${videoId}?rel=0&modestbranding=1`
+        ? `https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1&playsinline=1&rel=0&modestbranding=1`
         : null;
     }
   } catch {
@@ -72,26 +70,6 @@ function MatchingMediaPanel({
             미디어가 준비되지 않았습니다.
           </div>
         )}
-        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(8,8,10,0.12),rgba(8,8,10,0.78))]" />
-        <div className="absolute right-0 bottom-0 left-0 p-6 sm:p-8">
-          <div className="flex flex-wrap items-center gap-2 text-[11px] font-medium tracking-[0.2em] uppercase">
-            <span className="rounded-full border border-white/12 bg-black/24 px-3 py-1.5 text-white/70">
-              {genreTitle}
-            </span>
-            {candidate.trailer_url ? (
-              <span className="inline-flex items-center gap-1 rounded-full border border-[#972020]/30 bg-[#180a0a] px-3 py-1.5 text-[#f07272]">
-                <PlayCircle size={12} />
-                Trailer
-              </span>
-            ) : null}
-          </div>
-          <h2 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-[40px]">
-            {candidate.title}
-          </h2>
-          <p className="mt-3 text-sm leading-7 break-keep text-white/68 sm:text-base">
-            {candidate.genres.join(' · ')}
-          </p>
-        </div>
       </div>
       <div className="flex flex-1 flex-col border-t border-white/8 bg-[linear-gradient(180deg,rgba(18,18,20,0.94),rgba(11,11,12,0.98))] px-6 py-6 sm:px-8 sm:py-7">
         <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/features/matching/store/useMatchingStore.ts
+++ b/src/features/matching/store/useMatchingStore.ts
@@ -19,6 +19,10 @@ interface MatchingStoreState {
     genre: MatchingGenreCard,
     candidates: MatchingCandidateItem[],
   ) => void;
+  restartFlow: (
+    genre: MatchingGenreCard,
+    candidates: MatchingCandidateItem[],
+  ) => void;
   setRating: (gameId: number, rating: MatchingRatingValue) => void;
   toggleLiked: (gameId: number) => void;
   goNext: () => void;
@@ -92,6 +96,14 @@ export const useMatchingStore = create<MatchingStoreState>((set) => ({
           isSameGenre,
         ),
       };
+    }),
+  restartFlow: (genre, candidates) =>
+    set({
+      selectedGenreSlug: genre.slug,
+      selectedGenreId: genre.genreId,
+      candidates,
+      currentIndex: 0,
+      evaluationsByGameId: createEvaluationMap(candidates),
     }),
   setRating: (gameId, rating) =>
     set((state) => ({

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -49,6 +49,7 @@ function MatchingGenreDetailPage() {
     (state) => state.evaluationsByGameId,
   );
   const initializeFlow = useMatchingStore((state) => state.initializeFlow);
+  const restartFlow = useMatchingStore((state) => state.restartFlow);
   const setRating = useMatchingStore((state) => state.setRating);
   const toggleLiked = useMatchingStore((state) => state.toggleLiked);
   const goNext = useMatchingStore((state) => state.goNext);
@@ -100,12 +101,14 @@ function MatchingGenreDetailPage() {
   const isCompleted = submitMatchResponsesMutation.isSuccess;
 
   const handleRestart = () => {
-    resetFlow();
     submitMatchResponsesMutation.reset();
 
     if (genre && candidates.length > 0) {
-      initializeFlow(genre, candidates);
+      restartFlow(genre, candidates);
+      return;
     }
+
+    resetFlow();
   };
 
   const handleSubmit = async () => {
@@ -401,22 +404,23 @@ function MatchingGenreDetailPage() {
                     </p>
                   ) : null}
 
-                  <div className="mt-auto flex flex-wrap items-center justify-between gap-3 pt-8">
-                    <button
-                      type="button"
-                      onClick={goPrevious}
-                      disabled={!canGoPrevious}
-                      className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/[0.02] disabled:text-white/28"
-                    >
-                      <ChevronLeft size={16} />
-                      이전
-                    </button>
+                  {isLastCard ? (
+                    <div className="mt-auto pt-8">
+                      <p className="mx-auto mb-3 w-full max-w-[420px] text-center text-sm leading-6 break-keep text-white/42">
+                        5개 게임의 평가가 모두 준비되면 제출할 수 있어요.
+                      </p>
 
-                    {isLastCard ? (
-                      <div className="flex flex-col items-end gap-3">
-                        <p className="text-right text-sm leading-6 break-keep text-white/48 sm:max-w-[30ch]">
-                          5개 게임의 평가가 모두 준비되면 제출할 수 있어요.
-                        </p>
+                      <div className="flex flex-wrap items-end justify-between gap-3">
+                        <button
+                          type="button"
+                          onClick={goPrevious}
+                          disabled={!canGoPrevious}
+                          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/[0.02] disabled:text-white/28"
+                        >
+                          <ChevronLeft size={16} />
+                          이전
+                        </button>
+
                         <button
                           type="button"
                           onClick={() => void handleSubmit()}
@@ -434,7 +438,19 @@ function MatchingGenreDetailPage() {
                           ) : null}
                         </button>
                       </div>
-                    ) : (
+                    </div>
+                  ) : (
+                    <div className="mt-auto flex flex-wrap items-end justify-between gap-3 pt-8">
+                      <button
+                        type="button"
+                        onClick={goPrevious}
+                        disabled={!canGoPrevious}
+                        className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/[0.02] disabled:text-white/28"
+                      >
+                        <ChevronLeft size={16} />
+                        이전
+                      </button>
+
                       <button
                         type="button"
                         onClick={goNext}
@@ -444,8 +460,8 @@ function MatchingGenreDetailPage() {
                         다음
                         <ChevronRight size={16} />
                       </button>
-                    )}
-                  </div>
+                    </div>
+                  )}
                 </article>
               ) : null}
             </div>


### PR DESCRIPTION
## 관련 이슈

- closes #126 

## 변경 내용

- 매칭 페이지 유튜브 트레일러가 진입 시 자동 재생되도록 수정
- 트레일러 위에 있던 오버레이 텍스트/배지를 제거해 영상 자체를 더 크게 볼 수 있도록 정리
- 트레일러 클릭 영역을 방해하던 요소를 정리해 영상 조작이 더 자연스럽게 동작하도록 개선
- `같은 장르 다시하기` 클릭 시 이전 별점/좋아요 상태가 남지 않고 처음부터 다시 시작되도록 수정
- 마지막 카드에서 제출 안내 문구 때문에 버튼이 아래로 밀리던 레이아웃을 조정

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
