### PR TITLE
fix(chatbot): SSE 복구 및 API 경로 문서 정합성 반영

### DIFF
--- a/docs/ai/api-contract.md
+++ b/docs/ai/api-contract.md
@@ -15,7 +15,7 @@
 
 ### 2. 인증 관련 API 엔드포인트
 
-- **소셜 로그인 진입**: `GET /api/v1/accounts/login/{google|kakao|naver}` (백엔드 제공 OAuth 시작점)
+- **소셜 로그인 진입**: `GET /api/v1/accounts/social-login/{google|kakao|naver}` (백엔드 제공 OAuth 시작점)
 - **토큰 갱신**: `POST /api/v1/accounts/token/refresh` (쿠키의 리프레시 토큰을 사용하여 액세스 토큰 재발급)
 - **로그아웃**: `POST /api/v1/accounts/logout` (액세스 토큰 무효화 및 서버측 쿠키 삭제 요청)
 
@@ -171,8 +171,8 @@ MSW mock은 실제 API 경로와 응답 구조를 최대한 동일하게 맞춥�
 ### API Endpoints
 
 ```text
-POST   /api/v1/support/chat/send    # 메시지 전송 및 AI 응답 (Streaming)
-GET    /api/v1/support/faq          # 자주 묻는 질문 목록 조회
+POST   /api/v1/chatbot/messages     # 메시지 전송 (세션 생성/재사용)
+GET    /api/v1/chatbot/stream       # AI 응답 스트리밍 (SSE, query: session_id)
 ```
 
 ### Integration Details
@@ -180,6 +180,7 @@ GET    /api/v1/support/faq          # 자주 묻는 질문 목록 조회
 - **Widget**: `SupportChatWidget`을 통해 전역 레이아웃(`App.tsx`)에 배치.
 - **Mocking**: 백엔드 미완성 시 MSW를 통해 스트리밍 응답 시뮬레이션.
 - **State**: `useSupportChatStore`를 통한 대화 내역 및 위젯 상태 관리.
+- **Boundary**: 고객센터 챗봇 API(`/api/v1/chatbot/*`)는 설문 챗봇 API(`/api/v1/survey/chatbot/*`)와 별개로 운영하며, 경로를 혼용하지 않습니다.
 
 ---
 

--- a/src/components/support-chat/SupportChatComposer.tsx
+++ b/src/components/support-chat/SupportChatComposer.tsx
@@ -53,7 +53,15 @@ function SupportChatComposer({
           <SendHorizontal size={16} />
         </button>
       </form>
-      {error ? <p className="mt-1 text-xs text-[#ff8b84]">{error}</p> : null}
+      {error ? (
+        <p
+          className="mt-1 text-xs text-[#ff8b84]"
+          role="alert"
+          aria-live="assertive"
+        >
+          {error}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/src/components/support-chat/SupportChatPanel.tsx
+++ b/src/components/support-chat/SupportChatPanel.tsx
@@ -66,6 +66,10 @@ function SupportChatPanel({
       <div
         ref={viewportRef}
         className="support-chat-scrollbar flex-1 overflow-y-auto px-4 py-4"
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions text"
+        aria-label="고객센터 챗봇 대화 내역"
       >
         <div className="flex flex-col gap-4">
           {messages.map((message) => (

--- a/src/components/support-chat/SupportChatWidget.tsx
+++ b/src/components/support-chat/SupportChatWidget.tsx
@@ -184,12 +184,12 @@ function SupportChatWidget() {
       return;
     }
 
-    const assistantMessageId = crypto.randomUUID();
+    const assistantPlaceholderMessageId = crypto.randomUUID();
 
     clearError();
     hideQuickActions();
     appendUserMessage(trimmedMessage);
-    beginAssistantMessage(assistantMessageId);
+    beginAssistantMessage(assistantPlaceholderMessageId);
     setSubmitting(true);
 
     try {
@@ -223,17 +223,19 @@ function SupportChatWidget() {
         signal: abortController.signal,
         onEvent: (event) => {
           if (event.type === 'chunk') {
-            appendAssistantChunk(assistantMessageId, event.content);
+            appendAssistantChunk(assistantPlaceholderMessageId, event.content);
           }
 
           if (event.type === 'complete') {
-            finalizeAssistantMessage(assistantMessageId);
+            finalizeAssistantMessage(assistantPlaceholderMessageId);
             setSubmitting(false);
           }
         },
       });
     } catch (requestError) {
-      removeMessage(assistantMessageId);
+      // 스트림 실패 시에는 사용자 메시지는 보존하고,
+      // 임시 assistant 메시지만 제거한 뒤 오류 메시지를 안내한다.
+      removeMessage(assistantPlaceholderMessageId);
       const errorMessage = extractSupportChatErrorMessage(requestError);
 
       if (errorMessage) {

--- a/src/features/support-chat/api/chatbot.ts
+++ b/src/features/support-chat/api/chatbot.ts
@@ -6,6 +6,8 @@ import type {
   ChatbotStreamEvent,
 } from '../types/supportChat';
 
+// 고객센터 챗봇 전용 엔드포인트.
+// 설문 챗봇(`/api/v1/survey/chatbot/*`)과 경로를 명확히 분리해 사용한다.
 const CHATBOT_BASE_PATH = '/api/v1/chatbot';
 
 const createApiUrl = (
@@ -97,10 +99,24 @@ const parseSseEvent = (chunk: string): ChatbotStreamEvent | null => {
     return null;
   }
 
-  const parsed = JSON.parse(dataLines.join('\n')) as {
+  let parsed: {
     session_id?: number;
     content?: string;
   };
+
+  try {
+    parsed = JSON.parse(dataLines.join('\n')) as {
+      session_id?: number;
+      content?: string;
+    };
+  } catch (error) {
+    // 일부 malformed chunk가 와도 스트림 전체를 중단하지 않고 해당 이벤트만 건너뛴다.
+    if (import.meta.env.DEV) {
+      console.warn('[support-chat] SSE 이벤트 파싱에 실패했습니다.', error);
+    }
+
+    return null;
+  }
 
   if (eventName === 'start' && typeof parsed.session_id === 'number') {
     return {

--- a/src/features/support-chat/mocks/handlers.ts
+++ b/src/features/support-chat/mocks/handlers.ts
@@ -10,6 +10,8 @@ import type {
   ChatbotMessageResponse,
 } from '../types/supportChat';
 
+// 고객센터 챗봇 mock 전용 엔드포인트.
+// 설문 챗봇(`/api/v1/survey/chatbot/*`) mock과 경계를 분리한다.
 const CHATBOT_BASE_PATH = '/api/v1/chatbot';
 
 type MockChatSession = {


### PR DESCRIPTION
## 관련 이슈

- closes #146 

## 변경 내용

-고객센터 챗봇 API 경계 명확화
  * 고객센터 챗봇은 /api/v1/chatbot/messages, /api/v1/chatbot/stream 경로만 사용하도록 코드 주석/구조를 정리했습니다.
  * 설문 챗봇(/api/v1/survey/chatbot/*)과 경로 혼용 방지 내용을 코드/문서에 명시했습니다.
-고객센터 챗봇 SSE 안정화
  * SSE 이벤트 파싱을 이벤트 단위 예외 복구 방식으로 변경해, malformed chunk 발생 시 전체 스트림이 중단되지 않도록 개선했습니다.
-스트림 실패 UX 명확화
  * 실패 시 사용자 메시지는 유지하고, 임시 assistant 메시지만 제거한 뒤 에러 메시지를 노출하도록 동작을 명확히 했습니다.
-접근성 보강
  * 대화 영역에 role="log", aria-live 추가
  * 에러 메시지에 role="alert", aria-live 추가
-API 계약 문서 정합성 반영
  * 소셜 로그인/고객센터 챗봇 경로를 현재 코드와 일치하도록 docs/ai/api-contract.md를 수정했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
