### PR TITLE
[Feat] 매칭 완료 후 추천 결과로 바로 이동

### DIFF
--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -49,12 +49,10 @@ function MatchingGenreDetailPage() {
     (state) => state.evaluationsByGameId,
   );
   const initializeFlow = useMatchingStore((state) => state.initializeFlow);
-  const restartFlow = useMatchingStore((state) => state.restartFlow);
   const setRating = useMatchingStore((state) => state.setRating);
   const toggleLiked = useMatchingStore((state) => state.toggleLiked);
   const goNext = useMatchingStore((state) => state.goNext);
   const goPrevious = useMatchingStore((state) => state.goPrevious);
-  const resetFlow = useMatchingStore((state) => state.resetFlow);
 
   useEffect(() => {
     if (!genre || candidates.length === 0) {
@@ -90,27 +88,9 @@ function MatchingGenreDetailPage() {
     displayCandidates.every(
       (candidate) => evaluationsByGameId[candidate.game_id]?.rating !== null,
     );
-  const likedCount = displayCandidates.filter(
-    (candidate) => evaluationsByGameId[candidate.game_id]?.isLiked,
-  ).length;
-  const ratedCount = displayCandidates.filter(
-    (candidate) => evaluationsByGameId[candidate.game_id]?.rating !== null,
-  ).length;
   const submitErrorMessage = submitMatchResponsesMutation.error
     ? extractApiErrorMessage(submitMatchResponsesMutation.error)
     : null;
-  const isCompleted = submitMatchResponsesMutation.isSuccess;
-
-  const handleRestart = () => {
-    submitMatchResponsesMutation.reset();
-
-    if (genre && candidates.length > 0) {
-      restartFlow(genre, candidates);
-      return;
-    }
-
-    resetFlow();
-  };
 
   const handleSubmit = async () => {
     if (!allCandidatesRated || displayCandidates.length === 0) {
@@ -125,6 +105,7 @@ function MatchingGenreDetailPage() {
           is_liked: evaluationsByGameId[candidate.game_id]!.isLiked,
         })),
       });
+      navigate(`/${ROUTES.RECOMMENDATION_LIST}?source=match`);
     } catch {
       return;
     }
@@ -216,87 +197,6 @@ function MatchingGenreDetailPage() {
               <ChevronLeft size={16} />
               다른 장르 보기
             </Link>
-          </section>
-        ) : isCompleted ? (
-          <section className="mx-auto max-w-[920px]">
-            <div className="survey-panel px-6 py-8 sm:px-8 sm:py-10">
-              <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
-                Matching Complete
-              </p>
-              <h1 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl">
-                매칭 평가가 모두 저장되었어요.
-              </h1>
-              <p className="mt-4 max-w-[56ch] text-sm leading-7 break-keep text-white/60 sm:text-base">
-                {genre.title} 장르에서 남긴 평가를 바탕으로 추천 결과를 확인할
-                수 있어요. 다른 장르를 둘러보거나, 같은 장르를 다시 평가해도
-                괜찮습니다.
-              </p>
-
-              <div className="mt-8 grid gap-4 sm:grid-cols-3">
-                <div className="rounded-[24px] border border-white/8 bg-white/[0.03] px-5 py-5">
-                  <p className="text-[11px] font-medium tracking-[0.22em] text-white/34 uppercase">
-                    Rated
-                  </p>
-                  <p className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white">
-                    {ratedCount}
-                  </p>
-                  <p className="mt-2 text-sm text-white/52">
-                    평가를 완료한 게임 수
-                  </p>
-                </div>
-
-                <div className="rounded-[24px] border border-white/8 bg-white/[0.03] px-5 py-5">
-                  <p className="text-[11px] font-medium tracking-[0.22em] text-white/34 uppercase">
-                    Liked
-                  </p>
-                  <p className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white">
-                    {likedCount}
-                  </p>
-                  <p className="mt-2 text-sm text-white/52">
-                    좋아요 표시한 게임 수
-                  </p>
-                </div>
-
-                <div className="rounded-[24px] border border-white/8 bg-white/[0.03] px-5 py-5">
-                  <p className="text-[11px] font-medium tracking-[0.22em] text-white/34 uppercase">
-                    Genre
-                  </p>
-                  <p className="mt-3 text-2xl font-semibold tracking-[-0.03em] text-white">
-                    {genre.title}
-                  </p>
-                  <p className="mt-2 text-sm text-white/52">
-                    이번에 완료한 장르 매칭
-                  </p>
-                </div>
-              </div>
-
-              <div className="mt-8 flex flex-wrap gap-3">
-                <button
-                  type="button"
-                  onClick={() =>
-                    navigate(`/${ROUTES.RECOMMENDATION_LIST}?source=match`)
-                  }
-                  className="inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212]"
-                >
-                  추천 결과 보기
-                  <ChevronRight size={16} />
-                </button>
-                <button
-                  type="button"
-                  onClick={handleRestart}
-                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
-                >
-                  같은 장르 다시하기
-                </button>
-                <Link
-                  to={`/${ROUTES.MATCHING_LIST}`}
-                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
-                >
-                  <ChevronLeft size={16} />
-                  다른 장르 보기
-                </Link>
-              </div>
-            </div>
           </section>
         ) : (
           <section className="mx-auto max-w-[980px]">


### PR DESCRIPTION
## 관련 이슈

- closes #165 

## 변경 내용

- 매칭 평가 제출 성공 후 중간 완료 화면을 제거
- 마지막 카드에서 `제출하기` 성공 시 추천 결과 페이지로 바로 이동하도록 수정
- 완료 화면에서 보여주던 중복 요약 단계를 제거해 매칭 흐름을 단순화
- 제출 실패 시에는 기존처럼 현재 페이지에서 에러 문구를 유지하도록 동작 유지

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 매칭 완료 후 결과 이동 흐름 단순화에 집중했습니다.
- 완료 화면에 있던 `같은 장르 다시하기` 동선은 이번 PR 범위에서 함께 제거되었습니다.
