### PR TITLE
[Feat] 설문 페이지 단일 화면 레이아웃 개선

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -308,34 +308,34 @@ function SurveyChatPanel() {
   };
 
   return (
-    <section className="survey-panel overflow-hidden">
-      <div className="border-b border-white/8 px-4 py-4 sm:px-5 md:px-8 md:py-5">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <section className="survey-panel flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="border-b border-white/8 px-4 py-3.5 sm:px-5 md:px-6 md:py-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="max-w-2xl">
-            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#6c2323] bg-[#1a0a0a] px-3 py-1 text-xs font-semibold tracking-[0.2em] text-[#ff8f8f] uppercase">
+            <div className="mb-2.5 inline-flex items-center gap-2 rounded-full border border-[#6c2323] bg-[#1a0a0a] px-3 py-1 text-[11px] font-semibold tracking-[0.2em] text-[#ff8f8f] uppercase">
               <Sparkles size={14} />
               {isMockServiceWorkerEnabled() ? '체험 모드' : '개인화 설문'}
             </div>
-            <h2 className="text-2xl font-bold text-white md:text-3xl">
+            <h2 className="text-[22px] font-bold text-white sm:text-2xl md:text-[28px]">
               AI 취향 설문
             </h2>
-            <p className="mt-2 text-sm leading-6 break-keep text-white/58 md:text-base">
+            <p className="mt-1.5 text-sm leading-6 break-keep text-white/58 md:text-[15px]">
               최근 재미있었던 게임 경험, 선호 장르, 원하는 플레이 감각을 편하게
               말해주시면 추천 결과로 자연스럽게 이어져요.
             </p>
             {isMockServiceWorkerEnabled() ? (
-              <p className="mt-3 text-sm leading-6 text-[#ffb0b0]">
+              <p className="mt-2 text-[13px] leading-5 text-[#ffb0b0]">
                 체험 모드에서 설문 흐름을 먼저 확인할 수 있어요.
               </p>
             ) : null}
           </div>
 
-          <div className="flex flex-wrap items-center gap-3">
+          <div className="flex flex-wrap items-center gap-2.5">
             <button
               type="button"
               onClick={handleReset}
               disabled={isSubmitting}
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-2.5 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-60"
             >
               <RotateCcw size={16} />
               설문 초기화
@@ -345,7 +345,7 @@ function SurveyChatPanel() {
               type="button"
               onClick={handleMoveToRecommendation}
               disabled={!recommendationReady || isSubmitting}
-              className="inline-flex items-center gap-2 rounded-xl bg-[linear-gradient(135deg,#ee2525,#9b1010)] px-4 py-3 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(150,0,0,0.32)] transition hover:translate-y-[-1px] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
+              className="inline-flex items-center gap-2 rounded-xl bg-[linear-gradient(135deg,#ee2525,#9b1010)] px-4 py-2.5 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(150,0,0,0.32)] transition hover:translate-y-[-1px] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
             >
               추천 결과 보기
               <ChevronRight size={16} />
@@ -354,15 +354,15 @@ function SurveyChatPanel() {
         </div>
       </div>
 
-      <div className="survey-grid gap-4 px-3 py-4 sm:px-4 sm:py-5 md:gap-6 md:px-8 md:py-8">
-        <div className="space-y-4">
+      <div className="survey-grid min-h-0 flex-1 gap-3 px-3 py-3 sm:px-4 sm:py-4 md:gap-4 md:px-6 md:py-5">
+        <div className="min-h-0 space-y-3">
           <SurveyProgress progress={progress} />
 
-          <section className="survey-panel px-4 py-4 sm:px-5 sm:py-5">
-            <h3 className="text-sm font-semibold tracking-[0.18em] text-white/42 uppercase">
+          <section className="survey-panel px-4 py-4 sm:px-5 md:py-4">
+            <h3 className="text-[13px] font-semibold tracking-[0.18em] text-white/42 uppercase">
               안내사항
             </h3>
-            <div className="mt-3 space-y-3 text-sm leading-6 text-white/60">
+            <div className="mt-2.5 space-y-2.5 text-sm leading-6 text-white/60">
               <p>
                 답변은 게임 취향, 플레이 스타일, 선호 장르처럼 게임과 관련된
                 내용 위주로 작성해 주세요.
@@ -378,14 +378,14 @@ function SurveyChatPanel() {
           </section>
         </div>
 
-        <div className="survey-panel flex min-h-[640px] flex-col">
+        <div className="survey-panel flex min-h-0 flex-col">
           <div
             ref={viewportRef}
-            className="survey-message-scroll flex-1 space-y-5 px-4 py-4 sm:px-5 sm:py-5 md:px-6"
+            className="survey-message-scroll flex-1 space-y-4 px-4 py-4 sm:px-5 sm:py-4 md:px-6"
           >
             {!messages.length && isSubmitting ? (
               <div className="flex w-full justify-start">
-                <div className="rounded-3xl border border-white/8 bg-white/[0.04] px-4 py-4 text-sm text-white/60">
+                <div className="rounded-3xl border border-white/8 bg-white/[0.04] px-4 py-3.5 text-sm text-white/60">
                   AI가 첫 질문을 준비하고 있습니다...
                 </div>
               </div>
@@ -423,10 +423,10 @@ function SurveyChatPanel() {
             ) : null}
           </div>
 
-          <div className="border-t border-white/8 px-4 py-4 sm:px-5 sm:py-5 md:px-6">
-            <form ref={formRef} onSubmit={handleSubmit} className="space-y-4">
+          <div className="border-t border-white/8 px-4 py-3.5 sm:px-5 sm:py-4 md:px-6">
+            <form ref={formRef} onSubmit={handleSubmit} className="space-y-3">
               <label className="block">
-                <span className="mb-3 block text-sm font-semibold text-white/65">
+                <span className="mb-2.5 block text-sm font-semibold text-white/65">
                   {recommendationReady
                     ? '설문이 완료되었습니다.'
                     : '지금 떠오르는 취향이나 최근 즐긴 게임 이야기를 적어보세요.'}
@@ -441,13 +441,13 @@ function SurveyChatPanel() {
                       ? "추천 결과가 준비되었어요. 우측 상단의 '추천 결과 보기' 버튼을 눌러 다음 단계로 이동해 주세요."
                       : '예: 도전적인 보스전은 좋아하지만, 분위기는 너무 어둡지 않고 탐험하는 재미가 있는 게임이 좋아요.'
                   }
-                  className="min-h-[120px] w-full resize-none rounded-[24px] border border-white/10 bg-[#0e0e10] px-4 py-4 text-[15px] leading-7 text-white transition outline-none placeholder:text-white/26 focus:border-[#b42525] focus:bg-[#121214] sm:px-5"
+                  className="min-h-[104px] w-full resize-none rounded-[22px] border border-white/10 bg-[#0e0e10] px-4 py-3.5 text-[15px] leading-6 text-white transition outline-none placeholder:text-white/26 focus:border-[#b42525] focus:bg-[#121214] sm:px-5 md:min-h-[88px]"
                   disabled={isSubmitting || recommendationReady}
                 />
               </label>
 
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <p className="text-sm text-white/40">
+              <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-[13px] leading-5 text-white/40">
                   {recommendationReady
                     ? "설문이 끝났습니다. 우측 상단의 '추천 결과 보기' 버튼을 누르면 바로 추천 리스트로 이동합니다."
                     : 'Enter 키로 전송하고, Shift + Enter로 줄바꿈할 수 있습니다.'}
@@ -456,7 +456,7 @@ function SurveyChatPanel() {
                 <button
                   type="submit"
                   disabled={isSubmitting || recommendationReady}
-                  className="inline-flex items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3.5 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(139,0,0,0.28)] transition hover:translate-y-[-1px] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(139,0,0,0.28)] transition hover:translate-y-[-1px] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
                 >
                   <SendHorizontal size={16} />
                   {recommendationReady

--- a/src/features/survey/components/SurveyProgress.tsx
+++ b/src/features/survey/components/SurveyProgress.tsx
@@ -10,25 +10,25 @@ function SurveyProgress({ progress }: SurveyProgressProps) {
   const percentage = Math.max(0, Math.min(progress.completion_rate * 100, 100));
 
   return (
-    <section className="survey-panel p-5">
-      <div className="mb-3 flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-white/[0.05] text-[#ff4d4d]">
+    <section className="survey-panel p-4">
+      <div className="mb-2.5 flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/[0.05] text-[#ff4d4d]">
             <Activity size={18} />
           </div>
-          <div>
+          <div className="space-y-0.5">
             <p className="text-sm font-semibold text-white">진행률</p>
-            <p className="text-sm text-white/55">
+            <p className="text-[13px] leading-5 text-white/55">
               답변이 구체적일수록 남은 질문 수가 줄어들 수 있습니다.
             </p>
           </div>
         </div>
-        <p className="text-sm font-semibold text-[#ff7a7a]">
+        <p className="pt-0.5 text-sm font-semibold text-[#ff7a7a]">
           {Math.round(percentage)}%
         </p>
       </div>
 
-      <div className="h-2.5 overflow-hidden rounded-full bg-white/8">
+      <div className="h-2 overflow-hidden rounded-full bg-white/8">
         <div
           className="h-full rounded-full bg-[linear-gradient(90deg,#ff3434,#ff7f50)] transition-[width] duration-500"
           style={{ width: `${percentage}%` }}

--- a/src/index.css
+++ b/src/index.css
@@ -148,11 +148,13 @@
 
   .survey-grid {
     display: grid;
-    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+    min-height: 0;
+    grid-template-columns: minmax(0, 300px) minmax(0, 1fr);
   }
 
   .survey-message-scroll {
-    max-height: min(66vh, 720px);
+    min-height: 0;
+    max-height: min(54vh, 560px);
     overflow-y: auto;
     scrollbar-width: thin;
     scrollbar-color: rgba(255, 255, 255, 0.18) transparent;

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -13,16 +13,16 @@ function SurveyPage() {
       <div className="app-aurora pointer-events-none absolute inset-0 opacity-90" />
       <Header fixed />
 
-      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-3 pt-24 pb-10 sm:px-4 sm:pt-28 sm:pb-12 md:px-8 md:pt-32 md:pb-16">
-        <section className="mb-8 flex flex-col gap-5">
-          <div className="inline-flex w-fit items-center rounded-full border border-[#5e1717] bg-[#150707] px-4 py-1.5 text-xs font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
+      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-3 pt-[5.5rem] pb-8 sm:px-4 sm:pt-24 sm:pb-10 md:h-[100dvh] md:max-h-[100dvh] md:overflow-hidden md:px-8 md:pt-[6.5rem] md:pb-8">
+        <section className="mb-5 flex shrink-0 flex-col gap-3 md:mb-4 md:gap-2.5">
+          <div className="inline-flex w-fit items-center rounded-full border border-[#5e1717] bg-[#150707] px-3.5 py-1.5 text-[11px] font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
             개인화 설문
           </div>
           <div className="max-w-3xl">
-            <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl md:text-5xl">
+            <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl md:text-[44px]">
               설문 조사
             </h1>
-            <p className="mt-4 max-w-2xl text-base leading-7 text-white/62">
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-white/62 sm:text-base md:mt-2.5">
               대화형 AI 설문으로 플레이 스타일을 빠르게 파악하고, 이어지는 추천
               리스트까지 자연스럽게 연결합니다.
             </p>


### PR DESCRIPTION
## 관련 이슈

- closes #167 

## 변경 내용

- 설문 페이지 상단 hero 영역과 여백을 압축해 한 화면에 더 자연스럽게 들어오도록 조정
- 설문 진행 패널과 안내사항 카드의 세로 여백을 정리
- 설문 패널을 `flex-1 / min-h-0` 구조로 조정해 페이지 전체 스크롤보다 채팅 영역 내부 스크롤이 우선되도록 개선
- 채팅 패널의 메시지 영역, 입력 영역, 버튼 영역 높이를 조정해 데스크톱에서 한 화면 사용성을 개선
- 입력창 포커스 및 전송 UX는 유지하면서 전체 레이아웃만 압축

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷
<img width="1728" height="897" alt="스크린샷 2026-04-22 오전 10 49 33" src="https://github.com/user-attachments/assets/c195538e-68d3-4a77-92d4-d4e9fe0026eb" />


## 참고사항

- 이번 PR은 설문 페이지 레이아웃과 사용성 개선에 집중했습니다.
- 모바일에서는 기존처럼 자연스러운 세로 흐름을 유지하고, 데스크톱/노트북 환경에서의 스크롤을 줄이는 방향으로 조정했습니다.
