### PR TITLE
[Feat] 매칭 페이지 단일 화면 레이아웃 개선

### DIFF
--- a/src/features/matching/components/MatchingGuideCards.tsx
+++ b/src/features/matching/components/MatchingGuideCards.tsx
@@ -23,19 +23,19 @@ const guideCards = [
 
 function MatchingGuideCards() {
   return (
-    <div className="grid gap-4 md:grid-cols-3">
+    <div className="grid gap-3 md:grid-cols-3">
       {guideCards.map(({ title, description, icon: Icon }) => (
         <article
           key={title}
-          className="rounded-[24px] border border-white/8 bg-white/[0.025] px-5 py-6 shadow-[0_18px_34px_rgba(0,0,0,0.16)]"
+          className="rounded-[22px] border border-white/8 bg-white/[0.025] px-4 py-5 shadow-[0_18px_34px_rgba(0,0,0,0.16)]"
         >
-          <div className="flex h-11 w-11 items-center justify-center rounded-full border border-[#9c1b1b]/35 bg-[#150909] text-[#e34141]">
-            <Icon size={20} />
+          <div className="flex h-10 w-10 items-center justify-center rounded-full border border-[#9c1b1b]/35 bg-[#150909] text-[#e34141]">
+            <Icon size={18} />
           </div>
-          <h2 className="mt-5 text-lg font-semibold tracking-[-0.02em] text-white">
+          <h2 className="mt-4 text-base font-semibold tracking-[-0.02em] text-white">
             {title}
           </h2>
-          <p className="mt-3 text-sm leading-6 break-keep text-white/58">
+          <p className="mt-2 text-[13px] leading-5 break-keep text-white/58">
             {description}
           </p>
         </article>

--- a/src/features/matching/components/MatchingMediaPanel.tsx
+++ b/src/features/matching/components/MatchingMediaPanel.tsx
@@ -51,29 +51,29 @@ function MatchingMediaPanel({
     )} 감각을 대표하는 후보예요. 영상과 이미지를 보고 취향에 얼마나 맞는지 편하게 판단해보세요.`;
 
   return (
-    <article className="flex h-full flex-col overflow-hidden rounded-[28px] border border-white/8 bg-[#0d0d0f] shadow-[0_26px_52px_rgba(0,0,0,0.28)]">
-      <div className="relative shrink-0">
+    <article className="flex h-full flex-col overflow-hidden rounded-[26px] border border-white/8 bg-[#0d0d0f] shadow-[0_24px_48px_rgba(0,0,0,0.28)]">
+      <div className="relative aspect-[16/8.6] shrink-0">
         {embedUrl ? (
           <iframe
             src={embedUrl}
             title={`${candidate.title} 트레일러`}
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen
-            className="aspect-[16/9] w-full border-0"
+            className="h-full w-full border-0"
           />
         ) : imageUrl ? (
           <img
             src={imageUrl}
             alt={candidate.title}
-            className="aspect-[16/9] w-full object-cover"
+            className="h-full w-full object-cover"
           />
         ) : (
-          <div className="flex aspect-[16/9] w-full items-center justify-center bg-[#111113] text-sm text-white/45">
+          <div className="flex h-full w-full items-center justify-center bg-[#111113] text-sm text-white/45">
             미디어가 준비되지 않았습니다.
           </div>
         )}
       </div>
-      <div className="flex flex-1 flex-col border-t border-white/8 bg-[linear-gradient(180deg,rgba(18,18,20,0.94),rgba(11,11,12,0.98))] px-6 py-6 sm:px-8 sm:py-7">
+      <div className="flex flex-1 flex-col border-t border-white/8 bg-[linear-gradient(180deg,rgba(18,18,20,0.94),rgba(11,11,12,0.98))] px-5 py-5 sm:px-6 sm:py-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
             이 카드에서 볼 포인트
@@ -83,32 +83,32 @@ function MatchingMediaPanel({
           </span>
         </div>
 
-        <p className="mt-4 text-sm leading-7 break-keep text-white/62">
+        <p className="mt-3 text-sm leading-6 break-keep text-white/62">
           {candidateSummary}
         </p>
 
-        <div className="mt-5 grid gap-3 sm:grid-cols-3">
-          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-4 py-4">
-            <p className="text-[11px] font-medium tracking-[0.18em] text-white/34 uppercase">
+        <div className="mt-4 grid gap-2.5 sm:grid-cols-3">
+          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3.5">
+            <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
               평균 평점
             </p>
-            <p className="mt-2 text-xl font-semibold text-white">
+            <p className="mt-1.5 text-lg font-semibold text-white">
               {candidate.rating?.toFixed(1) ?? 'N/A'}
             </p>
           </div>
-          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-4 py-4">
-            <p className="text-[11px] font-medium tracking-[0.18em] text-white/34 uppercase">
+          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3.5">
+            <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
               미디어
             </p>
-            <p className="mt-2 text-sm font-medium text-white/78">
+            <p className="mt-1.5 text-sm font-medium text-white/78">
               {candidate.trailer_url ? '트레일러 제공' : '이미지 미리보기'}
             </p>
           </div>
-          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-4 py-4">
-            <p className="text-[11px] font-medium tracking-[0.18em] text-white/34 uppercase">
+          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3.5">
+            <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
               장르 감각
             </p>
-            <p className="mt-2 text-sm font-medium text-white/78">
+            <p className="mt-1.5 text-sm font-medium text-white/78">
               {candidate.genres[0] ?? genreTitle}
             </p>
           </div>

--- a/src/features/matching/components/MatchingRatingStars.tsx
+++ b/src/features/matching/components/MatchingRatingStars.tsx
@@ -22,7 +22,7 @@ function MatchingRatingStars({ value, onRate }: MatchingRatingStarsProps) {
             onClick={() => onRate(ratingValue)}
             aria-label={`${ratingValue}점 선택`}
             aria-pressed={value === ratingValue}
-            className={`flex h-11 w-11 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
+            className={`flex h-10 w-10 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
               isActive
                 ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
                 : 'border-white/10 bg-white/[0.03] text-white/34 hover:border-white/18 hover:text-white/72'

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -116,7 +116,7 @@ function MatchingGenreDetailPage() {
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.12),transparent_24%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
       <Header fixed />
 
-      <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1180px] px-4 pt-24 pb-14 sm:px-6 sm:pt-28 md:px-8 md:pt-32 md:pb-18">
+      <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1120px] px-4 pt-[5.5rem] pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-[6.25rem] md:pb-14">
         {!genre || !isValidGenreSlug ? (
           <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 sm:px-8 sm:py-12">
             <p className="text-sm font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
@@ -199,25 +199,25 @@ function MatchingGenreDetailPage() {
             </Link>
           </section>
         ) : (
-          <section className="mx-auto max-w-[980px]">
+          <section className="mx-auto max-w-[960px]">
             <div className="text-center">
               <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
                 {safeIndex + 1} / {totalSteps} 단계
               </p>
-              <h1 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[44px]">
+              <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[40px]">
                 매칭 과정을 따라가세요
               </h1>
-              <p className="mt-4 text-sm leading-7 break-keep text-white/58 sm:text-base">
+              <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
                 {totalGamesLabel}을 차례대로 평가하고, 마음에 드는 게임은 하트로
                 표시해둘 수 있어요.
               </p>
             </div>
 
-            <div className="mt-10">
+            <div className="mt-7">
               <MatchingGuideCards />
             </div>
 
-            <div className="mt-8 grid gap-5 lg:grid-cols-[1.1fr_0.9fr]">
+            <div className="mt-6 grid gap-4 lg:grid-cols-[1.08fr_0.92fr]">
               {currentCandidate ? (
                 <MatchingMediaPanel
                   candidate={currentCandidate}
@@ -227,13 +227,13 @@ function MatchingGenreDetailPage() {
               ) : null}
 
               {currentCandidate && currentEvaluation ? (
-                <article className="survey-panel flex flex-col px-6 py-7 sm:px-8 sm:py-8">
+                <article className="survey-panel flex flex-col px-5 py-6 sm:px-6">
                   <div className="flex items-start justify-between gap-4">
                     <div className="min-w-0 flex-1">
                       <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
                         Candidate {safeIndex + 1}
                       </p>
-                      <h2 className="mt-3 text-2xl font-semibold tracking-[-0.02em] break-keep text-white sm:text-[30px]">
+                      <h2 className="mt-2.5 text-2xl font-semibold tracking-[-0.02em] break-keep text-white sm:text-[28px]">
                         {currentCandidate.title}
                       </h2>
                     </div>
@@ -246,7 +246,7 @@ function MatchingGenreDetailPage() {
                           ? '좋아요 해제'
                           : '좋아요 추가'
                       }
-                      className={`mt-0.5 inline-flex h-12 w-12 shrink-0 items-center justify-center self-start rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
+                      className={`mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center self-start rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
                         currentEvaluation.isLiked
                           ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
                           : 'border-white/10 bg-white/[0.03] text-white/54 hover:border-white/20 hover:text-white/80'
@@ -261,7 +261,7 @@ function MatchingGenreDetailPage() {
                     </button>
                   </div>
 
-                  <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-white/46">
+                  <div className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-white/46">
                     <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
                       장르 {currentCandidate.genres.join(' · ')}
                     </span>
@@ -270,14 +270,14 @@ function MatchingGenreDetailPage() {
                     </span>
                   </div>
 
-                  <div className="mt-8">
+                  <div className="mt-6">
                     <p className="text-sm font-semibold text-white">
                       이 게임은 얼마나 끌리나요?
                     </p>
-                    <p className="mt-2 text-sm leading-6 break-keep text-white/55">
+                    <p className="mt-1.5 text-sm leading-6 break-keep text-white/55">
                       별점을 남기면 다음 카드로 넘어갈 수 있어요.
                     </p>
-                    <div className="mt-5">
+                    <div className="mt-4">
                       <MatchingRatingStars
                         value={currentEvaluation.rating}
                         onRate={(rating) =>
@@ -287,7 +287,7 @@ function MatchingGenreDetailPage() {
                     </div>
                   </div>
 
-                  <div className="mt-8 rounded-[22px] border border-white/8 bg-white/[0.03] px-5 py-5">
+                  <div className="mt-6 rounded-[20px] border border-white/8 bg-white/[0.03] px-4 py-4">
                     <p className="text-sm leading-7 break-keep text-white/64">
                       {isLastCard
                         ? currentEvaluation.rating === null
@@ -300,13 +300,13 @@ function MatchingGenreDetailPage() {
                   </div>
 
                   {submitErrorMessage ? (
-                    <p className="mt-4 text-sm leading-6 break-keep text-[#ffc2c2]">
+                    <p className="mt-3 text-sm leading-6 break-keep text-[#ffc2c2]">
                       {submitErrorMessage}
                     </p>
                   ) : null}
 
                   {isLastCard ? (
-                    <div className="mt-auto pt-8">
+                    <div className="mt-auto pt-6">
                       <p className="mx-auto mb-3 w-full max-w-[420px] text-center text-sm leading-6 break-keep text-white/42">
                         {totalSteps}개 게임의 평가가 모두 준비되면 제출할 수
                         있어요.
@@ -342,7 +342,7 @@ function MatchingGenreDetailPage() {
                       </div>
                     </div>
                   ) : (
-                    <div className="mt-auto flex flex-wrap items-end justify-between gap-3 pt-8">
+                    <div className="mt-auto flex flex-wrap items-end justify-between gap-3 pt-6">
                       <button
                         type="button"
                         onClick={goPrevious}
@@ -368,7 +368,7 @@ function MatchingGenreDetailPage() {
               ) : null}
             </div>
 
-            <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <div className="mt-6 flex flex-wrap justify-center gap-3">
               <Link
                 to={`/${ROUTES.MATCHING_LIST}`}
                 className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -33,48 +33,48 @@ function MatchingListPage() {
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.18),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
       <Header fixed />
 
-      <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1180px] px-4 pt-24 pb-14 sm:px-6 sm:pt-28 md:px-8 md:pt-32 md:pb-18">
-        <section className="mx-auto max-w-[920px]">
-          <div className="mb-10 text-center sm:mb-12">
+      <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1120px] px-4 pt-[5.5rem] pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-[6.25rem] md:pb-14">
+        <section className="mx-auto max-w-[960px]">
+          <div className="mb-7 text-center sm:mb-8">
             <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
               Matching
             </p>
-            <h1 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[44px]">
+            <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[42px]">
               장르별 게임 매칭
             </h1>
-            <p className="mt-4 text-sm leading-6 break-keep text-white/58 sm:text-base">
+            <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
               다양한 카테고리의 게임을 만나보세요!
             </p>
           </div>
 
-          <div className="grid gap-5 md:grid-cols-2">
+          <div className="grid gap-4 md:grid-cols-2">
             {MATCHING_GENRES.map((genre) => (
               <Link
                 key={genre.slug}
                 to={`/${ROUTES.MATCHING_LIST}/${genre.slug}`}
-                className="group overflow-hidden rounded-[26px] border border-white/8 bg-[#0c0c0d] p-3 shadow-[0_20px_42px_rgba(0,0,0,0.28)] transition hover:border-[#a31c1c]/65 hover:bg-[#111112]"
+                className="group overflow-hidden rounded-[24px] border border-white/8 bg-[#0c0c0d] p-2.5 shadow-[0_18px_36px_rgba(0,0,0,0.26)] transition hover:border-[#a31c1c]/65 hover:bg-[#111112]"
               >
-                <div className="relative overflow-hidden rounded-[20px]">
+                <div className="relative overflow-hidden rounded-[18px]">
                   <img
                     src={genreImageMap.get(genre.genreId) ?? genre.thumbnailUrl}
                     alt={genre.title}
-                    className="aspect-[16/9] w-full object-cover transition duration-300 group-hover:scale-[1.025] group-hover:brightness-110"
+                    className="aspect-[16/8.4] w-full object-cover transition duration-300 group-hover:scale-[1.025] group-hover:brightness-110"
                   />
                   <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,6,8,0.18),rgba(6,6,8,0.72))]" />
-                  <p className="absolute top-4 left-4 text-[11px] font-medium tracking-[0.2em] text-white/76 uppercase">
+                  <p className="absolute top-3.5 left-3.5 text-[10px] font-medium tracking-[0.2em] text-white/76 uppercase">
                     {genre.subtitle}
                   </p>
-                  <div className="absolute right-4 bottom-4 left-4 flex items-end justify-between gap-4">
+                  <div className="absolute right-3.5 bottom-3.5 left-3.5 flex items-end justify-between gap-3">
                     <div>
-                      <h2 className="text-2xl font-semibold tracking-[-0.02em] text-white">
+                      <h2 className="text-[22px] font-semibold tracking-[-0.02em] text-white">
                         {genre.title}
                       </h2>
-                      <p className="mt-2 max-w-[28ch] text-sm leading-6 break-keep text-white/72">
+                      <p className="mt-1.5 max-w-[24ch] text-[13px] leading-5 break-keep text-white/72">
                         {genre.description}
                       </p>
                     </div>
-                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-black/28 text-white/78 transition group-hover:border-[#b02525]/60 group-hover:text-white">
-                      <ChevronRight size={18} />
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-white/10 bg-black/28 text-white/78 transition group-hover:border-[#b02525]/60 group-hover:text-white">
+                      <ChevronRight size={17} />
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
## 관련 이슈

- closes #169 

## 변경 내용

- 매칭 장르 선택 화면의 상단 hero 영역과 카드 간격을 압축해 데스크톱에서 더 단정하게 보이도록 조정
- 장르 선택 화면은 기존 2x4 구조를 유지하면서 카드 높이와 내부 텍스트 밀도를 소폭 정리
- 매칭 상세 화면의 상단 안내, 가이드 카드, 미디어 패널, 별점/버튼 영역 간격을 조정해 전체 페이지 높이를 압축
- 미디어 패널의 트레일러/이미지 영역과 하단 정보 패널 높이 균형을 재조정
- 별점 버튼, 좋아요 버튼, 안내 박스 등 인터랙션 요소 크기를 크게 해치지 않는 범위에서 세로 길이를 줄이도록 정리

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 매칭 페이지 레이아웃과 데스크톱 사용성 개선에 집중했습니다.
- 장르 선택 화면은 4x2로 변경하지 않고 기존 2x4 구성을 유지했습니다.
- 빌드 시 chunk size warning은 남아 있지만 기능 오류는 아닙니다.
