### PR TITLE
[Fix] 소셜 로그인 쿠키 기반 인증 플로우 정리

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 
+import { refreshAccessToken } from '../features/auth/api/auth';
 import { apiBaseUrl } from '../lib/env';
 import { useAuthStore } from '../store/useAuthStore';
 
@@ -60,16 +61,7 @@ api.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        // Refresh Token은 쿠키에 담겨 자동으로 전송됨
-        const response = await axios.post(
-          `${apiBaseUrl}/api/v1/accounts/token/refresh`,
-          {},
-          {
-            withCredentials: true,
-          },
-        );
-
-        const { access_token } = response.data;
+        const { access_token } = await refreshAccessToken();
 
         // 새 토큰 저장
         useAuthStore.getState().setAccessToken(access_token);

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,6 +1,7 @@
-import { AxiosError } from 'axios';
+import axios, { AxiosError } from 'axios';
 
 import { api } from '@/api/axios';
+import { apiBaseUrl } from '@/lib/env';
 import { AUTH_BASE_PATH } from '../constants/auth';
 import type {
   CheckIdDuplicateRequest,
@@ -14,11 +15,13 @@ import type {
   LoginRequest,
   LoginResponse,
   LogoutResponse,
-  SocialAuthProvider,
-  SocialLoginCallbackRequest,
+  RefreshAccessTokenResponse,
   SignupRequest,
   SignupResponse,
 } from '../types/auth';
+
+const normalizeApiBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
+const authApiUrl = `${normalizeApiBaseUrl(apiBaseUrl)}${AUTH_BASE_PATH}`;
 
 export const login = async (payload: LoginRequest) => {
   const response = await api.post<LoginResponse>(
@@ -35,14 +38,15 @@ export const logout = async () => {
   return response.data;
 };
 
-export const completeSocialLogin = async (
-  provider: SocialAuthProvider,
-  payload: SocialLoginCallbackRequest,
-) => {
-  const response = await api.get<LoginResponse>(
-    `${AUTH_BASE_PATH}/social-login/${provider}/callback`,
+export const refreshAccessToken = async () => {
+  const response = await axios.post<RefreshAccessTokenResponse>(
+    `${authApiUrl}/token/refresh`,
+    {},
     {
-      params: payload,
+      withCredentials: true,
+      headers: {
+        'Content-Type': 'application/json',
+      },
     },
   );
 

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -17,11 +17,14 @@ import type {
 import { createMockUserMap, type MockUserRecord } from './mockUsers';
 
 const mockUsers = createMockUserMap();
+const AUTH_CALLBACK_PATH = '/callback';
 
 const validGenders: AuthGender[] = ['M', 'W'];
 
 const createAccessToken = (loginId: string) => `mock-access-token-${loginId}`;
 const createRefreshToken = (loginId: string) => `mock-refresh-token-${loginId}`;
+let refreshSessionLoginId: string | null = null;
+let pendingSocialLoginId: string | null = null;
 
 const getAuthorizedUser = (authorization: string | null) => {
   if (!authorization?.startsWith('Bearer ')) {
@@ -70,17 +73,12 @@ const findUserByNickname = (nickname: string) =>
 const isSocialAuthProvider = (value: string): value is SocialAuthProvider =>
   value === 'google' || value === 'kakao' || value === 'naver';
 
-const getMockSocialCallbackQueryString = (provider: SocialAuthProvider) => {
-  const searchParams = new URLSearchParams({
-    code: provider === 'naver' ? 'tester-social-code' : 'demo-social-code',
-    provider,
-  });
-
+const getMockSocialLoginId = (provider: SocialAuthProvider) => {
   if (provider === 'naver') {
-    searchParams.set('state', 'naver-mock-state');
+    return 'pgti-tester';
   }
 
-  return searchParams.toString();
+  return 'pgti-demo';
 };
 
 const loginHandlers = [
@@ -97,12 +95,14 @@ const loginHandlers = [
       );
     }
 
+    pendingSocialLoginId = getMockSocialLoginId(provider);
+
     await delay(120);
 
     return new HttpResponse(null, {
       status: 302,
       headers: {
-        Location: `/callback?${getMockSocialCallbackQueryString(provider)}`,
+        Location: AUTH_CALLBACK_PATH,
       },
     });
   }),
@@ -135,6 +135,7 @@ const loginHandlers = [
     }
 
     await delay(500);
+    refreshSessionLoginId = user.loginId;
 
     return HttpResponse.json({
       access_token: createAccessToken(user.loginId),
@@ -142,63 +143,27 @@ const loginHandlers = [
     });
   }),
 
-  http.get(
-    `${AUTH_BASE_PATH}/social-login/:provider/callback`,
-    async ({ params, request }) => {
-      const provider =
-        typeof params.provider === 'string' ? params.provider.trim() : '';
+  http.post(`${AUTH_BASE_PATH}/token/refresh`, async () => {
+    const loginId = pendingSocialLoginId ?? refreshSessionLoginId;
 
-      if (!isSocialAuthProvider(provider)) {
-        return HttpResponse.json(
-          {
-            error_detail: '지원하지 않는 소셜 로그인 제공자입니다.',
-          },
-          { status: 404 },
-        );
-      }
+    if (!loginId) {
+      return HttpResponse.json(
+        {
+          error_detail: '로그인 세션이 만료되었습니다.',
+        },
+        { status: 403 },
+      );
+    }
 
-      const url = new URL(request.url);
-      const code = url.searchParams.get('code')?.trim() ?? '';
-      const state = url.searchParams.get('state')?.trim() ?? '';
+    pendingSocialLoginId = null;
+    refreshSessionLoginId = loginId;
 
-      if (!code) {
-        return getFieldValidationError('code', '인가 코드가 필요합니다.');
-      }
+    await delay(180);
 
-      if (provider === 'naver' && !state) {
-        return getFieldValidationError(
-          'state',
-          '네이버 로그인 state 값이 필요합니다.',
-        );
-      }
-
-      if (code === 'suspended-account') {
-        return HttpResponse.json(
-          {
-            error_detail: '정지된 계정입니다.',
-            suspended_at: '2026-04-01T09:00:00+09:00',
-          },
-          { status: 403 },
-        );
-      }
-
-      const user =
-        code === 'tester-social-code'
-          ? mockUsers.get('pgti-tester')
-          : mockUsers.get('pgti-demo');
-
-      if (!user) {
-        return getUnauthorizedError('연결된 회원 정보를 찾을 수 없습니다.');
-      }
-
-      await delay(450);
-
-      return HttpResponse.json({
-        access_token: createAccessToken(user.loginId),
-        refresh_token: createRefreshToken(user.loginId),
-      });
-    },
-  ),
+    return HttpResponse.json({
+      access_token: createAccessToken(loginId),
+    });
+  }),
 ];
 
 const signupHandlers = [
@@ -253,66 +218,89 @@ const signupHandlers = [
       );
     }
 
-    if (password.length <= 8) {
-      return getFieldValidationError('password', '비밀번호가 8자 이하입니다.');
+    if (password.length < 8) {
+      return getFieldValidationError(
+        'password',
+        '비밀번호는 8자 이상이어야 합니다.',
+      );
     }
 
     if (password !== passwordCheck) {
       return getFieldValidationError(
         'password_check',
-        '비밀번호와 일치하지 않습니다.',
+        '비밀번호가 일치하지 않습니다.',
       );
     }
 
     if (mockUsers.has(loginId)) {
-      return getDuplicateError('이미 중복된 회원가입 내역이 존재합니다.');
+      return getDuplicateError('이미 사용 중인 아이디입니다.');
     }
 
     if (findUserByNickname(nickname)) {
-      return getDuplicateError('이미 중복된 닉네임이 존재합니다.');
+      return getDuplicateError('이미 사용 중인 닉네임입니다.');
     }
 
-    const createdUser: MockUserRecord = {
+    const newUser: MockUserRecord = {
       id: mockUsers.size + 1,
       loginId,
       password,
       name,
       nickname,
       gender,
-      note: '회원가입 mock으로 생성된 계정',
+      note: 'MSW 회원가입으로 생성된 테스트 계정',
     };
 
-    mockUsers.set(loginId, createdUser);
+    mockUsers.set(loginId, newUser);
 
-    await delay(600);
+    await delay(450);
 
-    return HttpResponse.json(
-      {
-        detail: '회원가입이 완료되었습니다.',
-      },
-      { status: 201 },
-    );
+    return HttpResponse.json({
+      detail: '회원가입이 완료되었습니다.',
+    });
   }),
-];
 
-const logoutHandlers = [
-  http.post(`${AUTH_BASE_PATH}/logout`, async ({ request }) => {
-    const authorization = request.headers.get('Authorization');
+  http.post(`${AUTH_BASE_PATH}/check-id`, async ({ request }) => {
+    const body = (await request.json()) as CheckIdDuplicateRequest;
+    const loginId = body.login_id.trim();
 
-    if (!authorization?.startsWith('Bearer ')) {
-      return HttpResponse.json(
-        {
-          error_detail: '인증 정보가 유효하지 않거나 만료되었습니다.',
-        } satisfies LogoutResponse | { error_detail: string },
-        { status: 401 },
+    if (!loginId) {
+      return getFieldValidationError(
+        'login_id',
+        '"login_id"이 필드는 필수 항목입니다.',
       );
     }
 
-    await delay(200);
+    await delay(150);
+
+    if (mockUsers.has(loginId)) {
+      return getDuplicateError('이미 사용 중인 아이디입니다.');
+    }
 
     return HttpResponse.json({
-      detail: '로그아웃 되었습니다.',
-    } satisfies LogoutResponse);
+      detail: '사용 가능한 아이디입니다.',
+    });
+  }),
+
+  http.post(`${AUTH_BASE_PATH}/check-nickname`, async ({ request }) => {
+    const body = (await request.json()) as CheckNicknameDuplicateRequest;
+    const nickname = body.nickname.trim();
+
+    if (!nickname) {
+      return getFieldValidationError(
+        'nickname',
+        '"nickname"이 필드는 필수 항목입니다.',
+      );
+    }
+
+    await delay(150);
+
+    if (findUserByNickname(nickname)) {
+      return getDuplicateError('이미 사용 중인 닉네임입니다.');
+    }
+
+    return HttpResponse.json({
+      detail: '사용 가능한 닉네임입니다.',
+    });
   }),
 ];
 
@@ -322,19 +310,19 @@ const accountHandlers = [
     const user = getAuthorizedUser(authorization);
 
     if (!user) {
-      return getUnauthorizedError(
-        '인증 정보가 유효하지 않거나 만료되었습니다.',
-      );
+      return getUnauthorizedError('로그인이 필요합니다.');
     }
 
     await delay(180);
 
-    return HttpResponse.json({
+    const responseBody: CurrentUserProfileResponse = {
       login_id: user.loginId,
       name: user.name,
       nickname: user.nickname,
       gender: user.gender,
-    } satisfies CurrentUserProfileResponse);
+    };
+
+    return HttpResponse.json(responseBody);
   }),
 
   http.post(`${AUTH_BASE_PATH}/change-password`, async ({ request }) => {
@@ -342,9 +330,7 @@ const accountHandlers = [
     const user = getAuthorizedUser(authorization);
 
     if (!user) {
-      return getUnauthorizedError(
-        '인증 정보가 유효하지 않거나 만료되었습니다.',
-      );
+      return getUnauthorizedError('로그인이 필요합니다.');
     }
 
     const body = (await request.json()) as ChangePasswordRequest;
@@ -355,48 +341,50 @@ const accountHandlers = [
     if (!currentPassword) {
       return getFieldValidationError(
         'current_password',
-        '현재 비밀번호를 입력해주세요.',
+        '"current_password"이 필드는 필수 항목입니다.',
       );
     }
 
     if (!nextPassword) {
       return getFieldValidationError(
         'new_password',
-        '새 비밀번호를 입력해주세요.',
+        '"new_password"이 필드는 필수 항목입니다.',
       );
     }
 
     if (!nextPasswordConfirm) {
       return getFieldValidationError(
         'new_password_confirm',
-        '새 비밀번호를 한번 더 입력해주세요.',
+        '"new_password_confirm"이 필드는 필수 항목입니다.',
       );
     }
 
     if (user.password !== currentPassword) {
-      return getFieldValidationError(
-        'current_password',
-        '현재 비밀번호가 일치하지 않습니다.',
+      return HttpResponse.json(
+        {
+          error_detail: '현재 비밀번호가 올바르지 않습니다.',
+        },
+        { status: 400 },
       );
     }
 
-    if (nextPassword.length <= 8) {
+    if (nextPassword.length < 8) {
       return getFieldValidationError(
         'new_password',
-        '비밀번호가 8자 이하입니다.',
+        '비밀번호는 8자 이상이어야 합니다.',
       );
     }
 
     if (nextPassword !== nextPasswordConfirm) {
       return getFieldValidationError(
         'new_password_confirm',
-        '비밀번호와 일치하지 않습니다.',
+        '비밀번호가 일치하지 않습니다.',
       );
     }
 
     user.password = nextPassword;
 
-    await delay(350);
+    await delay(240);
 
     return HttpResponse.json({
       detail: '비밀번호가 변경되었습니다.',
@@ -408,73 +396,41 @@ const accountHandlers = [
     const user = getAuthorizedUser(authorization);
 
     if (!user) {
-      return getUnauthorizedError(
-        '인증 정보가 유효하지 않거나 만료되었습니다.',
-      );
+      return getUnauthorizedError('로그인이 필요합니다.');
     }
-
-    await delay(400);
 
     mockUsers.delete(user.loginId);
 
+    await delay(220);
+
     return HttpResponse.json({
-      detail: `${user.nickname} 계정이 탈퇴 처리되었습니다.`,
+      detail: '회원 탈퇴가 완료되었습니다.',
     } satisfies DeleteAccountResponse);
   }),
 ];
 
-const duplicateCheckHandlers = [
-  http.post(`${AUTH_BASE_PATH}/check-id`, async ({ request }) => {
-    const body = (await request.json()) as CheckIdDuplicateRequest;
-    const value = body.login_id.trim();
+const logoutHandlers = [
+  http.post(`${AUTH_BASE_PATH}/logout`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+    const user = getAuthorizedUser(authorization);
 
-    if (!value) {
-      return getFieldValidationError(
-        'login_id',
-        '"login_id"이 필드는 필수 항목입니다.',
-      );
+    if (!user) {
+      return getUnauthorizedError('로그인이 필요합니다.');
     }
 
-    await delay(250);
-
-    if (mockUsers.has(value)) {
-      return getDuplicateError('중복된 아이디가 존재합니다.');
-    }
+    await delay(200);
+    refreshSessionLoginId = null;
+    pendingSocialLoginId = null;
 
     return HttpResponse.json({
-      detail: '사용가능한 아이디 입니다.',
-    });
-  }),
-
-  http.post(`${AUTH_BASE_PATH}/check-nickname`, async ({ request }) => {
-    const body = (await request.json()) as CheckNicknameDuplicateRequest;
-    const value = body.nickname.trim();
-
-    if (!value) {
-      return getFieldValidationError(
-        'nickname',
-        '"nickname"이 필드는 필수 항목입니다.',
-      );
-    }
-
-    await delay(250);
-
-    const isDuplicate = Boolean(findUserByNickname(value));
-
-    if (isDuplicate) {
-      return getDuplicateError('중복된 닉네임이 존재합니다.');
-    }
-
-    return HttpResponse.json({
-      detail: '사용가능한 닉네임 입니다.',
-    });
+      detail: '로그아웃 되었습니다.',
+    } satisfies LogoutResponse);
   }),
 ];
 
 export const authHandlers = [
   ...loginHandlers,
   ...signupHandlers,
-  ...logoutHandlers,
   ...accountHandlers,
-  ...duplicateCheckHandlers,
+  ...logoutHandlers,
 ];

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -11,6 +11,10 @@ export interface LoginResponse {
   refresh_token?: string | null;
 }
 
+export interface RefreshAccessTokenResponse {
+  access_token: string;
+}
+
 export interface LogoutResponse {
   detail: string;
 }
@@ -59,11 +63,6 @@ export interface CheckIdDuplicateRequest {
 
 export interface DuplicateCheckResponse {
   detail: string;
-}
-
-export interface SocialLoginCallbackRequest {
-  code: string;
-  state?: string;
 }
 
 export type { ErrorResponseBody } from './api';

--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -18,18 +18,12 @@ const SOCIAL_AUTH_START_PATHS: Record<SocialAuthProvider, string> = {
   naver: `${AUTH_BASE_PATH}/social-login/naver`,
 };
 
-const isSocialAuthProvider = (
-  value: string | null | undefined,
-): value is SocialAuthProvider =>
-  value === 'google' || value === 'kakao' || value === 'naver';
-
-const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value);
-
 const getSocialLoginStartUrlFromEnv = (provider: SocialAuthProvider) => {
   const env = import.meta.env as Record<string, string | undefined>;
 
   for (const envKey of SOCIAL_AUTH_START_URL_ENV_KEYS[provider]) {
     const value = env[envKey]?.trim();
+
     if (value) {
       return value;
     }
@@ -45,17 +39,10 @@ export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
     return configuredUrl;
   }
 
-  if (apiBaseUrl) {
-    if (isAbsoluteUrl(apiBaseUrl)) {
-      return new URL(SOCIAL_AUTH_START_PATHS[provider], apiBaseUrl).toString();
-    }
+  const normalizedApiBaseUrl = apiBaseUrl.trim().replace(/\/$/, '');
 
-    if (typeof window !== 'undefined') {
-      return new URL(
-        SOCIAL_AUTH_START_PATHS[provider],
-        window.location.origin,
-      ).toString();
-    }
+  if (normalizedApiBaseUrl) {
+    return `${normalizedApiBaseUrl}${SOCIAL_AUTH_START_PATHS[provider]}`;
   }
 
   return SOCIAL_AUTH_START_PATHS[provider];
@@ -77,34 +64,20 @@ export const clearPendingSocialAuthProvider = () => {
   window.sessionStorage.removeItem(PENDING_SOCIAL_PROVIDER_STORAGE_KEY);
 };
 
-export const getSocialCallbackProvider = (searchParams: URLSearchParams) => {
-  const providerFromQuery = searchParams.get('provider');
-
-  if (isSocialAuthProvider(providerFromQuery)) {
-    clearPendingSocialAuthProvider();
-    return providerFromQuery;
-  }
-
-  if (typeof window === 'undefined') {
+const getSocialCallbackErrorMessageFromCode = (errorCode: string | null) => {
+  if (!errorCode) {
     return null;
   }
 
-  const providerFromStorage = window.sessionStorage.getItem(
-    PENDING_SOCIAL_PROVIDER_STORAGE_KEY,
-  );
-  clearPendingSocialAuthProvider();
+  if (errorCode === 'social-login-failed') {
+    return '소셜 로그인에 실패했습니다. 다시 시도해 주세요.';
+  }
 
-  return isSocialAuthProvider(providerFromStorage) ? providerFromStorage : null;
+  return errorCode;
 };
 
 export const getSocialCallbackErrorMessage = (searchParams: URLSearchParams) =>
   searchParams.get('error_description') ||
   searchParams.get('error_detail') ||
   searchParams.get('detail') ||
-  searchParams.get('error');
-
-export const getSocialCallbackCode = (searchParams: URLSearchParams) =>
-  searchParams.get('code')?.trim() || null;
-
-export const getSocialCallbackState = (searchParams: URLSearchParams) =>
-  searchParams.get('state')?.trim() || null;
+  getSocialCallbackErrorMessageFromCode(searchParams.get('error'));

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -4,41 +4,18 @@ import { useLocation, useNavigate } from 'react-router';
 import AuthLayout from '../components/layout/AuthLayout';
 import { ROUTES } from '../constants/routes';
 import {
-  completeSocialLogin,
   extractAuthApiErrorMessage,
-  extractSuspendedAccountInfo,
   getCurrentUserProfile,
+  refreshAccessToken,
 } from '../features/auth/api/auth';
 import {
   clearPendingSocialAuthProvider,
-  getSocialCallbackCode,
   getSocialCallbackErrorMessage,
-  getSocialCallbackProvider,
-  getSocialCallbackState,
 } from '../features/auth/utils/socialAuth';
 import { useAuthStore } from '../store/useAuthStore';
 
-const DEFAULT_CALLBACK_ERROR_MESSAGE =
-  '소셜 로그인 처리에 실패했습니다. 다시 시도해 주세요.';
-const INVALID_CALLBACK_ERROR_MESSAGE =
-  '인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.';
-
-const formatSuspendedAt = (suspendedAt: string | null) => {
-  if (!suspendedAt) {
-    return '정지 일시 정보가 없습니다.';
-  }
-
-  const suspendedDate = new Date(suspendedAt);
-
-  if (Number.isNaN(suspendedDate.getTime())) {
-    return suspendedAt;
-  }
-
-  return new Intl.DateTimeFormat('ko-KR', {
-    dateStyle: 'long',
-    timeStyle: 'short',
-  }).format(suspendedDate);
-};
+const DEFAULT_REFRESH_ERROR_MESSAGE =
+  '세션을 확인하지 못했습니다. 다시 로그인해 주세요.';
 
 function AuthCallbackPage() {
   const navigate = useNavigate();
@@ -46,7 +23,7 @@ function AuthCallbackPage() {
   const { setAuth, clearAuth } = useAuthStore();
   const handledSearchRef = useRef<string | null>(null);
   const [statusMessage, setStatusMessage] = useState(
-    '소셜 로그인 정보를 확인하고 있습니다.',
+    '소셜 로그인 세션을 확인하는 중입니다.',
   );
 
   useEffect(() => {
@@ -60,9 +37,10 @@ function AuthCallbackPage() {
 
     const handleAuthCallback = async () => {
       const searchParams = new URLSearchParams(location.search);
-
       const callbackErrorMessage = getSocialCallbackErrorMessage(searchParams);
+
       if (callbackErrorMessage) {
+        clearAuth();
         clearPendingSocialAuthProvider();
         navigate(`/${ROUTES.LOGIN}`, {
           replace: true,
@@ -71,30 +49,9 @@ function AuthCallbackPage() {
         return;
       }
 
-      const provider = getSocialCallbackProvider(searchParams);
-      const code = getSocialCallbackCode(searchParams);
-      const socialState =
-        provider === 'naver'
-          ? (getSocialCallbackState(searchParams) ?? undefined)
-          : undefined;
-
-      if (!provider || !code || (provider === 'naver' && !socialState)) {
-        clearPendingSocialAuthProvider();
-        navigate(`/${ROUTES.LOGIN}`, {
-          replace: true,
-          state: {
-            errorMessage: INVALID_CALLBACK_ERROR_MESSAGE,
-          },
-        });
-        return;
-      }
-
       try {
-        const loginResponse = await completeSocialLogin(provider, {
-          code,
-          ...(provider === 'naver' ? { state: socialState } : {}),
-        });
-        useAuthStore.getState().setAccessToken(loginResponse.access_token);
+        const { access_token: accessToken } = await refreshAccessToken();
+        useAuthStore.getState().setAccessToken(accessToken);
 
         const profile = await getCurrentUserProfile();
 
@@ -102,9 +59,8 @@ function AuthCallbackPage() {
           return;
         }
 
-        setAuth(loginResponse.access_token, profile);
+        setAuth(accessToken, profile);
         clearPendingSocialAuthProvider();
-
         navigate(ROUTES.HOME, { replace: true });
       } catch (error) {
         if (!isMounted) {
@@ -113,33 +69,14 @@ function AuthCallbackPage() {
 
         clearAuth();
         clearPendingSocialAuthProvider();
-
-        const suspendedAccountInfo = extractSuspendedAccountInfo(error);
-        if (suspendedAccountInfo) {
-          const suspendedAtLabel = formatSuspendedAt(
-            suspendedAccountInfo.suspendedAt,
-          );
-          const alertMessage = `정지된 계정입니다.\n정지 일시: ${suspendedAtLabel}`;
-
-          window.alert(alertMessage);
-
-          navigate(`/${ROUTES.LOGIN}`, {
-            replace: true,
-            state: {
-              errorMessage: `정지된 계정입니다. 정지 일시: ${suspendedAtLabel}`,
-            },
-          });
-          return;
-        }
-
-        setStatusMessage(DEFAULT_CALLBACK_ERROR_MESSAGE);
+        setStatusMessage(DEFAULT_REFRESH_ERROR_MESSAGE);
 
         navigate(`/${ROUTES.LOGIN}`, {
           replace: true,
           state: {
             errorMessage:
               extractAuthApiErrorMessage(error) ||
-              DEFAULT_CALLBACK_ERROR_MESSAGE,
+              DEFAULT_REFRESH_ERROR_MESSAGE,
           },
         });
       }
@@ -155,7 +92,7 @@ function AuthCallbackPage() {
   return (
     <AuthLayout
       title="로그인 확인"
-      subtitle="소셜 로그인 정보를 확인하고 있습니다."
+      subtitle="소셜 로그인 세션을 확인하고 있습니다."
       withPanel
       panelClassName="max-w-[500px]"
     >

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '../features/auth/api/auth';
 import { useLoginMutation } from '../features/auth/api/useAuthApi';
 import type { LoginRequest } from '../features/auth/types/auth';
+import { getSocialCallbackErrorMessage } from '../features/auth/utils/socialAuth';
 import { mockServiceWorkerEnabled } from '../lib/env';
 import { useAuthStore } from '../store/useAuthStore';
 
@@ -96,8 +97,11 @@ function LoginPage() {
   });
   const [apiFieldErrors, setApiFieldErrors] = useState<LoginFieldErrors>({});
   const locationState = location.state as LoginLocationState | null;
+  const locationSearchErrorMessage = getSocialCallbackErrorMessage(
+    new URLSearchParams(location.search),
+  );
   const [formMessage, setFormMessage] = useState(
-    locationState?.errorMessage ?? '',
+    locationState?.errorMessage ?? locationSearchErrorMessage ?? '',
   );
   const [noticeMessage, setNoticeMessage] = useState(
     locationState?.noticeMessage ?? '',
@@ -108,6 +112,16 @@ function LoginPage() {
     password: apiFieldErrors.password ?? fieldErrors.password,
   };
   const showMockAccounts = mockServiceWorkerEnabled && mockAccounts.length > 0;
+
+  useEffect(() => {
+    setFormMessage(
+      locationState?.errorMessage ?? locationSearchErrorMessage ?? '',
+    );
+  }, [locationState?.errorMessage, locationSearchErrorMessage]);
+
+  useEffect(() => {
+    setNoticeMessage(locationState?.noticeMessage ?? '');
+  }, [locationState?.noticeMessage]);
 
   useEffect(() => {
     if (!mockServiceWorkerEnabled) {


### PR DESCRIPTION
## 관련 이슈

- closes #130

## 변경 내용

- 소셜 로그인 시작 URL 기본 경로를 `/api/v1/accounts/social-login/{provider}` 기준으로 정리했습니다.
- 소셜 로그인 버튼 클릭 시 환경변수 우선, fallback은 최신 백엔드 시작 엔드포인트를 사용하도록 수정했습니다.
- 소셜 로그인 콜백 페이지에서 URL query의 `access_token` 또는 `code`를 직접 소비하던 의존을 제거했습니다.
- 콜백 페이지 진입 시 `POST /api/v1/accounts/token/refresh`를 호출해 HttpOnly Cookie 기반으로 `access_token`을 재발급받도록 변경했습니다.
- refresh 성공 시 `access_token`을 메모리 store에 저장하고 `/api/v1/accounts/me` 조회 후 사용자 정보를 반영한 뒤 메인 페이지로 이동하도록 정리했습니다.
- refresh 실패 시 인증 상태를 초기화하고 로그인 페이지로 복귀하면서 에러 메시지를 표시하도록 수정했습니다.
- auth API 계층에 `refreshAccessToken()` 함수를 분리해 콜백 페이지와 axios interceptor가 같은 refresh 경계를 재사용하도록 맞췄습니다.
- 로그인 페이지에서 `/login?error=social-login-failed` 형태의 실패 리다이렉트 메시지를 표시할 수 있도록 유지했습니다.
- MSW mock도 백엔드 최신 흐름에 맞춰 소셜 로그인 시작 -> 프론트 콜백 리다이렉트 -> refresh 응답 구조로 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 최신 합의 기준으로 `refresh_token`은 요청 body가 아니라 HttpOnly Cookie로 전달되는 전제를 기준으로 구현했습니다.
- 소셜 로그인 성공 후 백엔드가 프론트 콜백 페이지로 redirect하고, 프론트는 콜백 페이지에서 `POST /api/v1/accounts/token/refresh`를 호출해 `access_token`을 메모리에 저장하는 흐름으로 맞췄습니다.
- 실제 브라우저에서 소셜 provider 연동까지는 아직 확인하지 않았고, 현재는 lint/build와 MSW 기준 흐름까지 검증했습니다.
