### PR TITLE
[Feat] 게임 상세 모달 YouTube 트레일러 iframe 추가

### DIFF
--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -36,6 +36,18 @@ const DETAIL_NOT_FOUND_MESSAGE = '해당 게임 상세 정보를 찾을 수 없�
 const TOAST_DURATION_MS = 3000;
 const DETAIL_REFRESH_INTERVAL_MS = 10_000;
 
+const toYouTubeEmbedUrl = (url: string): string | null => {
+  const match = url.match(
+    /(?:youtube\.com\/watch\?(?:.*&)?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/,
+  );
+  return match ? `https://www.youtube.com/embed/${match[1]}` : null;
+};
+
+const resolveEmbedUrl = (
+  embedUrl: string | null,
+  videoUrl: string | null,
+): string | null => embedUrl ?? (videoUrl ? toYouTubeEmbedUrl(videoUrl) : null);
+
 const getLikeErrorMessage = (error: unknown) => {
   if (error instanceof AxiosError) {
     if (error.response?.status === 401) {
@@ -185,6 +197,11 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
   );
   const imageUrl =
     imageCandidates.find((url) => !failedImageUrls.includes(url)) ?? null;
+  const promoVideoUrl = detail?.promoVideoUrl?.trim() || null;
+  const promoEmbedUrl = resolveEmbedUrl(
+    detail?.promoEmbedUrl?.trim() || null,
+    promoVideoUrl,
+  );
   const detailRows = [
     { label: '게임 출시일', value: formatNullableText(detail?.releaseDate) },
     { label: '게임 개발사', value: formatNullableText(detail?.developer) },
@@ -382,18 +399,47 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
 
             <div className="px-5 pb-6 sm:px-7 sm:pb-7">
               <div className="flex aspect-video min-h-44 items-center justify-center overflow-hidden rounded-lg border border-[#5a1115]/70 bg-[#2a1711] shadow-[inset_0_0_42px_rgba(255,75,85,0.08)] sm:min-h-72">
-                <div className="px-4 text-center">
-                  <PlayCircle
-                    aria-hidden="true"
-                    className="mx-auto h-12 w-12 text-white/55 sm:h-16 sm:w-16"
+                {promoEmbedUrl ? (
+                  <iframe
+                    title={`${title} 프로모션 영상`}
+                    src={promoEmbedUrl}
+                    className="h-full w-full"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    referrerPolicy="strict-origin-when-cross-origin"
+                    allowFullScreen
                   />
-                  <p className="mt-4 text-sm font-semibold text-white/75 sm:text-base">
-                    프로모션 동영상 영역
-                  </p>
-                  <p className="mt-2 text-xs text-white/45 sm:text-sm">
-                    영상 URL 정책이 확정되면 이 영역에 iframe을 연결합니다.
-                  </p>
-                </div>
+                ) : promoVideoUrl ? (
+                  <a
+                    href={promoVideoUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="group flex h-full w-full flex-col items-center justify-center px-4 text-center transition hover:bg-black/10"
+                  >
+                    <PlayCircle
+                      aria-hidden="true"
+                      className="h-12 w-12 text-white/65 transition group-hover:scale-105 group-hover:text-white sm:h-16 sm:w-16"
+                    />
+                    <p className="mt-4 text-sm font-semibold text-white/80 sm:text-base">
+                      프로모션 영상을 새 창에서 보기
+                    </p>
+                    <p className="mt-2 text-xs text-white/50 sm:text-sm">
+                      {title} 관련 영상 페이지로 이동합니다.
+                    </p>
+                  </a>
+                ) : (
+                  <div className="px-4 text-center">
+                    <PlayCircle
+                      aria-hidden="true"
+                      className="mx-auto h-12 w-12 text-white/55 sm:h-16 sm:w-16"
+                    />
+                    <p className="mt-4 text-sm font-semibold text-white/75 sm:text-base">
+                      프로모션 영상 N/A
+                    </p>
+                    <p className="mt-2 text-xs text-white/45 sm:text-sm">
+                      제공된 영상 정보가 없습니다.
+                    </p>
+                  </div>
+                )}
               </div>
 
               <dl className="mt-6 divide-y divide-white/10 border-y border-white/10">

--- a/src/features/games/mockGameDetails.ts
+++ b/src/features/games/mockGameDetails.ts
@@ -68,6 +68,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '황금률이 무너진 틈새의 땅을 배경으로, 플레이어는 빛바랜 자가 되어 엘든 링의 힘을 되찾기 위한 여정을 떠납니다. 방대한 오픈 월드와 던전, 강력한 보스전, 자유도 높은 빌드 구성이 핵심입니다.',
     likeCount: 0,
     officialSite: 'https://www.eldenring.com/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/qqiC88f9ogU',
   }),
   2358720: createMockGameDetail({
     gameId: 2358720,
@@ -80,6 +81,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '서유기에서 영감을 받은 액션 RPG입니다. 천명자는 신화 속 존재와 맞서며 잊힌 진실을 좇고, 빠른 전투와 변신 능력, 보스 공략을 중심으로 모험을 진행합니다.',
     likeCount: 0,
     officialSite: 'https://www.heishenhua.com/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/0Zw-mo0EFt0',
   }),
   2679460: createMockGameDetail({
     gameId: 2679460,
@@ -92,6 +94,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '왕의 죽음 이후 혼란에 빠진 판타지 세계에서 주인공 일행이 새로운 왕을 정하는 선거에 뛰어듭니다. 턴제 전투, 아키타입 성장, 동료와의 유대가 결합된 RPG입니다.',
     likeCount: 0,
     officialSite: 'https://metaphor.atlus.com/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/yQPk4cVrU_w',
   }),
   1845910: createMockGameDetail({
     gameId: 1845910,
@@ -105,6 +108,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
     likeCount: 0,
     officialSite:
       'https://www.ea.com/games/dragon-age/dragon-age-the-veilguard',
+    promoEmbedUrl: 'https://www.youtube.com/embed/NdtmtuzICOI',
   }),
   1086940: createMockGameDetail({
     gameId: 1086940,
@@ -117,6 +121,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '던전 앤 드래곤 5판 규칙을 기반으로 한 파티 RPG입니다. 플레이어의 선택과 주사위 판정이 전투, 대화, 탐험 결과를 크게 바꾸며 다양한 방식으로 이야기를 풀어갈 수 있습니다.',
     likeCount: 0,
     officialSite: 'https://baldursgate3.game/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/1T22wNvoNiU',
   }),
   292030: createMockGameDetail({
     gameId: 292030,
@@ -129,6 +134,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '괴물 사냥꾼 게롤트가 시리를 찾아 전쟁과 음모가 뒤섞인 대륙을 누비는 오픈 월드 RPG입니다. 선택에 따라 달라지는 퀘스트와 풍부한 서사가 강점입니다.',
     likeCount: 0,
     officialSite: 'https://www.thewitcher.com/witcher3',
+    promoEmbedUrl: 'https://www.youtube.com/embed/XHrskkHf958',
   }),
   1091500: createMockGameDetail({
     gameId: 1091500,
@@ -141,6 +147,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '거대 기업과 갱단이 지배하는 나이트 시티에서 용병 V가 생존과 자유를 위해 싸우는 오픈 월드 RPG입니다. 사이버웨어, 총격전, 해킹, 선택형 서사가 결합되어 있습니다.',
     likeCount: 0,
     officialSite: 'https://www.cyberpunk.net/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/UnA7tepsc7s',
   }),
   582010: createMockGameDetail({
     gameId: 582010,
@@ -153,6 +160,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '신대륙을 조사하는 헌터가 거대한 몬스터를 추적하고 사냥하는 액션 게임입니다. 장비 제작, 협동 플레이, 몬스터별 패턴 공략이 핵심 재미입니다.',
     likeCount: 0,
     officialSite: 'https://www.monsterhunter.com/world/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/KsmAreIFel0',
   }),
   814380: createMockGameDetail({
     gameId: 814380,
@@ -165,6 +173,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '전국 시대풍 세계에서 외팔이 늑대가 주군을 구하기 위해 싸우는 액션 어드벤처입니다. 자세를 무너뜨리는 검극, 잠입, 의수 도구 활용이 전투의 중심입니다.',
     likeCount: 0,
     officialSite: 'https://www.sekirothegame.com/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/aUnEezrBFoA',
   }),
   2050650: createMockGameDetail({
     gameId: 2050650,
@@ -177,6 +186,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '요원 레온 S. 케네디가 납치된 대통령의 딸을 구하기 위해 폐쇄적인 마을로 향하는 서바이벌 호러 액션입니다. 원작의 긴장감을 현대적인 조작과 연출로 재구성했습니다.',
     likeCount: 0,
     officialSite: 'https://www.residentevil.com/re4/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/isN_Y9ULtXY',
   }),
   553850: createMockGameDetail({
     gameId: 553850,
@@ -189,6 +199,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '슈퍼 지구를 위해 외계 세력과 싸우는 협동 슈팅 게임입니다. 분대 전술, 스트라타젬 호출, 아군 오사까지 포함한 혼란스러운 전장이 특징입니다.',
     likeCount: 0,
     officialSite: 'https://www.playstation.com/games/helldivers-2/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/Ahx35iVJn10',
   }),
   1623730: createMockGameDetail({
     gameId: 1623730,
@@ -201,6 +212,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '팰을 수집하고 함께 전투, 건축, 생산을 이어가는 오픈 월드 생존 게임입니다. 기지 운영과 탐험, 협동 플레이가 결합되어 있습니다.',
     likeCount: 0,
     officialSite: 'https://www.pocketpair.jp/palworld',
+    promoEmbedUrl: 'https://www.youtube.com/embed/ZPu9yAOEYkQ',
   }),
   1145350: createMockGameDetail({
     gameId: 1145350,
@@ -213,6 +225,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '저승의 공주 멜리노에가 시간의 티탄 크로노스에 맞서는 로그라이크 액션 게임입니다. 반복 도전 속에서 무기, 은혜, 주문을 조합해 새로운 빌드를 완성합니다.',
     likeCount: 0,
     officialSite: 'https://www.supergiantgames.com/games/hades-ii/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/txQKYcbIAHU',
   }),
   367520: createMockGameDetail({
     gameId: 367520,
@@ -225,6 +238,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '몰락한 왕국 할로우네스트를 탐험하는 메트로배니아 액션 게임입니다. 정교한 플랫폼, 보스전, 탐험을 통해 세계의 비밀을 천천히 밝혀갑니다.',
     likeCount: 0,
     officialSite: 'https://www.hollowknight.com/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/UAO2urG23S4',
   }),
   1627720: createMockGameDetail({
     gameId: 1627720,
@@ -237,6 +251,7 @@ export const mockGameDetails: Record<number, GameDetail> = {
       '피노키오를 어둡게 재해석한 소울라이크 액션 RPG입니다. 기계 인형이 폭주한 크라트에서 진실과 거짓을 오가며 전투와 선택을 이어갑니다.',
     likeCount: 0,
     officialSite: 'https://www.liesofp.com/',
+    promoEmbedUrl: 'https://www.youtube.com/embed/kXZoKdr-xeo',
   }),
   1868140: createMockGameDetail({
     gameId: 1868140,


### PR DESCRIPTION
## 관련 이슈

- closes #189

## 변경 내용

- `GameDetailModal.tsx`: YouTube watch URL → embed URL 자동 변환 함수 추가
  - `toYouTubeEmbedUrl`: `youtube.com/watch?v=` 또는 `youtu.be/` 형식을 embed URL로 변환
  - `resolveEmbedUrl`: `promoEmbedUrl` 우선, 없으면 `promoVideoUrl`에서 자동 변환
  - 모달 내 `<iframe>`으로 트레일러 인라인 재생 지원
- `mockGameDetails.ts`: 15개 게임에 공식 YouTube 트레일러 `promoEmbedUrl` 추가 (개발 환경 테스트용)
  - 엘든 링, 검은 신화: 오공, 메타포: 리판타지오, 발더스 게이트 3 등

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="2032" height="1162" alt="스크린샷 2026-04-22 오후 4 20 29" src="https://github.com/user-attachments/assets/d0dcea19-7cf2-46eb-a5ff-935939a154b5" />


## 참고사항

- `promoEmbedUrl`이 없고 `promoVideoUrl`이 YouTube watch URL이 아닌 경우(예: 검색 URL) iframe 영역이 렌더링되지 않습니다
- mock 데이터의 embed URL은 개발 테스트 전용이며, 실 서버 연동 시 BE 응답값을 그대로 사용합니다