### PR TITLE
[Chore] 추천 결과 mock rating 스케일 및 표시 정리

### DIFF
--- a/src/features/games/components/GameCard.tsx
+++ b/src/features/games/components/GameCard.tsx
@@ -12,7 +12,7 @@ type GameCardProps = {
 };
 
 const formatRating = (rating: number | null) =>
-  typeof rating === 'number' ? rating.toFixed(1) : 'N/A';
+  typeof rating === 'number' ? `${rating.toFixed(1)}점` : 'N/A';
 
 const GameCard = ({ game, onSelectGame }: GameCardProps) => {
   const genreLabel = game.genres.length > 0 ? game.genres[0] : 'N/A';
@@ -52,7 +52,7 @@ const GameCard = ({ game, onSelectGame }: GameCardProps) => {
             {genreLabel}
           </p>
         </div>
-        <span className="text-base font-medium text-[#e10d15]">
+        <span className="text-base font-medium whitespace-nowrap text-[#e10d15]">
           {formatRating(game.rating)}
         </span>
       </div>

--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -23,7 +23,7 @@ const EXTERNAL_LINK_LABELS: Array<{
 ];
 
 const formatDetailRating = (rating: number | null) =>
-  typeof rating === 'number' ? rating.toFixed(1) : 'N/A';
+  typeof rating === 'number' ? `${rating.toFixed(1)}점` : 'N/A';
 
 const formatNullableText = (value: string | null | undefined) =>
   value?.trim() ? value : 'N/A';
@@ -355,7 +355,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                 </div>
                 <p className="mt-3 text-sm text-white/65">{genreLabel}</p>
                 <p className="mt-2 text-sm text-white/70">
-                  평점{' '}
+                  평점 기준{' '}
                   <span className="font-semibold text-[#ff4b55]">
                     {formatDetailRating(game.rating)}
                   </span>

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -56,6 +56,11 @@ const getRankedMatchResults = () =>
     return a.created_at_order - b.created_at_order;
   });
 
+const toMockRecommendationRating = (candidateRating: number | null) =>
+  typeof candidateRating === 'number'
+    ? Number((candidateRating * 20).toFixed(1))
+    : null;
+
 export const matchingHandlers = [
   http.get('/api/v1/match/genres/image-url', async ({ request }) => {
     const url = new URL(request.url);
@@ -186,7 +191,7 @@ export const matchingHandlers = [
         title: candidate.title,
         genres: candidate.genres,
         thumbnail_url: candidate.thumbnail_url,
-        rating: result.rating,
+        rating: toMockRecommendationRating(candidate.rating),
         is_liked: result.is_liked,
       };
     });

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -26,7 +26,7 @@ const recommendations: SurveyApiResultItem[] = [
     genres: ['RPG', '어드벤처'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=800&q=80',
-    rating: 4.8,
+    rating: 95.8,
     is_liked: false,
   },
   {
@@ -35,7 +35,7 @@ const recommendations: SurveyApiResultItem[] = [
     genres: ['액션', 'RPG'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1542751371-adc38448a05e?auto=format&fit=crop&w=800&q=80',
-    rating: 4.6,
+    rating: 91.6,
     is_liked: true,
   },
   {
@@ -44,7 +44,7 @@ const recommendations: SurveyApiResultItem[] = [
     genres: ['전략', '시뮬레이션'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1493711662062-fa541adb3fc8?auto=format&fit=crop&w=800&q=80',
-    rating: 4.4,
+    rating: 88.4,
     is_liked: false,
   },
   {
@@ -53,7 +53,7 @@ const recommendations: SurveyApiResultItem[] = [
     genres: ['슈팅', '로그라이트'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1511882150382-421056c89033?auto=format&fit=crop&w=800&q=80',
-    rating: 4.3,
+    rating: 86.9,
     is_liked: false,
   },
   {
@@ -62,7 +62,7 @@ const recommendations: SurveyApiResultItem[] = [
     genres: ['비주얼 노벨', '퍼즐'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1518709268805-4e9042af2176?auto=format&fit=crop&w=800&q=80',
-    rating: 4.7,
+    rating: 93.7,
     is_liked: true,
   },
   {
@@ -71,7 +71,7 @@ const recommendations: SurveyApiResultItem[] = [
     genres: ['레이싱', '스포츠'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1486572788966-cfd3df1f5b42?auto=format&fit=crop&w=800&q=80',
-    rating: 4.1,
+    rating: 82.4,
     is_liked: false,
   },
   {
@@ -80,7 +80,7 @@ const recommendations: SurveyApiResultItem[] = [
     genres: ['어드벤처', '스토리'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1493711662062-fa541adb3fc8?auto=format&fit=crop&w=800&q=80',
-    rating: 4.5,
+    rating: 89.8,
     is_liked: false,
   },
   {
@@ -89,7 +89,7 @@ const recommendations: SurveyApiResultItem[] = [
     genres: ['FPS', '협동'],
     thumbnail_url:
       'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=800&q=80',
-    rating: 4.2,
+    rating: 84.6,
     is_liked: true,
   },
 ];


### PR DESCRIPTION
## 관련 이슈

- closes #173 

## 변경 내용

- 설문 추천 결과 mock rating을 100점 스케일 + 소수점 1자리 기준으로 정리
- 매칭 추천 결과 mock rating도 사용자 별점(1~5)을 그대로 노출하지 않도록 정리
- 추천 결과 화면이 백엔드에서 정렬/가공된 rating을 그대로 보여주는 구조에 맞춰 mock 응답 톤을 통일
- 메인 게임 카드 rating 표기를 `xx.x점` 형식으로 명확화
- 게임 상세 모달 rating 표기도 100점 기준으로 읽히도록 문구를 정

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 이미 머지된 mock 데이터 확장 PR과 분리해서, 남은 rating 스케일 정합성만 따로 정리한 작업입니다.
- 빌드 시 chunk size warning은 남아 있지만 기능 오류는 아닙니다.
