### PR TITLE
[Fix] 메인 장르 필터 재열기 스크롤 UX를 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.claude/

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -177,11 +177,23 @@ type GenreFilterProps = {
 
 const GenreFilter = ({ selectedGenre, onSelectGenre }: GenreFilterProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const selectedOptionRef = useRef<HTMLButtonElement | null>(null);
 
   const selectGenre = (genre: GameGenreFilter) => {
     onSelectGenre(genre);
     setIsOpen(false);
   };
+
+  useEffect(() => {
+    if (!isOpen || !selectedOptionRef.current) {
+      return;
+    }
+
+    selectedOptionRef.current.scrollIntoView({
+      block: 'nearest',
+      inline: 'nearest',
+    });
+  }, [isOpen, selectedGenre]);
 
   return (
     <div
@@ -221,6 +233,7 @@ const GenreFilter = ({ selectedGenre, onSelectGenre }: GenreFilterProps) => {
                 <button
                   type="button"
                   onClick={() => selectGenre(genre)}
+                  ref={isSelected ? selectedOptionRef : undefined}
                   aria-label={isSelected ? `${genre} 선택됨` : `${genre} 선택`}
                   className={`flex min-h-10 w-full cursor-pointer items-center justify-between gap-3 rounded-md px-3 text-left text-sm transition ${
                     isSelected


### PR DESCRIPTION
## 관련 이슈

- closes #153

## 변경 내용

- 장르 메뉴를 다시 열 때 현재 선택된 장르가 바로 보이도록 자동 스크롤을 추가했습니다.
- `scrollIntoView({ block: 'nearest' })` 기준으로 최소 이동만 발생하게 처리했습니다.
- 메뉴 mount / unmount 구조와 선택 후 닫힘 동작은 그대로 유지했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷


https://github.com/user-attachments/assets/89a0b234-c91a-4018-a00b-b90491d9b5e7



## 참고사항

- 마지막 스크롤 위치 복원이 아니라 현재 선택값 기준으로 위치를 맞추는 UX입니다.