### PR TITLE
[Fix] 빈 게임 목록 박스 높이를 카드 높이에 정확하게 맞춤

### DIFF
--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -222,7 +222,7 @@ const GenreFilter = ({ selectedGenre, onSelectGenre }: GenreFilterProps) => {
       {isOpen ? (
         <ul
           id={GENRE_FILTER_MENU_ID}
-          className="genre-menu-scrollbar absolute top-full left-0 z-30 mt-2 max-h-72 w-full overflow-y-auto rounded-lg border border-white/15 bg-[#101010] p-1 shadow-[0_18px_50px_rgba(0,0,0,0.55)]"
+          className="genre-menu-scrollbar bg-mypage-soft absolute top-full left-0 z-30 mt-2 max-h-72 w-full overflow-y-auto rounded-lg border border-white/15 p-1 shadow-[0_18px_50px_rgba(0,0,0,0.55)]"
         >
           {GAME_GENRE_FILTERS.map((genre) => {
             const isSelected = genre === selectedGenre;
@@ -450,7 +450,7 @@ const EmptyGameList = ({ isFiltered }: EmptyGameListProps) => {
       <div className="px-[clamp(1rem,5vw,20rem)] py-2">
         <div ref={containerRef}>
           <div
-            className="flex items-center justify-center rounded-lg border border-white/10 bg-[#101010] px-6 text-center"
+            className="bg-mypage-soft flex items-center justify-center rounded-lg border border-white/10 px-6 text-center"
             style={cardHeight ? { height: `${cardHeight}px` } : undefined}
           >
             <p className="text-base text-white/65">

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -58,7 +58,6 @@ const GAME_CARD_SWIPER_BREAKPOINTS = {
   },
 } as const;
 const GAME_CARD_SKELETON_COUNT = 6;
-const GAME_CARD_MEASURE_SLIDE_COUNT = 6;
 
 const MainPage = () => {
   const [searchText, setSearchText] = useState('');
@@ -397,24 +396,49 @@ type EmptyGameListProps = {
 };
 
 const EmptyGameList = ({ isFiltered }: EmptyGameListProps) => {
-  const cardMeasureRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const [cardHeight, setCardHeight] = useState<number | null>(null);
 
   useEffect(() => {
-    const card = cardMeasureRef.current;
+    const el = containerRef.current;
 
-    if (!card || typeof ResizeObserver === 'undefined') {
+    if (!el || typeof ResizeObserver === 'undefined') {
       return;
     }
 
-    const updateCardHeight = () => {
-      setCardHeight(card.getBoundingClientRect().height);
+    const compute = () => {
+      const containerWidth = el.getBoundingClientRect().width;
+      const vw = window.innerWidth;
+
+      const sorted = (
+        Object.keys(GAME_CARD_SWIPER_BREAKPOINTS) as unknown as number[]
+      )
+        .map(Number)
+        .sort((a, b) => b - a);
+
+      let perView = 1;
+      let gap = 20;
+
+      for (const bp of sorted) {
+        if (vw >= bp) {
+          const config =
+            GAME_CARD_SWIPER_BREAKPOINTS[
+              bp as keyof typeof GAME_CARD_SWIPER_BREAKPOINTS
+            ];
+          perView = config.slidesPerView;
+          gap = config.spaceBetween;
+          break;
+        }
+      }
+
+      const slideWidth = (containerWidth - gap * (perView - 1)) / perView;
+      setCardHeight(Math.round(slideWidth * (5 / 4) + 92));
     };
 
-    updateCardHeight();
+    compute();
 
-    const resizeObserver = new ResizeObserver(updateCardHeight);
-    resizeObserver.observe(card);
+    const resizeObserver = new ResizeObserver(compute);
+    resizeObserver.observe(el);
 
     return () => {
       resizeObserver.disconnect();
@@ -423,44 +447,18 @@ const EmptyGameList = ({ isFiltered }: EmptyGameListProps) => {
 
   return (
     <div className="relative left-1/2 w-screen -translate-x-1/2">
-      <div className="relative px-[clamp(1rem,5vw,20rem)] py-2">
-        <div
-          aria-hidden="true"
-          className="pointer-events-none invisible absolute inset-0"
-        >
-          <Swiper
-            slidesPerView={1}
-            slidesPerGroup={1}
-            spaceBetween={20}
-            watchOverflow
-            breakpoints={GAME_CARD_SWIPER_BREAKPOINTS}
-            className="overflow-visible!"
+      <div className="px-[clamp(1rem,5vw,20rem)] py-2">
+        <div ref={containerRef}>
+          <div
+            className="flex items-center justify-center rounded-lg border border-white/10 bg-[#101010] px-6 text-center"
+            style={cardHeight ? { height: `${cardHeight}px` } : undefined}
           >
-            {Array.from(
-              { length: GAME_CARD_MEASURE_SLIDE_COUNT },
-              (_, index) => (
-                <SwiperSlide key={index} className="h-auto!">
-                  <div
-                    ref={index === 0 ? cardMeasureRef : undefined}
-                    className={GAME_CARD_SHELL_CLASS}
-                  >
-                    <div className={GAME_CARD_MEDIA_CLASS} />
-                    <div className={GAME_CARD_BODY_CLASS} />
-                  </div>
-                </SwiperSlide>
-              ),
-            )}
-          </Swiper>
-        </div>
-        <div
-          className="flex items-center justify-center rounded-lg border border-white/10 bg-[#101010] px-6 text-center"
-          style={cardHeight ? { height: `${cardHeight}px` } : undefined}
-        >
-          <p className="text-base text-white/65">
-            {isFiltered
-              ? '조건에 맞는 게임 목록이 없습니다.'
-              : '표시할 인기 게임 목록이 없습니다.'}
-          </p>
+            <p className="text-base text-white/65">
+              {isFiltered
+                ? '조건에 맞는 게임 목록이 없습니다.'
+                : '표시할 인기 게임 목록이 없습니다.'}
+            </p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 관련 이슈

- closes #152

## 변경 내용

기존 invisible Swiper를 이용한 카드 높이 측정 방식을 제거하고 수학적 계산으로 교체했습니다.

**버그 원인:**
- invisible(`visibility:hidden`) Swiper는 브라우저가 레이아웃 계산에서 제외하므로 Swiper breakpoints가 즉시 적용되지 않음
- 초기 측정이 `slidesPerView=1` (전체 너비) 상태로 이루어져 실제 카드보다 훨씬 큰 값이 측정됨
- `absolute inset-0` 구조로 인한 circular height dependency 존재

**수정 내용:**
- `containerRef`로 Swiper 컨테이너 너비를 관찰
- `GAME_CARD_SWIPER_BREAKPOINTS` + 현재 viewport 너비 → 현재 `slidesPerView`, `spaceBetween` 파악
- `slideWidth = (containerWidth - gap × (perView-1)) / perView`
- `cardHeight = slideWidth × (5/4) + 92px` (aspect-4/5 미디어 영역 + 92px 본문 영역)
- 불필요해진 `GAME_CARD_MEASURE_SLIDE_COUNT` 상수 제거

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 게임 없는 장르 선택 시 빈 상태 박스 높이가 실제 카드와 동일한지 확인
- [x] 모바일 / 태블릿 / 데스크톱 각 breakpoint에서 높이 확인

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.

## 스크린샷


https://github.com/user-attachments/assets/79f6a1ce-f180-4748-b4e2-48efead5742a



## 참고사항

- `GAME_CARD_SHELL_CLASS`의 `grid-rows-[minmax(0,1fr)_92px]`에서 92px을 직접 참조합니다.
- `GAME_CARD_MEDIA_CLASS`의 `aspect-4/5`에서 5/4 비율을 직접 참조합니다.
- 이 두 값이 변경될 경우 본 계산도 함께 업데이트가 필요합니다.