### PR TITLE
[Refactor] 마이페이지 프로필·찜 목록 실서버 연동 및 MSW 동작 보강

### DIFF
--- a/docs/ai/api-contract.md
+++ b/docs/ai/api-contract.md
@@ -18,6 +18,10 @@
 - **소셜 로그인 진입**: `GET /api/v1/accounts/social-login/{google|kakao|naver}` (백엔드 제공 OAuth 시작점)
 - **토큰 갱신**: `POST /api/v1/accounts/token/refresh` (쿠키의 리프레시 토큰을 사용하여 액세스 토큰 재발급)
 - **로그아웃**: `POST /api/v1/accounts/logout` (액세스 토큰 무효화 및 서버측 쿠키 삭제 요청)
+- **비밀번호 변경**: `POST /api/v1/accounts/me/change-password`
+- **회원 탈퇴**: `DELETE /api/v1/accounts/me` (request body에 `password` 포함)
+- **마이페이지 찜 목록 조회**: `GET /api/v1/accounts/me/game-like`
+- **마이페이지 찜 해제**: `DELETE /api/v1/accounts/me/game-like/{game_id}`
 
 ### 3. 로그아웃 및 세션 초기화 규정
 
@@ -29,6 +33,11 @@
 
 - **Axios Interceptor**: 모든 API 요청에서 `401 Unauthorized` 발생 시 `/token/refresh`를 자동 호출하여 세션 연장 시도.
 - **세션 만료 처리**: 리프레시 토큰 만료로 갱신 실패 시, '세션 만료' 안내 후 강제 로그아웃 및 로그인 페이지로 유도.
+
+### 5. 마이페이지 프로필 표시 필드
+
+- `GET /api/v1/accounts/me` 응답은 최소 `nickname`, `name`, `gender`, `email`을 포함한다고 가정합니다.
+- 프론트 마이페이지 상단 프로필 영역은 위 4개 필드를 우선 노출하고, 누락 값은 `N/A`로 처리합니다.
 
 ## Survey and Recommendation
 

--- a/src/components/mypage/ConfirmModal.tsx
+++ b/src/components/mypage/ConfirmModal.tsx
@@ -38,9 +38,9 @@ function ConfirmModal({
 
       <div className="bg-mypage-panel border-mypage-panel shadow-mypage-float relative z-10 w-full max-w-md rounded-[28px] border px-5 py-6 backdrop-blur-xl sm:px-6">
         <h2 className="text-2xl font-semibold text-white">{title}</h2>
-        <p className="text-mypage-muted mt-3 text-sm/6 sm:text-base/7">
+        <div className="text-mypage-muted mt-3 text-sm/6 sm:text-base/7">
           {description}
-        </p>
+        </div>
 
         <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
           <AuthButton

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -5,23 +5,37 @@ import AuthButton from '../auth/AuthButton';
 
 type MyPageProfileSectionProps = {
   nickname: string;
+  name: string;
+  email: string | null;
+  genderLabel: string;
+  profileImageUrl?: string | null;
   isProfileLoading?: boolean;
+  isProfileImageUploading?: boolean;
   isLoggingOut: boolean;
   isPasswordPanelOpen: boolean;
   onPasswordToggle: () => void;
   onLogout: () => void;
+  onProfileImageSelect?: (file: File | null) => void;
   children?: ReactNode;
 };
 
 function MyPageProfileSection({
   nickname,
+  name,
+  email,
+  genderLabel,
+  profileImageUrl = null,
   isProfileLoading = false,
+  isProfileImageUploading = false,
   isLoggingOut,
   isPasswordPanelOpen,
   onPasswordToggle,
   onLogout,
+  onProfileImageSelect,
   children,
 }: MyPageProfileSectionProps) {
+  const hasProfileImage = Boolean(profileImageUrl?.trim());
+
   return (
     <section className="border-mypage-panel bg-mypage-panel shadow-mypage-float rounded-[28px] border px-5 py-8 text-center backdrop-blur-xl sm:px-8 sm:py-10">
       <h1 className="text-[clamp(2rem,4.8vw,2.75rem)] font-semibold text-white">
@@ -29,9 +43,32 @@ function MyPageProfileSection({
       </h1>
 
       <div className="mt-8 flex justify-center">
-        <div className="border-mypage-panel bg-mypage-card flex h-28 w-28 items-center justify-center rounded-full border">
-          <CircleUserRound size={42} className="text-white/85" />
+        <div className="border-mypage-panel bg-mypage-card relative flex h-28 w-28 items-center justify-center overflow-hidden rounded-full border">
+          {hasProfileImage ? (
+            <img
+              src={profileImageUrl!}
+              alt={`${nickname} 프로필 이미지`}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <CircleUserRound size={42} className="text-white/85" />
+          )}
         </div>
+      </div>
+      <div className="mt-3 flex justify-center">
+        <label className="border-mypage-panel bg-mypage-card text-mypage-muted focus-within:ring-mypage-panel relative inline-flex cursor-pointer items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-[#050505] hover:text-white">
+          <input
+            type="file"
+            accept="image/*"
+            className="sr-only"
+            disabled={isProfileLoading || isProfileImageUploading}
+            onChange={(event) => {
+              onProfileImageSelect?.(event.target.files?.[0] ?? null);
+              event.currentTarget.value = '';
+            }}
+          />
+          {isProfileImageUploading ? '업로드 중...' : '프로필 이미지 변경'}
+        </label>
       </div>
 
       {isProfileLoading ? (
@@ -45,6 +82,22 @@ function MyPageProfileSection({
           <p className="text-mypage-muted mt-2 text-sm/6">
             계정 정보와 찜한 게임 목록을 한곳에서 관리할 수 있습니다.
           </p>
+          <dl className="border-mypage-panel bg-mypage-card mt-5 grid gap-3 rounded-2xl border px-4 py-4 text-left text-sm/6 sm:grid-cols-3 sm:gap-4 sm:px-5">
+            <div>
+              <dt className="text-mypage-muted text-xs/5">이름</dt>
+              <dd className="mt-1 font-medium text-white">{name}</dd>
+            </div>
+            <div>
+              <dt className="text-mypage-muted text-xs/5">이메일</dt>
+              <dd className="mt-1 truncate font-medium text-white">
+                {email || 'N/A'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-mypage-muted text-xs/5">성별</dt>
+              <dd className="mt-1 font-medium text-white">{genderLabel}</dd>
+            </div>
+          </dl>
         </>
       )}
 

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -67,7 +67,7 @@ function MyPageProfileSection({
               event.currentTarget.value = '';
             }}
           />
-          {isProfileImageUploading ? '업로드 중...' : '프로필 이미지 변경'}
+          {isProfileImageUploading ? '업로드 중...' : '프로필 변경'}
         </label>
       </div>
 

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -9,15 +9,22 @@ import type {
   ChangePasswordRequest,
   ChangePasswordResponse,
   CurrentUserProfileResponse,
+  DeleteAccountRequest,
   DeleteAccountResponse,
+  DeleteLikedGameResponse,
   DuplicateCheckResponse,
   ErrorResponseBody,
+  LikedGamesRequest,
+  LikedGamesResponse,
   LoginRequest,
   LoginResponse,
   LogoutResponse,
+  ProfileImagePresignedUrlRequest,
+  ProfileImagePresignedUrlResponse,
   RefreshAccessTokenResponse,
   SignupRequest,
   SignupResponse,
+  UploadFileToS3Request,
 } from '../types/auth';
 
 const normalizeApiBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
@@ -61,18 +68,68 @@ export const getCurrentUserProfile = async () => {
   return response.data;
 };
 
-export const changePassword = async (payload: ChangePasswordRequest) => {
-  const response = await api.post<ChangePasswordResponse>(
-    `${AUTH_BASE_PATH}/change-password`,
+export const getLikedGames = async (payload: LikedGamesRequest = {}) => {
+  const response = await api.get<LikedGamesResponse>(
+    `${AUTH_BASE_PATH}/me/game-like`,
+    {
+      params: payload,
+    },
+  );
+
+  return response.data;
+};
+
+export const unlikeLikedGame = async (gameId: number) => {
+  const response = await api.delete<DeleteLikedGameResponse>(
+    `${AUTH_BASE_PATH}/me/game-like/${gameId}`,
+  );
+
+  return response.data;
+};
+
+export const getProfileImagePresignedUrl = async (
+  payload: ProfileImagePresignedUrlRequest,
+) => {
+  // Presigned URL 발급 경로는 백엔드 정책 고정 시 해당 엔드포인트로 유지합니다.
+  const response = await api.post<ProfileImagePresignedUrlResponse>(
+    `${AUTH_BASE_PATH}/me/profile-image/presigned-url`,
     payload,
   );
 
   return response.data;
 };
 
-export const deleteAccount = async () => {
-  const response = await api.post<DeleteAccountResponse>(
-    `${AUTH_BASE_PATH}/delete-account`,
+export const uploadFileToS3 = async ({
+  presigned_url,
+  file,
+  content_type,
+}: UploadFileToS3Request) => {
+  const resolvedContentType =
+    content_type || file.type || 'application/octet-stream';
+
+  await axios.put(presigned_url, file, {
+    headers: {
+      'Content-Type': resolvedContentType,
+    },
+    withCredentials: false,
+  });
+};
+
+export const changePassword = async (payload: ChangePasswordRequest) => {
+  const response = await api.post<ChangePasswordResponse>(
+    `${AUTH_BASE_PATH}/me/change-password`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const deleteAccount = async (payload: DeleteAccountRequest) => {
+  const response = await api.delete<DeleteAccountResponse>(
+    `${AUTH_BASE_PATH}/me`,
+    {
+      data: payload,
+    },
   );
 
   return response.data;

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -1,15 +1,25 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   checkIdDuplicate,
   checkNicknameDuplicate,
   changePassword,
   deleteAccount,
+  getProfileImagePresignedUrl,
   getCurrentUserProfile,
+  getLikedGames,
   login,
   logout,
   signup,
+  unlikeLikedGame,
+  uploadFileToS3,
 } from './auth';
+import type {
+  LikedGamesResponse,
+  LikedGamesRequest,
+  ProfileImagePresignedUrlRequest,
+  UploadFileToS3Request,
+} from '../types/auth';
 
 export const useLoginMutation = () =>
   useMutation({
@@ -35,6 +45,69 @@ export const useCurrentUserProfileQuery = (enabled = true) =>
     queryFn: getCurrentUserProfile,
     enabled,
     staleTime: 60_000,
+  });
+
+export const useLikedGamesQuery = (
+  enabled = true,
+  payload: LikedGamesRequest = {},
+) =>
+  useQuery({
+    queryKey: ['auth', 'me', 'game-like', payload.page ?? 1, payload.page_size],
+    queryFn: () => getLikedGames(payload),
+    enabled,
+    staleTime: 60_000,
+  });
+
+export const useUnlikeLikedGameMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['auth', 'me', 'game-like', 'unlike'],
+    mutationFn: unlikeLikedGame,
+    onSuccess: (_, gameId) => {
+      queryClient.setQueriesData<LikedGamesResponse>(
+        { queryKey: ['auth', 'me', 'game-like'] },
+        (current) => {
+          if (!current) {
+            return current;
+          }
+
+          const nextResults = current.results.filter(
+            (likedGame) => likedGame.game_id !== gameId,
+          );
+
+          if (nextResults.length === current.results.length) {
+            return current;
+          }
+
+          return {
+            ...current,
+            count: Math.max(0, current.count - 1),
+            results: nextResults,
+          };
+        },
+      );
+      void queryClient.invalidateQueries({
+        queryKey: ['auth', 'me', 'game-like'],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['games', 'detail', gameId],
+      });
+    },
+  });
+};
+
+export const useProfileImagePresignedUrlMutation = () =>
+  useMutation({
+    mutationKey: ['auth', 'me', 'profile-image', 'presigned-url'],
+    mutationFn: (payload: ProfileImagePresignedUrlRequest) =>
+      getProfileImagePresignedUrl(payload),
+  });
+
+export const useUploadFileToS3Mutation = () =>
+  useMutation({
+    mutationKey: ['auth', 'me', 'profile-image', 'upload'],
+    mutationFn: (payload: UploadFileToS3Request) => uploadFileToS3(payload),
   });
 
 export const useChangePasswordMutation = () =>

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -8,9 +8,15 @@ import type {
   ChangePasswordRequest,
   ChangePasswordResponse,
   CurrentUserProfileResponse,
+  DeleteAccountRequest,
   DeleteAccountResponse,
+  DeleteLikedGameResponse,
+  LikedGameItemResponse,
+  LikedGamesResponse,
   LoginRequest,
   LogoutResponse,
+  ProfileImagePresignedUrlRequest,
+  ProfileImagePresignedUrlResponse,
   SocialAuthProvider,
   SignupRequest,
 } from '../types/auth';
@@ -23,8 +29,62 @@ const validGenders: AuthGender[] = ['M', 'W'];
 
 const createAccessToken = (loginId: string) => `mock-access-token-${loginId}`;
 const createRefreshToken = (loginId: string) => `mock-refresh-token-${loginId}`;
+const MOCK_S3_HOST = 'https://mock-s3.oz-union-16.com';
 let refreshSessionLoginId: string | null = null;
 let pendingSocialLoginId: string | null = null;
+
+const mockLikedGamesByLoginId = new Map<string, LikedGameItemResponse[]>([
+  [
+    'pgti-demo',
+    [
+      {
+        game_id: 901,
+        game_title: 'Eclipse Gate',
+        thumbnail_url:
+          'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=1200&q=80',
+        genres: ['Action', 'RPG'],
+        liked_at: '2026-04-17T10:15:00Z',
+      },
+      {
+        game_id: 902,
+        game_title: 'Frozen Crown',
+        thumbnail_url:
+          'https://images.unsplash.com/photo-1542751371-adc38448a05e?auto=format&fit=crop&w=1200&q=80',
+        genres: ['Adventure', 'Action'],
+        liked_at: '2026-04-18T08:30:00Z',
+      },
+      {
+        game_id: 905,
+        game_title: 'Moonlit Archive',
+        thumbnail_url:
+          'https://images.unsplash.com/photo-1518709268805-4e9042af2176?auto=format&fit=crop&w=1200&q=80',
+        genres: ['Puzzle', 'Adventure'],
+        liked_at: '2026-04-19T02:20:00Z',
+      },
+    ],
+  ],
+  [
+    'pgti-tester',
+    [
+      {
+        game_id: 903,
+        game_title: 'Crimson Trail',
+        thumbnail_url:
+          'https://images.unsplash.com/photo-1511882150382-421056c89033?auto=format&fit=crop&w=1200&q=80',
+        genres: ['Action', 'Shooter'],
+        liked_at: '2026-04-15T06:42:00Z',
+      },
+      {
+        game_id: 906,
+        game_title: 'Neon Drift',
+        thumbnail_url:
+          'https://images.unsplash.com/photo-1486572788966-cfd3df1f5b42?auto=format&fit=crop&w=1200&q=80',
+        genres: ['Racing', 'Arcade'],
+        liked_at: '2026-04-20T13:05:00Z',
+      },
+    ],
+  ],
+]);
 
 const getAuthorizedUser = (authorization: string | null) => {
   if (!authorization?.startsWith('Bearer ')) {
@@ -91,6 +151,27 @@ const getMockSocialLoginId = (provider: SocialAuthProvider) => {
   }
 
   return 'pgti-demo';
+};
+
+const parsePositiveInteger = (value: string | null, fallback: number) => {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsedValue = Number(value);
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    return fallback;
+  }
+
+  return parsedValue;
+};
+
+const sanitizeFileName = (fileName: string) => {
+  const normalizedFileName = fileName.trim().replace(/\s+/g, '-');
+  const safeFileName = normalizedFileName.replace(/[^a-zA-Z0-9._-]/g, '_');
+
+  return safeFileName || `profile-${Date.now()}.png`;
 };
 
 const loginHandlers = [
@@ -267,10 +348,13 @@ const signupHandlers = [
       name,
       nickname,
       gender,
+      email: `${loginId}@example.com`,
+      profileImageUrl: null,
       note: 'MSW 회원가입으로 생성된 테스트 계정',
     };
 
     mockUsers.set(loginId, newUser);
+    mockLikedGamesByLoginId.set(loginId, []);
 
     await delay(450);
 
@@ -340,12 +424,139 @@ const accountHandlers = [
       name: user.name,
       nickname: user.nickname,
       gender: user.gender,
+      email: user.email,
+      profile_img_url: user.profileImageUrl,
     };
 
     return HttpResponse.json(responseBody);
   }),
 
-  http.post(`${AUTH_BASE_PATH}/change-password`, async ({ request }) => {
+  http.post(
+    `${AUTH_BASE_PATH}/me/profile-image/presigned-url`,
+    async ({ request }) => {
+      const authorization = request.headers.get('Authorization');
+      const user = getAuthorizedUser(authorization);
+
+      if (!user) {
+        return getUnauthorizedError('로그인이 필요합니다.');
+      }
+
+      const body = (await request.json()) as ProfileImagePresignedUrlRequest;
+      const fileName = body.file_name.trim();
+      const contentType = body.content_type.trim();
+
+      if (!fileName) {
+        return getFieldValidationError(
+          'file_name',
+          '"file_name"이 필드는 필수 항목입니다.',
+        );
+      }
+
+      if (!contentType) {
+        return getFieldValidationError(
+          'content_type',
+          '"content_type"이 필드는 필수 항목입니다.',
+        );
+      }
+
+      const uploadFileName = `${Date.now()}-${sanitizeFileName(fileName)}`;
+      const responseBody: ProfileImagePresignedUrlResponse = {
+        presigned_url: `${MOCK_S3_HOST}/upload/${user.loginId}/${uploadFileName}`,
+        file_url: `${MOCK_S3_HOST}/public/${user.loginId}/${uploadFileName}`,
+      };
+
+      await delay(100);
+
+      return HttpResponse.json(responseBody);
+    },
+  ),
+
+  http.get(`${AUTH_BASE_PATH}/me/game-like`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+    const user = getAuthorizedUser(authorization);
+
+    if (!user) {
+      return getUnauthorizedError('로그인이 필요합니다.');
+    }
+
+    const requestUrl = new URL(request.url);
+    const page = parsePositiveInteger(requestUrl.searchParams.get('page'), 1);
+    const pageSize = parsePositiveInteger(
+      requestUrl.searchParams.get('page_size'),
+      20,
+    );
+    const likedGames = mockLikedGamesByLoginId.get(user.loginId) ?? [];
+    const startIndex = (page - 1) * pageSize;
+    const pagedResults = likedGames.slice(startIndex, startIndex + pageSize);
+
+    await delay(200);
+
+    return HttpResponse.json({
+      count: likedGames.length,
+      results: pagedResults,
+    } satisfies LikedGamesResponse);
+  }),
+
+  http.put(`${MOCK_S3_HOST}/upload/:loginId/:fileName`, async ({ params }) => {
+    const loginId = typeof params.loginId === 'string' ? params.loginId : '';
+    const fileName = typeof params.fileName === 'string' ? params.fileName : '';
+    const user = mockUsers.get(loginId);
+
+    if (user && fileName) {
+      user.profileImageUrl = `${MOCK_S3_HOST}/public/${loginId}/${fileName}`;
+    }
+
+    await delay(120);
+
+    return new HttpResponse(null, { status: 200 });
+  }),
+
+  http.delete(
+    `${AUTH_BASE_PATH}/me/game-like/:gameId`,
+    async ({ request, params }) => {
+      const authorization = request.headers.get('Authorization');
+      const user = getAuthorizedUser(authorization);
+
+      if (!user) {
+        return getUnauthorizedError('로그인이 필요합니다.');
+      }
+
+      const gameIdParam =
+        typeof params.gameId === 'string' ? params.gameId.trim() : '';
+      const gameId = Number(gameIdParam);
+
+      if (!Number.isInteger(gameId) || gameId <= 0) {
+        return getFieldValidationError(
+          'game_id',
+          '유효한 게임 ID를 전달해주세요.',
+        );
+      }
+
+      const likedGames = mockLikedGamesByLoginId.get(user.loginId) ?? [];
+      const nextLikedGames = likedGames.filter(
+        (game) => game.game_id !== gameId,
+      );
+
+      if (nextLikedGames.length === likedGames.length) {
+        return HttpResponse.json(
+          {
+            error_detail: '찜한 게임을 찾을 수 없습니다.',
+          },
+          { status: 404 },
+        );
+      }
+
+      mockLikedGamesByLoginId.set(user.loginId, nextLikedGames);
+
+      await delay(200);
+
+      return HttpResponse.json({
+        detail: '찜한 게임이 목록에서 삭제되었습니다.',
+      } satisfies DeleteLikedGameResponse);
+    },
+  ),
+
+  http.post(`${AUTH_BASE_PATH}/me/change-password`, async ({ request }) => {
     const authorization = request.headers.get('Authorization');
     const user = getAuthorizedUser(authorization);
 
@@ -411,7 +622,7 @@ const accountHandlers = [
     } satisfies ChangePasswordResponse);
   }),
 
-  http.post(`${AUTH_BASE_PATH}/delete-account`, async ({ request }) => {
+  http.delete(`${AUTH_BASE_PATH}/me`, async ({ request }) => {
     const authorization = request.headers.get('Authorization');
     const user = getAuthorizedUser(authorization);
 
@@ -419,7 +630,30 @@ const accountHandlers = [
       return getUnauthorizedError('로그인이 필요합니다.');
     }
 
+    const body = (await request.json().catch(() => ({}))) as
+      | DeleteAccountRequest
+      | Record<string, unknown>;
+    const password =
+      typeof body.password === 'string' ? body.password.trim() : '';
+
+    if (!password) {
+      return getFieldValidationError(
+        'password',
+        '"password"이 필드는 필수 항목입니다.',
+      );
+    }
+
+    if (user.password !== password) {
+      return HttpResponse.json(
+        {
+          error_detail: '현재 비밀번호가 올바르지 않습니다.',
+        },
+        { status: 400 },
+      );
+    }
+
     mockUsers.delete(user.loginId);
+    mockLikedGamesByLoginId.delete(user.loginId);
 
     await delay(220);
 

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -1,6 +1,8 @@
 import { delay, http, HttpResponse } from 'msw';
 
 import { AUTH_BASE_PATH } from '../constants/auth';
+import { mockTopGames } from '../../games/mockGames';
+import type { RawGameLikeResponse } from '../../games/types';
 import type {
   AuthGender,
   CheckIdDuplicateRequest,
@@ -33,58 +35,17 @@ const MOCK_S3_HOST = 'https://mock-s3.oz-union-16.com';
 let refreshSessionLoginId: string | null = null;
 let pendingSocialLoginId: string | null = null;
 
-const mockLikedGamesByLoginId = new Map<string, LikedGameItemResponse[]>([
-  [
-    'pgti-demo',
-    [
-      {
-        game_id: 901,
-        game_title: 'Eclipse Gate',
-        thumbnail_url:
-          'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=1200&q=80',
-        genres: ['Action', 'RPG'],
-        liked_at: '2026-04-17T10:15:00Z',
-      },
-      {
-        game_id: 902,
-        game_title: 'Frozen Crown',
-        thumbnail_url:
-          'https://images.unsplash.com/photo-1542751371-adc38448a05e?auto=format&fit=crop&w=1200&q=80',
-        genres: ['Adventure', 'Action'],
-        liked_at: '2026-04-18T08:30:00Z',
-      },
-      {
-        game_id: 905,
-        game_title: 'Moonlit Archive',
-        thumbnail_url:
-          'https://images.unsplash.com/photo-1518709268805-4e9042af2176?auto=format&fit=crop&w=1200&q=80',
-        genres: ['Puzzle', 'Adventure'],
-        liked_at: '2026-04-19T02:20:00Z',
-      },
-    ],
-  ],
-  [
-    'pgti-tester',
-    [
-      {
-        game_id: 903,
-        game_title: 'Crimson Trail',
-        thumbnail_url:
-          'https://images.unsplash.com/photo-1511882150382-421056c89033?auto=format&fit=crop&w=1200&q=80',
-        genres: ['Action', 'Shooter'],
-        liked_at: '2026-04-15T06:42:00Z',
-      },
-      {
-        game_id: 906,
-        game_title: 'Neon Drift',
-        thumbnail_url:
-          'https://images.unsplash.com/photo-1486572788966-cfd3df1f5b42?auto=format&fit=crop&w=1200&q=80',
-        genres: ['Racing', 'Arcade'],
-        liked_at: '2026-04-20T13:05:00Z',
-      },
-    ],
-  ],
-]);
+const mockLikedGamesByLoginId = new Map<string, LikedGameItemResponse[]>(
+  [...mockUsers.keys()].map((loginId) => [loginId, []]),
+);
+const mockGameLikeCountByGameId = new Map<number, number>();
+const mockUploadedProfileImagesByPath = new Map<
+  string,
+  { contentType: string; bytes: ArrayBuffer }
+>();
+const mockTopGameById = new Map(
+  mockTopGames.map((game) => [game.gameId, game]),
+);
 
 const getAuthorizedUser = (authorization: string | null) => {
   if (!authorization?.startsWith('Bearer ')) {
@@ -172,6 +133,51 @@ const sanitizeFileName = (fileName: string) => {
   const safeFileName = normalizedFileName.replace(/[^a-zA-Z0-9._-]/g, '_');
 
   return safeFileName || `profile-${Date.now()}.png`;
+};
+
+const getProfileImagePathKey = (loginId: string, fileName: string) =>
+  `${loginId}/${fileName}`;
+
+const getOrCreateLikedGames = (loginId: string) => {
+  const likedGames = mockLikedGamesByLoginId.get(loginId);
+
+  if (likedGames) {
+    return likedGames;
+  }
+
+  const nextLikedGames: LikedGameItemResponse[] = [];
+  mockLikedGamesByLoginId.set(loginId, nextLikedGames);
+
+  return nextLikedGames;
+};
+
+const getCurrentLikeCount = (gameId: number) =>
+  Math.max(0, mockGameLikeCountByGameId.get(gameId) ?? 0);
+
+const increaseLikeCount = (gameId: number) => {
+  const nextLikeCount = getCurrentLikeCount(gameId) + 1;
+  mockGameLikeCountByGameId.set(gameId, nextLikeCount);
+
+  return nextLikeCount;
+};
+
+const decreaseLikeCount = (gameId: number) => {
+  const nextLikeCount = Math.max(0, getCurrentLikeCount(gameId) - 1);
+  mockGameLikeCountByGameId.set(gameId, nextLikeCount);
+
+  return nextLikeCount;
+};
+
+const createLikedGameItem = (gameId: number): LikedGameItemResponse => {
+  const game = mockTopGameById.get(gameId);
+
+  return {
+    game_id: gameId,
+    game_title: game?.name ?? `게임 ${gameId}`,
+    thumbnail_url: game?.thumbnailUrl ?? null,
+    genres: game?.genres ?? [],
+    liked_at: new Date().toISOString(),
+  };
 };
 
 const loginHandlers = [
@@ -485,7 +491,7 @@ const accountHandlers = [
       requestUrl.searchParams.get('page_size'),
       20,
     );
-    const likedGames = mockLikedGamesByLoginId.get(user.loginId) ?? [];
+    const likedGames = getOrCreateLikedGames(user.loginId);
     const startIndex = (page - 1) * pageSize;
     const pagedResults = likedGames.slice(startIndex, startIndex + pageSize);
 
@@ -497,18 +503,49 @@ const accountHandlers = [
     } satisfies LikedGamesResponse);
   }),
 
-  http.put(`${MOCK_S3_HOST}/upload/:loginId/:fileName`, async ({ params }) => {
+  http.put(
+    `${MOCK_S3_HOST}/upload/:loginId/:fileName`,
+    async ({ request, params }) => {
+      const loginId = typeof params.loginId === 'string' ? params.loginId : '';
+      const fileName =
+        typeof params.fileName === 'string' ? params.fileName : '';
+      const user = mockUsers.get(loginId);
+
+      if (user && fileName) {
+        const bytes = await request.arrayBuffer();
+        const contentType =
+          request.headers.get('Content-Type') || 'application/octet-stream';
+        const imageKey = getProfileImagePathKey(loginId, fileName);
+
+        mockUploadedProfileImagesByPath.set(imageKey, {
+          bytes,
+          contentType,
+        });
+        user.profileImageUrl = `${MOCK_S3_HOST}/public/${loginId}/${fileName}`;
+      }
+
+      await delay(120);
+
+      return new HttpResponse(null, { status: 200 });
+    },
+  ),
+
+  http.get(`${MOCK_S3_HOST}/public/:loginId/:fileName`, async ({ params }) => {
     const loginId = typeof params.loginId === 'string' ? params.loginId : '';
     const fileName = typeof params.fileName === 'string' ? params.fileName : '';
-    const user = mockUsers.get(loginId);
+    const imageKey = getProfileImagePathKey(loginId, fileName);
+    const uploadedImage = mockUploadedProfileImagesByPath.get(imageKey);
 
-    if (user && fileName) {
-      user.profileImageUrl = `${MOCK_S3_HOST}/public/${loginId}/${fileName}`;
+    if (!uploadedImage) {
+      return new HttpResponse(null, { status: 404 });
     }
 
-    await delay(120);
-
-    return new HttpResponse(null, { status: 200 });
+    return new HttpResponse(uploadedImage.bytes, {
+      status: 200,
+      headers: {
+        'Content-Type': uploadedImage.contentType,
+      },
+    });
   }),
 
   http.delete(
@@ -532,7 +569,7 @@ const accountHandlers = [
         );
       }
 
-      const likedGames = mockLikedGamesByLoginId.get(user.loginId) ?? [];
+      const likedGames = getOrCreateLikedGames(user.loginId);
       const nextLikedGames = likedGames.filter(
         (game) => game.game_id !== gameId,
       );
@@ -547,6 +584,7 @@ const accountHandlers = [
       }
 
       mockLikedGamesByLoginId.set(user.loginId, nextLikedGames);
+      decreaseLikeCount(gameId);
 
       await delay(200);
 
@@ -654,12 +692,91 @@ const accountHandlers = [
 
     mockUsers.delete(user.loginId);
     mockLikedGamesByLoginId.delete(user.loginId);
+    [...mockUploadedProfileImagesByPath.keys()]
+      .filter((key) => key.startsWith(`${user.loginId}/`))
+      .forEach((key) => {
+        mockUploadedProfileImagesByPath.delete(key);
+      });
 
     await delay(220);
 
     return HttpResponse.json({
       detail: '회원 탈퇴가 완료되었습니다.',
     } satisfies DeleteAccountResponse);
+  }),
+];
+
+const gameLikeHandlers = [
+  http.post('/api/v1/games/:gameId/like', async ({ request, params }) => {
+    const authorization = request.headers.get('Authorization');
+    const user = getAuthorizedUser(authorization);
+
+    if (!user) {
+      return getUnauthorizedError('로그인이 필요합니다.');
+    }
+
+    const gameIdParam =
+      typeof params.gameId === 'string' ? params.gameId.trim() : '';
+    const gameId = Number(gameIdParam);
+
+    if (!Number.isInteger(gameId) || gameId <= 0) {
+      return getFieldValidationError(
+        'game_id',
+        '유효한 게임 ID를 전달해주세요.',
+      );
+    }
+
+    const likedGames = getOrCreateLikedGames(user.loginId);
+    const alreadyLiked = likedGames.some((game) => game.game_id === gameId);
+
+    if (!alreadyLiked) {
+      likedGames.unshift(createLikedGameItem(gameId));
+      increaseLikeCount(gameId);
+    }
+
+    await delay(180);
+
+    return HttpResponse.json({
+      game_id: gameId,
+      is_liked: true,
+      like_count: getCurrentLikeCount(gameId),
+    } satisfies RawGameLikeResponse);
+  }),
+
+  http.delete('/api/v1/games/:gameId/like', async ({ request, params }) => {
+    const authorization = request.headers.get('Authorization');
+    const user = getAuthorizedUser(authorization);
+
+    if (!user) {
+      return getUnauthorizedError('로그인이 필요합니다.');
+    }
+
+    const gameIdParam =
+      typeof params.gameId === 'string' ? params.gameId.trim() : '';
+    const gameId = Number(gameIdParam);
+
+    if (!Number.isInteger(gameId) || gameId <= 0) {
+      return getFieldValidationError(
+        'game_id',
+        '유효한 게임 ID를 전달해주세요.',
+      );
+    }
+
+    const likedGames = getOrCreateLikedGames(user.loginId);
+    const nextLikedGames = likedGames.filter((game) => game.game_id !== gameId);
+
+    if (nextLikedGames.length !== likedGames.length) {
+      mockLikedGamesByLoginId.set(user.loginId, nextLikedGames);
+      decreaseLikeCount(gameId);
+    }
+
+    await delay(180);
+
+    return HttpResponse.json({
+      game_id: gameId,
+      is_liked: false,
+      like_count: getCurrentLikeCount(gameId),
+    } satisfies RawGameLikeResponse);
   }),
 ];
 
@@ -686,5 +803,6 @@ export const authHandlers = [
   ...loginHandlers,
   ...signupHandlers,
   ...accountHandlers,
+  ...gameLikeHandlers,
   ...logoutHandlers,
 ];

--- a/src/features/auth/mocks/mockUsers.ts
+++ b/src/features/auth/mocks/mockUsers.ts
@@ -7,6 +7,8 @@ export type MockUserRecord = {
   name: string;
   nickname: string;
   gender: AuthGender;
+  email: string;
+  profileImageUrl: string | null;
   note: string;
 };
 
@@ -23,6 +25,9 @@ export const mockAuthSeedUsers: MockUserRecord[] = [
     name: 'PGTI 데모',
     nickname: '데모유저',
     gender: 'M',
+    email: 'pgti-demo@example.com',
+    profileImageUrl:
+      'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=400&q=80',
     note: '기본 로그인, 추천, 설문, 마이페이지 확인용 계정',
   },
   {
@@ -32,6 +37,9 @@ export const mockAuthSeedUsers: MockUserRecord[] = [
     name: 'PGTI 테스터',
     nickname: '테스트유저',
     gender: 'W',
+    email: 'pgti-tester@example.com',
+    profileImageUrl:
+      'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=400&q=80',
     note: '중복 확인, 계정 전환, 비교 테스트용 계정',
   },
 ];

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -33,11 +33,55 @@ export interface DeleteAccountResponse {
   detail: string;
 }
 
+export interface DeleteAccountRequest {
+  password: string;
+}
+
+export interface DeleteLikedGameResponse {
+  detail: string;
+}
+
+export interface LikedGamesRequest {
+  page?: number;
+  page_size?: number;
+}
+
+export interface LikedGameItemResponse {
+  game_id: number;
+  game_title: string;
+  thumbnail_url: string | null;
+  genres: string[];
+  liked_at: string;
+}
+
+export interface LikedGamesResponse {
+  count: number;
+  results: LikedGameItemResponse[];
+}
+
 export interface CurrentUserProfileResponse {
   login_id: string;
   name: string;
   nickname: string;
   gender: AuthGender;
+  email?: string | null;
+  profile_img_url?: string | null;
+}
+
+export interface ProfileImagePresignedUrlRequest {
+  file_name: string;
+  content_type: string;
+}
+
+export interface ProfileImagePresignedUrlResponse {
+  presigned_url: string;
+  file_url: string;
+}
+
+export interface UploadFileToS3Request {
+  presigned_url: string;
+  file: File | Blob;
+  content_type?: string;
 }
 
 export interface SignupRequest {

--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -3,6 +3,7 @@ import { AxiosError } from 'axios';
 import { ExternalLink, Heart, PlayCircle, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import ToastMessage from '../../../components/mypage/ToastMessage';
+import type { LikedGamesResponse } from '../../auth/types/auth';
 import { useAuthStore } from '../../../store/useAuthStore';
 import { getGameDetail, likeGame, unlikeGame } from '../gameApi';
 import type { GameDetail, GameListItem } from '../types';
@@ -96,6 +97,32 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
               }
             : currentDetail,
       );
+
+      queryClient.setQueriesData<LikedGamesResponse>(
+        { queryKey: ['auth', 'me', 'game-like'] },
+        (current) => {
+          if (!current || response.isLiked) {
+            return current;
+          }
+
+          const nextResults = current.results.filter(
+            (likedGame) => likedGame.game_id !== response.gameId,
+          );
+
+          if (nextResults.length === current.results.length) {
+            return current;
+          }
+
+          return {
+            ...current,
+            count: Math.max(0, current.count - 1),
+            results: nextResults,
+          };
+        },
+      );
+      void queryClient.invalidateQueries({
+        queryKey: ['auth', 'me', 'game-like'],
+      });
     },
     onError: (error) => {
       setToast({

--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -101,8 +101,32 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
       queryClient.setQueriesData<LikedGamesResponse>(
         { queryKey: ['auth', 'me', 'game-like'] },
         (current) => {
-          if (!current || response.isLiked) {
+          if (!current) {
             return current;
+          }
+
+          if (response.isLiked) {
+            const alreadyExists = current.results.some(
+              (likedGame) => likedGame.game_id === response.gameId,
+            );
+
+            if (alreadyExists) {
+              return current;
+            }
+
+            const nextLikedGame = {
+              game_id: response.gameId,
+              game_title: (detail?.title ?? game.name).trim() || 'N/A',
+              thumbnail_url: detail?.coverImageUrl ?? game.thumbnailUrl,
+              genres: detail?.genres?.length ? detail.genres : game.genres,
+              liked_at: new Date().toISOString(),
+            };
+
+            return {
+              ...current,
+              count: current.count + 1,
+              results: [nextLikedGame, ...current.results],
+            };
           }
 
           const nextResults = current.results.filter(

--- a/src/features/mypage/mockData.ts
+++ b/src/features/mypage/mockData.ts
@@ -11,6 +11,7 @@ export const mockFavoriteGames: FavoriteGamePreview[] = [
     summary: '차원의 문 너머에서 펼쳐지는 탐험과 전투를 다시 즐겨보세요.',
     thumbnailUrl:
       'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=1200&q=80',
+    genres: ['Action', 'RPG'],
   },
   {
     gameId: 902,
@@ -18,6 +19,7 @@ export const mockFavoriteGames: FavoriteGamePreview[] = [
     summary: '서늘한 설원과 거대한 성채가 인상적인 액션 어드벤처입니다.',
     thumbnailUrl:
       'https://images.unsplash.com/photo-1542751371-adc38448a05e?auto=format&fit=crop&w=1200&q=80',
+    genres: ['Adventure', 'Action'],
   },
   {
     gameId: 903,
@@ -25,6 +27,7 @@ export const mockFavoriteGames: FavoriteGamePreview[] = [
     summary: '붉게 물든 협곡을 따라 몰입감 있는 전투와 성장 루프를 경험하세요.',
     thumbnailUrl:
       'https://images.unsplash.com/photo-1511882150382-421056c89033?auto=format&fit=crop&w=1200&q=80',
+    genres: ['Action', 'Shooter'],
   },
   {
     gameId: 904,
@@ -32,6 +35,7 @@ export const mockFavoriteGames: FavoriteGamePreview[] = [
     summary: '별빛 아래 펼쳐지는 성채 수비전과 전략적인 플레이가 특징입니다.',
     thumbnailUrl:
       'https://images.unsplash.com/photo-1493711662062-fa541adb3fc8?auto=format&fit=crop&w=1200&q=80',
+    genres: ['Strategy', 'Simulation'],
   },
   {
     gameId: 905,
@@ -39,6 +43,7 @@ export const mockFavoriteGames: FavoriteGamePreview[] = [
     summary: '고요한 도서관 속 숨겨진 퍼즐과 서사를 차근차근 풀어보세요.',
     thumbnailUrl:
       'https://images.unsplash.com/photo-1518709268805-4e9042af2176?auto=format&fit=crop&w=1200&q=80',
+    genres: ['Puzzle', 'Adventure'],
   },
   {
     gameId: 906,
@@ -46,5 +51,6 @@ export const mockFavoriteGames: FavoriteGamePreview[] = [
     summary: '강렬한 분위기의 레이싱과 속도감을 원하는 날에 딱 어울립니다.',
     thumbnailUrl:
       'https://images.unsplash.com/photo-1486572788966-cfd3df1f5b42?auto=format&fit=crop&w=1200&q=80',
+    genres: ['Racing', 'Arcade'],
   },
 ];

--- a/src/features/mypage/types.ts
+++ b/src/features/mypage/types.ts
@@ -7,4 +7,5 @@ export interface FavoriteGamePreview {
   title: string;
   summary: string;
   thumbnailUrl: string | null;
+  genres: string[];
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -91,7 +91,15 @@ const enableMocking = async () => {
   const { worker } = await import('./mocks/browser');
 
   await worker.start({
-    onUnhandledRequest: 'bypass',
+    // DEV + MSW 환경에서 API 핸들러 누락을 빠르게 찾기 위한 로깅 정책.
+    onUnhandledRequest: (request, print) => {
+      const { pathname } = new URL(request.url);
+      const isApiRequest = pathname.startsWith('/api/');
+
+      if (isApiRequest) {
+        print.warning();
+      }
+    },
     serviceWorker: {
       url: '/mockServiceWorker.js',
     },

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -93,8 +93,8 @@ const getSignupFieldErrors = (
         ? '비밀번호를 입력해주세요.'
         : touchedState.password &&
             trimmedPassword.length > 0 &&
-            trimmedPassword.length <= 8
-          ? '비밀번호가 8자 이하입니다.'
+            trimmedPassword.length < 8
+          ? '비밀번호는 8자 이상이어야 합니다.'
           : '',
     password_check:
       touchedState.password_check && !trimmedPasswordCheck
@@ -440,7 +440,7 @@ function SignupPage() {
 
       <form
         className="space-y-3 sm:space-y-3.5"
-        autoComplete="off"
+        autoComplete="on"
         onSubmit={handleSubmit}
       >
         <div
@@ -456,7 +456,7 @@ function SignupPage() {
           name="name"
           label="이름"
           type="text"
-          autoComplete="off"
+          autoComplete="name"
           placeholder="이름을 입력하세요"
           maxLength={NAME_MAX_LENGTH}
           value={formValues.name}
@@ -482,7 +482,7 @@ function SignupPage() {
           name="login_id"
           label="아이디"
           type="text"
-          autoComplete="new-password"
+          autoComplete="username"
           placeholder="아이디를 입력하세요"
           maxLength={LOGIN_ID_MAX_LENGTH}
           value={formValues.login_id}
@@ -540,7 +540,7 @@ function SignupPage() {
           name="nickname"
           label="닉네임"
           type="text"
-          autoComplete="off"
+          autoComplete="nickname"
           placeholder="닉네임을 입력하세요"
           maxLength={NICKNAME_MAX_LENGTH}
           value={formValues.nickname}

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -2,6 +2,7 @@ import type { FormEvent } from 'react';
 import { Heart, ShieldAlert } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router';
+import { useQueryClient } from '@tanstack/react-query';
 
 import AuthButton from '../../components/auth/AuthButton';
 import Header from '../../components/common/Header';
@@ -23,9 +24,19 @@ import {
   useChangePasswordMutation,
   useCurrentUserProfileQuery,
   useDeleteAccountMutation,
+  useLikedGamesQuery,
+  useProfileImagePresignedUrlMutation,
+  useUnlikeLikedGameMutation,
+  useUploadFileToS3Mutation,
 } from '../../features/auth/api/useAuthApi';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
-import { mockFavoriteGames } from '../../features/mypage/mockData';
+import type {
+  AuthGender,
+  CurrentUserProfileResponse,
+  LikedGameItemResponse,
+} from '../../features/auth/types/auth';
+import GameDetailModal from '../../features/games/components/GameDetailModal';
+import type { GameListItem } from '../../features/games/types';
 import type { FavoriteGamePreview } from '../../features/mypage/types';
 import {
   clearAuthTokens,
@@ -75,8 +86,8 @@ const getPasswordFieldErrors = (
         ? '새 비밀번호를 입력해주세요.'
         : touchedState.newPassword &&
             trimmedNewPassword.length > 0 &&
-            trimmedNewPassword.length <= 8
-          ? '비밀번호가 8자 이하입니다.'
+            trimmedNewPassword.length < 8
+          ? '비밀번호는 8자 이상이어야 합니다.'
           : '',
     newPasswordConfirm:
       touchedState.newPasswordConfirm && !trimmedNewPasswordConfirm
@@ -98,13 +109,75 @@ const mapPasswordApiFieldErrors = (
   newPasswordConfirm: fieldErrors.new_password_confirm,
 });
 
+const formatLikedAt = (likedAt: string) => {
+  const date = new Date(likedAt);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toLocaleDateString('ko-KR');
+};
+
+const toFavoriteGamePreview = (
+  game: LikedGameItemResponse,
+): FavoriteGamePreview => {
+  const normalizedGenres = game.genres.filter((genre) => genre.trim());
+  const likedAtLabel = formatLikedAt(game.liked_at);
+
+  const summaryParts = [
+    normalizedGenres.length > 0
+      ? `장르: ${normalizedGenres.join(', ')}`
+      : '장르 정보 없음',
+    likedAtLabel ? `찜한 날짜: ${likedAtLabel}` : null,
+  ].filter(Boolean);
+
+  return {
+    gameId: game.game_id,
+    title: game.game_title.trim() || 'N/A',
+    summary: summaryParts.join(' · '),
+    thumbnailUrl: game.thumbnail_url,
+    genres: normalizedGenres,
+  };
+};
+
+const toFavoriteGameListItem = (game: FavoriteGamePreview): GameListItem => ({
+  gameId: game.gameId,
+  name: game.title,
+  genres: game.genres.length > 0 ? game.genres : ['N/A'],
+  thumbnailUrl: game.thumbnailUrl,
+  rating: null,
+  isLiked: true,
+});
+
+const toGenderLabel = (gender?: AuthGender) => {
+  if (gender === 'M') {
+    return '남성';
+  }
+
+  if (gender === 'W') {
+    return '여성';
+  }
+
+  return 'N/A';
+};
+
 function MyPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const hasAccessToken = Boolean(getAccessToken());
   const { logout, isPending: isLogoutPending } = useLogoutAction();
   const changePasswordMutation = useChangePasswordMutation();
   const deleteAccountMutation = useDeleteAccountMutation();
+  const unlikeLikedGameMutation = useUnlikeLikedGameMutation();
+  const profileImagePresignedUrlMutation =
+    useProfileImagePresignedUrlMutation();
+  const uploadFileToS3Mutation = useUploadFileToS3Mutation();
   const profileQuery = useCurrentUserProfileQuery(hasAccessToken);
+  const likedGamesQuery = useLikedGamesQuery(hasAccessToken, {
+    page: 1,
+    page_size: 100,
+  });
   const storedAccount = useAuthStore((state) => state.account);
 
   const [isPasswordPanelOpen, setIsPasswordPanelOpen] = useState(false);
@@ -118,9 +191,12 @@ function MyPage() {
   const [passwordPanelMessage, setPasswordPanelMessage] =
     useState<PasswordPanelMessage>(null);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [favoriteGames, setFavoriteGames] = useState(mockFavoriteGames);
+  const [deletePassword, setDeletePassword] = useState('');
+  const [deletePasswordError, setDeletePasswordError] = useState('');
   const [selectedFavoriteGame, setSelectedFavoriteGame] =
     useState<FavoriteGamePreview | null>(null);
+  const [selectedDetailGame, setSelectedDetailGame] =
+    useState<GameListItem | null>(null);
 
   const localFieldErrors = useMemo(
     () => getPasswordFieldErrors(passwordValues, touchedState),
@@ -134,6 +210,9 @@ function MyPage() {
     newPasswordConfirm:
       apiFieldErrors.newPasswordConfirm ?? localFieldErrors.newPasswordConfirm,
   };
+  const favoriteGames = useMemo(() => {
+    return (likedGamesQuery.data?.results ?? []).map(toFavoriteGamePreview);
+  }, [likedGamesQuery.data]);
 
   useEffect(() => {
     if (!toast) {
@@ -186,6 +265,15 @@ function MyPage() {
   const favoriteCount = favoriteGames.length;
   const resolvedProfile = profileQuery.data ?? storedAccount;
   const isProfileLoading = profileQuery.isLoading && !resolvedProfile;
+  const isFavoriteGamesLoading = likedGamesQuery.isLoading && !favoriteCount;
+  const isFavoriteGamesError = likedGamesQuery.isError && !favoriteCount;
+  const profileName = resolvedProfile?.name || 'N/A';
+  const profileEmail = resolvedProfile?.email || null;
+  const profileGenderLabel = toGenderLabel(resolvedProfile?.gender);
+  const profileImageUrl = resolvedProfile?.profile_img_url ?? null;
+  const isProfileImageUploading =
+    profileImagePresignedUrlMutation.isPending ||
+    uploadFileToS3Mutation.isPending;
 
   const resetPasswordPanel = () => {
     setPasswordValues(initialPasswordValues);
@@ -284,8 +372,17 @@ function MyPage() {
   };
 
   const handleDeleteAccount = async () => {
+    const trimmedPassword = deletePassword.trim();
+
+    if (!trimmedPassword) {
+      setDeletePasswordError('현재 비밀번호를 입력해주세요.');
+      return;
+    }
+
     try {
-      const response = await deleteAccountMutation.mutateAsync();
+      const response = await deleteAccountMutation.mutateAsync({
+        password: trimmedPassword,
+      });
 
       clearAuthTokens();
       navigate(`/${ROUTES.LOGIN}`, {
@@ -295,34 +392,109 @@ function MyPage() {
         },
       });
     } catch (error) {
+      const fieldErrors = extractAuthApiFieldErrors(error);
+
+      if (fieldErrors.password) {
+        setDeletePasswordError(fieldErrors.password);
+        return;
+      }
+
+      const errorMessage = extractAuthApiErrorMessage(error);
+
+      if (errorMessage.includes('비밀번호')) {
+        setDeletePasswordError(errorMessage);
+        return;
+      }
+
+      setToast({
+        tone: 'error',
+        message: errorMessage,
+      });
+    }
+  };
+
+  const handleProfileImageSelect = async (file: File | null) => {
+    if (!file) {
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      setToast({
+        tone: 'error',
+        message: '이미지 파일만 업로드할 수 있습니다.',
+      });
+      return;
+    }
+
+    try {
+      const presignedResponse =
+        await profileImagePresignedUrlMutation.mutateAsync({
+          file_name: file.name,
+          content_type: file.type || 'application/octet-stream',
+        });
+
+      await uploadFileToS3Mutation.mutateAsync({
+        presigned_url: presignedResponse.presigned_url,
+        file,
+        content_type: file.type || 'application/octet-stream',
+      });
+
+      queryClient.setQueryData<CurrentUserProfileResponse>(
+        ['auth', 'me'],
+        (currentProfile) =>
+          currentProfile
+            ? {
+                ...currentProfile,
+                profile_img_url: presignedResponse.file_url,
+              }
+            : currentProfile,
+      );
+
+      if (resolvedProfile) {
+        setAuthAccount({
+          ...resolvedProfile,
+          profile_img_url: presignedResponse.file_url,
+        });
+      }
+
+      void queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
+      setToast({
+        tone: 'success',
+        message: '프로필 이미지가 변경되었습니다.',
+      });
+    } catch (error) {
       setToast({
         tone: 'error',
         message: extractAuthApiErrorMessage(error),
       });
-      setIsDeleteModalOpen(false);
     }
   };
 
-  const handleFavoriteGameCardClick = () => {
-    setToast({
-      tone: 'success',
-      message: '게임 상세 페이지는 현재 준비 중입니다.',
-    });
+  const handleFavoriteGameCardClick = (game: FavoriteGamePreview) => {
+    setSelectedDetailGame(toFavoriteGameListItem(game));
   };
 
-  const handleFavoriteGameDeleteConfirm = () => {
+  const handleFavoriteGameDeleteConfirm = async () => {
     if (!selectedFavoriteGame) {
       return;
     }
 
-    setFavoriteGames((current) =>
-      current.filter((game) => game.gameId !== selectedFavoriteGame.gameId),
-    );
-    setSelectedFavoriteGame(null);
-    setToast({
-      tone: 'success',
-      message: '찜한 게임이 목록에서 삭제되었습니다.',
-    });
+    try {
+      const response = await unlikeLikedGameMutation.mutateAsync(
+        selectedFavoriteGame.gameId,
+      );
+
+      setSelectedFavoriteGame(null);
+      setToast({
+        tone: 'success',
+        message: response.detail || '찜한 게임이 목록에서 삭제되었습니다.',
+      });
+    } catch (error) {
+      setToast({
+        tone: 'error',
+        message: extractAuthApiErrorMessage(error),
+      });
+    }
   };
 
   return (
@@ -333,12 +505,20 @@ function MyPage() {
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-[clamp(1rem,5vw,20rem)] pt-24 pb-14 sm:pt-28 sm:pb-16 lg:pt-32">
         <MyPageProfileSection
           nickname={resolvedProfile?.nickname ?? '회원'}
+          name={profileName}
+          email={profileEmail}
+          genderLabel={profileGenderLabel}
+          profileImageUrl={profileImageUrl}
           isProfileLoading={isProfileLoading}
+          isProfileImageUploading={isProfileImageUploading}
           isLoggingOut={isLogoutPending}
           isPasswordPanelOpen={isPasswordPanelOpen}
           onPasswordToggle={() => setIsPasswordPanelOpen((current) => !current)}
           onLogout={() => {
             void logout();
+          }}
+          onProfileImageSelect={(file) => {
+            void handleProfileImageSelect(file);
           }}
         >
           {isPasswordPanelOpen ? (
@@ -370,14 +550,24 @@ function MyPage() {
               </div>
             </div>
             <p className="text-mypage-muted text-sm">
-              {favoriteCount > 0
-                ? `총 ${favoriteCount}개의 게임이 저장되어 있어요`
-                : '아직 저장된 게임이 없어요'}
+              {isFavoriteGamesLoading
+                ? '찜 목록을 불러오는 중입니다.'
+                : favoriteCount > 0
+                  ? `총 ${favoriteCount}개의 게임이 저장되어 있어요`
+                  : '아직 저장된 게임이 없어요'}
             </p>
           </div>
 
           <div className="mypage-scrollbar mt-5 max-h-[720px] overflow-y-auto pr-1">
-            {favoriteCount > 0 ? (
+            {isFavoriteGamesLoading ? (
+              <p
+                role="status"
+                aria-live="polite"
+                className="text-mypage-muted py-8 text-center text-sm"
+              >
+                찜 목록을 불러오는 중입니다...
+              </p>
+            ) : favoriteCount > 0 ? (
               <div className="grid gap-4 md:grid-cols-2">
                 {favoriteGames.map((game) => (
                   <FavoriteGameCard
@@ -388,6 +578,14 @@ function MyPage() {
                   />
                 ))}
               </div>
+            ) : isFavoriteGamesError ? (
+              <p
+                role="status"
+                aria-live="polite"
+                className="py-8 text-center text-sm text-red-300"
+              >
+                찜 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+              </p>
             ) : (
               <FavoriteGamesEmptyState />
             )}
@@ -405,7 +603,11 @@ function MyPage() {
             type="button"
             variant="secondary"
             className="border-mypage-divider text-mypage-muted w-full max-w-44 hover:text-white"
-            onClick={() => setIsDeleteModalOpen(true)}
+            onClick={() => {
+              setDeletePassword('');
+              setDeletePasswordError('');
+              setIsDeleteModalOpen(true);
+            }}
           >
             회원탈퇴
           </AuthButton>
@@ -424,10 +626,49 @@ function MyPage() {
       <ConfirmModal
         open={isDeleteModalOpen}
         title="회원탈퇴 하시겠습니까?"
-        description="탈퇴를 진행하면 현재 로그인 세션이 종료되고, 로그인 화면으로 이동합니다."
+        description={
+          <div className="space-y-3">
+            <p>
+              탈퇴를 진행하면 현재 로그인 세션이 종료되고, 로그인 화면으로
+              이동합니다.
+            </p>
+            <div className="space-y-2">
+              <label
+                htmlFor="delete-account-password"
+                className="block text-sm font-medium text-white"
+              >
+                현재 비밀번호
+              </label>
+              <input
+                id="delete-account-password"
+                type="password"
+                autoComplete="current-password"
+                value={deletePassword}
+                onChange={(event) => {
+                  setDeletePassword(event.target.value);
+
+                  if (deletePasswordError) {
+                    setDeletePasswordError('');
+                  }
+                }}
+                className="auth-input-autofill placeholder-login-muted bg-login-field border-login-field h-12 w-full rounded-xl border px-4 text-base text-white transition outline-none hover:border-white/15 focus-visible:ring-2 focus-visible:ring-white/20"
+                placeholder="현재 비밀번호를 입력하세요"
+              />
+              {deletePasswordError ? (
+                <p className="pl-1 text-sm/5 font-medium text-red-400">
+                  {deletePasswordError}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        }
         confirmLabel="회원탈퇴"
         isPending={deleteAccountMutation.isPending}
-        onClose={() => setIsDeleteModalOpen(false)}
+        onClose={() => {
+          setIsDeleteModalOpen(false);
+          setDeletePassword('');
+          setDeletePasswordError('');
+        }}
         onConfirm={() => {
           void handleDeleteAccount();
         }}
@@ -438,9 +679,19 @@ function MyPage() {
         description={`'${selectedFavoriteGame?.title ?? ''}'을(를) 찜한 목록에서 삭제하시겠습니까?`}
         confirmLabel="예"
         cancelLabel="아니오"
+        isPending={unlikeLikedGameMutation.isPending}
         onClose={() => setSelectedFavoriteGame(null)}
-        onConfirm={handleFavoriteGameDeleteConfirm}
+        onConfirm={() => {
+          void handleFavoriteGameDeleteConfirm();
+        }}
       />
+      {selectedDetailGame ? (
+        <GameDetailModal
+          key={selectedDetailGame.gameId}
+          game={selectedDetailGame}
+          onClose={() => setSelectedDetailGame(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -460,7 +460,7 @@ function MyPage() {
       void queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
       setToast({
         tone: 'success',
-        message: '프로필 이미지가 변경되었습니다.',
+        message: '프로필이 변경되었습니다.',
       });
     } catch (error) {
       setToast({


### PR DESCRIPTION
## 관련 이슈

- closes #148 

## 변경 내용

- 마이페이지 프로필 버튼 문구를 `프로필 변경`으로 변경
- 프로필 이미지 업로드(MSW) 반영 로직 보강
- Presigned URL 발급 후 PUT 업로드 시 mock-s3 public URL에서 실제 이미지 응답하도록 처리
- 마이페이지 찜 목록의 기존 하드코딩/기본 데이터 제거, 사용자별 실제 찜 상태 기반으로 변경
- `/api/v1/games/:gameId/like` (POST/DELETE) MSW 핸들러 추가
- 상세 모달에서 찜/찜해제 시 마이페이지 목록이 즉시 반영되도록 React Query 캐시 동기화 처리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

https://github.com/user-attachments/assets/78cc4099-7a37-4f9b-9676-4441a4ef2b7e

## 참고사항

- 이번 변경은 MSW(개발/mock) 동작 보강 중심이며, 실서버 API 계약은 기존 구조를 유지했습니다.
- 브라우저 수동 검증 및 스크린샷 첨부 후 체크박스 업데이트 부탁드립니다.
