### PR TITLE
[Feat] 설문 추천 결과 API 계약 최신화

### DIFF
--- a/src/features/survey/api/survey.ts
+++ b/src/features/survey/api/survey.ts
@@ -122,7 +122,7 @@ export const normalizeSurveyResultResponse = (
   payload: SurveyApiResultResponse,
 ): SurveyResultResponse => ({
   session_id: payload.session_id,
-  user_id: payload.user_id,
+  user_id: typeof payload.user_id === 'number' ? payload.user_id : undefined,
   count:
     typeof payload.count === 'number'
       ? payload.count

--- a/src/features/survey/api/useSurveyApi.ts
+++ b/src/features/survey/api/useSurveyApi.ts
@@ -22,17 +22,13 @@ export const useResetSurveyMutation = () =>
     mutationFn: resetSurveySession,
   });
 
-export const useSurveyResultsInfinite = (
-  sessionId: string | null,
-  enabled = true,
-) =>
+export const useSurveyResultsInfinite = (enabled = true) =>
   useInfiniteQuery({
-    queryKey: ['survey-results', sessionId],
+    queryKey: ['survey-results'],
     initialPageParam: null as string | null,
-    enabled: Boolean(sessionId) && enabled,
+    enabled,
     queryFn: ({ pageParam }) =>
       getSurveyResults({
-        session_id: sessionId!,
         cursor: pageParam ?? undefined,
         page_size: 5,
       }),

--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -295,12 +295,8 @@ function SurveyChatPanel() {
   };
 
   const handleMoveToRecommendation = () => {
-    if (!sessionId) {
-      return;
-    }
-
     startTransition(() => {
-      navigate(`/${ROUTES.RECOMMENDATION_LIST}?session_id=${sessionId}`);
+      navigate(`/${ROUTES.RECOMMENDATION_LIST}?source=survey`);
     });
   };
 

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -99,6 +99,7 @@ interface MockSurveySession {
 }
 
 const surveySessions = new Map<string, MockSurveySession>();
+let latestCompletedSurveySessionId: string | null = null;
 
 const createSessionId = () => crypto.randomUUID();
 
@@ -215,6 +216,7 @@ export const surveyHandlers = [
 
       if (session.askedQuestions >= session.totalQuestions) {
         surveySessions.set(sessionId, session);
+        latestCompletedSurveySessionId = sessionId;
 
         return HttpResponse.json({
           session_id: sessionId,
@@ -245,15 +247,10 @@ export const surveyHandlers = [
 
   http.get('/api/v1/survey/result', async ({ request }) => {
     const url = new URL(request.url);
-    const sessionId = url.searchParams.get('session_id');
     const cursor = Number(url.searchParams.get('cursor') ?? '0');
-    const pageSize = Number(url.searchParams.get('page_size') ?? '4');
+    const pageSize = Number(url.searchParams.get('page_size') ?? '5');
 
-    if (!sessionId) {
-      return getErrorResponse(400, 'session_id는 필수입니다.');
-    }
-
-    if (!surveySessions.has(sessionId)) {
+    if (!latestCompletedSurveySessionId) {
       return getErrorResponse(404, '설문 추천 결과를 찾을 수 없습니다.');
     }
 
@@ -264,7 +261,6 @@ export const surveyHandlers = [
     await delay(500);
 
     return HttpResponse.json({
-      session_id: sessionId,
       user_id: 1,
       count: recommendations.length,
       next,
@@ -280,6 +276,9 @@ export const surveyHandlers = [
     }
 
     surveySessions.delete(body.session_id);
+    if (latestCompletedSurveySessionId === body.session_id) {
+      latestCompletedSurveySessionId = null;
+    }
 
     const nextSessionId = createSessionId();
     surveySessions.set(nextSessionId, {

--- a/src/features/survey/types/survey.ts
+++ b/src/features/survey/types/survey.ts
@@ -83,7 +83,6 @@ export interface SurveyResetResponse {
 }
 
 export interface SurveyResultQuery {
-  session_id: string;
   sort?: string;
   cursor?: string;
   page_size?: number;
@@ -110,7 +109,7 @@ export interface SurveyResultItem {
 
 export interface SurveyApiResultResponse {
   session_id?: string;
-  user_id: number;
+  user_id?: number;
   count?: number | null;
   next?: string | null;
   results: SurveyApiResultItem[];
@@ -118,7 +117,7 @@ export interface SurveyApiResultResponse {
 
 export interface SurveyResultResponse {
   session_id?: string;
-  user_id: number;
+  user_id?: number;
   count: number;
   next: string | null;
   results: SurveyResultItem[];

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -209,16 +209,17 @@ function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
 function RecommendationListPage() {
   const [searchParams] = useSearchParams();
   const [selectedGame, setSelectedGame] = useState<GameListItem | null>(null);
-  const sessionId = searchParams.get('session_id');
   const source = searchParams.get('source');
+  const legacySessionId = searchParams.get('session_id');
   const isMatchSource = source === 'match';
+  const isSurveySource =
+    source === 'survey' || (!source && Boolean(legacySessionId));
   const isMockMode = isMockServiceWorkerEnabled();
   const hasAccessToken = Boolean(getAccessToken());
   const canAccessPage = isMockMode || hasAccessToken;
 
   const surveyResultsQuery = useSurveyResultsInfinite(
-    sessionId,
-    !isMatchSource && canAccessPage,
+    !isMatchSource && isSurveySource && canAccessPage,
   );
   const matchResultsQuery = useMatchResultsInfinite(
     'rating_desc',
@@ -319,7 +320,7 @@ function RecommendationListPage() {
                 켜두면 추천 결과 흐름을 확인할 수 있습니다.
               </p>
             </section>
-          ) : !sessionId && !isMatchSource ? (
+          ) : !isMatchSource && !isSurveySource ? (
             <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
               <h2 className="text-2xl font-bold text-white">
                 먼저 설문을 완료해 주세요.


### PR DESCRIPTION
## 관련 이슈

- closes #130 

## 변경 내용

- 설문 추천 결과 조회 API를 최신 명세 기준으로 정리
- `GET /api/v1/survey/result` 요청에서 `session_id` 의존 제거
- 설문 추천 결과 타입에서 `user_id`를 optional로 완화
- 설문 결과 조회 훅이 `session_id` 없이 동작하도록 수정
- 설문 완료 후 추천 결과 페이지 이동을 `source=survey` 기준으로 변경
- 추천 결과 페이지가 `source=survey` 및 legacy `session_id` 링크를 모두 처리하도록 정리
- MSW 설문 추천 결과 응답도 최신 계약에 맞게 수정
  - 완료된 설문이 없으면 404
  - 완료된 설문이 있으면 `count`, `next`, `results` 반환

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 기존 `session_id` 기반 링크는 당장 깨지지 않도록 fallback 처리했습니다.
