### PR TITLE
[Fix] 메인 CTA 디자인 및 첫 화면 레이아웃 정리

### DIFF
--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -504,11 +504,11 @@ const RecommendationCta = ({
       <div
         role="img"
         aria-label={iconLabel}
-        className="flex h-12 w-12 items-center justify-center rounded-lg border border-[#5a1115]/70 bg-[#1f0809] text-[#ff4b55] shadow-[inset_0_0_22px_rgba(255,75,85,0.12),0_12px_28px_rgba(0,0,0,0.24)] sm:h-14 sm:w-14"
+        className="flex h-16 w-16 items-center justify-center text-[#d20b12] sm:h-18 sm:w-18"
       >
-        <Icon aria-hidden="true" className="h-6 w-6 sm:h-7 sm:w-7" />
+        <Icon aria-hidden="true" className="h-8 w-8 sm:h-9 sm:w-9" />
       </div>
-      <h3 className="mt-7 text-2xl leading-tight font-bold sm:text-3xl lg:mt-5 lg:text-[28px]">
+      <h3 className="mt-4 text-2xl leading-tight font-bold sm:text-3xl lg:mt-3 lg:text-[28px]">
         {title}
       </h3>
       <p className="mt-5 max-w-xl text-sm leading-6 text-white/70 sm:text-base lg:mt-3 lg:text-[15px] lg:leading-6">


### PR DESCRIPTION
## 관련 이슈

- closes #186 

## 변경 내용

- 메인 페이지 데스크톱 첫 화면 세로 간격을 재배치했습니다.
- 헤더와 상단 필터 영역 간격을 넓히고, Swiper와 CTA 섹션 간격을 줄였습니다.
- CTA 카드의 데스크톱 높이와 내부 세로 간격을 조정했습니다.
- CTA 문구를 현재 UX 톤에 맞게 정리했습니다.
  - 설문 조사 하러가기 -> 설문 시작
  - 매칭 시작 / 장르별 매칭 제목-버튼 문구 정리
- CTA 아이콘을 배경/테두리 없이 브랜드 레드 단색으로 정리했습니다.
- CTA 아이콘 크기와 아이콘-제목 간 간격을 조정했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="2032" height="1162" alt="스크린샷 2026-04-22 오후 2 33 16" src="https://github.com/user-attachments/assets/f943a65f-3b2d-497f-82c6-98540c7ef4bf" />

## 참고사항

- 모바일/태블릿은 기존처럼 자연스러운 세로 스크롤을 유지합니다.
- 이번 PR은 메인 CTA 디자인과 데스크톱 첫 화면 세로 리듬 정리에 집중했습니다.
