### PR TITLE
[Feat] 인증 화면 UI 개선 및 소셜 로그인 콜백 연동

### DIFF
--- a/src/components/auth/AuthInputActionButton.tsx
+++ b/src/components/auth/AuthInputActionButton.tsx
@@ -9,13 +9,14 @@ type AuthInputActionButtonProps = {
 function AuthInputActionButton({
   children,
   type = 'button',
+  className = '',
   ...props
 }: AuthInputActionButtonProps) {
   return (
     <AuthButton
       type={type}
       variant="secondary"
-      className="w-full sm:w-24 sm:shrink-0"
+      className={`w-full border-2 border-[#ff9a57] bg-[#fff4ea] text-sm font-semibold text-[#9a4316] shadow-[0_10px_24px_rgba(255,154,87,0.18)] hover:border-[#ff8a3d] hover:bg-[#ffead9] hover:text-[#7a2f08] sm:w-[5.75rem] sm:shrink-0 ${className}`}
       {...props}
     >
       {children}

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -29,15 +29,15 @@ function AuthRadioGroup({
   disabled = false,
 }: AuthRadioGroupProps) {
   return (
-    <fieldset className="space-y-3.5">
+    <fieldset className="space-y-3">
       <legend className="text-login-label block text-sm font-medium">
         {label}
       </legend>
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-3 pt-1 sm:flex-nowrap sm:justify-between">
+      <div className="grid grid-cols-2 gap-3 pt-1">
         {options.map((option) => (
           <label
             key={option.value}
-            className="group flex min-w-0 flex-1 cursor-pointer items-center justify-start gap-2 sm:justify-center"
+            className="group block min-w-0 cursor-pointer"
           >
             <input
               type="radio"
@@ -53,13 +53,12 @@ function AuthRadioGroup({
               className="peer sr-only"
             />
             <span
-              className={`peer-checked:border-login-primary flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors group-hover:border-white/25 peer-disabled:opacity-60 ${
-                errorMessage ? 'border-red-500' : 'border-login-field'
+              className={`flex h-14 items-center justify-center rounded-2xl border px-4 text-sm font-semibold transition-all group-hover:border-white/20 group-hover:text-white/85 peer-checked:border-[#ff8a3d] peer-checked:bg-[linear-gradient(135deg,rgba(255,138,61,0.24),rgba(255,110,48,0.1))] peer-checked:text-white peer-checked:shadow-[0_14px_32px_rgba(255,138,61,0.18)] peer-disabled:opacity-60 ${
+                errorMessage
+                  ? 'border-red-500/80 bg-white/[0.03] text-red-200'
+                  : 'border-login-field text-login-helper bg-white/[0.03]'
               }`}
             >
-              <span className="bg-login-primary h-2 w-2 rounded-full opacity-0 transition-opacity peer-checked:opacity-100" />
-            </span>
-            <span className="text-login-helper text-sm/5 font-medium transition-colors group-hover:text-white/85 peer-checked:text-white peer-disabled:opacity-60">
               {option.label}
             </span>
           </label>

--- a/src/components/auth/AuthSocialLoginGroup.tsx
+++ b/src/components/auth/AuthSocialLoginGroup.tsx
@@ -4,6 +4,8 @@ import AuthFormMessage from './AuthFormMessage';
 import SocialLoginButton from '../login/SocialLoginButton';
 import {
   getSocialLoginStartUrl,
+  setPendingSocialAuthProvider,
+  clearPendingSocialAuthProvider,
   type SocialAuthProvider,
 } from '../../features/auth/utils/socialAuth';
 
@@ -19,9 +21,9 @@ const GROUP_SIZE_CLASS_NAMES = {
 
 const BUTTON_SIZE_CLASS_NAMES = {
   default: {
-    google: 'h-14 sm:h-[61px]',
-    kakao: 'h-14 sm:h-[59px]',
-    naver: 'h-14 sm:h-[59px]',
+    google: 'h-14',
+    kakao: 'h-14',
+    naver: 'h-14',
     label: '',
   },
   compact: {
@@ -90,10 +92,12 @@ function AuthSocialLoginGroup({
   const handleSocialLogin = (provider: SocialAuthProvider) => {
     try {
       const redirectUrl = getSocialLoginStartUrl(provider);
+      setPendingSocialAuthProvider(provider);
       setRedirectingProvider(provider);
       setErrorMessage('');
       window.location.assign(redirectUrl);
     } catch {
+      clearPendingSocialAuthProvider();
       setRedirectingProvider(null);
       setErrorMessage(
         '소셜 로그인 시작 주소를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.',

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import { ROUTES } from '../../constants/routes';
 import { useAuthStore } from '../../store/useAuthStore';
 import HeaderProfileMenu from './HeaderProfileMenu';
@@ -7,8 +7,20 @@ type HeaderProps = {
   fixed?: boolean;
 };
 
+const HIDDEN_GUEST_ACTION_PATHS = new Set([
+  `/${ROUTES.LOGIN}`,
+  `/${ROUTES.SIGNUP}`,
+  `/${ROUTES.LEGACY_SIGNUP}`,
+  `/${ROUTES.AUTH_CALLBACK}`,
+  `/${ROUTES.LEGACY_AUTH_CALLBACK}`,
+]);
+
 const Header = ({ fixed = true }: HeaderProps) => {
+  const location = useLocation();
   const isLoggedIn = useAuthStore((state) => Boolean(state.accessToken));
+  const shouldHideGuestActions = HIDDEN_GUEST_ACTION_PATHS.has(
+    location.pathname,
+  );
 
   return (
     <header
@@ -29,24 +41,26 @@ const Header = ({ fixed = true }: HeaderProps) => {
 
         <div className="flex items-center gap-2 sm:gap-3">
           {!isLoggedIn ? (
-            <>
-              <Link
-                to={`/${ROUTES.LOGIN}`}
-                className="header-btn-outline flex h-9 w-20 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
-              >
-                <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
-                  로그인
-                </span>
-              </Link>
-              <Link
-                to={`/${ROUTES.SIGNUP}`}
-                className="header-btn-solid flex h-9 w-22 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
-              >
-                <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
-                  회원가입
-                </span>
-              </Link>
-            </>
+            shouldHideGuestActions ? null : (
+              <>
+                <Link
+                  to={`/${ROUTES.LOGIN}`}
+                  className="header-btn-outline flex h-9 w-20 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
+                >
+                  <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
+                    로그인
+                  </span>
+                </Link>
+                <Link
+                  to={`/${ROUTES.SIGNUP}`}
+                  className="header-btn-solid flex h-9 w-22 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
+                >
+                  <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
+                    회원가입
+                  </span>
+                </Link>
+              </>
+            )
           ) : (
             <HeaderProfileMenu />
           )}

--- a/src/components/common/LegacyRouteRedirect.tsx
+++ b/src/components/common/LegacyRouteRedirect.tsx
@@ -1,0 +1,13 @@
+import { Navigate, useLocation } from 'react-router';
+
+type LegacyRouteRedirectProps = {
+  to: string;
+};
+
+function LegacyRouteRedirect({ to }: LegacyRouteRedirectProps) {
+  const location = useLocation();
+
+  return <Navigate to={`${to}${location.search}`} replace />;
+}
+
+export default LegacyRouteRedirect;

--- a/src/components/login/SocialLoginButton.tsx
+++ b/src/components/login/SocialLoginButton.tsx
@@ -22,11 +22,11 @@ function SocialLoginButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`flex w-full items-center justify-center gap-3 rounded-full px-0 transition-all duration-200 hover:-translate-y-0.5 hover:brightness-105 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-70 ${className}`}
+      className={`flex w-full items-center justify-center gap-3 rounded-full px-5 transition-all duration-200 hover:-translate-y-0.5 hover:brightness-105 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-70 ${className}`}
     >
       {icon}
       <span
-        className={`text-base/6 font-normal sm:text-lg/7 ${labelClassName}`}
+        className={`text-base/6 font-semibold sm:text-lg/7 ${labelClassName}`}
       >
         {label}
       </span>

--- a/src/components/support-chat/SupportChatWidget.tsx
+++ b/src/components/support-chat/SupportChatWidget.tsx
@@ -26,8 +26,12 @@ const getPageLabel = (pathname: string) => {
     return '로그인';
   }
 
-  if (pathname === '/signup') {
+  if (pathname === '/join' || pathname === '/signup') {
     return '회원가입';
+  }
+
+  if (pathname === '/callback' || pathname === '/auth/callback') {
+    return '로그인';
   }
 
   if (pathname === '/my-page') {

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -4,8 +4,10 @@ export const ROUTES = {
   MATCHING_LIST: 'matching-list',
   MATCHING_GENRE_DETAIL: 'matching-list/:genreSlug',
   RECOMMENDATION_LIST: 'recommendation-list',
-  AUTH_CALLBACK: 'auth/callback',
+  AUTH_CALLBACK: 'callback',
+  LEGACY_AUTH_CALLBACK: 'auth/callback',
   LOGIN: 'login',
-  SIGNUP: 'signup',
+  SIGNUP: 'join',
+  LEGACY_SIGNUP: 'signup',
   MY_PAGE: 'my-page',
 } as const;

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -39,9 +39,11 @@ export const completeSocialLogin = async (
   provider: SocialAuthProvider,
   payload: SocialLoginCallbackRequest,
 ) => {
-  const response = await api.post<LoginResponse>(
-    `${AUTH_BASE_PATH}/login/${provider}`,
-    payload,
+  const response = await api.get<LoginResponse>(
+    `${AUTH_BASE_PATH}/social-login/${provider}/callback`,
+    {
+      params: payload,
+    },
   );
 
   return response.data;

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -14,6 +14,8 @@ import type {
   LoginRequest,
   LoginResponse,
   LogoutResponse,
+  SocialAuthProvider,
+  SocialLoginCallbackRequest,
   SignupRequest,
   SignupResponse,
 } from '../types/auth';
@@ -29,6 +31,18 @@ export const login = async (payload: LoginRequest) => {
 
 export const logout = async () => {
   const response = await api.post<LogoutResponse>(`${AUTH_BASE_PATH}/logout`);
+
+  return response.data;
+};
+
+export const completeSocialLogin = async (
+  provider: SocialAuthProvider,
+  payload: SocialLoginCallbackRequest,
+) => {
+  const response = await api.post<LoginResponse>(
+    `${AUTH_BASE_PATH}/login/${provider}`,
+    payload,
+  );
 
   return response.data;
 };
@@ -166,4 +180,25 @@ export const extractAuthApiErrorMessage = (error: unknown) => {
   }
 
   return '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+};
+
+export const extractSuspendedAccountInfo = (error: unknown) => {
+  if (!(error instanceof AxiosError) || error.response?.status !== 403) {
+    return null;
+  }
+
+  const data = error.response.data as ErrorResponseBody | undefined;
+  const errorMessage =
+    extractFieldErrorMessage(data?.error_detail) ||
+    extractFieldErrorMessage(data?.detail);
+
+  if (errorMessage !== '정지된 계정입니다.') {
+    return null;
+  }
+
+  return {
+    message: errorMessage,
+    suspendedAt:
+      typeof data?.suspended_at === 'string' ? data.suspended_at : null,
+  };
 };

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -12,7 +12,6 @@ import type {
   LoginRequest,
   LogoutResponse,
   SocialAuthProvider,
-  SocialLoginCallbackRequest,
   SignupRequest,
 } from '../types/auth';
 import { createMockUserMap, type MockUserRecord } from './mockUsers';
@@ -71,7 +70,43 @@ const findUserByNickname = (nickname: string) =>
 const isSocialAuthProvider = (value: string): value is SocialAuthProvider =>
   value === 'google' || value === 'kakao' || value === 'naver';
 
+const getMockSocialCallbackQueryString = (provider: SocialAuthProvider) => {
+  const searchParams = new URLSearchParams({
+    code: provider === 'naver' ? 'tester-social-code' : 'demo-social-code',
+    provider,
+  });
+
+  if (provider === 'naver') {
+    searchParams.set('state', 'naver-mock-state');
+  }
+
+  return searchParams.toString();
+};
+
 const loginHandlers = [
+  http.get(`${AUTH_BASE_PATH}/social-login/:provider`, async ({ params }) => {
+    const provider =
+      typeof params.provider === 'string' ? params.provider.trim() : '';
+
+    if (!isSocialAuthProvider(provider)) {
+      return HttpResponse.json(
+        {
+          error_detail: '지원하지 않는 소셜 로그인 제공자입니다.',
+        },
+        { status: 404 },
+      );
+    }
+
+    await delay(120);
+
+    return new HttpResponse(null, {
+      status: 302,
+      headers: {
+        Location: `/callback?${getMockSocialCallbackQueryString(provider)}`,
+      },
+    });
+  }),
+
   http.post(`${AUTH_BASE_PATH}/login`, async ({ request }) => {
     const body = (await request.json()) as LoginRequest;
     const loginId = body.login_id.trim();
@@ -107,8 +142,8 @@ const loginHandlers = [
     });
   }),
 
-  http.post(
-    `${AUTH_BASE_PATH}/login/:provider`,
+  http.get(
+    `${AUTH_BASE_PATH}/social-login/:provider/callback`,
     async ({ params, request }) => {
       const provider =
         typeof params.provider === 'string' ? params.provider.trim() : '';
@@ -122,9 +157,9 @@ const loginHandlers = [
         );
       }
 
-      const body = (await request.json()) as SocialLoginCallbackRequest;
-      const code = body.code?.trim() ?? '';
-      const state = body.state?.trim() ?? '';
+      const url = new URL(request.url);
+      const code = url.searchParams.get('code')?.trim() ?? '';
+      const state = url.searchParams.get('state')?.trim() ?? '';
 
       if (!code) {
         return getFieldValidationError('code', '인가 코드가 필요합니다.');

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -11,6 +11,8 @@ import type {
   DeleteAccountResponse,
   LoginRequest,
   LogoutResponse,
+  SocialAuthProvider,
+  SocialLoginCallbackRequest,
   SignupRequest,
 } from '../types/auth';
 import { createMockUserMap, type MockUserRecord } from './mockUsers';
@@ -66,6 +68,9 @@ const getUnauthorizedError = (message: string) =>
 const findUserByNickname = (nickname: string) =>
   [...mockUsers.values()].find((user) => user.nickname === nickname);
 
+const isSocialAuthProvider = (value: string): value is SocialAuthProvider =>
+  value === 'google' || value === 'kakao' || value === 'naver';
+
 const loginHandlers = [
   http.post(`${AUTH_BASE_PATH}/login`, async ({ request }) => {
     const body = (await request.json()) as LoginRequest;
@@ -101,6 +106,64 @@ const loginHandlers = [
       refresh_token: createRefreshToken(user.loginId),
     });
   }),
+
+  http.post(
+    `${AUTH_BASE_PATH}/login/:provider`,
+    async ({ params, request }) => {
+      const provider =
+        typeof params.provider === 'string' ? params.provider.trim() : '';
+
+      if (!isSocialAuthProvider(provider)) {
+        return HttpResponse.json(
+          {
+            error_detail: '지원하지 않는 소셜 로그인 제공자입니다.',
+          },
+          { status: 404 },
+        );
+      }
+
+      const body = (await request.json()) as SocialLoginCallbackRequest;
+      const code = body.code?.trim() ?? '';
+      const state = body.state?.trim() ?? '';
+
+      if (!code) {
+        return getFieldValidationError('code', '인가 코드가 필요합니다.');
+      }
+
+      if (provider === 'naver' && !state) {
+        return getFieldValidationError(
+          'state',
+          '네이버 로그인 state 값이 필요합니다.',
+        );
+      }
+
+      if (code === 'suspended-account') {
+        return HttpResponse.json(
+          {
+            error_detail: '정지된 계정입니다.',
+            suspended_at: '2026-04-01T09:00:00+09:00',
+          },
+          { status: 403 },
+        );
+      }
+
+      const user =
+        code === 'tester-social-code'
+          ? mockUsers.get('pgti-tester')
+          : mockUsers.get('pgti-demo');
+
+      if (!user) {
+        return getUnauthorizedError('연결된 회원 정보를 찾을 수 없습니다.');
+      }
+
+      await delay(450);
+
+      return HttpResponse.json({
+        access_token: createAccessToken(user.loginId),
+        refresh_token: createRefreshToken(user.loginId),
+      });
+    },
+  ),
 ];
 
 const signupHandlers = [

--- a/src/features/auth/types/api.ts
+++ b/src/features/auth/types/api.ts
@@ -1,4 +1,5 @@
 export interface ErrorResponseBody {
   detail?: string | Record<string, string[]>;
   error_detail?: string | Record<string, string[]>;
+  suspended_at?: string | null;
 }

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -1,4 +1,5 @@
 export type AuthGender = 'M' | 'W';
+export type SocialAuthProvider = 'google' | 'kakao' | 'naver';
 
 export interface LoginRequest {
   login_id: string;
@@ -58,6 +59,11 @@ export interface CheckIdDuplicateRequest {
 
 export interface DuplicateCheckResponse {
   detail: string;
+}
+
+export interface SocialLoginCallbackRequest {
+  code: string;
+  state?: string;
 }
 
 export type { ErrorResponseBody } from './api';

--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -12,10 +12,10 @@ const SOCIAL_AUTH_START_URL_ENV_KEYS: Record<SocialAuthProvider, string[]> = {
   naver: ['VITE_NAVER_LOGIN_URL', 'VITE_SOCIAL_LOGIN_NAVER_URL'],
 };
 
-const SOCIAL_AUTH_LOGIN_PATHS: Record<SocialAuthProvider, string> = {
-  google: `${AUTH_BASE_PATH}/login/google`,
-  kakao: `${AUTH_BASE_PATH}/login/kakao`,
-  naver: `${AUTH_BASE_PATH}/login/naver`,
+const SOCIAL_AUTH_START_PATHS: Record<SocialAuthProvider, string> = {
+  google: `${AUTH_BASE_PATH}/social-login/google`,
+  kakao: `${AUTH_BASE_PATH}/social-login/kakao`,
+  naver: `${AUTH_BASE_PATH}/social-login/naver`,
 };
 
 const isSocialAuthProvider = (
@@ -47,18 +47,18 @@ export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
 
   if (apiBaseUrl) {
     if (isAbsoluteUrl(apiBaseUrl)) {
-      return new URL(SOCIAL_AUTH_LOGIN_PATHS[provider], apiBaseUrl).toString();
+      return new URL(SOCIAL_AUTH_START_PATHS[provider], apiBaseUrl).toString();
     }
 
     if (typeof window !== 'undefined') {
       return new URL(
-        SOCIAL_AUTH_LOGIN_PATHS[provider],
+        SOCIAL_AUTH_START_PATHS[provider],
         window.location.origin,
       ).toString();
     }
   }
 
-  return SOCIAL_AUTH_LOGIN_PATHS[provider];
+  return SOCIAL_AUTH_START_PATHS[provider];
 };
 
 export const setPendingSocialAuthProvider = (provider: SocialAuthProvider) => {

--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -1,34 +1,41 @@
 import { apiBaseUrl } from '@/lib/env';
-import { ROUTES } from '@/constants/routes';
 import { AUTH_BASE_PATH } from '../constants/auth';
+import type { SocialAuthProvider } from '../types/auth';
 
-export type SocialAuthProvider = 'google' | 'kakao' | 'naver';
+export type { SocialAuthProvider } from '../types/auth';
 
-const SOCIAL_AUTH_START_URL_ENV_KEYS: Record<SocialAuthProvider, string> = {
-  google: 'VITE_SOCIAL_LOGIN_GOOGLE_URL',
-  kakao: 'VITE_SOCIAL_LOGIN_KAKAO_URL',
-  naver: 'VITE_SOCIAL_LOGIN_NAVER_URL',
+const PENDING_SOCIAL_PROVIDER_STORAGE_KEY = 'pending-social-auth-provider';
+
+const SOCIAL_AUTH_START_URL_ENV_KEYS: Record<SocialAuthProvider, string[]> = {
+  google: ['VITE_GOOGLE_LOGIN_URL', 'VITE_SOCIAL_LOGIN_GOOGLE_URL'],
+  kakao: ['VITE_KAKAO_LOGIN_URL', 'VITE_SOCIAL_LOGIN_KAKAO_URL'],
+  naver: ['VITE_NAVER_LOGIN_URL', 'VITE_SOCIAL_LOGIN_NAVER_URL'],
 };
 
-const SOCIAL_AUTH_DEFAULT_PATHS: Record<SocialAuthProvider, string> = {
-  google: `${AUTH_BASE_PATH}/oauth/google/login`,
-  kakao: `${AUTH_BASE_PATH}/oauth/kakao/login`,
-  naver: `${AUTH_BASE_PATH}/oauth/naver/login`,
+const SOCIAL_AUTH_LOGIN_PATHS: Record<SocialAuthProvider, string> = {
+  google: `${AUTH_BASE_PATH}/login/google`,
+  kakao: `${AUTH_BASE_PATH}/login/kakao`,
+  naver: `${AUTH_BASE_PATH}/login/naver`,
 };
+
+const isSocialAuthProvider = (
+  value: string | null | undefined,
+): value is SocialAuthProvider =>
+  value === 'google' || value === 'kakao' || value === 'naver';
+
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
 
 const getSocialLoginStartUrlFromEnv = (provider: SocialAuthProvider) => {
   const env = import.meta.env as Record<string, string | undefined>;
-  const value = env[SOCIAL_AUTH_START_URL_ENV_KEYS[provider]]?.trim();
 
-  return value || null;
-};
-
-const getSocialCallbackUrl = () => {
-  if (typeof window === 'undefined') {
-    return `/${ROUTES.AUTH_CALLBACK}`;
+  for (const envKey of SOCIAL_AUTH_START_URL_ENV_KEYS[provider]) {
+    const value = env[envKey]?.trim();
+    if (value) {
+      return value;
+    }
   }
 
-  return new URL(`/${ROUTES.AUTH_CALLBACK}`, window.location.origin).toString();
+  return null;
 };
 
 export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
@@ -38,20 +45,56 @@ export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
     return configuredUrl;
   }
 
-  const basePath = SOCIAL_AUTH_DEFAULT_PATHS[provider];
-  const callbackUrl = getSocialCallbackUrl();
-
   if (apiBaseUrl) {
-    const url = new URL(basePath, apiBaseUrl);
-    url.searchParams.set('redirect_uri', callbackUrl);
-    return url.toString();
+    if (isAbsoluteUrl(apiBaseUrl)) {
+      return new URL(SOCIAL_AUTH_LOGIN_PATHS[provider], apiBaseUrl).toString();
+    }
+
+    if (typeof window !== 'undefined') {
+      return new URL(
+        SOCIAL_AUTH_LOGIN_PATHS[provider],
+        window.location.origin,
+      ).toString();
+    }
   }
 
-  const searchParams = new URLSearchParams({
-    redirect_uri: callbackUrl,
-  });
+  return SOCIAL_AUTH_LOGIN_PATHS[provider];
+};
 
-  return `${basePath}?${searchParams.toString()}`;
+export const setPendingSocialAuthProvider = (provider: SocialAuthProvider) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.sessionStorage.setItem(PENDING_SOCIAL_PROVIDER_STORAGE_KEY, provider);
+};
+
+export const clearPendingSocialAuthProvider = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.sessionStorage.removeItem(PENDING_SOCIAL_PROVIDER_STORAGE_KEY);
+};
+
+export const getSocialCallbackProvider = (searchParams: URLSearchParams) => {
+  const providerFromQuery = searchParams.get('provider');
+
+  if (isSocialAuthProvider(providerFromQuery)) {
+    clearPendingSocialAuthProvider();
+    return providerFromQuery;
+  }
+
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const providerFromStorage = window.sessionStorage.getItem(
+    PENDING_SOCIAL_PROVIDER_STORAGE_KEY,
+  );
+  clearPendingSocialAuthProvider();
+
+  return isSocialAuthProvider(providerFromStorage) ? providerFromStorage : null;
 };
 
 export const getSocialCallbackErrorMessage = (searchParams: URLSearchParams) =>
@@ -60,5 +103,8 @@ export const getSocialCallbackErrorMessage = (searchParams: URLSearchParams) =>
   searchParams.get('detail') ||
   searchParams.get('error');
 
-export const getSocialCallbackAccessToken = (searchParams: URLSearchParams) =>
-  searchParams.get('access_token') || searchParams.get('token');
+export const getSocialCallbackCode = (searchParams: URLSearchParams) =>
+  searchParams.get('code')?.trim() || null;
+
+export const getSocialCallbackState = (searchParams: URLSearchParams) =>
+  searchParams.get('state')?.trim() || null;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router';
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import App from './App';
+import LegacyRouteRedirect from './components/common/LegacyRouteRedirect';
 import { ROUTES } from './constants/routes';
 import { isMockServiceWorkerEnabled } from './lib/env';
 import MatchingListPage from './pages/matching/MatchingListPage';
@@ -53,8 +54,16 @@ const router = createBrowserRouter([
         element: <AuthCallbackPage />,
       },
       {
+        path: ROUTES.LEGACY_AUTH_CALLBACK,
+        element: <LegacyRouteRedirect to={`/${ROUTES.AUTH_CALLBACK}`} />,
+      },
+      {
         path: ROUTES.SIGNUP,
         element: <SignupPage />,
+      },
+      {
+        path: ROUTES.LEGACY_SIGNUP,
+        element: <Navigate to={`/${ROUTES.SIGNUP}`} replace />,
       },
       {
         path: ROUTES.MY_PAGE,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router';
+import { createBrowserRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import App from './App';
@@ -63,7 +63,7 @@ const router = createBrowserRouter([
       },
       {
         path: ROUTES.LEGACY_SIGNUP,
-        element: <Navigate to={`/${ROUTES.SIGNUP}`} replace />,
+        element: <LegacyRouteRedirect to={`/${ROUTES.SIGNUP}`} />,
       },
       {
         path: ROUTES.MY_PAGE,

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -1,45 +1,69 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import AuthLayout from '../components/layout/AuthLayout';
 import { ROUTES } from '../constants/routes';
 import {
+  completeSocialLogin,
   extractAuthApiErrorMessage,
+  extractSuspendedAccountInfo,
   getCurrentUserProfile,
 } from '../features/auth/api/auth';
 import {
-  getSocialCallbackAccessToken,
+  clearPendingSocialAuthProvider,
+  getSocialCallbackCode,
   getSocialCallbackErrorMessage,
+  getSocialCallbackProvider,
+  getSocialCallbackState,
 } from '../features/auth/utils/socialAuth';
 import { useAuthStore } from '../store/useAuthStore';
 
-/**
- * [Refactor] 인증 아키텍처 업데이트 (#94)
- * - 소셜 로그인 성공 후 백엔드에서 리다이렉트된 콜백을 처리합니다.
- * - URL 파라미터에서 access_token을 추출하고, 유저 정보를 페칭합니다.
- * - Refresh Token은 이미 백엔드에 의해 HttpOnly 쿠키로 설정된 상태여야 합니다.
- */
-
 const DEFAULT_CALLBACK_ERROR_MESSAGE =
   '소셜 로그인 처리에 실패했습니다. 다시 시도해 주세요.';
+const INVALID_CALLBACK_ERROR_MESSAGE =
+  '인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.';
+
+const formatSuspendedAt = (suspendedAt: string | null) => {
+  if (!suspendedAt) {
+    return '정지 일시 정보가 없습니다.';
+  }
+
+  const suspendedDate = new Date(suspendedAt);
+
+  if (Number.isNaN(suspendedDate.getTime())) {
+    return suspendedAt;
+  }
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'long',
+    timeStyle: 'short',
+  }).format(suspendedDate);
+};
 
 function AuthCallbackPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { setAuth, clearAuth } = useAuthStore();
+  const handledSearchRef = useRef<string | null>(null);
   const [statusMessage, setStatusMessage] = useState(
-    '소셜 로그인 정보를 확인하는 중입니다.',
+    '소셜 로그인 정보를 확인하고 있습니다.',
   );
 
   useEffect(() => {
+    if (handledSearchRef.current === location.search) {
+      return;
+    }
+
+    handledSearchRef.current = location.search;
+
     let isMounted = true;
 
     const handleAuthCallback = async () => {
       const searchParams = new URLSearchParams(location.search);
 
-      // 1. 에러 파라미터 확인
       const callbackErrorMessage = getSocialCallbackErrorMessage(searchParams);
       if (callbackErrorMessage) {
+        clearPendingSocialAuthProvider();
         navigate(`/${ROUTES.LOGIN}`, {
           replace: true,
           state: { errorMessage: callbackErrorMessage },
@@ -47,37 +71,67 @@ function AuthCallbackPage() {
         return;
       }
 
-      // 2. Access Token 추출
-      const accessToken = getSocialCallbackAccessToken(searchParams);
-      if (!accessToken) {
+      const provider = getSocialCallbackProvider(searchParams);
+      const code = getSocialCallbackCode(searchParams);
+      const socialState =
+        provider === 'naver'
+          ? (getSocialCallbackState(searchParams) ?? undefined)
+          : undefined;
+
+      if (!provider || !code || (provider === 'naver' && !socialState)) {
+        clearPendingSocialAuthProvider();
         navigate(`/${ROUTES.LOGIN}`, {
           replace: true,
           state: {
-            errorMessage:
-              '인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.',
+            errorMessage: INVALID_CALLBACK_ERROR_MESSAGE,
           },
         });
         return;
       }
 
       try {
-        // 3. 임시로 토큰 설정 후 유저 프로필 조회
-        // (getCurrentUserProfile 내부의 axiosInstance가 이 토큰을 사용함)
-        useAuthStore.getState().setAccessToken(accessToken);
+        const loginResponse = await completeSocialLogin(provider, {
+          code,
+          ...(provider === 'naver' ? { state: socialState } : {}),
+        });
+        useAuthStore.getState().setAccessToken(loginResponse.access_token);
 
         const profile = await getCurrentUserProfile();
 
-        if (!isMounted) return;
+        if (!isMounted) {
+          return;
+        }
 
-        // 4. 최종 인증 상태 저장
-        setAuth(accessToken, profile);
+        setAuth(loginResponse.access_token, profile);
+        clearPendingSocialAuthProvider();
 
-        // 5. 홈으로 이동
         navigate(ROUTES.HOME, { replace: true });
       } catch (error) {
-        if (!isMounted) return;
+        if (!isMounted) {
+          return;
+        }
 
         clearAuth();
+        clearPendingSocialAuthProvider();
+
+        const suspendedAccountInfo = extractSuspendedAccountInfo(error);
+        if (suspendedAccountInfo) {
+          const suspendedAtLabel = formatSuspendedAt(
+            suspendedAccountInfo.suspendedAt,
+          );
+          const alertMessage = `정지된 계정입니다.\n정지 일시: ${suspendedAtLabel}`;
+
+          window.alert(alertMessage);
+
+          navigate(`/${ROUTES.LOGIN}`, {
+            replace: true,
+            state: {
+              errorMessage: `정지된 계정입니다. 정지 일시: ${suspendedAtLabel}`,
+            },
+          });
+          return;
+        }
+
         setStatusMessage(DEFAULT_CALLBACK_ERROR_MESSAGE);
 
         navigate(`/${ROUTES.LOGIN}`, {
@@ -100,8 +154,8 @@ function AuthCallbackPage() {
 
   return (
     <AuthLayout
-      title="소셜 로그인"
-      subtitle="로그인 정보를 확인하고 있습니다."
+      title="로그인 확인"
+      subtitle="소셜 로그인 정보를 확인하고 있습니다."
       withPanel
       panelClassName="max-w-[500px]"
     >

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -259,7 +259,7 @@ function LoginPage() {
   return (
     <>
       <AuthLayout
-        title="Log In"
+        title="로그인"
         withPanel
         titleClassName={LOGIN_TITLE_CLASS_NAME}
         mainClassName={LOGIN_MAIN_CLASS_NAME}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -429,7 +429,7 @@ function SignupPage() {
 
   return (
     <AuthLayout
-      title="Join"
+      title="회원가입"
       subtitle="회원가입 후 취향 기반 게임 추천을 시작해보세요"
       withPanel
       subtitleClassName="mx-auto max-w-[290px] sm:max-w-[320px]"
@@ -439,7 +439,7 @@ function SignupPage() {
       <AuthDivider className="my-5 sm:my-6" />
 
       <form
-        className="space-y-3.5 sm:space-y-4"
+        className="space-y-3 sm:space-y-3.5"
         autoComplete="off"
         onSubmit={handleSubmit}
       >


### PR DESCRIPTION
## 관련 이슈

- closes #128

## 변경 내용

- 로그인/회원가입 화면의 영문 타이틀을 `로그인`, `회원가입`으로 한글화했습니다.
- `/login`, `/join`, `/callback` 경로에서는 헤더의 로그인/회원가입 버튼이 보이지 않도록 조건부 렌더링을 적용했습니다.
- 회원가입 페이지 입력 필드 간 간격을 소폭 줄여 한 화면에 더 많은 정보가 보이도록 조정했습니다.
- 소셜 로그인 버튼의 높이와 정렬을 일반 인증 버튼과 맞췄습니다.
- 입력창 내부 `중복확인` 버튼의 테두리와 배경 대비를 높여 가시성을 개선했습니다.
- 성별 선택 UI를 기본 라디오 버튼 대신 주황 포인트의 탭 스타일로 변경했습니다.
- 구글/카카오/네이버 소셜 로그인 버튼 클릭 시 `import.meta.env` 기반 URL로 리다이렉트되도록 연결했습니다.
- `/callback` 경로에서 인가 코드 `code`를 추출해 백엔드로 전달하는 콜백 처리 로직을 추가했고, 네이버는 `state`도 함께 전달하도록 구현했습니다.
- `403 Forbidden` 응답에서 `error_detail`이 `정지된 계정입니다.`인 경우 `suspended_at` 정보를 포함한 사용자 알림을 표시하도록 처리했습니다.
- `/join`, `/callback` 경로를 기준 라우트로 맞추고, 기존 `/signup`, `/auth/callback` 경로는 레거시 리다이렉트로 유지했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3312" height="1462" alt="image" src="https://github.com/user-attachments/assets/f2a8e8bf-6934-4539-beec-7620aca8f41e" />
<img width="3346" height="1686" alt="image" src="https://github.com/user-attachments/assets/1e6b1747-c270-4194-95ee-9d11040995bf" />


## 참고사항

- 소셜 로그인 콜백의 코드 교환 API는 명세에 상세 경로가 없어 `POST /api/v1/accounts/login/{provider}` 형태로 가정해 구현했습니다.
- 소셜 로그인 시작 URL은 `VITE_GOOGLE_LOGIN_URL`, `VITE_KAKAO_LOGIN_URL`, `VITE_NAVER_LOGIN_URL`을 우선 사용하고, 기존 키는 fallback으로 유지했습니다.
- 브라우저 실화면 확인과 스크린샷 첨부는 아직 진행하지 않았습니다.
