### PR TITLE
[Feat] 매칭 상세 화면 UI 표현 정리

### DIFF
--- a/src/features/matching/components/MatchingGuideCards.tsx
+++ b/src/features/matching/components/MatchingGuideCards.tsx
@@ -22,19 +22,19 @@ const guideCards = [
 
 function MatchingGuideCards() {
   return (
-    <div className="grid gap-3 md:grid-cols-3">
+    <div className="grid gap-2.5 md:grid-cols-3">
       {guideCards.map(({ title, description, icon: Icon }) => (
         <article
           key={title}
-          className="rounded-[22px] border border-white/8 bg-white/[0.025] px-4 py-5 shadow-[0_18px_34px_rgba(0,0,0,0.16)]"
+          className="rounded-[22px] border border-white/8 bg-white/[0.025] px-4 py-4 shadow-[0_18px_34px_rgba(0,0,0,0.16)]"
         >
           <div className="flex h-10 w-10 items-center justify-center rounded-full border border-[#9c1b1b]/35 bg-[#150909] text-[#e34141]">
             <Icon size={18} />
           </div>
-          <h2 className="mt-4 text-base font-semibold tracking-[-0.02em] text-white">
+          <h2 className="mt-3 text-base font-semibold tracking-[-0.02em] text-white">
             {title}
           </h2>
-          <p className="mt-2 text-[13px] leading-5 break-keep text-white/58">
+          <p className="mt-1.5 text-[13px] leading-5 break-keep text-white/58">
             {description}
           </p>
         </article>

--- a/src/features/matching/components/MatchingMediaPanel.tsx
+++ b/src/features/matching/components/MatchingMediaPanel.tsx
@@ -6,6 +6,16 @@ type MatchingMediaPanelProps = {
   stepLabel: string;
 };
 
+const formatMatchingCandidateRating = (rating: number | null) => {
+  if (typeof rating !== 'number') {
+    return 'N/A';
+  }
+
+  const normalizedRating = rating <= 5 ? rating * 20 : rating;
+
+  return `${normalizedRating.toFixed(1)}점`;
+};
+
 const getYoutubeEmbedUrl = (trailerUrl: string | null) => {
   if (!trailerUrl) {
     return null;
@@ -52,7 +62,7 @@ function MatchingMediaPanel({
 
   return (
     <article className="flex h-full flex-col overflow-hidden rounded-[26px] border border-white/8 bg-[#0d0d0f] shadow-[0_24px_48px_rgba(0,0,0,0.28)]">
-      <div className="relative aspect-[16/8.6] shrink-0">
+      <div className="relative aspect-[16/8.1] shrink-0">
         {embedUrl ? (
           <iframe
             src={embedUrl}
@@ -73,7 +83,7 @@ function MatchingMediaPanel({
           </div>
         )}
       </div>
-      <div className="flex flex-1 flex-col border-t border-white/8 bg-[linear-gradient(180deg,rgba(18,18,20,0.94),rgba(11,11,12,0.98))] px-5 py-5 sm:px-6 sm:py-6">
+      <div className="flex flex-1 flex-col border-t border-white/8 bg-[linear-gradient(180deg,rgba(18,18,20,0.94),rgba(11,11,12,0.98))] px-5 py-4.5 sm:px-6 sm:py-5">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
             이 카드에서 볼 포인트
@@ -83,28 +93,28 @@ function MatchingMediaPanel({
           </span>
         </div>
 
-        <p className="mt-3 text-sm leading-6 break-keep text-white/62">
+        <p className="mt-2.5 text-sm leading-6 break-keep text-white/62">
           {candidateSummary}
         </p>
 
-        <div className="mt-4 grid gap-2.5 sm:grid-cols-3">
-          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3.5">
+        <div className="mt-3.5 grid gap-2.5 sm:grid-cols-3">
+          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3">
             <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
               평균 평점
             </p>
             <p className="mt-1.5 text-lg font-semibold text-white">
-              {candidate.rating?.toFixed(1) ?? 'N/A'}
+              {formatMatchingCandidateRating(candidate.rating)}
             </p>
           </div>
-          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3.5">
+          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3">
             <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
               미디어
             </p>
             <p className="mt-1.5 text-sm font-medium text-white/78">
-              {candidate.trailer_url ? '트레일러 제공' : '이미지 미리보기'}
+              {candidate.trailer_url ? '유튜브 트레일러' : '이미지 미리보기'}
             </p>
           </div>
-          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3.5">
+          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3">
             <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
               장르 감각
             </p>

--- a/src/features/matching/components/MatchingRatingStars.tsx
+++ b/src/features/matching/components/MatchingRatingStars.tsx
@@ -22,7 +22,7 @@ function MatchingRatingStars({ value, onRate }: MatchingRatingStarsProps) {
             onClick={() => onRate(ratingValue)}
             aria-label={`${ratingValue}점 선택`}
             aria-pressed={value === ratingValue}
-            className={`flex h-10 w-10 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
+            className={`flex h-9.5 w-9.5 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
               isActive
                 ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
                 : 'border-white/10 bg-white/[0.03] text-white/34 hover:border-white/18 hover:text-white/72'

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -22,6 +22,16 @@ import { extractApiErrorMessage } from '../../features/survey/api/survey';
 import { isMockServiceWorkerEnabled } from '../../lib/env';
 import { getAccessToken } from '../../utils/auth';
 
+const formatMatchingCandidateRating = (rating: number | null) => {
+  if (typeof rating !== 'number') {
+    return 'N/A';
+  }
+
+  const normalizedRating = rating <= 5 ? rating * 20 : rating;
+
+  return `${normalizedRating.toFixed(1)}점`;
+};
+
 function MatchingGenreDetailPage() {
   const { genreSlug } = useParams();
   const navigate = useNavigate();
@@ -185,7 +195,7 @@ function MatchingGenreDetailPage() {
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.12),transparent_24%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
       <Header fixed />
 
-      <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1120px] px-4 pt-[5.5rem] pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-[6.25rem] md:pb-14">
+      <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1120px] px-4 pt-[5.25rem] pb-8 sm:px-6 sm:pt-[5.6rem] sm:pb-10 md:px-8 md:pt-[5.9rem] md:pb-12">
         {!genre || !isValidGenreSlug ? (
           <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 sm:px-8 sm:py-12">
             <p className="text-sm font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
@@ -269,25 +279,35 @@ function MatchingGenreDetailPage() {
           </section>
         ) : (
           <section className="mx-auto max-w-[960px]">
+            <div className="mb-4 flex justify-start sm:mb-5">
+              <Link
+                to={`/${ROUTES.MATCHING_LIST}`}
+                className="mt-2 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2.5 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] sm:mt-3"
+              >
+                <ChevronLeft size={16} />
+                다른 장르 보기
+              </Link>
+            </div>
+
             <div className="text-center">
               <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
                 {safeIndex + 1} / {totalSteps} 단계
               </p>
-              <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[40px]">
+              <h1 className="mt-2.5 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[40px]">
                 매칭 과정을 따라가세요
               </h1>
-              <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
+              <p className="mt-2.5 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
                 트레일러와 분위기를 보며 {totalGamesLabel}에 별점을 남겨보세요.
                 좋아요는 마음에 든 게임을 표시해 두고 마이페이지에서도 다시
                 확인할 수 있게 함께 저장돼요.
               </p>
             </div>
 
-            <div className="mt-7">
+            <div className="mt-5">
               <MatchingGuideCards />
             </div>
 
-            <div className="mt-6 grid gap-4 lg:grid-cols-[1.08fr_0.92fr]">
+            <div className="mt-5 grid gap-4 lg:grid-cols-[1.08fr_0.92fr]">
               {currentCandidate ? (
                 <MatchingMediaPanel
                   candidate={currentCandidate}
@@ -297,13 +317,13 @@ function MatchingGenreDetailPage() {
               ) : null}
 
               {currentCandidate && currentEvaluation ? (
-                <article className="survey-panel flex flex-col px-5 py-6 sm:px-6">
+                <article className="survey-panel flex flex-col px-5 py-5 sm:px-6 sm:py-5">
                   <div className="flex items-start justify-between gap-4">
                     <div className="min-w-0 flex-1">
                       <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
                         Candidate {safeIndex + 1}
                       </p>
-                      <h2 className="mt-2.5 text-2xl font-semibold tracking-[-0.02em] break-keep text-white sm:text-[28px]">
+                      <h2 className="mt-2 text-2xl font-semibold tracking-[-0.02em] break-keep text-white sm:text-[28px]">
                         {currentCandidate.title}
                       </h2>
                     </div>
@@ -331,23 +351,24 @@ function MatchingGenreDetailPage() {
                     </button>
                   </div>
 
-                  <div className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-white/46">
+                  <div className="mt-2.5 flex flex-wrap items-center gap-1.5 text-xs text-white/46">
                     <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
                       장르 {currentCandidate.genres.join(' · ')}
                     </span>
                     <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
-                      평균 평점 {currentCandidate.rating?.toFixed(1) ?? 'N/A'}
+                      평균 평점{' '}
+                      {formatMatchingCandidateRating(currentCandidate.rating)}
                     </span>
                   </div>
 
-                  <div className="mt-6">
+                  <div className="mt-5">
                     <p className="text-sm font-semibold text-white">
                       이 게임이 내 취향에 얼마나 가까운가요?
                     </p>
-                    <p className="mt-1.5 text-sm leading-6 break-keep text-white/55">
+                    <p className="mt-1 text-sm leading-6 break-keep text-white/55">
                       별점은 추천을 더 정교하게 만드는 선호도 평가로 반영돼요.
                     </p>
-                    <div className="mt-4">
+                    <div className="mt-3.5">
                       <MatchingRatingStars
                         value={currentEvaluation.rating}
                         onRate={(rating) =>
@@ -357,7 +378,7 @@ function MatchingGenreDetailPage() {
                     </div>
                   </div>
 
-                  <div className="mt-6 rounded-[20px] border border-white/8 bg-white/[0.03] px-4 py-4">
+                  <div className="mt-5 rounded-[20px] border border-white/8 bg-white/[0.03] px-4 py-3.5">
                     <p className="text-sm leading-7 break-keep text-white/64">
                       {isLastCard
                         ? currentEvaluation.rating === null
@@ -370,14 +391,14 @@ function MatchingGenreDetailPage() {
                   </div>
 
                   {submitErrorMessage ? (
-                    <p className="mt-3 text-sm leading-6 break-keep text-[#ffc2c2]">
+                    <p className="mt-2.5 text-sm leading-6 break-keep text-[#ffc2c2]">
                       {submitErrorMessage}
                     </p>
                   ) : null}
 
                   {isLastCard ? (
-                    <div className="mt-auto pt-6">
-                      <p className="mx-auto mb-3 w-full max-w-[420px] text-center text-sm leading-6 break-keep text-white/42">
+                    <div className="mt-auto pt-5">
+                      <p className="mx-auto mb-2.5 w-full max-w-[420px] text-center text-sm leading-6 break-keep text-white/42">
                         {totalSteps}개 게임의 선호도 평가가 모두 준비되면 제출할
                         수 있어요.
                       </p>
@@ -412,7 +433,7 @@ function MatchingGenreDetailPage() {
                       </div>
                     </div>
                   ) : (
-                    <div className="mt-auto flex flex-wrap items-end justify-between gap-3 pt-6">
+                    <div className="mt-auto flex flex-wrap items-end justify-between gap-3 pt-5">
                       <button
                         type="button"
                         onClick={goPrevious}
@@ -436,16 +457,6 @@ function MatchingGenreDetailPage() {
                   )}
                 </article>
               ) : null}
-            </div>
-
-            <div className="mt-6 flex flex-wrap justify-center gap-3">
-              <Link
-                to={`/${ROUTES.MATCHING_LIST}`}
-                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
-              >
-                <ChevronLeft size={16} />
-                다른 장르 보기
-              </Link>
             </div>
           </section>
         )}

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -278,132 +278,163 @@ function MatchingGenreDetailPage() {
             </Link>
           </section>
         ) : (
-          <section className="mx-auto max-w-[960px]">
-            <div className="mb-4 flex justify-start sm:mb-5">
+          <>
+            <div className="pointer-events-none absolute top-[4.85rem] left-1/2 z-20 w-screen -translate-x-1/2 pr-[clamp(1rem,5vw,20rem)] pl-[clamp(0.35rem,3vw,20rem)] sm:top-[5.15rem] md:top-[5.35rem]">
               <Link
                 to={`/${ROUTES.MATCHING_LIST}`}
-                className="mt-2 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2.5 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] sm:mt-3"
+                className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
               >
                 <ChevronLeft size={16} />
                 다른 장르 보기
               </Link>
             </div>
 
-            <div className="text-center">
-              <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
-                {safeIndex + 1} / {totalSteps} 단계
-              </p>
-              <h1 className="mt-2.5 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[40px]">
-                매칭 과정을 따라가세요
-              </h1>
-              <p className="mt-2.5 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
-                트레일러와 분위기를 보며 {totalGamesLabel}에 별점을 남겨보세요.
-                좋아요는 마음에 든 게임을 표시해 두고 마이페이지에서도 다시
-                확인할 수 있게 함께 저장돼요.
-              </p>
-            </div>
+            <section className="mx-auto max-w-[960px]">
+              <div className="text-center">
+                <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
+                  {safeIndex + 1} / {totalSteps} 단계
+                </p>
+                <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[40px]">
+                  매칭 과정을 따라가세요
+                </h1>
+                <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
+                  트레일러와 분위기를 보며 {totalGamesLabel}에 별점을
+                  남겨보세요. 좋아요는 마음에 든 게임을 표시해 두고
+                  마이페이지에서도 다시 확인할 수 있게 함께 저장돼요.
+                </p>
+              </div>
 
-            <div className="mt-5">
-              <MatchingGuideCards />
-            </div>
+              <div className="mt-7">
+                <MatchingGuideCards />
+              </div>
 
-            <div className="mt-5 grid gap-4 lg:grid-cols-[1.08fr_0.92fr]">
-              {currentCandidate ? (
-                <MatchingMediaPanel
-                  candidate={currentCandidate}
-                  genreTitle={genre.title}
-                  stepLabel={`${safeIndex + 1} / ${totalSteps} 단계`}
-                />
-              ) : null}
+              <div className="mt-6 grid gap-4 lg:grid-cols-[1.08fr_0.92fr]">
+                {currentCandidate ? (
+                  <MatchingMediaPanel
+                    candidate={currentCandidate}
+                    genreTitle={genre.title}
+                    stepLabel={`${safeIndex + 1} / ${totalSteps} 단계`}
+                  />
+                ) : null}
 
-              {currentCandidate && currentEvaluation ? (
-                <article className="survey-panel flex flex-col px-5 py-5 sm:px-6 sm:py-5">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0 flex-1">
-                      <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
-                        Candidate {safeIndex + 1}
-                      </p>
-                      <h2 className="mt-2 text-2xl font-semibold tracking-[-0.02em] break-keep text-white sm:text-[28px]">
-                        {currentCandidate.title}
-                      </h2>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => toggleLiked(currentCandidate.game_id)}
-                      aria-pressed={currentEvaluation.isLiked}
-                      aria-label={
-                        currentEvaluation.isLiked
-                          ? '좋아요 해제'
-                          : '좋아요 추가'
-                      }
-                      className={`mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center self-start rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
-                        currentEvaluation.isLiked
-                          ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
-                          : 'border-white/10 bg-white/[0.03] text-white/54 hover:border-white/20 hover:text-white/80'
-                      }`}
-                    >
-                      <Heart
-                        size={20}
-                        fill={
-                          currentEvaluation.isLiked ? 'currentColor' : 'none'
+                {currentCandidate && currentEvaluation ? (
+                  <article className="survey-panel flex flex-col px-5 py-5 sm:px-6 sm:py-5">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0 flex-1">
+                        <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
+                          Candidate {safeIndex + 1}
+                        </p>
+                        <h2 className="mt-2 text-2xl font-semibold tracking-[-0.02em] break-keep text-white sm:text-[28px]">
+                          {currentCandidate.title}
+                        </h2>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => toggleLiked(currentCandidate.game_id)}
+                        aria-pressed={currentEvaluation.isLiked}
+                        aria-label={
+                          currentEvaluation.isLiked
+                            ? '좋아요 해제'
+                            : '좋아요 추가'
                         }
-                      />
-                    </button>
-                  </div>
-
-                  <div className="mt-2.5 flex flex-wrap items-center gap-1.5 text-xs text-white/46">
-                    <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
-                      장르 {currentCandidate.genres.join(' · ')}
-                    </span>
-                    <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
-                      평균 평점{' '}
-                      {formatMatchingCandidateRating(currentCandidate.rating)}
-                    </span>
-                  </div>
-
-                  <div className="mt-5">
-                    <p className="text-sm font-semibold text-white">
-                      이 게임이 내 취향에 얼마나 가까운가요?
-                    </p>
-                    <p className="mt-1 text-sm leading-6 break-keep text-white/55">
-                      별점은 추천을 더 정교하게 만드는 선호도 평가로 반영돼요.
-                    </p>
-                    <div className="mt-3.5">
-                      <MatchingRatingStars
-                        value={currentEvaluation.rating}
-                        onRate={(rating) =>
-                          setRating(currentCandidate.game_id, rating)
-                        }
-                      />
+                        className={`mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center self-start rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
+                          currentEvaluation.isLiked
+                            ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
+                            : 'border-white/10 bg-white/[0.03] text-white/54 hover:border-white/20 hover:text-white/80'
+                        }`}
+                      >
+                        <Heart
+                          size={20}
+                          fill={
+                            currentEvaluation.isLiked ? 'currentColor' : 'none'
+                          }
+                        />
+                      </button>
                     </div>
-                  </div>
 
-                  <div className="mt-5 rounded-[20px] border border-white/8 bg-white/[0.03] px-4 py-3.5">
-                    <p className="text-sm leading-7 break-keep text-white/64">
-                      {isLastCard
-                        ? currentEvaluation.rating === null
-                          ? '마지막 후보예요. 별점을 남기면 지금까지의 선호도 평가를 제출하고 추천 결과로 바로 이어갈 수 있어요.'
-                          : '모든 선호도 평가가 준비됐어요. 제출하면 취향에 맞는 추천 결과를 바로 확인할 수 있어요.'
-                        : currentEvaluation.rating === null
-                          ? '트레일러와 분위기를 보고 지금 카드의 별점을 남겨 주세요.'
-                          : '별점은 취향 분석에 반영되고, 좋아요는 마이페이지에서 다시 볼 게임을 표시해 두는 용도로 저장돼요.'}
-                    </p>
-                  </div>
+                    <div className="mt-2.5 flex flex-wrap items-center gap-1.5 text-xs text-white/46">
+                      <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
+                        장르 {currentCandidate.genres.join(' · ')}
+                      </span>
+                      <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
+                        평균 평점{' '}
+                        {formatMatchingCandidateRating(currentCandidate.rating)}
+                      </span>
+                    </div>
 
-                  {submitErrorMessage ? (
-                    <p className="mt-2.5 text-sm leading-6 break-keep text-[#ffc2c2]">
-                      {submitErrorMessage}
-                    </p>
-                  ) : null}
-
-                  {isLastCard ? (
-                    <div className="mt-auto pt-5">
-                      <p className="mx-auto mb-2.5 w-full max-w-[420px] text-center text-sm leading-6 break-keep text-white/42">
-                        {totalSteps}개 게임의 선호도 평가가 모두 준비되면 제출할
-                        수 있어요.
+                    <div className="mt-5">
+                      <p className="text-sm font-semibold text-white">
+                        이 게임이 내 취향에 얼마나 가까운가요?
                       </p>
+                      <p className="mt-1 text-sm leading-6 break-keep text-white/55">
+                        별점은 추천을 더 정교하게 만드는 선호도 평가로 반영돼요.
+                      </p>
+                      <div className="mt-3.5">
+                        <MatchingRatingStars
+                          value={currentEvaluation.rating}
+                          onRate={(rating) =>
+                            setRating(currentCandidate.game_id, rating)
+                          }
+                        />
+                      </div>
+                    </div>
 
-                      <div className="flex flex-wrap items-end justify-between gap-3">
+                    <div className="mt-5 rounded-[20px] border border-white/8 bg-white/[0.03] px-4 py-3.5">
+                      <p className="text-sm leading-7 break-keep text-white/64">
+                        {isLastCard
+                          ? currentEvaluation.rating === null
+                            ? '마지막 후보예요. 별점을 남기면 지금까지의 선호도 평가를 제출하고 추천 결과로 바로 이어갈 수 있어요.'
+                            : '모든 선호도 평가가 준비됐어요. 제출하면 취향에 맞는 추천 결과를 바로 확인할 수 있어요.'
+                          : currentEvaluation.rating === null
+                            ? '트레일러와 분위기를 보고 지금 카드의 별점을 남겨 주세요.'
+                            : '별점은 취향 분석에 반영되고, 좋아요는 마이페이지에서 다시 볼 게임을 표시해 두는 용도로 저장돼요.'}
+                      </p>
+                    </div>
+
+                    {submitErrorMessage ? (
+                      <p className="mt-2.5 text-sm leading-6 break-keep text-[#ffc2c2]">
+                        {submitErrorMessage}
+                      </p>
+                    ) : null}
+
+                    {isLastCard ? (
+                      <div className="mt-auto pt-5">
+                        <p className="mx-auto mb-2.5 w-full max-w-[420px] text-center text-sm leading-6 break-keep text-white/42">
+                          {totalSteps}개 게임의 선호도 평가가 모두 준비되면
+                          제출할 수 있어요.
+                        </p>
+
+                        <div className="flex flex-wrap items-end justify-between gap-3">
+                          <button
+                            type="button"
+                            onClick={goPrevious}
+                            disabled={!canGoPrevious}
+                            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/[0.02] disabled:text-white/28"
+                          >
+                            <ChevronLeft size={16} />
+                            이전
+                          </button>
+
+                          <button
+                            type="button"
+                            onClick={() => void handleSubmit()}
+                            disabled={
+                              !allCandidatesRated ||
+                              submitMatchResponsesMutation.isPending
+                            }
+                            className="inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212] disabled:cursor-not-allowed disabled:bg-[#5c1a1a] disabled:text-white/44"
+                          >
+                            {submitMatchResponsesMutation.isPending
+                              ? '제출 중...'
+                              : '제출하기'}
+                            {!submitMatchResponsesMutation.isPending ? (
+                              <ChevronRight size={16} />
+                            ) : null}
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="mt-auto flex flex-wrap items-end justify-between gap-3 pt-5">
                         <button
                           type="button"
                           onClick={goPrevious}
@@ -416,49 +447,20 @@ function MatchingGenreDetailPage() {
 
                         <button
                           type="button"
-                          onClick={() => void handleSubmit()}
-                          disabled={
-                            !allCandidatesRated ||
-                            submitMatchResponsesMutation.isPending
-                          }
+                          onClick={goNext}
+                          disabled={!hasSelectedRating}
                           className="inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212] disabled:cursor-not-allowed disabled:bg-[#5c1a1a] disabled:text-white/44"
                         >
-                          {submitMatchResponsesMutation.isPending
-                            ? '제출 중...'
-                            : '제출하기'}
-                          {!submitMatchResponsesMutation.isPending ? (
-                            <ChevronRight size={16} />
-                          ) : null}
+                          다음
+                          <ChevronRight size={16} />
                         </button>
                       </div>
-                    </div>
-                  ) : (
-                    <div className="mt-auto flex flex-wrap items-end justify-between gap-3 pt-5">
-                      <button
-                        type="button"
-                        onClick={goPrevious}
-                        disabled={!canGoPrevious}
-                        className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/[0.02] disabled:text-white/28"
-                      >
-                        <ChevronLeft size={16} />
-                        이전
-                      </button>
-
-                      <button
-                        type="button"
-                        onClick={goNext}
-                        disabled={!hasSelectedRating}
-                        className="inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212] disabled:cursor-not-allowed disabled:bg-[#5c1a1a] disabled:text-white/44"
-                      >
-                        다음
-                        <ChevronRight size={16} />
-                      </button>
-                    </div>
-                  )}
-                </article>
-              ) : null}
-            </div>
-          </section>
+                    )}
+                  </article>
+                ) : null}
+              </div>
+            </section>
+          </>
         )}
       </main>
     </div>


### PR DESCRIPTION
## 관련 이슈

- closes #182 

## 변경 내용

- 매칭 상세 화면의 `다른 장르 보기` 동선을 하단에서 상단 왼쪽으로 이동
- 버튼 위치 조정에 맞춰 상세 화면 세로 밀도를 조금 더 압축해 스크롤 부담을 줄이도록 정리
- 가이드 카드, 미디어 패널, 별점 영역의 간격과 높이를 소폭 조정
- 매칭 후보 평균 평점을 100점 스케일 + 소수점 1자리 기준으로 표시되도록 수정
- `이 카드에서 볼 포인트` 영역의 미디어 문구를 `유튜브 트레일러` 기준으로 정리
- 매칭 상세 화면 오른쪽 패널의 평점 표시도 동일한 100점 스케일 기준으로 맞춤


## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="1708" height="894" alt="스크린샷 2026-04-22 오후 4 37 04" src="https://github.com/user-attachments/assets/75d47d92-928e-4263-ae73-622cd834cff6" />


## 참고사항

- 매칭 결과 mock이 평가한 후보를 그대로 재사용하는 문제는 별도 PR에서 분리해 수정할 예정입니다.
