### PR TITLE
[Refactor] 매칭 추천 결과 mock 정렬 기준 정리

### DIFF
--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -19,16 +19,38 @@ type StoredMatchResult = {
   rating: number;
   is_liked: boolean;
   created_at_order: number;
+  mock_rank_score: number;
 };
 
 const DEFAULT_RECOMMENDATION_PAGE_SIZE = 5;
 
 let storedMatchResults: StoredMatchResult[] = [];
 
+const calculateMockRankScore = ({
+  gameId,
+  rating,
+  isLiked,
+  createdAtOrder,
+  totalCount,
+}: {
+  gameId: number;
+  rating: number;
+  isLiked: boolean;
+  createdAtOrder: number;
+  totalCount: number;
+}) => {
+  const likedWeight = isLiked ? 35 : 0;
+  const ratingWeight = rating * 4;
+  const orderWeight = Math.max(totalCount - createdAtOrder, 0) * 2;
+  const tieBreakerWeight = gameId % 7;
+
+  return likedWeight + ratingWeight + orderWeight + tieBreakerWeight;
+};
+
 const getRankedMatchResults = () =>
   [...storedMatchResults].sort((a, b) => {
-    if (b.rating !== a.rating) {
-      return b.rating - a.rating;
+    if (b.mock_rank_score !== a.mock_rank_score) {
+      return b.mock_rank_score - a.mock_rank_score;
     }
 
     return a.created_at_order - b.created_at_order;
@@ -120,11 +142,18 @@ export const matchingHandlers = [
       }
     }
 
-    storedMatchResults = body.match_result.map((result, index) => ({
+    storedMatchResults = body.match_result.map((result, index, allResults) => ({
       game_id: result.game_id!,
       rating: result.rating!,
       is_liked: Boolean(result.is_liked),
       created_at_order: index,
+      mock_rank_score: calculateMockRankScore({
+        gameId: result.game_id!,
+        rating: result.rating!,
+        isLiked: Boolean(result.is_liked),
+        createdAtOrder: index,
+        totalCount: allResults.length,
+      }),
     }));
 
     await delay(500);


### PR DESCRIPTION
## 관련 이슈

- closes #149 

## 변경 내용

- 추천 결과 화면이 응답 순서를 그대로 사용하는 구조를 유지하는 전제에서 매칭 추천 결과 mock 정렬 기준을 정리
- 매칭 추천 결과 mock이 `rating` 순 정렬처럼만 보이지 않도록 내부 정렬 로직 수정
- mock 내부 정렬은 백엔드가 정렬해 내려준 결과처럼 보이도록 정리하고, 응답 shape는 그대로 유지
  - `count`
  - `next`
  - `results`
- 프론트 추천 결과 리스트는 추가 정렬 없이 응답 배열 순서를 그대로 렌더링하도록 유지

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 백엔드의 실제 `final_score` 계산식을 재현하는 것이 목적이 아닙니다.
- mock이 백엔드 정렬 결과처럼 보이도록 내부 ranking 기준만 정리하는 작업입니다.
