### PR TITLE
[Refactor] 설문 및 매칭 추천 결과 mock pagination 정리

### DIFF
--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -21,6 +21,8 @@ type StoredMatchResult = {
   created_at_order: number;
 };
 
+const DEFAULT_RECOMMENDATION_PAGE_SIZE = 5;
+
 let storedMatchResults: StoredMatchResult[] = [];
 
 const getRankedMatchResults = () =>
@@ -136,10 +138,16 @@ export const matchingHandlers = [
       })),
     });
   }),
-  http.get('/api/v1/match/responses/result', async () => {
+  http.get('/api/v1/match/responses/result', async ({ request }) => {
     if (storedMatchResults.length === 0) {
       return getErrorResponse(404, '매칭 추천 결과를 찾을 수 없습니다.');
     }
+
+    const url = new URL(request.url);
+    const cursor = Number(url.searchParams.get('cursor') ?? '0');
+    const pageSize = Number(
+      url.searchParams.get('page_size') ?? DEFAULT_RECOMMENDATION_PAGE_SIZE,
+    );
 
     const results = getRankedMatchResults().map((result) => {
       const candidate = matchingMockCandidateMapById.get(result.game_id)!;
@@ -153,14 +161,17 @@ export const matchingHandlers = [
         is_liked: result.is_liked,
       };
     });
+    const startIndex = Number.isNaN(cursor) ? 0 : cursor;
+    const nextIndex = startIndex + pageSize;
+    const next = nextIndex < results.length ? String(nextIndex) : null;
 
     await delay(450);
 
     return HttpResponse.json({
       user_id: 1,
       count: results.length,
-      next: null,
-      results,
+      next,
+      results: results.slice(startIndex, nextIndex),
     });
   }),
 ];

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -9,6 +9,7 @@ import type {
 const MIN_STEPS = 3;
 const DEFAULT_STEPS = 4;
 const MAX_STEPS = 5;
+const DEFAULT_RECOMMENDATION_PAGE_SIZE = 5;
 
 const surveyQuestions = [
   '스토리 중심의 몰입감을 더 중요하게 보시나요, 아니면 손맛과 시스템 완성도를 더 중요하게 보시나요?',
@@ -248,7 +249,9 @@ export const surveyHandlers = [
   http.get('/api/v1/survey/result', async ({ request }) => {
     const url = new URL(request.url);
     const cursor = Number(url.searchParams.get('cursor') ?? '0');
-    const pageSize = Number(url.searchParams.get('page_size') ?? '5');
+    const pageSize = Number(
+      url.searchParams.get('page_size') ?? DEFAULT_RECOMMENDATION_PAGE_SIZE,
+    );
 
     if (!latestCompletedSurveySessionId) {
       return getErrorResponse(404, '설문 추천 결과를 찾을 수 없습니다.');


### PR DESCRIPTION
## 관련 이슈

- closes #143 

## 변경 내용

- 설문 추천 결과 mock의 기본 `page_size` 기준을 5개로 명확히 정리
- 설문 추천 결과 mock이 `count`, `next`, `results` 기반 pagination 구조를 유지하도록 정리
- 매칭 추천 결과 mock도 설문 추천 결과와 동일한 더보기 버튼 방식으로 동작하도록 수정
- 매칭 추천 결과 응답에 `cursor`, `page_size`, `next` 계산을 추가
- 추천 결과 화면이 설문/매칭 모두 동일한 pagination UX로 동작하도록 mock 기준을 맞춤

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
