### PR TITLE
[Feat] 게임 API를 MSW handler 기반으로 통일

### DIFF
--- a/src/features/games/gameApi.ts
+++ b/src/features/games/gameApi.ts
@@ -1,8 +1,5 @@
-import { AxiosError } from 'axios';
-
 import { api } from '../../api/axios';
-import { getGameGenreId, matchesGenreFilter } from './genres';
-import { mockTopGames } from './mockGames';
+import { getGameGenreId } from './genres';
 import type {
   GameDetail,
   GameLikeResponse,
@@ -18,24 +15,10 @@ import type {
 const DEFAULT_PAGE_SIZE = 20;
 const DEFAULT_SORT = 'rating_desc';
 
-const hasApiBaseUrl = Boolean(import.meta.env.VITE_API_BASE_URL);
-
 const getGenreQueryParams = (genre: GetTopGamesParams['genre'] = '전체') => {
   const genreId = getGameGenreId(genre);
 
   return genreId ? { genre_id: genreId } : {};
-};
-
-const getMockDetail = async (gameId: number) => {
-  const { getMockGameDetail } = await import('./mockGameDetails');
-
-  return getMockGameDetail(gameId);
-};
-
-const updateMockLikeStatus = async (gameId: number, isLiked: boolean) => {
-  const { updateMockGameLikeStatus } = await import('./mockGameDetails');
-
-  return updateMockGameLikeStatus(gameId, isLiked);
 };
 
 const normalizeNullableString = (value: string | null | undefined) => {
@@ -81,52 +64,17 @@ const normalizeGameLikeResponse = (
   likeCount: response.like_count ?? 0,
 });
 
-const isNotFoundError = (error: unknown) =>
-  error instanceof AxiosError && error.response?.status === 404;
-
-const filterGames = (
-  games: GameListItem[],
-  {
-    search = '',
-    genre = '전체',
-  }: {
-    search?: string;
-    genre?: GetTopGamesParams['genre'];
-  } = {},
-) => {
-  const normalizedSearch = search.trim().toLowerCase();
-
-  return games.filter((game) => {
-    const matchesSearch =
-      !normalizedSearch ||
-      [game.name, ...game.genres].some((keyword) =>
-        keyword.toLowerCase().includes(normalizedSearch),
-      );
-    const matchesGenre = matchesGenreFilter(game.genres, genre);
-
-    return matchesSearch && matchesGenre;
-  });
-};
-
 export const getTopGames = async ({
   genre = '전체',
 }: GetTopGamesParams = {}): Promise<GameListItem[]> => {
-  if (!hasApiBaseUrl) {
-    return filterGames(mockTopGames, { genre });
-  }
+  const response = await api.get<GameListResponse>(
+    '/api/v1/games/list/top100',
+    {
+      params: getGenreQueryParams(genre),
+    },
+  );
 
-  try {
-    const response = await api.get<GameListResponse>(
-      '/api/v1/games/list/top100',
-      {
-        params: getGenreQueryParams(genre),
-      },
-    );
-
-    return response.data.results.map(normalizeGameListItem);
-  } catch {
-    return filterGames(mockTopGames, { genre });
-  }
+  return response.data.results.map(normalizeGameListItem);
 };
 
 export const searchGames = async ({
@@ -136,53 +84,29 @@ export const searchGames = async ({
   pageSize = DEFAULT_PAGE_SIZE,
   sort = DEFAULT_SORT,
 }: SearchGamesParams): Promise<GameListItem[]> => {
-  if (!hasApiBaseUrl) {
-    return filterGames(mockTopGames, { search, genre });
-  }
+  const response = await api.get<GameListResponse>('/api/v1/games/list', {
+    params: {
+      search,
+      fuzzy: true,
+      sort,
+      page,
+      page_size: pageSize,
+      ...getGenreQueryParams(genre),
+    },
+  });
 
-  try {
-    const response = await api.get<GameListResponse>('/api/v1/games/list', {
-      params: {
-        search,
-        fuzzy: true,
-        sort,
-        page,
-        page_size: pageSize,
-        ...getGenreQueryParams(genre),
-      },
-    });
-
-    return response.data.results.map(normalizeGameListItem);
-  } catch {
-    return filterGames(mockTopGames, { search, genre });
-  }
+  return response.data.results.map(normalizeGameListItem);
 };
 
 export const getGameDetail = async (gameId: number): Promise<GameDetail> => {
-  if (!hasApiBaseUrl) {
-    return getMockDetail(gameId);
-  }
+  const response = await api.get<RawGameDetailResponse>(
+    `/api/v1/games/list/${gameId}`,
+  );
 
-  try {
-    const response = await api.get<RawGameDetailResponse>(
-      `/api/v1/games/list/${gameId}`,
-    );
-
-    return normalizeGameDetail(response.data);
-  } catch (error) {
-    if (isNotFoundError(error)) {
-      throw error;
-    }
-
-    return getMockDetail(gameId);
-  }
+  return normalizeGameDetail(response.data);
 };
 
 export const likeGame = async (gameId: number): Promise<GameLikeResponse> => {
-  if (!hasApiBaseUrl) {
-    return updateMockLikeStatus(gameId, true);
-  }
-
   const response = await api.post<RawGameLikeResponse>(
     `/api/v1/games/${gameId}/like`,
   );
@@ -191,10 +115,6 @@ export const likeGame = async (gameId: number): Promise<GameLikeResponse> => {
 };
 
 export const unlikeGame = async (gameId: number): Promise<GameLikeResponse> => {
-  if (!hasApiBaseUrl) {
-    return updateMockLikeStatus(gameId, false);
-  }
-
   const response = await api.delete<RawGameLikeResponse>(
     `/api/v1/games/${gameId}/like`,
   );

--- a/src/features/games/mockGameDetails.ts
+++ b/src/features/games/mockGameDetails.ts
@@ -1,4 +1,3 @@
-import { mockTopGames } from './mockGames';
 import type { GameDetail } from './types';
 
 const steamCoverUrl = (gameId: number) =>
@@ -299,51 +298,4 @@ export const mockGameDetails: Record<number, GameDetail> = {
     likeCount: 1120,
     officialSite: 'https://terraria.org/',
   }),
-};
-
-export const getMockGameDetail = (gameId: number): GameDetail => {
-  const detail = mockGameDetails[gameId];
-
-  if (detail) {
-    return detail;
-  }
-
-  const game = mockTopGames.find((item) => item.gameId === gameId);
-
-  return {
-    gameId,
-    title: game?.name ?? 'N/A',
-    genres: game?.genres.length ? game.genres : ['N/A'],
-    releaseDate: null,
-    developer: null,
-    publisher: null,
-    promoVideoUrl: null,
-    promoEmbedUrl: null,
-    coverImageUrl: game?.thumbnailUrl ?? null,
-    description: null,
-    externalLinks: {
-      officialSite: null,
-      steam: game ? steamStoreUrl(game.gameId) : null,
-      epicStore: null,
-    },
-    likeCount: 0,
-    isLiked: game?.isLiked ?? null,
-  };
-};
-
-export const updateMockGameLikeStatus = (gameId: number, isLiked: boolean) => {
-  const detail = mockGameDetails[gameId] ?? getMockGameDetail(gameId);
-  const currentLiked = detail.isLiked === true;
-  const likeCountAdjustment = currentLiked === isLiked ? 0 : isLiked ? 1 : -1;
-  const likeCount = Math.max(0, detail.likeCount + likeCountAdjustment);
-
-  detail.isLiked = isLiked;
-  detail.likeCount = likeCount;
-  mockGameDetails[gameId] = detail;
-
-  return {
-    gameId,
-    isLiked,
-    likeCount,
-  };
 };

--- a/src/features/games/mocks/handlers.ts
+++ b/src/features/games/mocks/handlers.ts
@@ -1,0 +1,216 @@
+import { delay, http, HttpResponse } from 'msw';
+
+import { GAME_GENRE_ID_MAP } from '../genres';
+import {
+  getStoredGameDetail,
+  getStoredTop100Games,
+  searchStoredGames,
+  updateStoredGameLike,
+} from './state';
+import type {
+  GameDetail,
+  GameLikeResponse,
+  GameListItem,
+  RawGameDetailResponse,
+  RawGameLikeResponse,
+  RawGameListItem,
+} from '../types';
+
+const DEFAULT_GAME_PAGE_SIZE = 20;
+const DEFAULT_GAME_SORT = 'rating_desc';
+const validGenreIds = new Set(Object.values(GAME_GENRE_ID_MAP));
+
+const getErrorResponse = (status: number, message: string) =>
+  HttpResponse.json(
+    {
+      detail: message,
+    },
+    { status },
+  );
+
+const getUnauthorizedResponse = () =>
+  HttpResponse.json(
+    {
+      error_detail: '로그인이 필요합니다.',
+    },
+    { status: 401 },
+  );
+
+const parsePositiveInteger = (value: string | null, fallback: number) => {
+  const parsed = Number(value ?? fallback);
+
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const parseGenreId = (value: string | null) => {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+};
+
+const toRawGameListItem = (game: GameListItem): RawGameListItem => ({
+  game_id: game.gameId,
+  name: game.name,
+  genres: game.genres,
+  thumbnail_url: game.thumbnailUrl,
+  rating: game.rating,
+  is_liked: game.isLiked ?? null,
+});
+
+const toRawGameDetail = (detail: GameDetail): RawGameDetailResponse => ({
+  game_id: detail.gameId,
+  title: detail.title,
+  genres: detail.genres,
+  release_date: detail.releaseDate,
+  developer: detail.developer,
+  publisher: detail.publisher,
+  media: {
+    promo_video_url: detail.promoVideoUrl,
+    promo_embed_url: detail.promoEmbedUrl,
+    cover_image_url: detail.coverImageUrl,
+  },
+  description: detail.description,
+  external_links: {
+    official_site: detail.externalLinks.officialSite ?? null,
+    steam: detail.externalLinks.steam ?? null,
+    epic_store: detail.externalLinks.epicStore ?? null,
+  },
+  like_count: detail.likeCount,
+  is_liked: detail.isLiked,
+});
+
+const toRawGameLikeResponse = (
+  response: GameLikeResponse,
+): RawGameLikeResponse => ({
+  game_id: response.gameId,
+  is_liked: response.isLiked,
+  like_count: response.likeCount,
+});
+
+export const gamesHandlers = [
+  http.get('/api/v1/games/list/top100', async ({ request }) => {
+    const url = new URL(request.url);
+    const genreIdValue = url.searchParams.get('genre_id');
+    const genreId = parseGenreId(url.searchParams.get('genre_id'));
+
+    if (genreIdValue && (!genreId || !validGenreIds.has(genreId))) {
+      return getErrorResponse(400, '유효하지 않은 genre_id 입니다.');
+    }
+
+    const games = getStoredTop100Games({ genreId });
+
+    await delay(250);
+
+    return HttpResponse.json({
+      count: games.length,
+      ranked_at: '2026-04-21T00:00:00.000Z',
+      results: games.map(toRawGameListItem),
+    });
+  }),
+
+  http.get('/api/v1/games/list', async ({ request }) => {
+    const url = new URL(request.url);
+    const search = url.searchParams.get('search') ?? '';
+    const genreIdValue = url.searchParams.get('genre_id');
+    const genreId = parseGenreId(genreIdValue);
+    const sort =
+      (url.searchParams.get('sort') as
+        | 'rating_desc'
+        | 'like_desc'
+        | 'created_at'
+        | null) ?? DEFAULT_GAME_SORT;
+    const page = parsePositiveInteger(url.searchParams.get('page'), 1);
+    const pageSize = parsePositiveInteger(
+      url.searchParams.get('page_size'),
+      DEFAULT_GAME_PAGE_SIZE,
+    );
+
+    if (genreIdValue && (!genreId || !validGenreIds.has(genreId))) {
+      return getErrorResponse(400, '유효하지 않은 genre_id 입니다.');
+    }
+
+    const { count, results } = searchStoredGames({
+      search,
+      genreId,
+      sort:
+        sort === 'like_desc' || sort === 'created_at' || sort === 'rating_desc'
+          ? sort
+          : DEFAULT_GAME_SORT,
+      page,
+      pageSize,
+    });
+
+    await delay(300);
+
+    return HttpResponse.json({
+      count,
+      results: results.map(toRawGameListItem),
+    });
+  }),
+
+  http.get('/api/v1/games/list/:gameId', async ({ params }) => {
+    const gameId = Number(params.gameId);
+
+    if (!Number.isInteger(gameId) || gameId <= 0) {
+      return getErrorResponse(400, '유효하지 않은 game_id 입니다.');
+    }
+
+    const detail = getStoredGameDetail(gameId);
+
+    if (!detail) {
+      return getErrorResponse(404, '해당 게임 상세 정보를 찾을 수 없습니다.');
+    }
+
+    await delay(220);
+
+    return HttpResponse.json(toRawGameDetail(detail));
+  }),
+
+  http.post('/api/v1/games/:gameId/like', async ({ params, request }) => {
+    if (!request.headers.get('authorization')?.startsWith('Bearer ')) {
+      return getUnauthorizedResponse();
+    }
+
+    const gameId = Number(params.gameId);
+
+    if (!Number.isInteger(gameId) || gameId <= 0) {
+      return getErrorResponse(400, '유효하지 않은 game_id 입니다.');
+    }
+
+    const response = updateStoredGameLike(gameId, true);
+
+    if (!response) {
+      return getErrorResponse(404, '해당 게임을 찾을 수 없습니다.');
+    }
+
+    await delay(180);
+
+    return HttpResponse.json(toRawGameLikeResponse(response));
+  }),
+
+  http.delete('/api/v1/games/:gameId/like', async ({ params, request }) => {
+    if (!request.headers.get('authorization')?.startsWith('Bearer ')) {
+      return getUnauthorizedResponse();
+    }
+
+    const gameId = Number(params.gameId);
+
+    if (!Number.isInteger(gameId) || gameId <= 0) {
+      return getErrorResponse(400, '유효하지 않은 game_id 입니다.');
+    }
+
+    const response = updateStoredGameLike(gameId, false);
+
+    if (!response) {
+      return getErrorResponse(404, '해당 게임을 찾을 수 없습니다.');
+    }
+
+    await delay(180);
+
+    return HttpResponse.json(toRawGameLikeResponse(response));
+  }),
+];

--- a/src/features/games/mocks/state.ts
+++ b/src/features/games/mocks/state.ts
@@ -1,0 +1,227 @@
+import {
+  GAME_GENRE_ID_MAP,
+  matchesGenreFilter,
+  type GameGenreFilter,
+} from '../genres';
+import { mockGameDetails } from '../mockGameDetails';
+import { mockTopGames } from '../mockGames';
+import type { GameDetail, GameListItem, GameLikeResponse } from '../types';
+
+const steamStoreUrl = (gameId: number) =>
+  `https://store.steampowered.com/app/${gameId}`;
+
+const genreIdToFilterMap = new Map<number, GameGenreFilter>(
+  Object.entries(GAME_GENRE_ID_MAP).map(([genre, genreId]) => [
+    genreId,
+    genre as Exclude<GameGenreFilter, '전체'>,
+  ]),
+);
+
+const normalizeSearchKeyword = (value: string) => value.trim().toLowerCase();
+
+const cloneGameDetail = (detail: GameDetail): GameDetail => ({
+  ...detail,
+  genres: [...detail.genres],
+  externalLinks: { ...detail.externalLinks },
+});
+
+const createFallbackDetail = (game: GameListItem): GameDetail => ({
+  gameId: game.gameId,
+  title: game.name,
+  genres: game.genres.length ? [...game.genres] : ['N/A'],
+  releaseDate: null,
+  developer: null,
+  publisher: null,
+  promoVideoUrl: null,
+  promoEmbedUrl: null,
+  coverImageUrl: game.thumbnailUrl,
+  description: null,
+  externalLinks: {
+    officialSite: null,
+    steam: steamStoreUrl(game.gameId),
+    epicStore: null,
+  },
+  likeCount: 0,
+  isLiked: game.isLiked ?? null,
+});
+
+const storedTopGames = mockTopGames.map((game) => ({ ...game }));
+const topGameOrderById = new Map(
+  storedTopGames.map((game, index) => [game.gameId, index]),
+);
+const storedDetails = new Map(
+  Object.values(mockGameDetails).map((detail) => [
+    detail.gameId,
+    cloneGameDetail(detail),
+  ]),
+);
+
+storedTopGames.forEach((game) => {
+  const detail = storedDetails.get(game.gameId);
+
+  if (typeof detail?.isLiked === 'boolean') {
+    game.isLiked = detail.isLiked;
+  }
+});
+
+const getStoredTopGame = (gameId: number) =>
+  storedTopGames.find((game) => game.gameId === gameId) ?? null;
+
+const ensureStoredDetail = (gameId: number) => {
+  const existingDetail = storedDetails.get(gameId);
+
+  if (existingDetail) {
+    return existingDetail;
+  }
+
+  const topGame = getStoredTopGame(gameId);
+
+  if (!topGame) {
+    return null;
+  }
+
+  const fallbackDetail = createFallbackDetail(topGame);
+  storedDetails.set(gameId, fallbackDetail);
+
+  return fallbackDetail;
+};
+
+const getGenreFilterById = (genreId?: number) =>
+  genreId ? (genreIdToFilterMap.get(genreId) ?? null) : '전체';
+
+const getEffectiveLikeCount = (gameId: number) =>
+  ensureStoredDetail(gameId)?.likeCount ?? 0;
+
+const getEffectiveIsLiked = (gameId: number) =>
+  ensureStoredDetail(gameId)?.isLiked ?? getStoredTopGame(gameId)?.isLiked;
+
+const getHydratedTopGames = () =>
+  storedTopGames.map((game) => {
+    const isLiked = getEffectiveIsLiked(game.gameId);
+
+    return typeof isLiked === 'boolean' ? { ...game, isLiked } : { ...game };
+  });
+
+const sortGames = (
+  games: GameListItem[],
+  sort: 'rating_desc' | 'like_desc' | 'created_at',
+) =>
+  [...games].sort((left, right) => {
+    if (sort === 'created_at') {
+      return (
+        (topGameOrderById.get(left.gameId) ?? Number.MAX_SAFE_INTEGER) -
+        (topGameOrderById.get(right.gameId) ?? Number.MAX_SAFE_INTEGER)
+      );
+    }
+
+    if (sort === 'like_desc') {
+      const likeCountDiff =
+        getEffectiveLikeCount(right.gameId) -
+        getEffectiveLikeCount(left.gameId);
+
+      if (likeCountDiff !== 0) {
+        return likeCountDiff;
+      }
+    } else {
+      const leftRating = left.rating ?? Number.NEGATIVE_INFINITY;
+      const rightRating = right.rating ?? Number.NEGATIVE_INFINITY;
+      const ratingDiff = rightRating - leftRating;
+
+      if (ratingDiff !== 0) {
+        return ratingDiff;
+      }
+    }
+
+    return (
+      (topGameOrderById.get(left.gameId) ?? Number.MAX_SAFE_INTEGER) -
+      (topGameOrderById.get(right.gameId) ?? Number.MAX_SAFE_INTEGER)
+    );
+  });
+
+const filterGames = ({
+  search = '',
+  genreId,
+}: {
+  search?: string;
+  genreId?: number;
+}) => {
+  const normalizedSearch = normalizeSearchKeyword(search);
+  const selectedGenre = getGenreFilterById(genreId);
+
+  return getHydratedTopGames().filter((game) => {
+    const matchesSearch =
+      !normalizedSearch ||
+      [game.name, ...game.genres].some((keyword) =>
+        keyword.toLowerCase().includes(normalizedSearch),
+      );
+    const matchesGenre = selectedGenre
+      ? matchesGenreFilter(game.genres, selectedGenre)
+      : false;
+
+    return matchesSearch && matchesGenre;
+  });
+};
+
+export const getStoredTop100Games = ({ genreId }: { genreId?: number } = {}) =>
+  filterGames({ genreId }).slice(0, 100);
+
+export const searchStoredGames = ({
+  search = '',
+  genreId,
+  sort = 'rating_desc',
+  page = 1,
+  pageSize = 20,
+}: {
+  search?: string;
+  genreId?: number;
+  sort?: 'rating_desc' | 'like_desc' | 'created_at';
+  page?: number;
+  pageSize?: number;
+}) => {
+  const filteredGames = sortGames(filterGames({ search, genreId }), sort);
+  const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
+  const safePageSize =
+    Number.isFinite(pageSize) && pageSize > 0 ? Math.floor(pageSize) : 20;
+  const startIndex = (safePage - 1) * safePageSize;
+  const results = filteredGames.slice(startIndex, startIndex + safePageSize);
+
+  return {
+    count: filteredGames.length,
+    results,
+  };
+};
+
+export const getStoredGameDetail = (gameId: number) => {
+  const detail = ensureStoredDetail(gameId);
+
+  return detail ? cloneGameDetail(detail) : null;
+};
+
+export const updateStoredGameLike = (
+  gameId: number,
+  isLiked: boolean,
+): GameLikeResponse | null => {
+  const detail = ensureStoredDetail(gameId);
+
+  if (!detail) {
+    return null;
+  }
+
+  const currentLiked = detail.isLiked === true;
+  const likeCountAdjustment = currentLiked === isLiked ? 0 : isLiked ? 1 : -1;
+
+  detail.isLiked = isLiked;
+  detail.likeCount = Math.max(0, detail.likeCount + likeCountAdjustment);
+
+  const topGame = getStoredTopGame(gameId);
+
+  if (topGame) {
+    topGame.isLiked = isLiked;
+  }
+
+  return {
+    gameId,
+    isLiked,
+    likeCount: detail.likeCount,
+  };
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,10 +1,12 @@
 import { authHandlers } from '../features/auth/mocks/handlers';
+import { gamesHandlers } from '../features/games/mocks/handlers';
 import { matchingHandlers } from '../features/matching/mocks/handlers';
 import { supportChatHandlers } from '../features/support-chat/mocks/handlers';
 import { surveyHandlers } from '../features/survey/mocks/handlers';
 
 export const handlers = [
   ...authHandlers,
+  ...gamesHandlers,
   ...supportChatHandlers,
   ...surveyHandlers,
   ...matchingHandlers,


### PR DESCRIPTION
## 관련 이슈

- closes #151

## 변경 내용

- 게임 전용 MSW handler를 추가했습니다.
- 게임 목록, 검색, 상세, 좋아요 등록/취소를 MSW 응답으로 제공하도록 정리했습니다.
- 게임 mock 상태를 handler 내부 in-memory state로 관리하도록 변경했습니다.
- `gameApi.ts`에서 직접 mock fallback을 반환하던 분기를 제거했습니다.
- mock 모드에서도 항상 HTTP 요청을 보내고 MSW가 응답하도록 통일했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- 게임 mock 흐름을 다른 도메인과 동일한 MSW 기반 구조로 정리한 PR입니다.
- 목록 / 상세 / 좋아요 상태가 같은 mock 상태를 공유하도록 맞췄습니다.