### PR TITLE
[Feat] 매칭 후보 API adapter 정리

### DIFF
--- a/src/features/matching/api/matching.ts
+++ b/src/features/matching/api/matching.ts
@@ -1,5 +1,7 @@
 import { api } from '../../../api/axios';
 import type {
+  MatchingApiCandidateItem,
+  MatchingApiCandidatesResponse,
   MatchResultQuery,
   MatchResultResponse,
   MatchingCandidatesResponse,
@@ -9,8 +11,20 @@ import type {
 
 const MATCHING_BASE_PATH = '/api/v1/match';
 
+const normalizeMatchCandidate = (item: MatchingApiCandidateItem) => ({
+  game_id: item.game_id,
+  title: item.name?.trim() || '제목 정보 준비 중',
+  description:
+    item.description?.trim() || '게임 설명이 아직 준비되지 않았습니다.',
+  genres: Array.isArray(item.genres) ? item.genres : [],
+  thumbnail_url: null,
+  trailer_url: item.trailer_url ?? null,
+  rating: typeof item.rating === 'number' ? item.rating : null,
+  is_liked: Boolean(item.is_liked),
+});
+
 export const getMatchCandidates = async (genreId: number) => {
-  const response = await api.get<MatchingCandidatesResponse>(
+  const response = await api.get<MatchingApiCandidatesResponse>(
     `${MATCHING_BASE_PATH}/candidates`,
     {
       params: {
@@ -19,7 +33,13 @@ export const getMatchCandidates = async (genreId: number) => {
     },
   );
 
-  return response.data;
+  return {
+    genre_id: response.data.genre_id,
+    count: response.data.count,
+    results: Array.isArray(response.data.results)
+      ? response.data.results.map(normalizeMatchCandidate)
+      : [],
+  } satisfies MatchingCandidatesResponse;
 };
 
 export const submitMatchResponses = async (

--- a/src/features/matching/components/MatchingMediaPanel.tsx
+++ b/src/features/matching/components/MatchingMediaPanel.tsx
@@ -44,9 +44,11 @@ function MatchingMediaPanel({
 }: MatchingMediaPanelProps) {
   const embedUrl = getYoutubeEmbedUrl(candidate.trailer_url);
   const imageUrl = candidate.thumbnail_url;
-  const candidateSummary = `${genreTitle} 흐름에서 ${candidate.title}은 ${candidate.genres.join(
-    ' · ',
-  )} 감각을 대표하는 후보예요. 영상과 이미지를 보고 취향에 얼마나 맞는지 편하게 판단해보세요.`;
+  const candidateSummary =
+    candidate.description?.trim() ||
+    `${genreTitle} 흐름에서 ${candidate.title}은 ${candidate.genres.join(
+      ' · ',
+    )} 감각을 대표하는 후보예요. 영상과 이미지를 보고 취향에 얼마나 맞는지 편하게 판단해보세요.`;
 
   return (
     <article className="flex h-full flex-col overflow-hidden rounded-[28px] border border-white/8 bg-[#0d0d0f] shadow-[0_26px_52px_rgba(0,0,0,0.28)]">

--- a/src/features/matching/mocks/data.ts
+++ b/src/features/matching/mocks/data.ts
@@ -1,4 +1,13 @@
-import type { MatchingCandidateItem } from '../types';
+type MatchingMockCandidateRecord = {
+  game_id: number;
+  title: string;
+  description: string;
+  genres: string[];
+  thumbnail_url: string | null;
+  trailer_url: string | null;
+  rating: number | null;
+  is_liked: boolean;
+};
 
 const createCandidate = (
   gameId: number,
@@ -8,9 +17,11 @@ const createCandidate = (
   trailerUrl: string,
   rating: number,
   isLiked = false,
-): MatchingCandidateItem => ({
+  description = `${title}는 ${genres.join(' · ')} 흐름을 대표하는 후보 게임입니다.`,
+): MatchingMockCandidateRecord => ({
   game_id: gameId,
   title,
+  description,
   genres,
   thumbnail_url: thumbnailUrl,
   trailer_url: trailerUrl,
@@ -20,7 +31,7 @@ const createCandidate = (
 
 export const matchingMockCandidatesByGenreId: Record<
   number,
-  MatchingCandidateItem[]
+  MatchingMockCandidateRecord[]
 > = {
   1: [
     createCandidate(

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -52,8 +52,15 @@ export const matchingHandlers = [
     return HttpResponse.json({
       genre_id: genreId,
       count: candidates.length,
-      next: null,
-      results: candidates,
+      results: candidates.map((candidate) => ({
+        game_id: candidate.game_id,
+        name: candidate.title,
+        description: candidate.description,
+        genres: candidate.genres,
+        trailer_url: candidate.trailer_url,
+        rating: candidate.rating,
+        is_liked: candidate.is_liked,
+      })),
     });
   }),
   http.post('/api/v1/match/responses', async ({ request }) => {

--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -17,9 +17,26 @@ export type MatchingGenreCard = {
   thumbnailUrl: string;
 };
 
+export interface MatchingApiCandidateItem {
+  game_id: number;
+  name: string;
+  description: string;
+  genres: string[];
+  trailer_url: string | null;
+  rating: number | null;
+  is_liked: boolean;
+}
+
+export interface MatchingApiCandidatesResponse {
+  genre_id: number;
+  count: number;
+  results: MatchingApiCandidateItem[];
+}
+
 export interface MatchingCandidateItem {
   game_id: number;
   title: string;
+  description: string;
   genres: string[];
   thumbnail_url: string | null;
   trailer_url: string | null;
@@ -30,7 +47,6 @@ export interface MatchingCandidateItem {
 export interface MatchingCandidatesResponse {
   genre_id: number;
   count: number;
-  next: string | null;
   results: MatchingCandidateItem[];
 }
 


### PR DESCRIPTION
## 관련 이슈

- closes #134 

## 변경 내용

- 매칭 후보 조회 API를 최신 명세 기준으로 정리
- 후보 raw 응답 타입과 화면용 normalized 타입 분리
- `name` 필드를 adapter에서 `title`로 변환하도록 수정
- 후보 설명(`description`)을 화면에서 활용할 수 있도록 정리
- `thumbnail_url`이 없는 최신 계약을 고려해 미디어 fallback 정책을 정리
- MSW mock 후보 응답도 최신 계약 구조에 맞게 수정
- 매칭 상세 평가 화면이 normalized candidate만 사용하도록 정리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
