### PR TITLE
[Fix] 메인 페이지 CTA 문구 및 첫 화면 레이아웃 정리

### DIFF
--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -143,15 +143,15 @@ const MainPage = () => {
               iconLabel="설문 작성"
               title="설문 조사"
               description="설문에 참여하고 나에게 꼭 맞는 게임을 찾아보세요!"
-              buttonLabel="설문 조사 하러가기"
+              buttonLabel="설문 시작"
               to={`/${ROUTES.SURVEY}`}
             />
             <RecommendationCta
               icon={Search}
               iconLabel="게임 찾기"
-              title="매칭 시작"
+              title="장르별 매칭"
               description="어떤 게임을 할지 고민? 당신의 취향에 맞는 게임을 추천해드립니다!"
-              buttonLabel="장르별 매칭"
+              buttonLabel="매칭 시작"
               to={`/${ROUTES.MATCHING_LIST}`}
             />
           </section>

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -91,9 +91,9 @@ const MainPage = () => {
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <Header fixed />
-      <main className="min-h-screen pt-24 pb-10 text-white sm:pt-28 sm:pb-14 lg:pt-32">
-        <section className="w-full">
-          <div className="flex flex-col gap-4 px-[clamp(1rem,5vw,20rem)] sm:flex-row sm:items-center sm:justify-between">
+      <main className="min-h-screen pt-24 pb-10 text-white sm:pt-28 sm:pb-14 lg:h-screen lg:overflow-hidden lg:pt-24 lg:pb-4 xl:pt-26 xl:pb-5">
+        <section className="w-full lg:flex lg:h-full lg:flex-col">
+          <div className="flex flex-col gap-4 px-[clamp(1rem,5vw,20rem)] sm:flex-row sm:items-center sm:justify-between lg:gap-3">
             <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4 lg:flex-nowrap">
               <h2 className="min-w-0 text-xl leading-tight font-bold wrap-break-word text-white sm:text-2xl lg:text-[28px]">
                 {sectionTitle}
@@ -120,7 +120,7 @@ const MainPage = () => {
             </label>
           </div>
 
-          <div className="mt-4 sm:mt-5">
+          <div className="mt-4 sm:mt-5 lg:mt-4">
             {gamesQuery.isLoading ? (
               <GameCardSkeletonList />
             ) : games.length > 0 ? (
@@ -137,7 +137,7 @@ const MainPage = () => {
             )}
           </div>
 
-          <section className="mt-14 grid gap-6 px-[clamp(1rem,5vw,20rem)] lg:grid-cols-2">
+          <section className="mt-14 grid gap-6 px-[clamp(1rem,5vw,20rem)] lg:mt-6 lg:grid-cols-2 lg:gap-4 xl:mt-7">
             <RecommendationCta
               icon={ClipboardCheck}
               iconLabel="설문 작성"
@@ -500,7 +500,7 @@ const RecommendationCta = ({
     'hover:bg-header-accent-hover mt-7 inline-flex h-11 cursor-pointer items-center justify-center rounded-md bg-[#d20b12] px-7 text-sm font-semibold text-white transition focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]';
 
   return (
-    <article className="flex min-h-65 flex-col items-center justify-center rounded-lg border border-[#3a0b0d] bg-[#050505] px-6 py-9 text-center sm:min-h-70">
+    <article className="flex min-h-65 flex-col items-center justify-center rounded-lg border border-[#3a0b0d] bg-[#050505] px-6 py-9 text-center sm:min-h-70 lg:min-h-56 lg:px-5 lg:py-7">
       <div
         role="img"
         aria-label={iconLabel}
@@ -508,14 +508,14 @@ const RecommendationCta = ({
       >
         <Icon aria-hidden="true" className="h-6 w-6 sm:h-7 sm:w-7" />
       </div>
-      <h3 className="mt-7 text-2xl leading-tight font-bold sm:text-3xl">
+      <h3 className="mt-7 text-2xl leading-tight font-bold sm:text-3xl lg:mt-5 lg:text-[28px]">
         {title}
       </h3>
-      <p className="mt-5 max-w-xl text-sm leading-6 text-white/70 sm:text-base">
+      <p className="mt-5 max-w-xl text-sm leading-6 text-white/70 sm:text-base lg:mt-3 lg:text-[15px] lg:leading-6">
         {description}
       </p>
       {to ? (
-        <Link to={to} className={actionClassName}>
+        <Link to={to} className={`${actionClassName} lg:mt-5`}>
           {buttonLabel}
         </Link>
       ) : (
@@ -523,7 +523,7 @@ const RecommendationCta = ({
           type="button"
           onClick={showPendingMessage}
           title="준비 중입니다."
-          className={actionClassName}
+          className={`${actionClassName} lg:mt-5`}
         >
           {buttonLabel}
         </button>


### PR DESCRIPTION
## 관련 이슈

- closes #180

## 변경 내용

- 데스크톱 기준으로 헤더와 상단 필터 영역 간격을 넓히고, Swiper와 CTA 섹션 사이 간격을 줄였습니다.
- CTA 카드의 데스크톱 높이와 내부 세로 간격을 조정해 첫 화면 하단 공간을 더 자연스럽게 채우도록 했습니다.
- CTA 문구를 현재 UX 톤에 맞게 정리했습니다.
  - 설문 조사 하러가기 -> 설문 시작
  - 매칭 시작 / 장르별 매칭 제목-버튼 문구 정리

## 검증

- [x] npm run lint
- [x] npm run build
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="2032" height="1162" alt="스크린샷 2026-04-22 오후 1 57 21" src="https://github.com/user-attachments/assets/6e9f1017-30a7-4910-b1d1-73e4a5c0dd11" />


## 참고사항

- 모바일/태블릿은 기존처럼 자연스러운 세로 스크롤을 유지합니다.
- 데스크톱/노트북 기준으로 첫 화면 가독성과 CTA 밀도를 조정한 PR입니다.