### PR TITLE
[Fix] 메인 게임 카드 로딩 및 빈 상태 UI를 정리

### DIFF
--- a/src/features/games/components/GameCard.tsx
+++ b/src/features/games/components/GameCard.tsx
@@ -1,5 +1,10 @@
 import { useState } from 'react';
 import type { GameListItem } from '../types';
+import {
+  GAME_CARD_BODY_CLASS,
+  GAME_CARD_MEDIA_CLASS,
+  GAME_CARD_SHELL_CLASS,
+} from './gameCardLayout';
 
 type GameCardProps = {
   game: GameListItem;
@@ -18,10 +23,10 @@ const GameCard = ({ game, onSelectGame }: GameCardProps) => {
     <button
       type="button"
       onClick={() => onSelectGame(game)}
-      className="group grid h-full w-full cursor-pointer snap-start scroll-ml-2 grid-rows-[minmax(0,1fr)_92px] overflow-hidden rounded-lg border border-white/5 bg-[#141414] text-left text-white transition hover:border-[#d20b12]/70 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]"
+      className={`${GAME_CARD_SHELL_CLASS} group cursor-pointer snap-start scroll-ml-2 transition hover:border-[#d20b12]/70 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]`}
       aria-label={`${game.name} 상세 정보 열기`}
     >
-      <div className="relative aspect-4/5 overflow-hidden bg-[#090909]">
+      <div className={GAME_CARD_MEDIA_CLASS}>
         {thumbnailUrl ? (
           <img
             src={thumbnailUrl}
@@ -38,7 +43,7 @@ const GameCard = ({ game, onSelectGame }: GameCardProps) => {
         <div className="absolute inset-0 bg-linear-to-t from-black/70 via-black/20 to-transparent" />
       </div>
 
-      <div className="grid grid-cols-[1fr_auto] items-center gap-4 bg-[#151515] px-4 sm:px-5">
+      <div className={GAME_CARD_BODY_CLASS}>
         <div className="min-w-0">
           <h3 className="truncate text-base leading-7 font-medium sm:text-lg">
             {game.name}

--- a/src/features/games/components/gameCardLayout.ts
+++ b/src/features/games/components/gameCardLayout.ts
@@ -1,0 +1,8 @@
+export const GAME_CARD_SHELL_CLASS =
+  'grid h-full w-full grid-rows-[minmax(0,1fr)_92px] overflow-hidden rounded-lg border border-white/5 bg-[#141414] text-left text-white';
+
+export const GAME_CARD_MEDIA_CLASS =
+  'relative aspect-4/5 overflow-hidden bg-[#090909]';
+
+export const GAME_CARD_BODY_CLASS =
+  'grid grid-cols-[1fr_auto] items-center gap-4 bg-[#151515] px-4 sm:px-5';

--- a/src/features/games/mockGames.ts
+++ b/src/features/games/mockGames.ts
@@ -1,164 +1,147 @@
 import type { GameListItem } from './types';
 
+const steamPortraitThumbnailUrl = (gameId: number) =>
+  `https://cdn.cloudflare.steamstatic.com/steam/apps/${gameId}/library_600x900.jpg`;
+
 export const mockTopGames: GameListItem[] = [
   {
     gameId: 1245620,
     name: '엘든 링',
     genres: ['액션', 'RPG'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/1245620/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(1245620),
     rating: 9.2,
   },
   {
     gameId: 2358720,
     name: '검은 신화: 오공',
     genres: ['RPG'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/2358720/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(2358720),
     rating: 9.1,
   },
   {
     gameId: 2679460,
     name: '메타포: 리판타지오',
     genres: ['RPG', '전략'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/2679460/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(2679460),
     rating: 9.3,
   },
   {
     gameId: 1845910,
     name: '드래곤 에이지: 베일가드',
     genres: ['RPG', '어드벤처'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/1845910/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(1845910),
     rating: 8.8,
   },
   {
     gameId: 1086940,
     name: '발더스 게이트 3',
     genres: ['RPG'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/1086940/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(1086940),
     rating: 9.4,
   },
   {
     gameId: 292030,
     name: '더 위쳐 3',
     genres: ['어드벤처', 'RPG'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/292030/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(292030),
     rating: 9.0,
   },
   {
     gameId: 1091500,
     name: '사이버펑크 2077',
     genres: ['RPG', '액션'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/1091500/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(1091500),
     rating: 8.9,
   },
   {
     gameId: 582010,
     name: '몬스터 헌터: 월드',
     genres: ['액션', '어드벤처'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/582010/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(582010),
     rating: 8.8,
   },
   {
     gameId: 814380,
     name: '세키로: 섀도우 다이 트와이스',
     genres: ['액션', '어드벤처'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/814380/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(814380),
     rating: 9.0,
   },
   {
     gameId: 2050650,
     name: '바이오하자드 RE:4',
     genres: ['액션', '슈팅'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/2050650/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(2050650),
     rating: 8.9,
   },
   {
     gameId: 553850,
     name: '헬다이버즈 2',
     genres: ['슈팅', '액션'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/553850/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(553850),
     rating: 8.7,
   },
   {
     gameId: 1623730,
     name: '팰월드',
     genres: ['어드벤처', '시뮬레이션'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/1623730/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(1623730),
     rating: 8.3,
   },
   {
     gameId: 1145350,
     name: '하데스 2',
     genres: ['액션', '어드벤처'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/1145350/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(1145350),
     rating: 8.9,
   },
   {
     gameId: 367520,
     name: '할로우 나이트',
     genres: ['어드벤처', '플랫폼'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/367520/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(367520),
     rating: 9.4,
   },
   {
     gameId: 1627720,
     name: 'P의 거짓',
     genres: ['액션', 'RPG'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/1627720/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(1627720),
     rating: 8.6,
   },
   {
     gameId: 1868140,
     name: '데이브 더 다이버',
     genres: ['어드벤처', '시뮬레이션'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/1868140/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(1868140),
     rating: 8.8,
   },
   {
     gameId: 646570,
     name: '슬레이 더 스파이어',
     genres: ['전략', '카드 / 보드'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/646570/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(646570),
     rating: 9.1,
   },
   {
     gameId: 2379780,
     name: '발라트로',
     genres: ['카드 / 보드', '전략'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/2379780/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(2379780),
     rating: 9.2,
   },
   {
     gameId: 548430,
     name: '딥 락 갤럭틱',
     genres: ['슈팅', '액션'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/548430/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(548430),
     rating: 8.9,
   },
   {
     gameId: 105600,
     name: '테라리아',
     genres: ['어드벤처', '플랫폼'],
-    thumbnailUrl:
-      'https://cdn.cloudflare.steamstatic.com/steam/apps/105600/header.jpg',
+    thumbnailUrl: steamPortraitThumbnailUrl(105600),
     rating: 9.3,
   },
 ];

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -6,7 +6,7 @@ import {
   ClipboardCheck,
   Search,
 } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -15,6 +15,11 @@ import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
 import GameCard from '../../features/games/components/GameCard';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
+import {
+  GAME_CARD_BODY_CLASS,
+  GAME_CARD_MEDIA_CLASS,
+  GAME_CARD_SHELL_CLASS,
+} from '../../features/games/components/gameCardLayout';
 import { getTopGames, searchGames } from '../../features/games/gameApi';
 import { GAME_GENRE_FILTERS } from '../../features/games/genres';
 import { useDebouncedValue } from '../../features/games/hooks/useDebouncedValue';
@@ -25,6 +30,35 @@ import 'swiper/swiper.css';
 const SEARCH_DEBOUNCE_MS = 300;
 const GENRE_FILTER_MENU_ID = 'game-genre-filter-menu';
 const CTA_PENDING_MESSAGE = '준비 중입니다.';
+const GAME_CARD_SWIPER_BREAKPOINTS = {
+  640: {
+    slidesPerView: 2,
+    slidesPerGroup: 2,
+    spaceBetween: 20,
+  },
+  768: {
+    slidesPerView: 3,
+    slidesPerGroup: 3,
+    spaceBetween: 24,
+  },
+  1024: {
+    slidesPerView: 4,
+    slidesPerGroup: 4,
+    spaceBetween: 24,
+  },
+  1280: {
+    slidesPerView: 5,
+    slidesPerGroup: 5,
+    spaceBetween: 24,
+  },
+  1440: {
+    slidesPerView: 6,
+    slidesPerGroup: 6,
+    spaceBetween: 24,
+  },
+} as const;
+const GAME_CARD_SKELETON_COUNT = 6;
+const GAME_CARD_MEASURE_SLIDE_COUNT = 6;
 
 const MainPage = () => {
   const [searchText, setSearchText] = useState('');
@@ -95,20 +129,13 @@ const MainPage = () => {
                 key={`${debouncedSearchText}-${selectedGenre}`}
                 games={games}
                 onSelectGame={setSelectedGame}
+                showUpdatingOverlay={gamesQuery.isFetching}
               />
             ) : (
-              <div className="px-[clamp(1rem,5vw,20rem)]">
-                <EmptyGameList
-                  isFiltered={isSearchMode || selectedGenre !== '전체'}
-                />
-              </div>
+              <EmptyGameList
+                isFiltered={isSearchMode || selectedGenre !== '전체'}
+              />
             )}
-
-            {gamesQuery.isFetching && !gamesQuery.isLoading ? (
-              <p className="mt-3 px-[clamp(1rem,5vw,20rem)] text-sm text-white/50">
-                목록을 업데이트하는 중입니다.
-              </p>
-            ) : null}
           </div>
 
           <section className="mt-14 grid gap-6 px-[clamp(1rem,5vw,20rem)] lg:grid-cols-2">
@@ -218,9 +245,14 @@ const GenreFilter = ({ selectedGenre, onSelectGenre }: GenreFilterProps) => {
 type GameCarouselProps = {
   games: GameListItem[];
   onSelectGame: (game: GameListItem) => void;
+  showUpdatingOverlay?: boolean;
 };
 
-const GameCarousel = ({ games, onSelectGame }: GameCarouselProps) => {
+const GameCarousel = ({
+  games,
+  onSelectGame,
+  showUpdatingOverlay = false,
+}: GameCarouselProps) => {
   const swiperRef = useRef<SwiperInstance | null>(null);
 
   const scrollCards = (direction: 'previous' | 'next') => {
@@ -239,63 +271,69 @@ const GameCarousel = ({ games, onSelectGame }: GameCarouselProps) => {
   };
 
   return (
-    <div className="group/carousel relative left-1/2 w-screen -translate-x-1/2">
-      <SlideButton
-        direction="previous"
-        onClick={() => scrollCards('previous')}
-      />
+    <GameCardSwiperFrame
+      showNavigation
+      showUpdatingOverlay={showUpdatingOverlay}
+      onPrevious={() => scrollCards('previous')}
+      onNext={() => scrollCards('next')}
+      onSwiper={(swiper) => {
+        swiperRef.current = swiper;
+      }}
+    >
+      {games.map((game) => (
+        <SwiperSlide key={game.gameId} className="h-auto!">
+          <GameCard game={game} onSelectGame={onSelectGame} />
+        </SwiperSlide>
+      ))}
+    </GameCardSwiperFrame>
+  );
+};
 
-      <div className="px-[clamp(1rem,5vw,20rem)] py-2">
+type GameCardSwiperFrameProps = {
+  children: ReactNode;
+  showNavigation?: boolean;
+  showUpdatingOverlay?: boolean;
+  onPrevious?: () => void;
+  onNext?: () => void;
+  onSwiper?: (swiper: SwiperInstance) => void;
+};
+
+const GameCardSwiperFrame = ({
+  children,
+  showNavigation = false,
+  showUpdatingOverlay = false,
+  onPrevious,
+  onNext,
+  onSwiper,
+}: GameCardSwiperFrameProps) => (
+  <div className="group/carousel relative left-1/2 w-screen -translate-x-1/2">
+    {showNavigation && onPrevious ? (
+      <SlideButton direction="previous" onClick={onPrevious} />
+    ) : null}
+
+    <div className="px-[clamp(1rem,5vw,20rem)] py-2">
+      <div className="relative">
         <Swiper
-          onSwiper={(swiper) => {
-            swiperRef.current = swiper;
-          }}
+          onSwiper={onSwiper}
           slidesPerView={1}
           slidesPerGroup={1}
           spaceBetween={20}
           speed={450}
           watchOverflow
-          breakpoints={{
-            640: {
-              slidesPerView: 2,
-              slidesPerGroup: 2,
-              spaceBetween: 20,
-            },
-            768: {
-              slidesPerView: 3,
-              slidesPerGroup: 3,
-              spaceBetween: 24,
-            },
-            1024: {
-              slidesPerView: 4,
-              slidesPerGroup: 4,
-              spaceBetween: 24,
-            },
-            1280: {
-              slidesPerView: 5,
-              slidesPerGroup: 5,
-              spaceBetween: 24,
-            },
-            1440: {
-              slidesPerView: 6,
-              slidesPerGroup: 6,
-              spaceBetween: 24,
-            },
-          }}
+          breakpoints={GAME_CARD_SWIPER_BREAKPOINTS}
           className="overflow-visible!"
         >
-          {games.map((game) => (
-            <SwiperSlide key={game.gameId} className="h-auto!">
-              <GameCard game={game} onSelectGame={onSelectGame} />
-            </SwiperSlide>
-          ))}
+          {children}
         </Swiper>
+        {showUpdatingOverlay ? <GameListUpdatingOverlay /> : null}
       </div>
-
-      <SlideButton direction="next" onClick={() => scrollCards('next')} />
     </div>
-  );
-};
+
+    {showNavigation && onNext ? (
+      <SlideButton direction="next" onClick={onNext} />
+    ) : null}
+  </div>
+);
 
 type SlideButtonProps = {
   direction: 'previous' | 'next';
@@ -324,35 +362,105 @@ const SlideButton = ({ direction, onClick }: SlideButtonProps) => {
 };
 
 const GameCardSkeletonList = () => (
-  <div className="relative left-1/2 w-screen -translate-x-1/2 overflow-hidden py-2">
-    <div className="grid auto-cols-[100%] grid-flow-col gap-5 px-[clamp(1rem,5vw,20rem)] min-[1440px]:auto-cols-[calc((100%-120px)/6)] sm:auto-cols-[calc((100%-20px)/2)] md:auto-cols-[calc((100%-48px)/3)] lg:auto-cols-[calc((100%-72px)/4)] lg:gap-6 xl:auto-cols-[calc((100%-96px)/5)]">
-      {Array.from({ length: 5 }, (_, index) => (
-        <div
-          key={index}
-          className="animate-pulse overflow-hidden rounded-lg bg-[#141414]"
-        >
-          <div className="aspect-4/5 bg-white/5" />
-          <div className="space-y-3 p-5">
-            <div className="h-5 w-40 rounded bg-white/10" />
-            <div className="h-4 w-24 rounded bg-white/10" />
+  <GameCardSwiperFrame>
+    {Array.from({ length: GAME_CARD_SKELETON_COUNT }, (_, index) => (
+      <SwiperSlide key={index} className="h-auto!">
+        <div className={`${GAME_CARD_SHELL_CLASS} animate-pulse`}>
+          <div className={`${GAME_CARD_MEDIA_CLASS} bg-white/5`} />
+          <div className={GAME_CARD_BODY_CLASS}>
+            <div className="min-w-0">
+              <div className="h-5 w-40 rounded bg-white/10" />
+              <div className="mt-3 h-4 w-24 rounded bg-white/10" />
+            </div>
           </div>
         </div>
-      ))}
-    </div>
-  </div>
+      </SwiperSlide>
+    ))}
+  </GameCardSwiperFrame>
 );
 
 type EmptyGameListProps = {
   isFiltered: boolean;
 };
 
-const EmptyGameList = ({ isFiltered }: EmptyGameListProps) => (
-  <div className="flex min-h-80 items-center justify-center rounded-lg border border-white/10 bg-[#101010] px-6 text-center sm:min-h-90 lg:min-h-100">
-    <p className="text-base text-white/65">
-      {isFiltered
-        ? '조건에 맞는 게임 목록이 없습니다.'
-        : '표시할 인기 게임 목록이 없습니다.'}
-    </p>
+const EmptyGameList = ({ isFiltered }: EmptyGameListProps) => {
+  const cardMeasureRef = useRef<HTMLDivElement | null>(null);
+  const [cardHeight, setCardHeight] = useState<number | null>(null);
+
+  useEffect(() => {
+    const card = cardMeasureRef.current;
+
+    if (!card || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const updateCardHeight = () => {
+      setCardHeight(card.getBoundingClientRect().height);
+    };
+
+    updateCardHeight();
+
+    const resizeObserver = new ResizeObserver(updateCardHeight);
+    resizeObserver.observe(card);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <div className="relative left-1/2 w-screen -translate-x-1/2">
+      <div className="relative px-[clamp(1rem,5vw,20rem)] py-2">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none invisible absolute inset-0"
+        >
+          <Swiper
+            slidesPerView={1}
+            slidesPerGroup={1}
+            spaceBetween={20}
+            watchOverflow
+            breakpoints={GAME_CARD_SWIPER_BREAKPOINTS}
+            className="overflow-visible!"
+          >
+            {Array.from(
+              { length: GAME_CARD_MEASURE_SLIDE_COUNT },
+              (_, index) => (
+                <SwiperSlide key={index} className="h-auto!">
+                  <div
+                    ref={index === 0 ? cardMeasureRef : undefined}
+                    className={GAME_CARD_SHELL_CLASS}
+                  >
+                    <div className={GAME_CARD_MEDIA_CLASS} />
+                    <div className={GAME_CARD_BODY_CLASS} />
+                  </div>
+                </SwiperSlide>
+              ),
+            )}
+          </Swiper>
+        </div>
+        <div
+          className="flex items-center justify-center rounded-lg border border-white/10 bg-[#101010] px-6 text-center"
+          style={cardHeight ? { height: `${cardHeight}px` } : undefined}
+        >
+          <p className="text-base text-white/65">
+            {isFiltered
+              ? '조건에 맞는 게임 목록이 없습니다.'
+              : '표시할 인기 게임 목록이 없습니다.'}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const GameListUpdatingOverlay = () => (
+  <div className="pointer-events-none absolute inset-0 z-10 overflow-hidden rounded-lg">
+    <div className="absolute inset-0 bg-black/20 backdrop-blur-[1px]" />
+    <div className="absolute top-3 right-3 flex items-center gap-2">
+      <div className="h-2.5 w-14 animate-pulse rounded-full bg-white/20" />
+      <div className="h-2.5 w-8 animate-pulse rounded-full bg-white/15" />
+    </div>
   </div>
 );
 


### PR DESCRIPTION
## 관련 이슈

- closes #152

## 변경 내용

- 게임 카드 공통 레이아웃 클래스를 분리했습니다.
- 메인 게임 카드 로딩 스켈레톤을 실제 카드와 같은 `Swiper` 기반 구조로 정리했습니다.
- background refetch 시 텍스트 대신 overlay 표시로 변경했습니다.
- 빈 상태를 풀폭 박스로 유지하되, 실제 카드 높이에 맞춰 렌더링하도록 수정했습니다.
- 스켈레톤의 평점 placeholder를 제거했습니다.
- 메인 카드 mock 썸네일을 세로형 자산으로 교체했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

- 메인 카드
- 로딩 스켈레톤
- 빈 상태 박스
- background refetch overlay

## 참고사항

- 카드 / 스켈레톤 / 빈 상태의 시각적 기준을 최대한 맞추는 데 집중한 PR입니다.
- mock 썸네일 교체는 실서버 연결 전 화면 확인 품질을 위한 임시 정리입니다.