### PR TITLE
refactor(auth-ui): 로그인/회원가입 공통 UI 통일 및 로그인 API 에러 핸들링 보강

### DIFF
--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -8,6 +8,7 @@ type AuthInputFieldProps = {
   errorMessage?: string;
   helperMessage?: string;
   helperMessageTone?: AuthInputFieldMessageTone;
+  reserveMessageSpace?: boolean;
   action?: ReactNode;
   toast?: ReactNode;
   containerClassName?: string;
@@ -19,6 +20,7 @@ function AuthInputField({
   errorMessage,
   helperMessage,
   helperMessageTone = 'muted',
+  reserveMessageSpace = false,
   action,
   toast,
   containerClassName = '',
@@ -47,16 +49,20 @@ function AuthInputField({
           aria-invalid={Boolean(errorMessage)}
           className={`auth-input-autofill placeholder-login-muted bg-login-field h-14 min-w-0 flex-1 rounded-xl border px-4 text-base text-white transition outline-none focus-visible:ring-2 ${className} ${
             errorMessage
-              ? 'border-red-500 hover:border-red-400 focus-visible:ring-red-500/20'
-              : 'border-login-field hover:border-white/15 focus-visible:ring-white/20'
+              ? 'border-red-500 hover:border-red-400 focus-visible:border-red-400 focus-visible:ring-red-500/25'
+              : 'border-login-field hover:border-white/20 focus-visible:border-white/35 focus-visible:ring-white/25'
           }`}
         />
         {action}
         {toast}
       </div>
-      {resolvedMessage ? (
-        <p className={`pl-1 text-sm/5 font-medium ${resolvedMessageClassName}`}>
-          {resolvedMessage}
+      {resolvedMessage || reserveMessageSpace ? (
+        <p
+          role={errorMessage ? 'alert' : undefined}
+          aria-hidden={!resolvedMessage}
+          className={`min-h-5 pl-1 text-sm/5 font-medium ${resolvedMessage ? resolvedMessageClassName : 'text-transparent'}`}
+        >
+          {resolvedMessage ?? ''}
         </p>
       ) : null}
     </div>

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -13,6 +13,7 @@ type AuthRadioGroupProps = {
   defaultValue?: string;
   onChange?: ChangeEventHandler<HTMLInputElement>;
   errorMessage?: string;
+  reserveMessageSpace?: boolean;
   required?: boolean;
   disabled?: boolean;
 };
@@ -25,6 +26,7 @@ function AuthRadioGroup({
   defaultValue,
   onChange,
   errorMessage,
+  reserveMessageSpace = false,
   required = false,
   disabled = false,
 }: AuthRadioGroupProps) {
@@ -64,9 +66,13 @@ function AuthRadioGroup({
           </label>
         ))}
       </div>
-      {errorMessage ? (
-        <p className="pl-1 text-sm/5 font-medium text-red-400">
-          {errorMessage}
+      {errorMessage || reserveMessageSpace ? (
+        <p
+          role={errorMessage ? 'alert' : undefined}
+          aria-hidden={!errorMessage}
+          className={`min-h-5 pl-1 text-sm/5 font-medium ${errorMessage ? 'text-red-400' : 'text-transparent'}`}
+        >
+          {errorMessage ?? ''}
         </p>
       ) : null}
     </fieldset>

--- a/src/components/auth/authSharedStyles.ts
+++ b/src/components/auth/authSharedStyles.ts
@@ -1,0 +1,17 @@
+export const AUTH_SHARED_LAYOUT_CLASS_NAMES = {
+  panel: 'max-w-[560px] px-5 py-6 sm:px-9 sm:py-9',
+  content: 'max-w-[420px]',
+} as const;
+
+export const AUTH_SHARED_FORM_CLASS_NAMES = {
+  socialGroup: 'mt-6 sm:mt-7',
+  divider: 'my-5 sm:my-6',
+  form: 'space-y-3 sm:space-y-3.5',
+  feedbackMessage: 'text-sm/5',
+  submitButton: 'mt-1 h-14 w-full text-base/6 sm:mt-2',
+  auxiliaryLink:
+    'text-login-muted text-sm font-medium transition-colors hover:text-white/80',
+  footerSection: 'border-login-divider mt-5 border-t pt-4 sm:mt-6 sm:pt-5',
+  footerHelperText: 'text-login-helper text-center text-sm/5 font-normal',
+  footerLinkButton: 'mt-3 h-14 w-full text-base/6',
+} as const;

--- a/src/components/login/SocialLoginButton.tsx
+++ b/src/components/login/SocialLoginButton.tsx
@@ -25,9 +25,7 @@ function SocialLoginButton({
       className={`flex w-full items-center justify-center gap-3 rounded-full px-5 transition-all duration-200 hover:-translate-y-0.5 hover:brightness-105 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-70 ${className}`}
     >
       {icon}
-      <span
-        className={`text-base/6 font-semibold sm:text-lg/7 ${labelClassName}`}
-      >
+      <span className={`text-base/6 font-semibold ${labelClassName}`}>
         {label}
       </span>
     </button>

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -29,6 +29,12 @@ import type {
 
 const normalizeApiBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
 const authApiUrl = `${normalizeApiBaseUrl(apiBaseUrl)}${AUTH_BASE_PATH}`;
+const DEFAULT_API_ERROR_MESSAGE =
+  '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+const LOGIN_400_ERROR_MESSAGE = '아이디 또는 비밀번호를 입력해주세요.';
+const LOGIN_401_ERROR_MESSAGE = '아이디 또는 비밀번호가 올바르지 않습니다.';
+const LOGIN_403_ERROR_MESSAGE =
+  '접근 권한이 없거나 이용이 제한된 계정입니다. 고객센터에 문의하세요.';
 
 export const login = async (payload: LoginRequest) => {
   const response = await api.post<LoginResponse>(
@@ -242,7 +248,109 @@ export const extractAuthApiErrorMessage = (error: unknown) => {
     return errorDetailMessage;
   }
 
-  return '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+  return DEFAULT_API_ERROR_MESSAGE;
+};
+
+type LoginErrorStatusCode = 400 | 401 | 403;
+
+type ResolveLoginApiErrorResult = {
+  statusCode: LoginErrorStatusCode | null;
+  fieldErrors: Partial<Record<keyof LoginRequest, string>>;
+  message: string;
+  focusField: keyof LoginRequest | null;
+};
+
+const getFirstLoginErrorField = (
+  fieldErrors: Partial<Record<keyof LoginRequest, string>>,
+  payload?: Partial<LoginRequest>,
+) => {
+  if (fieldErrors.login_id) {
+    return 'login_id';
+  }
+
+  if (fieldErrors.password) {
+    return 'password';
+  }
+
+  if (payload) {
+    const loginId = payload.login_id?.trim() ?? '';
+    const password = payload.password?.trim() ?? '';
+
+    if (!loginId) {
+      return 'login_id';
+    }
+
+    if (!password) {
+      return 'password';
+    }
+  }
+
+  return null;
+};
+
+export const resolveLoginApiError = (
+  error: unknown,
+  payload?: Partial<LoginRequest>,
+): ResolveLoginApiErrorResult => {
+  const apiFieldErrors = extractAuthApiFieldErrors(error);
+  const fieldErrors = {
+    login_id: apiFieldErrors.login_id,
+    password: apiFieldErrors.password,
+  } satisfies Partial<Record<keyof LoginRequest, string>>;
+  const focusField = getFirstLoginErrorField(fieldErrors, payload);
+
+  if (!(error instanceof AxiosError)) {
+    return {
+      statusCode: null,
+      fieldErrors,
+      message: extractAuthApiErrorMessage(error),
+      focusField,
+    };
+  }
+
+  const statusCode = error.response?.status ?? null;
+
+  if (statusCode === 400) {
+    return {
+      statusCode,
+      fieldErrors,
+      message:
+        fieldErrors.login_id || fieldErrors.password
+          ? ''
+          : LOGIN_400_ERROR_MESSAGE,
+      focusField,
+    };
+  }
+
+  if (statusCode === 403) {
+    return {
+      statusCode,
+      fieldErrors,
+      message: LOGIN_403_ERROR_MESSAGE,
+      focusField,
+    };
+  }
+
+  if (statusCode === 401) {
+    const apiMessage = extractAuthApiErrorMessage(error);
+
+    return {
+      statusCode,
+      fieldErrors,
+      message:
+        apiMessage === DEFAULT_API_ERROR_MESSAGE
+          ? LOGIN_401_ERROR_MESSAGE
+          : apiMessage,
+      focusField: focusField ?? 'password',
+    };
+  }
+
+  return {
+    statusCode: null,
+    fieldErrors,
+    message: extractAuthApiErrorMessage(error),
+    focusField,
+  };
 };
 
 export const extractSuspendedAccountInfo = (error: unknown) => {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -11,11 +11,14 @@ import AuthLinkButton from '../components/auth/AuthLinkButton';
 import AuthLayout from '../components/layout/AuthLayout';
 import AuthInputField from '../components/auth/AuthInputField';
 import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
+import {
+  AUTH_SHARED_FORM_CLASS_NAMES,
+  AUTH_SHARED_LAYOUT_CLASS_NAMES,
+} from '../components/auth/authSharedStyles';
 import { ROUTES } from '../constants/routes';
 import {
   getCurrentUserProfile,
-  extractAuthApiErrorMessage,
-  extractAuthApiFieldErrors,
+  resolveLoginApiError,
 } from '../features/auth/api/auth';
 import { useLoginMutation } from '../features/auth/api/useAuthApi';
 import type { LoginRequest } from '../features/auth/types/auth';
@@ -44,23 +47,6 @@ type DevMockLoginAccountsResponse = {
   accounts: DevMockLoginAccount[];
 };
 
-const LOGIN_MAIN_CLASS_NAME = 'min-h-0 py-1 sm:py-1.5';
-const LOGIN_PANEL_CLASS_NAME =
-  'max-w-[452px] px-[clamp(0.75rem,1.7vw,1.25rem)] py-[clamp(0.75rem,1.6dvh,1rem)] sm:px-[clamp(0.875rem,2vw,1.5rem)] sm:py-[clamp(0.875rem,1.9dvh,1.25rem)]';
-const LOGIN_CONTENT_CLASS_NAME = 'max-w-[360px]';
-const LOGIN_TITLE_CLASS_NAME = 'text-[clamp(1.75rem,3.6dvh,2.375rem)]';
-const LOGIN_SOCIAL_GROUP_CLASS_NAME = 'mt-[clamp(0.5rem,1.2dvh,0.875rem)]';
-const LOGIN_DIVIDER_CLASS_NAME =
-  'my-[clamp(0.5rem,1.2dvh,0.75rem)] gap-2.5 py-0';
-const LOGIN_FORM_CLASS_NAME = 'space-y-[clamp(0.5rem,1.25dvh,0.75rem)]';
-const LOGIN_FIELD_CLASS_NAME =
-  'h-[clamp(2.5rem,4.8dvh,2.75rem)] rounded-[0.875rem] px-[clamp(0.75rem,1.5vw,0.9375rem)] text-[clamp(0.85rem,1.45dvh,0.9375rem)]';
-const LOGIN_PRIMARY_BUTTON_CLASS_NAME =
-  'mt-[clamp(0.375rem,1dvh,0.625rem)] h-[clamp(2.5rem,4.8dvh,2.75rem)] text-[clamp(0.9rem,1.55dvh,1rem)] leading-none';
-const LOGIN_SECONDARY_BUTTON_CLASS_NAME =
-  'mt-[clamp(0.5rem,1.2dvh,0.75rem)] h-[clamp(2.5rem,4.8dvh,2.75rem)] text-[clamp(0.9rem,1.55dvh,1rem)] leading-none';
-const LOGIN_SIGNUP_SECTION_CLASS_NAME =
-  'border-login-divider mt-[clamp(0.625rem,1.4dvh,0.875rem)] border-t pt-[clamp(0.5rem,1.2dvh,0.75rem)]';
 const LOGIN_MOCK_FAB_CLASS_NAME =
   'support-chat-fab group fixed left-4 bottom-4 z-[95] flex h-14 w-14 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none sm:left-6 sm:bottom-6';
 const LOGIN_MOCK_PANEL_CLASS_NAME =
@@ -81,6 +67,23 @@ const getLoginFieldErrors = (
         ? '비밀번호를 입력해주세요.'
         : '',
   } satisfies Record<LoginFieldName, string>;
+};
+
+const focusLoginFieldByName = (fieldName: LoginFieldName | null) => {
+  if (!fieldName) {
+    return;
+  }
+
+  const targetElementId =
+    fieldName === 'login_id' ? 'login-id' : 'login-password';
+
+  window.requestAnimationFrame(() => {
+    const targetElement = document.getElementById(targetElementId);
+
+    if (targetElement instanceof HTMLInputElement) {
+      targetElement.focus();
+    }
+  });
 };
 
 function LoginPage() {
@@ -259,6 +262,13 @@ function LoginPage() {
     const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
 
     if (hasLocalError) {
+      const firstInvalidField: LoginFieldName | null = nextFieldErrors.login_id
+        ? 'login_id'
+        : nextFieldErrors.password
+          ? 'password'
+          : null;
+
+      focusLoginFieldByName(firstInvalidField);
       return;
     }
 
@@ -276,14 +286,11 @@ function LoginPage() {
 
       navigate(ROUTES.HOME);
     } catch (error) {
-      const nextApiFieldErrors = extractAuthApiFieldErrors(error);
+      const resolvedError = resolveLoginApiError(error, payload);
 
-      if (Object.keys(nextApiFieldErrors).length > 0) {
-        setApiFieldErrors(nextApiFieldErrors);
-        return;
-      }
-
-      setFormMessage(extractAuthApiErrorMessage(error));
+      setApiFieldErrors(resolvedError.fieldErrors);
+      setFormMessage(resolvedError.message);
+      focusLoginFieldByName(resolvedError.focusField);
     }
   };
 
@@ -292,19 +299,19 @@ function LoginPage() {
       <AuthLayout
         title="로그인"
         withPanel
-        titleClassName={LOGIN_TITLE_CLASS_NAME}
-        mainClassName={LOGIN_MAIN_CLASS_NAME}
-        panelClassName={LOGIN_PANEL_CLASS_NAME}
-        contentClassName={LOGIN_CONTENT_CLASS_NAME}
+        panelClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.panel}
+        contentClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.content}
       >
         <AuthSocialLoginGroup
-          className={LOGIN_SOCIAL_GROUP_CLASS_NAME}
-          size="compact"
+          className={AUTH_SHARED_FORM_CLASS_NAMES.socialGroup}
         />
 
-        <AuthDivider className={LOGIN_DIVIDER_CLASS_NAME} />
+        <AuthDivider className={AUTH_SHARED_FORM_CLASS_NAMES.divider} />
 
-        <form className={LOGIN_FORM_CLASS_NAME} onSubmit={handleSubmit}>
+        <form
+          className={AUTH_SHARED_FORM_CLASS_NAMES.form}
+          onSubmit={handleSubmit}
+        >
           <AuthInputField
             id="login-id"
             name="login_id"
@@ -322,8 +329,7 @@ function LoginPage() {
             }
             errorMessage={resolvedFieldErrors.login_id}
             disabled={loginMutation.isPending}
-            containerClassName="pt-[clamp(0.125rem,0.3dvh,0.1875rem)]"
-            className={LOGIN_FIELD_CLASS_NAME}
+            reserveMessageSpace
           />
 
           <AuthInputField
@@ -343,21 +349,30 @@ function LoginPage() {
             }
             errorMessage={resolvedFieldErrors.password}
             disabled={loginMutation.isPending}
-            className={LOGIN_FIELD_CLASS_NAME}
+            reserveMessageSpace
           />
 
           {noticeMessage ? (
-            <AuthFormMessage tone="success">{noticeMessage}</AuthFormMessage>
+            <AuthFormMessage
+              tone="success"
+              className={AUTH_SHARED_FORM_CLASS_NAMES.feedbackMessage}
+            >
+              {noticeMessage}
+            </AuthFormMessage>
           ) : null}
 
           {formMessage ? (
-            <AuthFormMessage>{formMessage}</AuthFormMessage>
+            <AuthFormMessage
+              className={AUTH_SHARED_FORM_CLASS_NAMES.feedbackMessage}
+            >
+              {formMessage}
+            </AuthFormMessage>
           ) : null}
 
           <div className="flex justify-end">
             <button
               type="button"
-              className="text-login-muted text-[clamp(0.675rem,1.1dvh,0.75rem)] font-medium transition-colors hover:text-white/80"
+              className={AUTH_SHARED_FORM_CLASS_NAMES.auxiliaryLink}
             >
               아이디/비밀번호를 잊어버리셨나요?
             </button>
@@ -365,20 +380,20 @@ function LoginPage() {
 
           <AuthButton
             type="submit"
-            className={`w-full ${LOGIN_PRIMARY_BUTTON_CLASS_NAME}`}
+            className={AUTH_SHARED_FORM_CLASS_NAMES.submitButton}
             disabled={loginMutation.isPending}
           >
             {loginMutation.isPending ? '로그인 중...' : '로그인'}
           </AuthButton>
         </form>
 
-        <div className={LOGIN_SIGNUP_SECTION_CLASS_NAME}>
-          <p className="text-login-helper text-center text-[clamp(0.675rem,1.15dvh,0.75rem)] leading-[1.1rem] font-normal">
+        <div className={AUTH_SHARED_FORM_CLASS_NAMES.footerSection}>
+          <p className={AUTH_SHARED_FORM_CLASS_NAMES.footerHelperText}>
             아직 PGTI 회원이 아니신가요?
           </p>
           <AuthLinkButton
             to={`/${ROUTES.SIGNUP}`}
-            className={`w-full ${LOGIN_SECONDARY_BUTTON_CLASS_NAME}`}
+            className={AUTH_SHARED_FORM_CLASS_NAMES.footerLinkButton}
           >
             회원가입
           </AuthLinkButton>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -9,6 +9,10 @@ import AuthInputActionButton from '../components/auth/AuthInputActionButton';
 import AuthInputField from '../components/auth/AuthInputField';
 import AuthRadioGroup from '../components/auth/AuthRadioGroup';
 import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
+import {
+  AUTH_SHARED_FORM_CLASS_NAMES,
+  AUTH_SHARED_LAYOUT_CLASS_NAMES,
+} from '../components/auth/authSharedStyles';
 import AuthLayout from '../components/layout/AuthLayout';
 import ToastMessage from '../components/mypage/ToastMessage';
 import { ROUTES } from '../constants/routes';
@@ -432,14 +436,18 @@ function SignupPage() {
       title="회원가입"
       subtitle="회원가입 후 취향 기반 게임 추천을 시작해보세요"
       withPanel
+      panelClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.panel}
+      contentClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.content}
       subtitleClassName="mx-auto max-w-[290px] sm:max-w-[320px]"
     >
-      <AuthSocialLoginGroup className="mt-6 sm:mt-7" />
+      <AuthSocialLoginGroup
+        className={AUTH_SHARED_FORM_CLASS_NAMES.socialGroup}
+      />
 
-      <AuthDivider className="my-5 sm:my-6" />
+      <AuthDivider className={AUTH_SHARED_FORM_CLASS_NAMES.divider} />
 
       <form
-        className="space-y-3 sm:space-y-3.5"
+        className={AUTH_SHARED_FORM_CLASS_NAMES.form}
         autoComplete="on"
         onSubmit={handleSubmit}
       >
@@ -474,6 +482,7 @@ function SignupPage() {
               : ''
           }
           disabled={isSubmitting}
+          reserveMessageSpace
           containerClassName="pt-1"
         />
 
@@ -507,6 +516,7 @@ function SignupPage() {
             loginIdCheckState.tone === 'success' ? 'success' : 'muted'
           }
           disabled={isSubmitting}
+          reserveMessageSpace
           action={
             <AuthInputActionButton
               onClick={handleCheckLoginIdDuplicate}
@@ -562,6 +572,7 @@ function SignupPage() {
           }
           helperMessageTone="success"
           disabled={isSubmitting}
+          reserveMessageSpace
           action={
             <AuthInputActionButton
               onClick={handleCheckNicknameDuplicate}
@@ -609,6 +620,7 @@ function SignupPage() {
           }
           errorMessage={resolvedFieldErrors.password}
           disabled={isSubmitting}
+          reserveMessageSpace
         />
 
         <AuthInputField
@@ -630,6 +642,7 @@ function SignupPage() {
           }
           errorMessage={resolvedFieldErrors.password_check}
           disabled={isSubmitting}
+          reserveMessageSpace
         />
 
         <AuthRadioGroup
@@ -642,13 +655,20 @@ function SignupPage() {
           }
           errorMessage={resolvedFieldErrors.gender}
           disabled={isSubmitting}
+          reserveMessageSpace
         />
 
-        {formMessage ? <AuthFormMessage>{formMessage}</AuthFormMessage> : null}
+        {formMessage ? (
+          <AuthFormMessage
+            className={AUTH_SHARED_FORM_CLASS_NAMES.feedbackMessage}
+          >
+            {formMessage}
+          </AuthFormMessage>
+        ) : null}
 
         <AuthButton
           type="submit"
-          className="mt-1 w-full sm:mt-2"
+          className={AUTH_SHARED_FORM_CLASS_NAMES.submitButton}
           disabled={isSubmitting}
         >
           {isSubmitting ? '회원가입 중...' : '회원가입'}


### PR DESCRIPTION
## 관련 이슈

- closes #161

## 변경 내용

- 로그인/회원가입 공통 스타일(`authSharedStyles`) 추출 및 페이지 간 레이아웃/폼 규격 통일
- 로그인 폼 스케일/버튼 텍스트 밸런스 조정, 에러 메시지 스타일 공통화
- `POST /api/v1/accounts/login` 에러 처리 보강
- 400/401/403 상태코드 분기 처리 및 사용자 메시지 개선
- 400 검증 에러/로컬 검증 실패 시 해당 입력 필드로 포커스 이동 처리
- 입력/라디오 에러 메시지 영역 높이 고정으로 레이아웃 흔들림 완화

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

https://github.com/user-attachments/assets/543fa272-3638-4cb3-a145-25a8bdcee259


## 참고사항

- 로그인 에러 분기는 명세서의 `400/401/403` 상태코드를 기준으로 반영했습니다.
