### PR TITLE
[Feat] 매칭 장르 코드와 결과 조회 계약 정리

### DIFF
--- a/src/features/matching/api/useMatchingApi.ts
+++ b/src/features/matching/api/useMatchingApi.ts
@@ -22,17 +22,13 @@ export const useSubmitMatchResponsesMutation = () =>
     mutationFn: submitMatchResponses,
   });
 
-export const useMatchResultsInfinite = (
-  sort: 'rating_desc' | 'created_at' = 'rating_desc',
-  enabled = true,
-) =>
+export const useMatchResultsInfinite = (enabled = true) =>
   useInfiniteQuery({
-    queryKey: ['match-results', sort],
+    queryKey: ['match-results'],
     initialPageParam: null as string | null,
     enabled,
     queryFn: ({ pageParam }) =>
       getMatchResponseResults({
-        sort,
         cursor: pageParam ?? undefined,
         page_size: 5,
       }),

--- a/src/features/matching/genres.ts
+++ b/src/features/matching/genres.ts
@@ -32,7 +32,7 @@ export const MATCHING_GENRES: MatchingGenreCard[] = [
   },
   {
     slug: 'strategy-simulation',
-    genreId: 5,
+    genreId: 4,
     title: '전략 / 시뮬',
     subtitle: '판단과 운영의 재미',
     description:
@@ -42,7 +42,7 @@ export const MATCHING_GENRES: MatchingGenreCard[] = [
   },
   {
     slug: 'sports-racing',
-    genreId: 6,
+    genreId: 5,
     title: '스포츠 / 레이싱',
     subtitle: '속도감과 경쟁의 짜릿함',
     description:
@@ -52,7 +52,7 @@ export const MATCHING_GENRES: MatchingGenreCard[] = [
   },
   {
     slug: 'brain-strategy',
-    genreId: 13,
+    genreId: 6,
     title: '두뇌 / 전략',
     subtitle: '생각할수록 즐거운 플레이',
     description:
@@ -62,7 +62,7 @@ export const MATCHING_GENRES: MatchingGenreCard[] = [
   },
   {
     slug: 'shooting',
-    genreId: 4,
+    genreId: 7,
     title: '슈팅',
     subtitle: '반응속도와 타격감',
     description:
@@ -72,7 +72,7 @@ export const MATCHING_GENRES: MatchingGenreCard[] = [
   },
   {
     slug: 'rhythm',
-    genreId: 14,
+    genreId: 8,
     title: '음악 / 리듬',
     subtitle: '비트에 맞춘 템포 플레이',
     description:

--- a/src/features/matching/mocks/data.ts
+++ b/src/features/matching/mocks/data.ts
@@ -151,7 +151,7 @@ export const matchingMockCandidatesByGenreId: Record<
       4.7,
     ),
   ],
-  4: [
+  7: [
     createCandidate(
       730,
       'Counter-Strike 2',
@@ -194,7 +194,7 @@ export const matchingMockCandidatesByGenreId: Record<
       4.6,
     ),
   ],
-  5: [
+  4: [
     createCandidate(
       289070,
       'Sid Meier’s Civilization VI',
@@ -237,7 +237,7 @@ export const matchingMockCandidatesByGenreId: Record<
       4.9,
     ),
   ],
-  6: [
+  5: [
     createCandidate(
       1551360,
       'Forza Horizon 5',
@@ -280,7 +280,7 @@ export const matchingMockCandidatesByGenreId: Record<
       true,
     ),
   ],
-  13: [
+  6: [
     createCandidate(
       646570,
       'Slay the Spire',
@@ -323,7 +323,7 @@ export const matchingMockCandidatesByGenreId: Record<
       4.4,
     ),
   ],
-  14: [
+  8: [
     createCandidate(
       1817230,
       'Hi-Fi RUSH',

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -22,15 +22,14 @@ type StoredMatchResult = {
 
 let storedMatchResults: StoredMatchResult[] = [];
 
-const getSortedMatchResults = (sort: string) => {
-  const entries = [...storedMatchResults];
+const getRankedMatchResults = () =>
+  [...storedMatchResults].sort((a, b) => {
+    if (b.rating !== a.rating) {
+      return b.rating - a.rating;
+    }
 
-  if (sort === 'created_at') {
-    return entries.sort((a, b) => a.created_at_order - b.created_at_order);
-  }
-
-  return entries.sort((a, b) => b.rating - a.rating);
-};
+    return a.created_at_order - b.created_at_order;
+  });
 
 export const matchingHandlers = [
   http.get('/api/v1/match/candidates', async ({ request }) => {
@@ -106,22 +105,12 @@ export const matchingHandlers = [
       })),
     });
   }),
-  http.get('/api/v1/match/responses/result', async ({ request }) => {
-    const url = new URL(request.url);
-    const sort = url.searchParams.get('sort') ?? 'rating_desc';
-
-    if (!['rating_desc', 'created_at'].includes(sort)) {
-      return getErrorResponse(
-        400,
-        '유효하지 않은 sort 값입니다. (rating_desc, created_at)',
-      );
-    }
-
+  http.get('/api/v1/match/responses/result', async () => {
     if (storedMatchResults.length === 0) {
       return getErrorResponse(404, '매칭 추천 결과를 찾을 수 없습니다.');
     }
 
-    const results = getSortedMatchResults(sort).map((result) => {
+    const results = getRankedMatchResults().map((result) => {
       const candidate = matchingMockCandidateMapById.get(result.game_id)!;
 
       return {

--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -61,10 +61,7 @@ export interface SubmitMatchResponsesResponse {
   match_result: MatchResponseItem[];
 }
 
-export type MatchResultSort = 'rating_desc' | 'created_at';
-
 export interface MatchResultQuery {
-  sort?: MatchResultSort;
   cursor?: string;
   page_size?: number;
 }

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -222,7 +222,6 @@ function RecommendationListPage() {
     !isMatchSource && isSurveySource && canAccessPage,
   );
   const matchResultsQuery = useMatchResultsInfinite(
-    'rating_desc',
     isMatchSource && canAccessPage,
   );
   const activeQuery = isMatchSource ? matchResultsQuery : surveyResultsQuery;


### PR DESCRIPTION
## 관련 이슈

- closes #132 

## 변경 내용

- 매칭 장르 `genre_id`를 최신 요구사항 기준의 UI 코드 `1~8`로 정리
- 장르 코드 변경에 맞춰 매칭 mock 후보 데이터 키도 함께 재정렬
- 매칭 결과 조회 API에서 `sort` 파라미터를 보내지 않도록 수정
- 매칭 결과 조회 훅을 최신 명세의 고정 정렬 기준에 맞게 단순화
- 추천 결과 페이지의 매칭 결과 조회도 새 훅 시그니처에 맞춰 정리
- MSW 매칭 결과 조회 핸들러도 `sort` 검증 없이 고정 랭킹 반환 방식으로 수정

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
