### PR TITLE
fix(auth): MSW 환경 로그인 동기화 및 개발용 계정 정보 실시간 반영

### DIFF
--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -70,6 +70,18 @@ const getUnauthorizedError = (message: string) =>
 const findUserByNickname = (nickname: string) =>
   [...mockUsers.values()].find((user) => user.nickname === nickname);
 
+const getDevLoginAccounts = () =>
+  [...mockUsers.values()]
+    .sort((a, b) => a.id - b.id)
+    .map(({ loginId, password, name, nickname, gender, note }) => ({
+      loginId,
+      password,
+      name,
+      nickname,
+      gender,
+      note,
+    }));
+
 const isSocialAuthProvider = (value: string): value is SocialAuthProvider =>
   value === 'google' || value === 'kakao' || value === 'naver';
 
@@ -82,6 +94,14 @@ const getMockSocialLoginId = (provider: SocialAuthProvider) => {
 };
 
 const loginHandlers = [
+  http.get(`${AUTH_BASE_PATH}/dev-login-accounts`, async () => {
+    await delay(120);
+
+    return HttpResponse.json({
+      accounts: getDevLoginAccounts(),
+    });
+  }),
+
   http.get(`${AUTH_BASE_PATH}/social-login/:provider`, async ({ params }) => {
     const provider =
       typeof params.provider === 'string' ? params.provider.trim() : '';

--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -1,4 +1,4 @@
-import { apiBaseUrl } from '@/lib/env';
+import { apiBaseUrl, mockServiceWorkerEnabled } from '@/lib/env';
 import { AUTH_BASE_PATH } from '../constants/auth';
 import type { SocialAuthProvider } from '../types/auth';
 
@@ -33,6 +33,10 @@ const getSocialLoginStartUrlFromEnv = (provider: SocialAuthProvider) => {
 };
 
 export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
+  if (mockServiceWorkerEnabled) {
+    return SOCIAL_AUTH_START_PATHS[provider];
+  }
+
   const configuredUrl = getSocialLoginStartUrlFromEnv(provider);
 
   if (configuredUrl) {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,6 +1,20 @@
-export const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
+const readMswToggleValue = () => {
+  const env = import.meta.env as Record<string, string | undefined>;
+
+  return env.VITE_USE_MSW ?? env.VITE_ENABLE_MSW;
+};
+
+const isMockServiceWorkerEnabledInEnv = () =>
+  readMswToggleValue()?.trim().toLowerCase() !== 'false';
 
 export const mockServiceWorkerEnabled =
-  import.meta.env.DEV && import.meta.env.VITE_USE_MSW !== 'false';
+  import.meta.env.DEV && isMockServiceWorkerEnabledInEnv();
+
+const normalizedApiBaseUrl = (import.meta.env.VITE_API_BASE_URL ?? '')
+  .trim()
+  .replace(/\/$/, '');
+
+// MSW 모드에서는 절대 API 호스트를 비워, 상대 경로 요청이 핸들러에 안정적으로 매칭되게 한다.
+export const apiBaseUrl = mockServiceWorkerEnabled ? '' : normalizedApiBaseUrl;
 
 export const isMockServiceWorkerEnabled = () => mockServiceWorkerEnabled;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { KeyRound, X } from 'lucide-react';
 
+import { api } from '../api/axios';
 import AuthButton from '../components/auth/AuthButton';
 import AuthDivider from '../components/auth/AuthDivider';
 import AuthFormMessage from '../components/auth/AuthFormMessage';
@@ -37,6 +38,10 @@ type DevMockLoginAccount = {
   nickname: string;
   gender: string;
   note: string;
+};
+
+type DevMockLoginAccountsResponse = {
+  accounts: DevMockLoginAccount[];
 };
 
 const LOGIN_MAIN_CLASS_NAME = 'min-h-0 py-1 sm:py-1.5';
@@ -130,20 +135,32 @@ function LoginPage() {
 
     let isMounted = true;
 
-    void import('../features/auth/mocks/mockUsers')
-      .then(({ mockLoginAccounts }) => {
+    void api
+      .get<DevMockLoginAccountsResponse>('/api/v1/accounts/dev-login-accounts')
+      .then(({ data }) => {
         if (!isMounted) {
           return;
         }
 
-        setMockAccounts(mockLoginAccounts);
+        setMockAccounts(data.accounts);
       })
-      .catch(() => {
-        if (!isMounted) {
-          return;
-        }
+      .catch(async () => {
+        try {
+          const { mockLoginAccounts } =
+            await import('../features/auth/mocks/mockUsers');
 
-        setMockAccounts([]);
+          if (!isMounted) {
+            return;
+          }
+
+          setMockAccounts(mockLoginAccounts);
+        } catch {
+          if (!isMounted) {
+            return;
+          }
+
+          setMockAccounts([]);
+        }
       });
 
     return () => {


### PR DESCRIPTION
## 관련 이슈

- closes #139 

## 변경 내용

-DEV + MSW 환경에서 auth 요청이 실서버로 빠지지 않도록 apiBaseUrl 처리 로직을 정리했습니다. (src/lib/env.ts)
-MSW 활성 시 소셜 로그인 시작 URL도 상대 경로를 사용하도록 수정했습니다. (src/features/auth/utils/socialAuth.ts)
-MSW auth 핸들러에 개발용 계정 목록 조회 엔드포인트(GET /api/v1/accounts/dev-login-accounts)를 추가했습니다. (src/features/auth/mocks/handlers.ts)
-로그인 페이지에서 개발용 계정 패널 데이터를 고정 시드가 아닌 MSW 현재 상태로 조회하도록 변경했습니다(실패 시 시드 fallback). (src/pages/LoginPage.tsx)
-마이페이지에서 비밀번호 변경 시, 로그인 페이지 개발용 계정 패널의 비밀번호 표시도 변경값으로 반영됩니다.
top100 관련 변경은 요청대로 원복했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-dev + MSW에서만 개발용 계정 패널/목 로그인 동작을 사용하며, 배포 환경에서는 실서버 로그인 동작을 유지합니다.
