### PR TITLE
[Feat] 매칭 장르 대표 이미지 API 연동

### DIFF
--- a/src/features/matching/api/matching.ts
+++ b/src/features/matching/api/matching.ts
@@ -2,6 +2,7 @@ import { api } from '../../../api/axios';
 import type {
   MatchingApiCandidateItem,
   MatchingApiCandidatesResponse,
+  MatchingGenreImageResponse,
   MatchResultQuery,
   MatchResultResponse,
   MatchingCandidatesResponse,
@@ -40,6 +41,19 @@ export const getMatchCandidates = async (genreId: number) => {
       ? response.data.results.map(normalizeMatchCandidate)
       : [],
   } satisfies MatchingCandidatesResponse;
+};
+
+export const getMatchingGenreImage = async (genreId: number) => {
+  const response = await api.get<MatchingGenreImageResponse>(
+    `${MATCHING_BASE_PATH}/genres/image-url`,
+    {
+      params: {
+        genre_id: genreId,
+      },
+    },
+  );
+
+  return response.data;
 };
 
 export const submitMatchResponses = async (

--- a/src/features/matching/api/useMatchingApi.ts
+++ b/src/features/matching/api/useMatchingApi.ts
@@ -1,7 +1,13 @@
-import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueries,
+  useQuery,
+} from '@tanstack/react-query';
 
 import {
   getMatchCandidates,
+  getMatchingGenreImage,
   getMatchResponseResults,
   submitMatchResponses,
 } from './matching';
@@ -15,6 +21,30 @@ export const useMatchCandidatesQuery = (
     enabled: genreId !== null && enabled,
     queryFn: () => getMatchCandidates(genreId!),
     staleTime: 60_000,
+  });
+
+export const useMatchingGenreImageQuery = (
+  genreId: number | null,
+  enabled = true,
+) =>
+  useQuery({
+    queryKey: ['match-genre-image', genreId],
+    enabled: genreId !== null && enabled,
+    queryFn: () => getMatchingGenreImage(genreId!),
+    staleTime: 5 * 60_000,
+  });
+
+export const useMatchingGenreImageQueries = (
+  genreIds: number[],
+  enabled = true,
+) =>
+  useQueries({
+    queries: genreIds.map((genreId) => ({
+      queryKey: ['match-genre-image', genreId],
+      queryFn: () => getMatchingGenreImage(genreId),
+      enabled,
+      staleTime: 5 * 60_000,
+    })),
   });
 
 export const useSubmitMatchResponsesMutation = () =>

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { delay, http, HttpResponse } from 'msw';
 
+import { getMatchingGenreById } from '../genres';
 import {
   matchingMockCandidateMapById,
   matchingMockCandidatesByGenreId,
@@ -32,6 +33,29 @@ const getRankedMatchResults = () =>
   });
 
 export const matchingHandlers = [
+  http.get('/api/v1/match/genres/image-url', async ({ request }) => {
+    const url = new URL(request.url);
+    const genreIdValue = url.searchParams.get('genre_id');
+    const genreId = Number(genreIdValue);
+
+    if (!genreIdValue || Number.isNaN(genreId) || genreId <= 0) {
+      return getErrorResponse(400, '유효하지 않은 genre_id 입니다.');
+    }
+
+    const genre = getMatchingGenreById(genreId);
+
+    if (!genre) {
+      return getErrorResponse(404, '해당 장르의 이미지를 찾을 수 없습니다.');
+    }
+
+    await delay(300);
+
+    return HttpResponse.json({
+      genre_id: genre.genreId,
+      genre_name: genre.title,
+      image_url: genre.thumbnailUrl,
+    });
+  }),
   http.get('/api/v1/match/candidates', async ({ request }) => {
     const url = new URL(request.url);
     const genreIdValue = url.searchParams.get('genre_id');

--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -17,6 +17,12 @@ export type MatchingGenreCard = {
   thumbnailUrl: string;
 };
 
+export interface MatchingGenreImageResponse {
+  genre_id: number;
+  genre_name: string;
+  image_url: string;
+}
+
 export interface MatchingApiCandidateItem {
   game_id: number;
   name: string;

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -1,11 +1,33 @@
 import { ChevronRight } from 'lucide-react';
+import { useMemo } from 'react';
 import { Link } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
+import { useMatchingGenreImageQueries } from '../../features/matching/api/useMatchingApi';
 import { MATCHING_GENRES } from '../../features/matching/genres';
+import { isMockServiceWorkerEnabled } from '../../lib/env';
+import { getAccessToken } from '../../utils/auth';
 
 function MatchingListPage() {
+  const hasAccessToken = Boolean(getAccessToken());
+  const isMockMode = isMockServiceWorkerEnabled();
+  const canFetchGenreImages = isMockMode || hasAccessToken;
+  const genreImageQueries = useMatchingGenreImageQueries(
+    MATCHING_GENRES.map((genre) => genre.genreId),
+    canFetchGenreImages,
+  );
+  const genreImageMap = useMemo(
+    () =>
+      new Map(
+        genreImageQueries
+          .map((query) => query.data)
+          .filter((item): item is NonNullable<typeof item> => Boolean(item))
+          .map((item) => [item.genre_id, item.image_url]),
+      ),
+    [genreImageQueries],
+  );
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.18),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
@@ -34,7 +56,7 @@ function MatchingListPage() {
               >
                 <div className="relative overflow-hidden rounded-[20px]">
                   <img
-                    src={genre.thumbnailUrl}
+                    src={genreImageMap.get(genre.genreId) ?? genre.thumbnailUrl}
                     alt={genre.title}
                     className="aspect-[16/9] w-full object-cover transition duration-300 group-hover:scale-[1.025] group-hover:brightness-110"
                   />


### PR DESCRIPTION
## 관련 이슈

- closes #136 

## 변경 내용

- 매칭 장르 대표 이미지 API 타입을 추가
- `GET /api/v1/match/genres/image-url` 호출 함수와 query 훅을 추가
- 매칭 장르 선택 화면에서 API 이미지 우선 렌더링하도록 수정
- 이미지 API가 실패하거나 인증이 없는 경우 기존 하드코딩 썸네일을 fallback으로 유지
- MSW에 장르 이미지 API 핸들러를 추가해 mock 환경에서도 동일한 흐름을 확인할 수 있도록 정리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 카드 문구, 레이아웃, 매칭 상세 플로우 자체는 변경하지 않았습니다.