### PR TITLE
[Refactor] 챗봇 대화 저장 정책 변경 및 세션 휘발성 보장

### DIFF
--- a/src/features/support-chat/store/useSupportChatStore.ts
+++ b/src/features/support-chat/store/useSupportChatStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { createJSONStorage, persist } from 'zustand/middleware';
 
 import {
   createDefaultRouteContext,
@@ -40,8 +39,6 @@ type SupportChatStoreState = {
   removeMessage: (messageId: string) => void;
 };
 
-const STORAGE_KEY = 'support-chat-storage';
-
 const createMessage = (
   role: SupportChatMessage['role'],
   content: string,
@@ -72,104 +69,75 @@ const initialState = {
 };
 
 export const useSupportChatStore = create<SupportChatStoreState>()(
-  persist(
-    (set, get) => ({
-      ...initialState,
-      bootstrapConversation: (routeContext = get().routeContext) => {
-        const state = get();
+  (set, get) => ({
+    ...initialState,
+    bootstrapConversation: (routeContext = get().routeContext) => {
+      const state = get();
 
-        if (state.hasBootstrapped && state.messages.length > 0) {
-          if (routeContext.pathname !== state.routeContext.pathname) {
-            set({ routeContext });
-          }
-
-          return;
+      if (state.hasBootstrapped && state.messages.length > 0) {
+        if (routeContext.pathname !== state.routeContext.pathname) {
+          set({ routeContext });
         }
 
-        set({
-          ...initialState,
-          routeContext,
-        });
-      },
-      resetConversation: (routeContext = get().routeContext) =>
-        set({
-          ...initialState,
-          isOpen: true,
-          routeContext,
-        }),
-      openPanel: () => set({ isOpen: true }),
-      closePanel: () => set({ isOpen: false }),
-      togglePanel: () => set((state) => ({ isOpen: !state.isOpen })),
-      setRouteContext: (routeContext) => set({ routeContext }),
-      setSessionId: (sessionId) => set({ sessionId }),
-      setSubmitting: (isSubmitting) => set({ isSubmitting }),
-      setError: (error) => set({ error }),
-      clearError: () => set({ error: null }),
-      hideQuickActions: () => set({ showQuickActions: false }),
-      appendUserMessage: (content) =>
-        set((state) => ({
-          messages: [...state.messages, createMessage('user', content)],
-        })),
-      beginAssistantMessage: (messageId) =>
-        set((state) => ({
-          messages: [
-            ...state.messages,
-            createMessage('assistant', '', 'streaming', messageId),
-          ],
-        })),
-      appendAssistantChunk: (messageId, chunk) =>
-        set((state) => ({
-          messages: state.messages.map((message) =>
-            message.id === messageId
-              ? {
-                  ...message,
-                  content: `${message.content}${chunk}`,
-                }
-              : message,
-          ),
-        })),
-      finalizeAssistantMessage: (messageId) =>
-        set((state) => ({
-          messages: state.messages.map((message) =>
-            message.id === messageId
-              ? {
-                  ...message,
-                  status: 'complete',
-                }
-              : message,
-          ),
-        })),
-      removeMessage: (messageId) =>
-        set((state) => ({
-          messages: state.messages.filter(
-            (message) => message.id !== messageId,
-          ),
-        })),
-    }),
-    {
-      name: STORAGE_KEY,
-      storage: createJSONStorage(() => sessionStorage),
-      partialize: (state) => ({
-        sessionId: state.sessionId,
-        messages: state.messages,
-        quickActions: state.quickActions,
-        showQuickActions: state.showQuickActions,
-        hasBootstrapped: state.hasBootstrapped,
-        routeContext: state.routeContext,
-      }),
-      merge: (persistedState, currentState) => {
-        const mergedState = {
-          ...currentState,
-          ...(persistedState as Partial<typeof currentState>),
-        };
+        return;
+      }
 
-        return {
-          ...mergedState,
-          isOpen: false,
-          isSubmitting: false,
-          error: null,
-        };
-      },
+      set({
+        ...initialState,
+        routeContext,
+      });
     },
-  ),
+    resetConversation: (routeContext = get().routeContext) =>
+      set({
+        ...initialState,
+        isOpen: true,
+        routeContext,
+      }),
+    openPanel: () => set({ isOpen: true }),
+    closePanel: () => set({ isOpen: false }),
+    togglePanel: () => set((state) => ({ isOpen: !state.isOpen })),
+    setRouteContext: (routeContext) => set({ routeContext }),
+    setSessionId: (sessionId) => set({ sessionId }),
+    setSubmitting: (isSubmitting) => set({ isSubmitting }),
+    setError: (error) => set({ error }),
+    clearError: () => set({ error: null }),
+    hideQuickActions: () => set({ showQuickActions: false }),
+    appendUserMessage: (content) =>
+      set((state) => ({
+        messages: [...state.messages, createMessage('user', content)],
+      })),
+    beginAssistantMessage: (messageId) =>
+      set((state) => ({
+        messages: [
+          ...state.messages,
+          createMessage('assistant', '', 'streaming', messageId),
+        ],
+      })),
+    appendAssistantChunk: (messageId, chunk) =>
+      set((state) => ({
+        messages: state.messages.map((message) =>
+          message.id === messageId
+            ? {
+                ...message,
+                content: `${message.content}${chunk}`,
+              }
+            : message,
+        ),
+      })),
+    finalizeAssistantMessage: (messageId) =>
+      set((state) => ({
+        messages: state.messages.map((message) =>
+          message.id === messageId
+            ? {
+                ...message,
+                status: 'complete',
+              }
+            : message,
+        ),
+      })),
+    removeMessage: (messageId) =>
+      set((state) => ({
+        messages: state.messages.filter((message) => message.id !== messageId),
+      })),
+  }),
 );


### PR DESCRIPTION
## 관련 이슈

- closes #159

## 변경 내용

-useSupportChatStore에서 Zustand persist 미들웨어 및 sessionStorage 연동 로직 제거
-대화 내역(messages) 및 세션 상태를 메모리상에서만 관리하도록 변경
-요구사항(REQ-CHAT-001)에 따라 페이지 새로고침, 이동, 브라우저 종료 시 대화 데이터가 즉시 초기화되도록 수정

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-"새로운 대화하기" 버튼 클릭 시의 초기화 로직은 기존과 동일하게 정상 동작합니다.
