### PR TITLE
[Feat] 매칭 화면 문구와 개수 표시 정리

### DIFF
--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -72,6 +72,7 @@ function MatchingGenreDetailPage() {
       ? flowCandidates
       : candidates;
   const totalSteps = displayCandidates.length;
+  const totalGamesLabel = `${totalSteps}개의 게임`;
   const safeIndex =
     totalSteps > 0 ? Math.min(currentIndex, totalSteps - 1) : currentIndex;
   const currentCandidate = displayCandidates[safeIndex];
@@ -307,7 +308,7 @@ function MatchingGenreDetailPage() {
                 매칭 과정을 따라가세요
               </h1>
               <p className="mt-4 text-sm leading-7 break-keep text-white/58 sm:text-base">
-                5개의 게임을 차례대로 평가하고, 마음에 드는 게임은 하트로
+                {totalGamesLabel}을 차례대로 평가하고, 마음에 드는 게임은 하트로
                 표시해둘 수 있어요.
               </p>
             </div>
@@ -390,8 +391,8 @@ function MatchingGenreDetailPage() {
                     <p className="text-sm leading-7 break-keep text-white/64">
                       {isLastCard
                         ? currentEvaluation.rating === null
-                          ? '마지막 카드입니다. 별점을 선택하면 모든 평가를 한 번에 제출할 수 있어요.'
-                          : '마지막 카드까지 평가를 남겼어요. 제출하면 추천 결과를 바로 확인할 수 있어요.'
+                          ? '마지막 후보예요. 별점을 선택하면 지금까지 남긴 평가를 한 번에 제출할 수 있어요.'
+                          : '모든 평가가 준비됐어요. 제출하면 추천 결과를 바로 확인할 수 있어요.'
                         : currentEvaluation.rating === null
                           ? '현재 카드의 별점을 먼저 선택해 주세요.'
                           : '별점과 좋아요는 바로 저장되고, 이전 카드로 돌아가 수정할 수도 있어요.'}
@@ -407,7 +408,8 @@ function MatchingGenreDetailPage() {
                   {isLastCard ? (
                     <div className="mt-auto pt-8">
                       <p className="mx-auto mb-3 w-full max-w-[420px] text-center text-sm leading-6 break-keep text-white/42">
-                        5개 게임의 평가가 모두 준비되면 제출할 수 있어요.
+                        {totalSteps}개 게임의 평가가 모두 준비되면 제출할 수
+                        있어요.
                       </p>
 
                       <div className="flex flex-wrap items-end justify-between gap-3">

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -340,8 +340,8 @@ function RecommendationListPage() {
                 먼저 매칭 평가를 완료해 주세요.
               </h2>
               <p className="mt-4 text-base leading-7 break-keep text-white/60">
-                장르별 매칭에서 5개 게임 평가를 제출하면 추천 결과를 이
-                페이지에서 바로 확인할 수 있어요.
+                장르별 매칭 평가를 제출하면 추천 결과를 이 페이지에서 바로
+                확인할 수 있어요.
               </p>
               <Link
                 to={`/${ROUTES.MATCHING_LIST}`}


### PR DESCRIPTION
## 관련 이슈

- closes #140 

## 변경 내용

- 매칭 상세 페이지의 고정 `5개` 문구를 실제 후보 개수 기준으로 정리
- 매칭 진행 안내 문구를 `totalSteps` 기반으로 표시하도록 수정
- 마지막 카드 안내 문구를 현재 평가 상태에 맞게 자연스럽게 정리
- 제출 전 안내 문구도 실제 평가 개수 기준으로 표시되도록 수정
- 추천 결과 페이지의 매칭 유도 문구에서 고정 `5개 게임 평가` 표현 제거


## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
