### PR TITLE
[Feat] 매칭 문구 개선 및 재진입 상태 초기화

### DIFF
--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -180,6 +180,60 @@ const createLikedGameItem = (gameId: number): LikedGameItemResponse => {
   };
 };
 
+export const syncMockLikedGamesForAuthorization = (
+  authorization: string | null,
+  updates: Array<{
+    game_id: number;
+    game_title: string;
+    thumbnail_url: string | null;
+    genres: string[];
+    is_liked: boolean;
+  }>,
+) => {
+  const user = getAuthorizedUser(authorization);
+
+  if (!user || updates.length === 0) {
+    return;
+  }
+
+  const likedGamesById = new Map(
+    getOrCreateLikedGames(user.loginId).map((likedGame) => [
+      likedGame.game_id,
+      likedGame,
+    ]),
+  );
+
+  updates.forEach((update) => {
+    if (update.is_liked) {
+      const existingLikedGame = likedGamesById.get(update.game_id);
+
+      likedGamesById.set(update.game_id, {
+        game_id: update.game_id,
+        game_title:
+          update.game_title.trim() ||
+          existingLikedGame?.game_title ||
+          `게임 ${update.game_id}`,
+        thumbnail_url:
+          update.thumbnail_url ?? existingLikedGame?.thumbnail_url ?? null,
+        genres: update.genres.length
+          ? update.genres
+          : (existingLikedGame?.genres ?? []),
+        liked_at: existingLikedGame?.liked_at ?? new Date().toISOString(),
+      });
+
+      return;
+    }
+
+    likedGamesById.delete(update.game_id);
+  });
+
+  const nextLikedGames = [...likedGamesById.values()].sort(
+    (a, b) => Date.parse(b.liked_at) - Date.parse(a.liked_at),
+  );
+
+  mockLikedGamesByLoginId.set(user.loginId, nextLikedGames);
+};
+
 const loginHandlers = [
   http.get(`${AUTH_BASE_PATH}/dev-login-accounts`, async () => {
     await delay(120);

--- a/src/features/matching/components/MatchingGuideCards.tsx
+++ b/src/features/matching/components/MatchingGuideCards.tsx
@@ -2,21 +2,20 @@ import { Hand, Heart, Star } from 'lucide-react';
 
 const guideCards = [
   {
-    title: '카드를 넘겨보세요',
+    title: '빠르게 비교해 보세요',
     description:
-      '현재 게임의 분위기와 취향이 맞는지 보면서 차례대로 평가를 진행해요.',
+      '장르 안에서 결이 다른 게임을 차례로 보며 지금 끌리는 방향을 가볍게 확인해요.',
     icon: Hand,
   },
   {
-    title: '별점을 남겨보세요',
-    description:
-      '마음에 드는 정도를 별점으로 표현하면 다음 단계 추천 정확도가 높아져요.',
+    title: '별점으로 취향을 남겨요',
+    description: '별점은 추천을 더 정교하게 만드는 선호도 데이터로 반영돼요.',
     icon: Star,
   },
   {
-    title: '게임을 모아보세요',
+    title: '좋아요로 표시해 둬요',
     description:
-      '좋아 보이는 게임은 하트로 표시해두고 나중에 다시 살펴볼 수 있어요.',
+      '마음에 든 게임은 하트로 표시해 두고 마이페이지에서 다시 확인할 수 있어요.',
     icon: Heart,
   },
 ];

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { delay, http, HttpResponse } from 'msw';
 
+import { syncMockLikedGamesForAuthorization } from '../../auth/mocks/handlers';
 import { getMatchingGenreById } from '../genres';
 import {
   matchingMockCandidateMapById,
@@ -160,6 +161,21 @@ export const matchingHandlers = [
         totalCount: allResults.length,
       }),
     }));
+
+    syncMockLikedGamesForAuthorization(
+      request.headers.get('Authorization'),
+      body.match_result.map((result) => {
+        const candidate = matchingMockCandidateMapById.get(result.game_id!)!;
+
+        return {
+          game_id: candidate.game_id,
+          game_title: candidate.title,
+          thumbnail_url: candidate.thumbnail_url,
+          genres: candidate.genres,
+          is_liked: Boolean(result.is_liked),
+        };
+      }),
+    );
 
     await delay(500);
 

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -1,9 +1,11 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight, Heart } from 'lucide-react';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
+import type { LikedGamesResponse } from '../../features/auth/types/auth';
 import {
   useMatchCandidatesQuery,
   useSubmitMatchResponsesMutation,
@@ -23,6 +25,7 @@ import { getAccessToken } from '../../utils/auth';
 function MatchingGenreDetailPage() {
   const { genreSlug } = useParams();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const hasAccessToken = Boolean(getAccessToken());
   const isMockMode = isMockServiceWorkerEnabled();
   const canAccessPage = isMockMode || hasAccessToken;
@@ -48,20 +51,32 @@ function MatchingGenreDetailPage() {
   const evaluationsByGameId = useMatchingStore(
     (state) => state.evaluationsByGameId,
   );
-  const initializeFlow = useMatchingStore((state) => state.initializeFlow);
+  const restartFlow = useMatchingStore((state) => state.restartFlow);
   const setRating = useMatchingStore((state) => state.setRating);
   const toggleLiked = useMatchingStore((state) => state.toggleLiked);
   const goNext = useMatchingStore((state) => state.goNext);
   const goPrevious = useMatchingStore((state) => state.goPrevious);
+  const resetFlow = useMatchingStore((state) => state.resetFlow);
+  const hasInitializedFlowRef = useRef(false);
+
+  useLayoutEffect(() => {
+    resetFlow();
+    resetSubmitMatchResponsesMutation();
+  }, [resetFlow, resetSubmitMatchResponsesMutation]);
 
   useEffect(() => {
-    if (!genre || candidates.length === 0) {
+    hasInitializedFlowRef.current = false;
+  }, [genre?.slug]);
+
+  useEffect(() => {
+    if (!genre || candidates.length === 0 || hasInitializedFlowRef.current) {
       return;
     }
 
-    initializeFlow(genre, candidates);
+    restartFlow(genre, candidates);
+    hasInitializedFlowRef.current = true;
     resetSubmitMatchResponsesMutation();
-  }, [genre, candidates, initializeFlow, resetSubmitMatchResponsesMutation]);
+  }, [genre, candidates, restartFlow, resetSubmitMatchResponsesMutation]);
 
   const displayCandidates =
     selectedGenreSlug === genre?.slug &&
@@ -92,6 +107,59 @@ function MatchingGenreDetailPage() {
     ? extractApiErrorMessage(submitMatchResponsesMutation.error)
     : null;
 
+  const syncLikedGamesCache = () => {
+    queryClient.setQueriesData<LikedGamesResponse>(
+      { queryKey: ['auth', 'me', 'game-like'] },
+      (current) => {
+        if (!current) {
+          return current;
+        }
+
+        const likedAt = new Date().toISOString();
+        const nextLikedGamesById = new Map(
+          current.results.map((likedGame) => [likedGame.game_id, likedGame]),
+        );
+
+        displayCandidates.forEach((candidate) => {
+          const evaluation = evaluationsByGameId[candidate.game_id];
+
+          if (!evaluation) {
+            return;
+          }
+
+          if (evaluation.isLiked) {
+            const existingLikedGame = nextLikedGamesById.get(candidate.game_id);
+
+            nextLikedGamesById.set(candidate.game_id, {
+              game_id: candidate.game_id,
+              game_title: candidate.title,
+              thumbnail_url: candidate.thumbnail_url,
+              genres: candidate.genres,
+              liked_at: existingLikedGame?.liked_at ?? likedAt,
+            });
+            return;
+          }
+
+          nextLikedGamesById.delete(candidate.game_id);
+        });
+
+        const nextResults = [...nextLikedGamesById.values()].sort(
+          (a, b) => Date.parse(b.liked_at) - Date.parse(a.liked_at),
+        );
+
+        return {
+          ...current,
+          count: nextResults.length,
+          results: nextResults,
+        };
+      },
+    );
+
+    void queryClient.invalidateQueries({
+      queryKey: ['auth', 'me', 'game-like'],
+    });
+  };
+
   const handleSubmit = async () => {
     if (!allCandidatesRated || displayCandidates.length === 0) {
       return;
@@ -105,6 +173,7 @@ function MatchingGenreDetailPage() {
           is_liked: evaluationsByGameId[candidate.game_id]!.isLiked,
         })),
       });
+      syncLikedGamesCache();
       navigate(`/${ROUTES.RECOMMENDATION_LIST}?source=match`);
     } catch {
       return;
@@ -208,8 +277,9 @@ function MatchingGenreDetailPage() {
                 매칭 과정을 따라가세요
               </h1>
               <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
-                {totalGamesLabel}을 차례대로 평가하고, 마음에 드는 게임은 하트로
-                표시해둘 수 있어요.
+                트레일러와 분위기를 보며 {totalGamesLabel}에 별점을 남겨보세요.
+                좋아요는 마음에 든 게임을 표시해 두고 마이페이지에서도 다시
+                확인할 수 있게 함께 저장돼요.
               </p>
             </div>
 
@@ -272,10 +342,10 @@ function MatchingGenreDetailPage() {
 
                   <div className="mt-6">
                     <p className="text-sm font-semibold text-white">
-                      이 게임은 얼마나 끌리나요?
+                      이 게임이 내 취향에 얼마나 가까운가요?
                     </p>
                     <p className="mt-1.5 text-sm leading-6 break-keep text-white/55">
-                      별점을 남기면 다음 카드로 넘어갈 수 있어요.
+                      별점은 추천을 더 정교하게 만드는 선호도 평가로 반영돼요.
                     </p>
                     <div className="mt-4">
                       <MatchingRatingStars
@@ -291,11 +361,11 @@ function MatchingGenreDetailPage() {
                     <p className="text-sm leading-7 break-keep text-white/64">
                       {isLastCard
                         ? currentEvaluation.rating === null
-                          ? '마지막 후보예요. 별점을 선택하면 지금까지 남긴 평가를 한 번에 제출할 수 있어요.'
-                          : '모든 평가가 준비됐어요. 제출하면 추천 결과를 바로 확인할 수 있어요.'
+                          ? '마지막 후보예요. 별점을 남기면 지금까지의 선호도 평가를 제출하고 추천 결과로 바로 이어갈 수 있어요.'
+                          : '모든 선호도 평가가 준비됐어요. 제출하면 취향에 맞는 추천 결과를 바로 확인할 수 있어요.'
                         : currentEvaluation.rating === null
-                          ? '현재 카드의 별점을 먼저 선택해 주세요.'
-                          : '별점과 좋아요는 바로 저장되고, 이전 카드로 돌아가 수정할 수도 있어요.'}
+                          ? '트레일러와 분위기를 보고 지금 카드의 별점을 남겨 주세요.'
+                          : '별점은 취향 분석에 반영되고, 좋아요는 마이페이지에서 다시 볼 게임을 표시해 두는 용도로 저장돼요.'}
                     </p>
                   </div>
 
@@ -308,8 +378,8 @@ function MatchingGenreDetailPage() {
                   {isLastCard ? (
                     <div className="mt-auto pt-6">
                       <p className="mx-auto mb-3 w-full max-w-[420px] text-center text-sm leading-6 break-keep text-white/42">
-                        {totalSteps}개 게임의 평가가 모두 준비되면 제출할 수
-                        있어요.
+                        {totalSteps}개 게임의 선호도 평가가 모두 준비되면 제출할
+                        수 있어요.
                       </p>
 
                       <div className="flex flex-wrap items-end justify-between gap-3">

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -1,11 +1,12 @@
 import { ChevronRight } from 'lucide-react';
-import { useMemo } from 'react';
+import { useLayoutEffect, useMemo } from 'react';
 import { Link } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
 import { useMatchingGenreImageQueries } from '../../features/matching/api/useMatchingApi';
 import { MATCHING_GENRES } from '../../features/matching/genres';
+import { useMatchingStore } from '../../features/matching/store/useMatchingStore';
 import { isMockServiceWorkerEnabled } from '../../lib/env';
 import { getAccessToken } from '../../utils/auth';
 
@@ -13,6 +14,7 @@ function MatchingListPage() {
   const hasAccessToken = Boolean(getAccessToken());
   const isMockMode = isMockServiceWorkerEnabled();
   const canFetchGenreImages = isMockMode || hasAccessToken;
+  const resetFlow = useMatchingStore((state) => state.resetFlow);
   const genreImageQueries = useMatchingGenreImageQueries(
     MATCHING_GENRES.map((genre) => genre.genreId),
     canFetchGenreImages,
@@ -27,6 +29,10 @@ function MatchingListPage() {
       ),
     [genreImageQueries],
   );
+
+  useLayoutEffect(() => {
+    resetFlow();
+  }, [resetFlow]);
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
@@ -43,7 +49,8 @@ function MatchingListPage() {
               장르별 게임 매칭
             </h1>
             <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
-              다양한 카테고리의 게임을 만나보세요!
+              좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에 맞는
+              게임을 빠르게 추천해드려요.
             </p>
           </div>
 

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -517,7 +517,7 @@ function RecommendationListPage() {
               </h1>
               <p className="mt-4 max-w-[620px] text-sm leading-7 break-keep text-white/58 sm:text-base">
                 {isMatchSource
-                  ? '매칭 평가에서 남긴 별점과 좋아요를 바탕으로, 바로 확인해볼 만한 결과를 정리했어요.'
+                  ? '장르별 매칭에서 남긴 별점과 좋아요를 바탕으로 정리된 추천 결과예요. 마음에 드는 게임은 좋아요로 표시해 두고 마이페이지에서도 다시 확인할 수 있어요.'
                   : '설문에서 드러난 취향을 바탕으로, 지금 바로 플레이하고 싶어질 만한 게임들을 차분하게 정리해뒀어요.'}
               </p>
               <div className="mt-5 flex flex-wrap gap-2.5">
@@ -578,8 +578,8 @@ function RecommendationListPage() {
                 먼저 매칭 평가를 완료해 주세요.
               </h2>
               <p className="mt-4 text-base leading-7 break-keep text-white/60">
-                장르별 매칭 평가를 제출하면 추천 결과를 이 페이지에서 바로
-                확인할 수 있어요.
+                좋아하는 장르를 고르고 최대 5개 게임의 트레일러를 보며 별점을
+                남기면 추천 결과가 바로 준비돼요.
               </p>
               <Link
                 to={`/${ROUTES.MATCHING_LIST}`}
@@ -598,7 +598,7 @@ function RecommendationListPage() {
                     </p>
                     <p className="mt-3 text-sm leading-6 break-keep text-white/56">
                       {isMatchSource
-                        ? '평가를 바탕으로 정리된 결과를 비교해보고 마음에 드는 게임을 골라보세요.'
+                        ? '장르별 매칭에서 수집한 선호도 평가를 바탕으로 정리된 결과예요.'
                         : '마음에 드는 게임을 비교해보고, 더보기로 결과를 이어서 확인해보세요.'}
                     </p>
                   </div>

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -1,5 +1,8 @@
+import { useLayoutEffect } from 'react';
+
 import Header from '../../components/common/Header';
 import SurveyChatPanel from '../../features/survey/components/SurveyChatPanel';
+import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
 import { isMockServiceWorkerEnabled } from '../../lib/env';
 import { getAccessToken } from '../../utils/auth';
 
@@ -7,6 +10,11 @@ function SurveyPage() {
   const hasAccessToken = Boolean(getAccessToken());
   const isMockMode = isMockServiceWorkerEnabled();
   const canAccessSurvey = isMockMode || hasAccessToken;
+  const resetSurveyState = useSurveyStore((state) => state.resetSurveyState);
+
+  useLayoutEffect(() => {
+    resetSurveyState();
+  }, [resetSurveyState]);
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">


### PR DESCRIPTION
## 관련 이슈

- closes #175 

## 변경 내용

- 홈으로 이동했다가 다시 진입할 때 설문/매칭 이전 상태가 남지 않도록 흐름 초기화 처리
- 설문 재진입 시 이전 세션, 메시지, 진행률이 남지 않고 새 설문으로 시작하도록 수정
- 매칭 재진입 시 이전 장르, 별점, 좋아요, 진행 단계가 남지 않도록 초기화 처리
- 매칭 상단 소개 문구와 가이드 문구를 서비스 의도에 맞게 자연스럽게 정리
- 별점은 취향 반영용 선호도 평가, 좋아요는 마이페이지에서 다시 볼 게임 표시라는 의미가 더 잘 전달되도록 안내 문구를 수정
- 매칭 제출 성공 시 좋아요 상태가 마이페이지 찜 목록 query cache에 함께 반영되도록 연결
- MSW에서도 매칭 제출 시 좋아요 상태가 auth liked-games mock 상태에 반영되도록 정리
- 추천 결과 페이지의 매칭 안내 문구도 같은 기준으로 정리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
