### PR TITLE
refactor(auth): 세션 갱신 single-flight 및 인증 에러 처리 정책 정리

### DIFF
--- a/docs/ai/api-contract.md
+++ b/docs/ai/api-contract.md
@@ -17,6 +17,7 @@
 
 - **소셜 로그인 진입**: `GET /api/v1/accounts/social-login/{google|kakao|naver}` (백엔드 제공 OAuth 시작점)
 - **토큰 갱신**: `POST /api/v1/accounts/token/refresh` (쿠키의 리프레시 토큰을 사용하여 액세스 토큰 재발급)
+- **주의**: API 명세서 표에 `refresh_token` body 예시가 있어도, 실서버 동작 기준은 HttpOnly 쿠키 인증이며 프론트는 `withCredentials` 요청으로 맞춥니다.
 - **로그아웃**: `POST /api/v1/accounts/logout` (액세스 토큰 무효화 및 서버측 쿠키 삭제 요청)
 - **비밀번호 변경**: `POST /api/v1/accounts/me/change-password`
 - **회원 탈퇴**: `DELETE /api/v1/accounts/me` (request body에 `password` 포함)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,43 @@
-import { Outlet } from 'react-router';
+import { useEffect } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router';
+
+import { ROUTES } from './constants/routes';
+import {
+  AUTH_SESSION_EXPIRED_EVENT,
+  AUTH_SESSION_EXPIRED_NOTICE_MESSAGE,
+  type AuthSessionExpiredDetail,
+} from './features/auth/constants/session';
 import SupportChatWidget from './components/support-chat/SupportChatWidget';
 
 function App() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const handleSessionExpired = (event: Event) => {
+      const customEvent = event as CustomEvent<AuthSessionExpiredDetail>;
+      const noticeMessage =
+        customEvent.detail?.noticeMessage ||
+        AUTH_SESSION_EXPIRED_NOTICE_MESSAGE;
+      const loginPath = `/${ROUTES.LOGIN}`;
+      const shouldReplace = location.pathname === loginPath;
+
+      navigate(loginPath, {
+        replace: shouldReplace,
+        state: { noticeMessage },
+      });
+    };
+
+    window.addEventListener(AUTH_SESSION_EXPIRED_EVENT, handleSessionExpired);
+
+    return () => {
+      window.removeEventListener(
+        AUTH_SESSION_EXPIRED_EVENT,
+        handleSessionExpired,
+      );
+    };
+  }, [location.pathname, navigate]);
+
   return (
     <>
       <Outlet />

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,15 @@
-import axios from 'axios';
+import axios, {
+  AxiosError,
+  AxiosHeaders,
+  type InternalAxiosRequestConfig,
+} from 'axios';
 
+import { logAxiosError } from './logApiError';
 import { refreshAccessToken } from '../features/auth/api/auth';
+import {
+  AUTH_SESSION_EXPIRED_NOTICE_MESSAGE,
+  createAuthSessionExpiredEvent,
+} from '../features/auth/constants/session';
 import { apiBaseUrl } from '../lib/env';
 import { useAuthStore } from '../store/useAuthStore';
 
@@ -21,6 +30,62 @@ const AUTH_EXCLUDED_PATHS = [
 const shouldResetAuthSession = (requestUrl?: string) => {
   if (!requestUrl) return true;
   return !AUTH_EXCLUDED_PATHS.some((path) => requestUrl.includes(path));
+};
+
+type RetriableRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean;
+};
+
+let refreshAccessTokenPromise: Promise<string> | null = null;
+
+const clearAuthAndNotifySessionExpired = () => {
+  useAuthStore.getState().clearAuth();
+
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      createAuthSessionExpiredEvent({
+        noticeMessage: AUTH_SESSION_EXPIRED_NOTICE_MESSAGE,
+        source: 'refresh',
+      }),
+    );
+  }
+};
+
+const getRefreshedAccessToken = async () => {
+  if (!refreshAccessTokenPromise) {
+    refreshAccessTokenPromise = refreshAccessToken()
+      .then(({ access_token }) => {
+        useAuthStore.getState().setAccessToken(access_token);
+        return access_token;
+      })
+      .catch((refreshError) => {
+        clearAuthAndNotifySessionExpired();
+
+        if (refreshError instanceof AxiosError) {
+          logAxiosError(refreshError, 'auth-refresh');
+        } else {
+          console.error('[auth-refresh] unexpected error');
+        }
+
+        throw refreshError;
+      })
+      .finally(() => {
+        refreshAccessTokenPromise = null;
+      });
+  }
+
+  return refreshAccessTokenPromise;
+};
+
+const setAuthorizationHeader = (
+  config: RetriableRequestConfig,
+  accessToken: string,
+) => {
+  if (!config.headers) {
+    config.headers = new AxiosHeaders();
+  }
+
+  config.headers.Authorization = `Bearer ${accessToken}`;
 };
 
 export const api = axios.create({
@@ -50,10 +115,15 @@ api.interceptors.request.use(
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
-    const originalRequest = error.config;
+    if (!(error instanceof AxiosError)) {
+      return Promise.reject(error);
+    }
+
+    const originalRequest = error.config as RetriableRequestConfig | undefined;
 
     // 401 에러이고, 재시도한 적이 없으며, 인증 제외 경로가 아닐 때
     if (
+      originalRequest &&
       error.response?.status === 401 &&
       !originalRequest._retry &&
       shouldResetAuthSession(originalRequest.url)
@@ -61,28 +131,17 @@ api.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        const { access_token } = await refreshAccessToken();
-
-        // 새 토큰 저장
-        useAuthStore.getState().setAccessToken(access_token);
+        const accessToken = await getRefreshedAccessToken();
 
         // 원래 요청 재시도
-        originalRequest.headers.Authorization = `Bearer ${access_token}`;
+        setAuthorizationHeader(originalRequest, accessToken);
         return api(originalRequest);
       } catch (refreshError) {
-        // 리프레시 실패 시 (세션 만료) 로그아웃 처리
-        useAuthStore.getState().clearAuth();
-
-        // 브라우저 환경에서만 리다이렉트
-        if (typeof window !== 'undefined') {
-          window.location.href = '/login?expired=true';
-        }
-
         return Promise.reject(refreshError);
       }
     }
 
-    console.error('API 에러 발생:', error.response?.data || error.message);
+    logAxiosError(error, 'axios-response');
     return Promise.reject(error);
   },
 );

--- a/src/api/logApiError.ts
+++ b/src/api/logApiError.ts
@@ -1,0 +1,75 @@
+import type { AxiosError } from 'axios';
+
+const SENSITIVE_KEY_PATTERN =
+  /(token|password|authorization|cookie|secret|credential)/i;
+
+const toLoggablePath = (requestUrl?: string) => {
+  if (!requestUrl) {
+    return 'N/A';
+  }
+
+  try {
+    const normalizedUrl = new URL(
+      requestUrl,
+      typeof window === 'undefined'
+        ? 'http://localhost'
+        : window.location.origin,
+    );
+
+    return normalizedUrl.pathname;
+  } catch {
+    return requestUrl.split('?')[0] || requestUrl;
+  }
+};
+
+const maskSensitiveValue = (value: unknown, depth = 0): unknown => {
+  if (depth > 4) {
+    return '[masked-depth]';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => maskSensitiveValue(entry, depth + 1));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(
+        ([key, entryValue]) => [
+          key,
+          SENSITIVE_KEY_PATTERN.test(key)
+            ? '[masked]'
+            : maskSensitiveValue(entryValue, depth + 1),
+        ],
+      ),
+    );
+  }
+
+  return value;
+};
+
+export const logAxiosError = (error: AxiosError, source = 'api') => {
+  const method = error.config?.method?.toUpperCase() ?? 'UNKNOWN';
+  const path = toLoggablePath(error.config?.url);
+  const statusCode = error.response?.status ?? 'NETWORK_ERROR';
+
+  if (import.meta.env.DEV) {
+    console.error(`[${source}] API error`, {
+      method,
+      path,
+      statusCode,
+      code: error.code ?? null,
+      message: error.message,
+      response: maskSensitiveValue(error.response?.data),
+      request: maskSensitiveValue(error.config?.data),
+    });
+
+    return;
+  }
+
+  console.error(`[${source}] API error`, {
+    method,
+    path,
+    statusCode,
+    code: error.code ?? null,
+  });
+};

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -8,6 +8,7 @@ type AuthRadioOption = {
 type AuthRadioGroupProps = {
   label: string;
   name: string;
+  idPrefix?: string;
   options: readonly AuthRadioOption[];
   value?: string;
   defaultValue?: string;
@@ -21,6 +22,7 @@ type AuthRadioGroupProps = {
 function AuthRadioGroup({
   label,
   name,
+  idPrefix,
   options,
   value,
   defaultValue,
@@ -36,35 +38,44 @@ function AuthRadioGroup({
         {label}
       </legend>
       <div className="grid grid-cols-2 gap-3 pt-1">
-        {options.map((option) => (
-          <label
-            key={option.value}
-            className="group block min-w-0 cursor-pointer"
-          >
-            <input
-              type="radio"
-              name={name}
-              value={option.value}
-              checked={value !== undefined ? value === option.value : undefined}
-              defaultChecked={
-                value !== undefined ? undefined : defaultValue === option.value
-              }
-              onChange={onChange}
-              required={required}
-              disabled={disabled}
-              className="peer sr-only"
-            />
-            <span
-              className={`flex h-14 items-center justify-center rounded-2xl border px-4 text-sm font-semibold transition-all group-hover:border-white/20 group-hover:text-white/85 peer-checked:border-[#ff8a3d] peer-checked:bg-[linear-gradient(135deg,rgba(255,138,61,0.24),rgba(255,110,48,0.1))] peer-checked:text-white peer-checked:shadow-[0_14px_32px_rgba(255,138,61,0.18)] peer-disabled:opacity-60 ${
-                errorMessage
-                  ? 'border-red-500/80 bg-white/[0.03] text-red-200'
-                  : 'border-login-field text-login-helper bg-white/[0.03]'
-              }`}
+        {options.map((option) => {
+          const inputId = `${idPrefix ?? name}-${option.value}`;
+
+          return (
+            <label
+              key={option.value}
+              className="group block min-w-0 cursor-pointer"
             >
-              {option.label}
-            </span>
-          </label>
-        ))}
+              <input
+                id={inputId}
+                type="radio"
+                name={name}
+                value={option.value}
+                checked={
+                  value !== undefined ? value === option.value : undefined
+                }
+                defaultChecked={
+                  value !== undefined
+                    ? undefined
+                    : defaultValue === option.value
+                }
+                onChange={onChange}
+                required={required}
+                disabled={disabled}
+                className="peer sr-only"
+              />
+              <span
+                className={`flex h-14 items-center justify-center rounded-2xl border px-4 text-sm font-semibold transition-all group-hover:border-white/20 group-hover:text-white/85 peer-checked:border-[#ff8a3d] peer-checked:bg-[linear-gradient(135deg,rgba(255,138,61,0.24),rgba(255,110,48,0.1))] peer-checked:text-white peer-checked:shadow-[0_14px_32px_rgba(255,138,61,0.18)] peer-disabled:opacity-60 ${
+                  errorMessage
+                    ? 'border-red-500/80 bg-white/[0.03] text-red-200'
+                    : 'border-login-field text-login-helper bg-white/[0.03]'
+                }`}
+              >
+                {option.label}
+              </span>
+            </label>
+          );
+        })}
       </div>
       {errorMessage || reserveMessageSpace ? (
         <p

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -31,10 +31,27 @@ const normalizeApiBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
 const authApiUrl = `${normalizeApiBaseUrl(apiBaseUrl)}${AUTH_BASE_PATH}`;
 const DEFAULT_API_ERROR_MESSAGE =
   '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
-const LOGIN_400_ERROR_MESSAGE = '아이디 또는 비밀번호를 입력해주세요.';
-const LOGIN_401_ERROR_MESSAGE = '아이디 또는 비밀번호가 올바르지 않습니다.';
-const LOGIN_403_ERROR_MESSAGE =
-  '접근 권한이 없거나 이용이 제한된 계정입니다. 고객센터에 문의하세요.';
+const LOGIN_ERROR_POLICIES = {
+  400: {
+    fallbackMessage: '아이디 또는 비밀번호를 입력해주세요.',
+    defaultFocusField: null,
+    hideFormMessageWhenFieldError: true,
+    preferApiMessage: false,
+  },
+  401: {
+    fallbackMessage: '아이디 또는 비밀번호가 올바르지 않습니다.',
+    defaultFocusField: 'password',
+    hideFormMessageWhenFieldError: false,
+    preferApiMessage: true,
+  },
+  403: {
+    fallbackMessage:
+      '접근 권한이 없거나 이용이 제한된 계정입니다. 고객센터에 문의하세요.',
+    defaultFocusField: null,
+    hideFormMessageWhenFieldError: false,
+    preferApiMessage: true,
+  },
+} as const;
 
 export const login = async (payload: LoginRequest) => {
   const response = await api.post<LoginResponse>(
@@ -52,6 +69,8 @@ export const logout = async () => {
 };
 
 export const refreshAccessToken = async () => {
+  // 실서버 기준으로 refresh token은 HttpOnly 쿠키 기반으로 관리합니다.
+  // API 명세의 body 예시는 추후 문서 동기화 대상으로 두고, 현재는 빈 body 요청으로 고정합니다.
   const response = await axios.post<RefreshAccessTokenResponse>(
     `${authApiUrl}/token/refresh`,
     {},
@@ -252,16 +271,24 @@ export const extractAuthApiErrorMessage = (error: unknown) => {
 };
 
 type LoginErrorStatusCode = 400 | 401 | 403;
+type LoginFieldName = keyof LoginRequest;
+
+type LoginErrorPolicy = {
+  fallbackMessage: string;
+  defaultFocusField: LoginFieldName | null;
+  hideFormMessageWhenFieldError: boolean;
+  preferApiMessage: boolean;
+};
 
 type ResolveLoginApiErrorResult = {
   statusCode: LoginErrorStatusCode | null;
-  fieldErrors: Partial<Record<keyof LoginRequest, string>>;
+  fieldErrors: Partial<Record<LoginFieldName, string>>;
   message: string;
-  focusField: keyof LoginRequest | null;
+  focusField: LoginFieldName | null;
 };
 
 const getFirstLoginErrorField = (
-  fieldErrors: Partial<Record<keyof LoginRequest, string>>,
+  fieldErrors: Partial<Record<LoginFieldName, string>>,
   payload?: Partial<LoginRequest>,
 ) => {
   if (fieldErrors.login_id) {
@@ -288,6 +315,29 @@ const getFirstLoginErrorField = (
   return null;
 };
 
+const resolveLoginMessageByPolicy = ({
+  policy,
+  fieldErrors,
+  apiMessage,
+}: {
+  policy: LoginErrorPolicy;
+  fieldErrors: Partial<Record<LoginFieldName, string>>;
+  apiMessage: string;
+}) => {
+  if (
+    policy.hideFormMessageWhenFieldError &&
+    getFirstLoginErrorField(fieldErrors)
+  ) {
+    return '';
+  }
+
+  if (policy.preferApiMessage && apiMessage !== DEFAULT_API_ERROR_MESSAGE) {
+    return apiMessage;
+  }
+
+  return policy.fallbackMessage;
+};
+
 export const resolveLoginApiError = (
   error: unknown,
   payload?: Partial<LoginRequest>,
@@ -296,7 +346,7 @@ export const resolveLoginApiError = (
   const fieldErrors = {
     login_id: apiFieldErrors.login_id,
     password: apiFieldErrors.password,
-  } satisfies Partial<Record<keyof LoginRequest, string>>;
+  } satisfies Partial<Record<LoginFieldName, string>>;
   const focusField = getFirstLoginErrorField(fieldErrors, payload);
 
   if (!(error instanceof AxiosError)) {
@@ -309,39 +359,20 @@ export const resolveLoginApiError = (
   }
 
   const statusCode = error.response?.status ?? null;
+  const apiMessage = extractAuthApiErrorMessage(error);
 
-  if (statusCode === 400) {
-    return {
-      statusCode,
-      fieldErrors,
-      message:
-        fieldErrors.login_id || fieldErrors.password
-          ? ''
-          : LOGIN_400_ERROR_MESSAGE,
-      focusField,
-    };
-  }
-
-  if (statusCode === 403) {
-    return {
-      statusCode,
-      fieldErrors,
-      message: LOGIN_403_ERROR_MESSAGE,
-      focusField,
-    };
-  }
-
-  if (statusCode === 401) {
-    const apiMessage = extractAuthApiErrorMessage(error);
+  if (statusCode === 400 || statusCode === 401 || statusCode === 403) {
+    const policy = LOGIN_ERROR_POLICIES[statusCode];
 
     return {
       statusCode,
       fieldErrors,
-      message:
-        apiMessage === DEFAULT_API_ERROR_MESSAGE
-          ? LOGIN_401_ERROR_MESSAGE
-          : apiMessage,
-      focusField: focusField ?? 'password',
+      message: resolveLoginMessageByPolicy({
+        policy,
+        fieldErrors,
+        apiMessage,
+      }),
+      focusField: focusField ?? policy.defaultFocusField,
     };
   }
 

--- a/src/features/auth/constants/session.ts
+++ b/src/features/auth/constants/session.ts
@@ -1,0 +1,16 @@
+export const AUTH_SESSION_EXPIRED_EVENT = 'auth:session-expired';
+
+export const AUTH_SESSION_EXPIRED_NOTICE_MESSAGE =
+  '로그인 세션이 만료되었습니다. 다시 로그인해 주세요.';
+
+export type AuthSessionExpiredDetail = {
+  noticeMessage?: string;
+  source?: 'refresh' | 'manual';
+};
+
+export const createAuthSessionExpiredEvent = (
+  detail: AuthSessionExpiredDetail = {},
+) =>
+  new CustomEvent<AuthSessionExpiredDetail>(AUTH_SESSION_EXPIRED_EVENT, {
+    detail,
+  });

--- a/src/features/auth/utils/feedbackPriority.ts
+++ b/src/features/auth/utils/feedbackPriority.ts
@@ -1,0 +1,27 @@
+const hasText = (value?: string) => Boolean(value?.trim());
+const isFieldErrorMessage = (value: unknown): value is string =>
+  typeof value === 'string' && Boolean(value.trim());
+
+export const hasAnyFieldError = <FieldName extends string>(
+  fieldErrors: Partial<Record<FieldName, string>>,
+) => Object.values(fieldErrors).some(isFieldErrorMessage);
+
+export const resolveAuthFeedbackVisibility = <FieldName extends string>({
+  fieldErrors,
+  formMessage,
+  hasToast,
+}: {
+  fieldErrors: Partial<Record<FieldName, string>>;
+  formMessage?: string;
+  hasToast?: boolean;
+}) => {
+  const hasFieldError = hasAnyFieldError(fieldErrors);
+  const showFormMessage = !hasFieldError && hasText(formMessage);
+  const showToast = !hasFieldError && !showFormMessage && Boolean(hasToast);
+
+  return {
+    hasFieldError,
+    showFormMessage,
+    showToast,
+  };
+};

--- a/src/features/auth/utils/focusField.ts
+++ b/src/features/auth/utils/focusField.ts
@@ -1,0 +1,37 @@
+const isNonEmptyMessage = (value?: string) => Boolean(value?.trim());
+
+export const getFirstErrorFieldName = <FieldName extends string>(
+  fieldErrors: Partial<Record<FieldName, string>>,
+  fieldOrder: readonly FieldName[],
+): FieldName | null => {
+  for (const fieldName of fieldOrder) {
+    if (isNonEmptyMessage(fieldErrors[fieldName])) {
+      return fieldName;
+    }
+  }
+
+  return null;
+};
+
+export const focusFieldByName = <FieldName extends string>(
+  fieldName: FieldName | null,
+  fieldElementIdMap: Partial<Record<FieldName, string>>,
+) => {
+  if (!fieldName || typeof window === 'undefined') {
+    return;
+  }
+
+  const elementId = fieldElementIdMap[fieldName];
+
+  if (!elementId) {
+    return;
+  }
+
+  window.requestAnimationFrame(() => {
+    const targetElement = document.getElementById(elementId);
+
+    if (targetElement instanceof HTMLElement) {
+      targetElement.focus();
+    }
+  });
+};

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -20,8 +20,11 @@ import {
   getCurrentUserProfile,
   resolveLoginApiError,
 } from '../features/auth/api/auth';
+import { AUTH_SESSION_EXPIRED_NOTICE_MESSAGE } from '../features/auth/constants/session';
 import { useLoginMutation } from '../features/auth/api/useAuthApi';
 import type { LoginRequest } from '../features/auth/types/auth';
+import { resolveAuthFeedbackVisibility } from '../features/auth/utils/feedbackPriority';
+import { focusFieldByName } from '../features/auth/utils/focusField';
 import { getSocialCallbackErrorMessage } from '../features/auth/utils/socialAuth';
 import { mockServiceWorkerEnabled } from '../lib/env';
 import { useAuthStore } from '../store/useAuthStore';
@@ -69,21 +72,9 @@ const getLoginFieldErrors = (
   } satisfies Record<LoginFieldName, string>;
 };
 
-const focusLoginFieldByName = (fieldName: LoginFieldName | null) => {
-  if (!fieldName) {
-    return;
-  }
-
-  const targetElementId =
-    fieldName === 'login_id' ? 'login-id' : 'login-password';
-
-  window.requestAnimationFrame(() => {
-    const targetElement = document.getElementById(targetElementId);
-
-    if (targetElement instanceof HTMLInputElement) {
-      targetElement.focus();
-    }
-  });
+const LOGIN_FIELD_ELEMENT_IDS: Record<LoginFieldName, string> = {
+  login_id: 'login-id',
+  password: 'login-password',
 };
 
 function LoginPage() {
@@ -105,20 +96,32 @@ function LoginPage() {
   });
   const [apiFieldErrors, setApiFieldErrors] = useState<LoginFieldErrors>({});
   const locationState = location.state as LoginLocationState | null;
-  const locationSearchErrorMessage = getSocialCallbackErrorMessage(
-    new URLSearchParams(location.search),
-  );
+  const locationSearchParams = new URLSearchParams(location.search);
+  const locationSearchErrorMessage =
+    getSocialCallbackErrorMessage(locationSearchParams);
+  const locationSearchNoticeMessage =
+    locationSearchParams.get('expired') === 'true'
+      ? AUTH_SESSION_EXPIRED_NOTICE_MESSAGE
+      : '';
   const [formMessage, setFormMessage] = useState(
     locationState?.errorMessage ?? locationSearchErrorMessage ?? '',
   );
   const [noticeMessage, setNoticeMessage] = useState(
-    locationState?.noticeMessage ?? '',
+    locationState?.noticeMessage ?? locationSearchNoticeMessage,
   );
   const fieldErrors = getLoginFieldErrors(formValues, touchedState);
   const resolvedFieldErrors: Record<LoginFieldName, string> = {
     login_id: apiFieldErrors.login_id ?? fieldErrors.login_id,
     password: apiFieldErrors.password ?? fieldErrors.password,
   };
+  const feedbackVisibility = resolveAuthFeedbackVisibility({
+    fieldErrors: resolvedFieldErrors,
+    formMessage,
+  });
+  const showNoticeMessage =
+    !feedbackVisibility.hasFieldError &&
+    !feedbackVisibility.showFormMessage &&
+    Boolean(noticeMessage.trim());
   const showMockAccounts = mockServiceWorkerEnabled && mockAccounts.length > 0;
 
   useEffect(() => {
@@ -128,8 +131,10 @@ function LoginPage() {
   }, [locationState?.errorMessage, locationSearchErrorMessage]);
 
   useEffect(() => {
-    setNoticeMessage(locationState?.noticeMessage ?? '');
-  }, [locationState?.noticeMessage]);
+    setNoticeMessage(
+      locationState?.noticeMessage ?? locationSearchNoticeMessage,
+    );
+  }, [locationState?.noticeMessage, locationSearchNoticeMessage]);
 
   useEffect(() => {
     if (!mockServiceWorkerEnabled) {
@@ -268,7 +273,7 @@ function LoginPage() {
           ? 'password'
           : null;
 
-      focusLoginFieldByName(firstInvalidField);
+      focusFieldByName(firstInvalidField, LOGIN_FIELD_ELEMENT_IDS);
       return;
     }
 
@@ -290,7 +295,7 @@ function LoginPage() {
 
       setApiFieldErrors(resolvedError.fieldErrors);
       setFormMessage(resolvedError.message);
-      focusLoginFieldByName(resolvedError.focusField);
+      focusFieldByName(resolvedError.focusField, LOGIN_FIELD_ELEMENT_IDS);
     }
   };
 
@@ -352,7 +357,7 @@ function LoginPage() {
             reserveMessageSpace
           />
 
-          {noticeMessage ? (
+          {showNoticeMessage ? (
             <AuthFormMessage
               tone="success"
               className={AUTH_SHARED_FORM_CLASS_NAMES.feedbackMessage}
@@ -361,7 +366,7 @@ function LoginPage() {
             </AuthFormMessage>
           ) : null}
 
-          {formMessage ? (
+          {feedbackVisibility.showFormMessage ? (
             <AuthFormMessage
               className={AUTH_SHARED_FORM_CLASS_NAMES.feedbackMessage}
             >

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -28,6 +28,11 @@ import {
   useSignupMutation,
 } from '../features/auth/api/useAuthApi';
 import type { AuthGender, SignupRequest } from '../features/auth/types/auth';
+import { resolveAuthFeedbackVisibility } from '../features/auth/utils/feedbackPriority';
+import {
+  focusFieldByName,
+  getFirstErrorFieldName,
+} from '../features/auth/utils/focusField';
 import { setAccessToken, setAuthAccount } from '../utils/auth';
 
 type SignupFormValues = Omit<SignupRequest, 'gender'> & {
@@ -64,6 +69,24 @@ const initialDuplicateCheckState: DuplicateCheckState = {
   verifiedValue: null,
   message: '',
   tone: null,
+};
+
+const SIGNUP_FIELD_ORDER = [
+  'name',
+  'login_id',
+  'nickname',
+  'password',
+  'password_check',
+  'gender',
+] as const satisfies readonly SignupFieldName[];
+
+const SIGNUP_FIELD_ELEMENT_IDS: Record<SignupFieldName, string> = {
+  name: 'signup-name',
+  login_id: 'signup-id',
+  nickname: 'signup-nickname',
+  password: 'signup-password',
+  password_check: 'signup-password-confirm',
+  gender: 'signup-gender-M',
 };
 
 const getSignupFieldErrors = (
@@ -180,6 +203,11 @@ function SignupPage() {
       apiFieldErrors.password_check ?? localFieldErrors.password_check,
     gender: apiFieldErrors.gender ?? localFieldErrors.gender,
   };
+  const feedbackVisibility = resolveAuthFeedbackVisibility({
+    fieldErrors: resolvedFieldErrors,
+    formMessage,
+    hasToast: Boolean(duplicateCheckToast),
+  });
 
   const isSubmitting = signupMutation.isPending || loginMutation.isPending;
 
@@ -265,6 +293,7 @@ function SignupPage() {
     setFormMessage('');
 
     if (!trimmedLoginId) {
+      focusFieldByName('login_id', SIGNUP_FIELD_ELEMENT_IDS);
       return;
     }
 
@@ -309,6 +338,7 @@ function SignupPage() {
     setFormMessage('');
 
     if (!trimmedNickname) {
+      focusFieldByName('nickname', SIGNUP_FIELD_ELEMENT_IDS);
       return;
     }
 
@@ -370,6 +400,12 @@ function SignupPage() {
     const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
 
     if (hasLocalError || !formValues.gender) {
+      const firstInvalidField = getFirstErrorFieldName(
+        nextFieldErrors,
+        SIGNUP_FIELD_ORDER,
+      );
+
+      focusFieldByName(firstInvalidField, SIGNUP_FIELD_ELEMENT_IDS);
       return;
     }
 
@@ -387,6 +423,10 @@ function SignupPage() {
     } catch (error) {
       const nextApiFieldErrors = extractAuthApiFieldErrors(error);
       const nextMessage = extractAuthApiErrorMessage(error);
+      let focusTargetField = getFirstErrorFieldName(
+        nextApiFieldErrors as Partial<Record<SignupFieldName, string>>,
+        SIGNUP_FIELD_ORDER,
+      );
 
       if (Object.keys(nextApiFieldErrors).length > 0) {
         setApiFieldErrors(nextApiFieldErrors);
@@ -395,6 +435,7 @@ function SignupPage() {
           ...previous,
           nickname: nextMessage,
         }));
+        focusTargetField = 'nickname';
       } else if (
         nextMessage.includes('아이디') ||
         nextMessage.includes('회원가입')
@@ -403,9 +444,12 @@ function SignupPage() {
           ...previous,
           login_id: nextMessage,
         }));
+        focusTargetField = 'login_id';
       } else {
         setFormMessage(nextMessage);
       }
+
+      focusFieldByName(focusTargetField, SIGNUP_FIELD_ELEMENT_IDS);
 
       return;
     }
@@ -534,6 +578,7 @@ function SignupPage() {
             </AuthInputActionButton>
           }
           toast={
+            feedbackVisibility.showToast &&
             duplicateCheckToast?.anchor === 'login_id' ? (
               <ToastMessage
                 message={duplicateCheckToast.message}
@@ -590,6 +635,7 @@ function SignupPage() {
             </AuthInputActionButton>
           }
           toast={
+            feedbackVisibility.showToast &&
             duplicateCheckToast?.anchor === 'nickname' ? (
               <ToastMessage
                 message={duplicateCheckToast.message}
@@ -648,6 +694,7 @@ function SignupPage() {
         <AuthRadioGroup
           label="성별"
           name="gender"
+          idPrefix="signup-gender"
           value={formValues.gender}
           options={signupGenderOptions}
           onChange={(event) =>
@@ -658,7 +705,7 @@ function SignupPage() {
           reserveMessageSpace
         />
 
-        {formMessage ? (
+        {feedbackVisibility.showFormMessage ? (
           <AuthFormMessage
             className={AUTH_SHARED_FORM_CLASS_NAMES.feedbackMessage}
           >

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,12 +1,12 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import type { CurrentUserProfileResponse } from '../features/auth/types/auth';
 
 /**
- * [Refactor] 인증 아키텍처 업데이트 (#94)
- * - Access Token: 보안 강화를 위해 클라이언트 메모리(State)에서만 관리 (XSS 방어)
+ * [Auth] 새로고침 로그인 유지 업데이트
+ * - Access Token: 로컬 개발/테스트 흐름에 맞춰 localStorage 기반으로 유지합니다.
  * - Refresh Token: 브라우저 HttpOnly Cookie 기반 관리 (백엔드 주도)
- * - persist 미들웨어를 제거하여 새로고침 시 세션 만료를 의도하거나,
- *   Axios Interceptor를 통한 Silent Refresh로 세션을 유지합니다.
+ * - 로그아웃/세션 만료 시 localStorage 인증 데이터를 즉시 제거합니다.
  */
 
 interface AuthState {
@@ -19,37 +19,50 @@ interface AuthState {
   clearAuth: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  accessToken: null,
-  account: null,
-  isAuthenticated: false,
-
-  setAccessToken: (token) =>
-    set({
-      accessToken: token,
-      isAuthenticated: !!token,
-    }),
-
-  setAccount: (account) => set({ account }),
-
-  setAuth: (token, account) =>
-    set({
-      accessToken: token,
-      account: account,
-      isAuthenticated: true,
-    }),
-
-  clearAuth: () => {
-    set({
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
       accessToken: null,
       account: null,
       isAuthenticated: false,
-    });
 
-    // 기존 localStorage 기반 레거시 데이터 완전 삭제
-    clearLegacyAuthStorage();
-  },
-}));
+      setAccessToken: (token) =>
+        set({
+          accessToken: token,
+          isAuthenticated: !!token,
+        }),
+
+      setAccount: (account) => set({ account }),
+
+      setAuth: (token, account) =>
+        set({
+          accessToken: token,
+          account: account,
+          isAuthenticated: true,
+        }),
+
+      clearAuth: () => {
+        set({
+          accessToken: null,
+          account: null,
+          isAuthenticated: false,
+        });
+
+        // 기존 localStorage 기반 레거시 데이터 완전 삭제
+        clearLegacyAuthStorage();
+      },
+    }),
+    {
+      name: 'auth-storage',
+      storage: createJSONStorage(() => window.localStorage),
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+        account: state.account,
+        isAuthenticated: state.isAuthenticated,
+      }),
+    },
+  ),
+);
 
 /**
  * 기존 localStorage에 저장되던 모든 인증 관련 레거시 키를 삭제합니다.


### PR DESCRIPTION
## 관련 이슈

- closes #177

## 변경 내용

-Axios 401 처리에 refresh single-flight 적용 (동시 401에서도 refresh 1회만 수행)
-refresh 실패 시 clearAuth 후 라우터 기반 로그인 이동으로 통일 (하드 리로드 제거)
-로그인 400/401/403 에러 정책 객체화 및 메시지/포커스 우선순위 정리
-로그인/회원가입 공통 필드 포커스 유틸 및 피드백 우선순위 유틸 추가
-API 에러 로깅을 민감정보 마스킹 기반으로 정리 (DEV 상세, PROD 축약)
-새로고침 로그인 유지용 auth store persist(localStorage) 적용
-API 계약 문서에 refresh 쿠키 기반 실동작 기준 주석 반영

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
