### PR TITLE
[Feat] 게임 검색 무한스크롤 구현 및 윈도우 포커스 블러 버그 수정

### DIFF
--- a/src/features/games/gameApi.ts
+++ b/src/features/games/gameApi.ts
@@ -10,6 +10,7 @@ import type {
   RawGameLikeResponse,
   RawGameListItem,
   SearchGamesParams,
+  SearchGamesResult,
 } from './types';
 
 const DEFAULT_PAGE_SIZE = 20;
@@ -79,15 +80,16 @@ export const getTopGames = async ({
 
 export const searchGames = async ({
   search,
+  fuzzy = true,
   genre = '전체',
   page = 1,
   pageSize = DEFAULT_PAGE_SIZE,
   sort = DEFAULT_SORT,
-}: SearchGamesParams): Promise<GameListItem[]> => {
+}: SearchGamesParams): Promise<SearchGamesResult> => {
   const response = await api.get<GameListResponse>('/api/v1/games/list', {
     params: {
       search,
-      fuzzy: true,
+      fuzzy,
       sort,
       page,
       page_size: pageSize,
@@ -95,7 +97,10 @@ export const searchGames = async ({
     },
   });
 
-  return response.data.results.map(normalizeGameListItem);
+  return {
+    count: response.data.count ?? response.data.results.length,
+    results: response.data.results.map(normalizeGameListItem),
+  };
 };
 
 export const getGameDetail = async (gameId: number): Promise<GameDetail> => {

--- a/src/features/games/mocks/handlers.ts
+++ b/src/features/games/mocks/handlers.ts
@@ -18,12 +18,17 @@ import type {
 
 const DEFAULT_GAME_PAGE_SIZE = 20;
 const DEFAULT_GAME_SORT = 'rating_desc';
+const VALID_GAME_SORT_VALUES = new Set([
+  'rating_desc',
+  'like_desc',
+  'created_at',
+]);
 const validGenreIds = new Set(Object.values(GAME_GENRE_ID_MAP));
 
 const getErrorResponse = (status: number, message: string) =>
   HttpResponse.json(
     {
-      detail: message,
+      error_detail: message,
     },
     { status },
   );
@@ -98,7 +103,7 @@ export const gamesHandlers = [
     const genreId = parseGenreId(url.searchParams.get('genre_id'));
 
     if (genreIdValue && (!genreId || !validGenreIds.has(genreId))) {
-      return getErrorResponse(400, '유효하지 않은 genre_id 입니다.');
+      return getErrorResponse(400, '유효하지 않은 genre_id 입니다. (1~14)');
     }
 
     const games = getStoredTop100Games({ genreId });
@@ -106,7 +111,6 @@ export const gamesHandlers = [
     await delay(250);
 
     return HttpResponse.json({
-      count: games.length,
       ranked_at: '2026-04-21T00:00:00.000Z',
       results: games.map(toRawGameListItem),
     });
@@ -115,14 +119,10 @@ export const gamesHandlers = [
   http.get('/api/v1/games/list', async ({ request }) => {
     const url = new URL(request.url);
     const search = url.searchParams.get('search') ?? '';
+    const fuzzy = url.searchParams.get('fuzzy') !== 'false';
     const genreIdValue = url.searchParams.get('genre_id');
     const genreId = parseGenreId(genreIdValue);
-    const sort =
-      (url.searchParams.get('sort') as
-        | 'rating_desc'
-        | 'like_desc'
-        | 'created_at'
-        | null) ?? DEFAULT_GAME_SORT;
+    const sortValue = url.searchParams.get('sort');
     const page = parsePositiveInteger(url.searchParams.get('page'), 1);
     const pageSize = parsePositiveInteger(
       url.searchParams.get('page_size'),
@@ -130,16 +130,23 @@ export const gamesHandlers = [
     );
 
     if (genreIdValue && (!genreId || !validGenreIds.has(genreId))) {
-      return getErrorResponse(400, '유효하지 않은 genre_id 입니다.');
+      return getErrorResponse(400, '유효하지 않은 genre_id 입니다. (1~14)');
+    }
+
+    if (sortValue && !VALID_GAME_SORT_VALUES.has(sortValue)) {
+      return getErrorResponse(
+        400,
+        '유효하지 않은 sort 값입니다. (rating_desc, like_desc, created_at)',
+      );
     }
 
     const { count, results } = searchStoredGames({
       search,
+      fuzzy,
       genreId,
       sort:
-        sort === 'like_desc' || sort === 'created_at' || sort === 'rating_desc'
-          ? sort
-          : DEFAULT_GAME_SORT,
+        (sortValue as 'rating_desc' | 'like_desc' | 'created_at' | null) ??
+        DEFAULT_GAME_SORT,
       page,
       pageSize,
     });
@@ -162,7 +169,7 @@ export const gamesHandlers = [
     const detail = getStoredGameDetail(gameId);
 
     if (!detail) {
-      return getErrorResponse(404, '해당 게임 상세 정보를 찾을 수 없습니다.');
+      return getErrorResponse(404, '해당 게임을 찾을 수 없습니다.');
     }
 
     await delay(220);

--- a/src/features/games/mocks/state.ts
+++ b/src/features/games/mocks/state.ts
@@ -5,6 +5,7 @@ import {
 } from '../genres';
 import { mockGameDetails } from '../mockGameDetails';
 import { mockTopGames } from '../mockGames';
+import { createSearchKeyword, type SearchKeyword } from '../search';
 import type { GameDetail, GameListItem, GameLikeResponse } from '../types';
 
 const steamStoreUrl = (gameId: number) =>
@@ -17,7 +18,140 @@ const genreIdToFilterMap = new Map<number, GameGenreFilter>(
   ]),
 );
 
-const normalizeSearchKeyword = (value: string) => value.trim().toLowerCase();
+const getFuzzySearchDistance = (value: string) => {
+  if (value.length < 3) {
+    return 0;
+  }
+
+  if (value.length < 7) {
+    return 1;
+  }
+
+  return 2;
+};
+
+const getLevenshteinDistance = (
+  source: string,
+  target: string,
+  maxDistance: number,
+) => {
+  const sourceLength = source.length;
+  const targetLength = target.length;
+
+  if (Math.abs(sourceLength - targetLength) > maxDistance) {
+    return maxDistance + 1;
+  }
+
+  const previous = Array.from(
+    { length: targetLength + 1 },
+    (_, index) => index,
+  );
+  const current = new Array<number>(targetLength + 1).fill(0);
+
+  for (let sourceIndex = 1; sourceIndex <= sourceLength; sourceIndex += 1) {
+    current[0] = sourceIndex;
+    let rowMin = current[0];
+
+    for (let targetIndex = 1; targetIndex <= targetLength; targetIndex += 1) {
+      const substitutionCost =
+        source[sourceIndex - 1] === target[targetIndex - 1] ? 0 : 1;
+
+      current[targetIndex] = Math.min(
+        previous[targetIndex] + 1,
+        current[targetIndex - 1] + 1,
+        previous[targetIndex - 1] + substitutionCost,
+      );
+
+      rowMin = Math.min(rowMin, current[targetIndex]);
+    }
+
+    if (rowMin > maxDistance) {
+      return maxDistance + 1;
+    }
+
+    previous.splice(0, previous.length, ...current);
+  }
+
+  return previous[targetLength];
+};
+
+const includesFuzzyText = (
+  haystack: string,
+  needle: string,
+  maxDistance: number,
+) => {
+  if (!needle) {
+    return true;
+  }
+
+  if (!haystack || haystack.length < needle.length - maxDistance) {
+    return false;
+  }
+
+  if (haystack.includes(needle)) {
+    return true;
+  }
+
+  const minimumLength = Math.max(1, needle.length - maxDistance);
+  const maximumLength = Math.min(haystack.length, needle.length + maxDistance);
+
+  for (
+    let candidateLength = minimumLength;
+    candidateLength <= maximumLength;
+    candidateLength += 1
+  ) {
+    for (
+      let startIndex = 0;
+      startIndex <= haystack.length - candidateLength;
+      startIndex += 1
+    ) {
+      const candidate = haystack.slice(
+        startIndex,
+        startIndex + candidateLength,
+      );
+
+      if (
+        getLevenshteinDistance(candidate, needle, maxDistance) <= maxDistance
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const matchesSearchKeyword = (
+  candidate: SearchKeyword,
+  keyword: SearchKeyword,
+  fuzzy: boolean,
+) => {
+  if (!keyword.normalized) {
+    return true;
+  }
+
+  if (
+    candidate.normalized.includes(keyword.normalized) ||
+    candidate.collapsed.includes(keyword.collapsed) ||
+    candidate.stripped.includes(keyword.stripped)
+  ) {
+    return true;
+  }
+
+  if (!fuzzy) {
+    return false;
+  }
+
+  const fuzzySource = keyword.stripped || keyword.collapsed;
+  const fuzzyTarget = candidate.stripped || candidate.collapsed;
+  const maxDistance = getFuzzySearchDistance(fuzzySource);
+
+  if (!fuzzySource || !fuzzyTarget || maxDistance === 0) {
+    return false;
+  }
+
+  return includesFuzzyText(fuzzyTarget, fuzzySource, maxDistance);
+};
 
 const cloneGameDetail = (detail: GameDetail): GameDetail => ({
   ...detail,
@@ -140,19 +274,23 @@ const sortGames = (
 
 const filterGames = ({
   search = '',
+  fuzzy = true,
   genreId,
 }: {
   search?: string;
+  fuzzy?: boolean;
   genreId?: number;
 }) => {
-  const normalizedSearch = normalizeSearchKeyword(search);
+  const searchKeyword = createSearchKeyword(search);
   const selectedGenre = getGenreFilterById(genreId);
 
   return getHydratedTopGames().filter((game) => {
     const matchesSearch =
-      !normalizedSearch ||
-      [game.name, ...game.genres].some((keyword) =>
-        keyword.toLowerCase().includes(normalizedSearch),
+      !searchKeyword.normalized ||
+      matchesSearchKeyword(
+        createSearchKeyword(game.name),
+        searchKeyword,
+        fuzzy,
       );
     const matchesGenre = selectedGenre
       ? matchesGenreFilter(game.genres, selectedGenre)
@@ -167,18 +305,23 @@ export const getStoredTop100Games = ({ genreId }: { genreId?: number } = {}) =>
 
 export const searchStoredGames = ({
   search = '',
+  fuzzy = true,
   genreId,
   sort = 'rating_desc',
   page = 1,
   pageSize = 20,
 }: {
   search?: string;
+  fuzzy?: boolean;
   genreId?: number;
   sort?: 'rating_desc' | 'like_desc' | 'created_at';
   page?: number;
   pageSize?: number;
 }) => {
-  const filteredGames = sortGames(filterGames({ search, genreId }), sort);
+  const filteredGames = sortGames(
+    filterGames({ search, fuzzy, genreId }),
+    sort,
+  );
   const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
   const safePageSize =
     Number.isFinite(pageSize) && pageSize > 0 ? Math.floor(pageSize) : 20;

--- a/src/features/games/search.ts
+++ b/src/features/games/search.ts
@@ -1,0 +1,21 @@
+const SEARCH_WHITESPACE_REGEX = /\s+/g;
+const SEARCH_NOISE_REGEX = /[\s\p{P}\p{S}]+/gu;
+
+export type SearchKeyword = {
+  normalized: string;
+  collapsed: string;
+  stripped: string;
+};
+
+export const normalizeSearchText = (value: string) =>
+  value.normalize('NFKC').replace(SEARCH_WHITESPACE_REGEX, ' ').trim();
+
+export const createSearchKeyword = (value: string): SearchKeyword => {
+  const normalized = normalizeSearchText(value).toLowerCase();
+
+  return {
+    normalized,
+    collapsed: normalized.replace(SEARCH_WHITESPACE_REGEX, ''),
+    stripped: normalized.replace(SEARCH_NOISE_REGEX, ''),
+  };
+};

--- a/src/features/games/types.ts
+++ b/src/features/games/types.ts
@@ -84,8 +84,14 @@ export type GetTopGamesParams = {
 
 export type SearchGamesParams = {
   search: string;
+  fuzzy?: boolean;
   genre?: GameGenreFilter;
   page?: number;
   pageSize?: number;
   sort?: 'rating_desc' | 'like_desc' | 'created_at';
+};
+
+export type SearchGamesResult = {
+  count: number;
+  results: GameListItem[];
 };

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -7,7 +7,7 @@ import {
   Search,
 } from 'lucide-react';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import type { Swiper as SwiperInstance } from 'swiper';
@@ -23,11 +23,13 @@ import {
 import { getTopGames, searchGames } from '../../features/games/gameApi';
 import { GAME_GENRE_FILTERS } from '../../features/games/genres';
 import { useDebouncedValue } from '../../features/games/hooks/useDebouncedValue';
+import { normalizeSearchText } from '../../features/games/search';
 import type { GameListItem } from '../../features/games/types';
 import type { GameGenreFilter } from '../../features/games/genres';
 import 'swiper/swiper.css';
 
 const SEARCH_DEBOUNCE_MS = 300;
+const SEARCH_RESULT_PAGE_SIZE = 20;
 const GENRE_FILTER_MENU_ID = 'game-genre-filter-menu';
 const CTA_PENDING_MESSAGE = '준비 중입니다.';
 const GAME_CARD_SWIPER_BREAKPOINTS = {
@@ -64,26 +66,62 @@ const MainPage = () => {
   const [selectedGenre, setSelectedGenre] = useState<GameGenreFilter>('전체');
   const [selectedGame, setSelectedGame] = useState<GameListItem | null>(null);
   const debouncedSearchText = useDebouncedValue(
-    searchText.trim(),
+    normalizeSearchText(searchText),
     SEARCH_DEBOUNCE_MS,
   );
   const isSearchMode = debouncedSearchText.length > 0;
 
-  const gamesQuery = useQuery({
-    queryKey: [
-      'games',
-      isSearchMode ? 'search' : 'top100',
-      debouncedSearchText,
-      selectedGenre,
-    ],
-    queryFn: () =>
-      isSearchMode
-        ? searchGames({ search: debouncedSearchText, genre: selectedGenre })
-        : getTopGames({ genre: selectedGenre }),
+  const topGamesQuery = useQuery({
+    queryKey: ['games', 'top100', selectedGenre],
+    enabled: !isSearchMode,
+    queryFn: () => getTopGames({ genre: selectedGenre }),
     staleTime: 60_000,
+    refetchOnWindowFocus: false,
   });
 
-  const games = gamesQuery.data ?? [];
+  const searchGamesQuery = useInfiniteQuery({
+    queryKey: ['games', 'search', debouncedSearchText, selectedGenre],
+    enabled: isSearchMode,
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) =>
+      searchGames({
+        search: debouncedSearchText,
+        genre: selectedGenre,
+        page: pageParam,
+        pageSize: SEARCH_RESULT_PAGE_SIZE,
+      }),
+    getNextPageParam: (lastPage, allPages) => {
+      const loadedCount = allPages.reduce(
+        (count, page) => count + page.results.length,
+        0,
+      );
+
+      if (loadedCount >= lastPage.count) {
+        return undefined;
+      }
+
+      return allPages.length + 1;
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const games = isSearchMode
+    ? (searchGamesQuery.data?.pages.flatMap((page) => page.results) ?? [])
+    : (topGamesQuery.data ?? []);
+  const isGamesLoading = isSearchMode
+    ? searchGamesQuery.isLoading
+    : topGamesQuery.isLoading;
+  const isGamesUpdating = isSearchMode
+    ? searchGamesQuery.isFetching &&
+      !searchGamesQuery.isLoading &&
+      !searchGamesQuery.isFetchingNextPage
+    : topGamesQuery.isFetching;
+  const hasMoreSearchResults = isSearchMode
+    ? Boolean(
+        searchGamesQuery.hasNextPage || searchGamesQuery.isFetchingNextPage,
+      )
+    : false;
   const sectionTitle = isSearchMode
     ? `"${debouncedSearchText}" 검색 결과`
     : '인기 TOP 100 🔥';
@@ -121,15 +159,23 @@ const MainPage = () => {
           </div>
 
           <div className="mt-4 sm:mt-5 lg:mt-4">
-            {gamesQuery.isLoading ? (
+            {isGamesLoading ? (
               <GameCardSkeletonList />
             ) : games.length > 0 ? (
-              <GameCarousel
-                key={`${debouncedSearchText}-${selectedGenre}`}
-                games={games}
-                onSelectGame={setSelectedGame}
-                showUpdatingOverlay={gamesQuery.isFetching}
-              />
+              <>
+                <GameCarousel
+                  key={`${debouncedSearchText}-${selectedGenre}`}
+                  games={games}
+                  onSelectGame={setSelectedGame}
+                  showUpdatingOverlay={isGamesUpdating}
+                />
+                {hasMoreSearchResults ? (
+                  <SearchResultMoreAction
+                    isLoading={searchGamesQuery.isFetchingNextPage}
+                    onClick={() => void searchGamesQuery.fetchNextPage()}
+                  />
+                ) : null}
+              </>
             ) : (
               <EmptyGameList
                 isFiltered={isSearchMode || selectedGenre !== '전체'}
@@ -168,6 +214,30 @@ const MainPage = () => {
     </div>
   );
 };
+
+type SearchResultMoreActionProps = {
+  isLoading: boolean;
+  onClick: () => void;
+};
+
+const SearchResultMoreAction = ({
+  isLoading,
+  onClick,
+}: SearchResultMoreActionProps) => (
+  <div className="mt-4 flex justify-end px-[clamp(1rem,5vw,20rem)]">
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isLoading}
+      className="inline-flex min-w-30 cursor-pointer items-center justify-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white/82 transition hover:border-[#6f2525] hover:bg-[#160b0b] hover:text-white disabled:cursor-not-allowed disabled:opacity-45"
+    >
+      {isLoading ? '불러오는 중...' : '더보기'}
+      {!isLoading ? (
+        <ChevronRight aria-hidden="true" className="h-4 w-4" />
+      ) : null}
+    </button>
+  </div>
+);
 
 type GenreFilterProps = {
   selectedGenre: GameGenreFilter;


### PR DESCRIPTION
## 관련 이슈

- closes #188

## 변경 내용

- `search.ts` 신규: `normalizeSearchText`(한글 자모 정규화), `createSearchKeyword` 유틸 분리
- `types.ts`: `SearchGamesResult` 타입 추가 (`count` + `results`)
- `gameApi.ts`: `searchGames`에서 중복 정규화 제거, 반환 타입을 `SearchGamesResult`로 변경
- `MainPage.tsx`: 단일 쿼리를 `topGamesQuery`(useQuery) / `searchGamesQuery`(useInfiniteQuery)로 분리, `refetchOnWindowFocus: false` 적용
- `mocks/state.ts`: Levenshtein distance 기반 fuzzy 검색 로직 추가 (`getLevenshteinDistance`, `includesFuzzyText`)
- `mocks/handlers.ts`: 무한스크롤 페이지네이션 mock 응답 처리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 블러 버그 원인: React Query `refetchOnWindowFocus: true` 기본값 + `staleTime 60s` 조합으로, 탭 복귀 시 백그라운드 리패치가 발생해 `GameListUpdatingOverlay`의 `backdrop-blur`가 렌더링됨 → `refetchOnWindowFocus: false`로 해결
- 검색 정규화는 `MainPage`에서 debounce 전에 한 번만 수행하도록 정리 (기존에는 `gameApi.ts`에서 중복 수행)