### PR TITLE
[Feat] 매칭 추천 결과 mock 추천 로직 정리

### DIFF
--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -234,6 +234,20 @@ export const syncMockLikedGamesForAuthorization = (
   mockLikedGamesByLoginId.set(user.loginId, nextLikedGames);
 };
 
+export const getMockLikedGameIdsForAuthorization = (
+  authorization: string | null,
+) => {
+  const user = getAuthorizedUser(authorization);
+
+  if (!user) {
+    return new Set<number>();
+  }
+
+  return new Set(
+    getOrCreateLikedGames(user.loginId).map((game) => game.game_id),
+  );
+};
+
 const loginHandlers = [
   http.get(`${AUTH_BASE_PATH}/dev-login-accounts`, async () => {
     await delay(120);

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -1,6 +1,11 @@
 import { delay, http, HttpResponse } from 'msw';
 
-import { syncMockLikedGamesForAuthorization } from '../../auth/mocks/handlers';
+import {
+  getMockLikedGameIdsForAuthorization,
+  syncMockLikedGamesForAuthorization,
+} from '../../auth/mocks/handlers';
+import { matchesGenreFilter, type GameGenreFilter } from '../../games/genres';
+import { mockTopGames } from '../../games/mockGames';
 import { getMatchingGenreById } from '../genres';
 import {
   matchingMockCandidateMapById,
@@ -24,8 +29,20 @@ type StoredMatchResult = {
 };
 
 const DEFAULT_RECOMMENDATION_PAGE_SIZE = 5;
+const DEFAULT_RECOMMENDATION_TOTAL_COUNT = 15;
 
 let storedMatchResults: StoredMatchResult[] = [];
+
+const MATCHING_RESULT_GENRE_FILTERS: Record<number, GameGenreFilter[]> = {
+  1: ['액션', '대전 / 격투'],
+  2: ['어드벤처', '플랫폼'],
+  3: ['RPG', '어드벤처'],
+  4: ['전략', '시뮬레이션'],
+  5: ['스포츠', '레이싱'],
+  6: ['전략', '카드 / 보드', '퍼즐'],
+  7: ['슈팅', '액션'],
+  8: ['음악 / 리듬', '퍼즐'],
+};
 
 const calculateMockRankScore = ({
   gameId,
@@ -61,6 +78,127 @@ const toMockRecommendationRating = (candidateRating: number | null) =>
   typeof candidateRating === 'number'
     ? Number((candidateRating * 20).toFixed(1))
     : null;
+
+const normalizeGenre = (value: string) => value.trim().toLowerCase();
+
+const getSelectedGenreIdFromStoredResults = () => {
+  const firstStoredResult = storedMatchResults[0];
+
+  if (!firstStoredResult) {
+    return null;
+  }
+
+  return (
+    Object.entries(matchingMockCandidatesByGenreId).find(([, candidates]) =>
+      candidates.some(
+        (candidate) => candidate.game_id === firstStoredResult.game_id,
+      ),
+    )?.[0] ?? null
+  );
+};
+
+const getGenreAffinityScore = (genres: string[], genreId: number | null) => {
+  if (!genreId) {
+    return 0;
+  }
+
+  const filters = MATCHING_RESULT_GENRE_FILTERS[genreId] ?? [];
+
+  return filters.reduce(
+    (score, filter) => score + (matchesGenreFilter(genres, filter) ? 18 : 0),
+    0,
+  );
+};
+
+const getGenreOverlapScore = (
+  sourceGenres: string[],
+  targetGenres: string[],
+) => {
+  const sourceGenreSet = new Set(sourceGenres.map(normalizeGenre));
+
+  return targetGenres.reduce((score, genre) => {
+    return sourceGenreSet.has(normalizeGenre(genre)) ? score + 1 : score;
+  }, 0);
+};
+
+const getMockRecommendationResults = (authorization: string | null) => {
+  const selectedGenreId = Number(getSelectedGenreIdFromStoredResults());
+  const evaluatedGameIds = new Set(
+    storedMatchResults.map((result) => result.game_id),
+  );
+  const currentLikedGameIds =
+    getMockLikedGameIdsForAuthorization(authorization);
+  const rankedEvaluations = getRankedMatchResults();
+
+  const scoredResults = mockTopGames
+    .filter((game) => !evaluatedGameIds.has(game.gameId))
+    .map((game) => {
+      const genreAffinityScore = getGenreAffinityScore(
+        game.genres,
+        selectedGenreId,
+      );
+      const popularityScore =
+        typeof game.rating === 'number' ? game.rating * 0.28 : 0;
+      const tasteScore = rankedEvaluations.reduce((score, evaluation) => {
+        const candidate = matchingMockCandidateMapById.get(evaluation.game_id);
+
+        if (!candidate) {
+          return score;
+        }
+
+        const sharedGenreCount = getGenreOverlapScore(
+          candidate.genres,
+          game.genres,
+        );
+
+        if (sharedGenreCount === 0) {
+          return score;
+        }
+
+        const ratingWeight = (evaluation.rating - 3) * 9;
+        const likedWeight = evaluation.is_liked ? 10 : 0;
+        const overlapWeight = sharedGenreCount * 6;
+
+        return score + ratingWeight + likedWeight + overlapWeight;
+      }, 0);
+      const score =
+        genreAffinityScore +
+        popularityScore +
+        tasteScore +
+        ((game.gameId % 13) + 1) / 10;
+
+      return {
+        game_id: game.gameId,
+        title: game.name,
+        genres: game.genres,
+        thumbnail_url: game.thumbnailUrl,
+        rating:
+          typeof game.rating === 'number'
+            ? Number(game.rating.toFixed(1))
+            : null,
+        is_liked: currentLikedGameIds.has(game.gameId),
+        mock_recommendation_score: score,
+      };
+    })
+    .sort((a, b) => {
+      if (b.mock_recommendation_score !== a.mock_recommendation_score) {
+        return b.mock_recommendation_score - a.mock_recommendation_score;
+      }
+
+      return (b.rating ?? 0) - (a.rating ?? 0);
+    });
+
+  return scoredResults
+    .slice(0, DEFAULT_RECOMMENDATION_TOTAL_COUNT)
+    .map(({ game_id, title, genres, thumbnail_url, rating, is_liked }) => ({
+      game_id,
+      title,
+      genres,
+      thumbnail_url,
+      rating,
+      is_liked,
+    }));
+};
 
 export const matchingHandlers = [
   http.get('/api/v1/match/genres/image-url', async ({ request }) => {
@@ -199,18 +337,15 @@ export const matchingHandlers = [
       url.searchParams.get('page_size') ?? DEFAULT_RECOMMENDATION_PAGE_SIZE,
     );
 
-    const results = getRankedMatchResults().map((result) => {
-      const candidate = matchingMockCandidateMapById.get(result.game_id)!;
-
-      return {
-        game_id: candidate.game_id,
-        title: candidate.title,
-        genres: candidate.genres,
-        thumbnail_url: candidate.thumbnail_url,
-        rating: toMockRecommendationRating(candidate.rating),
-        is_liked: result.is_liked,
-      };
-    });
+    const results = getMockRecommendationResults(
+      request.headers.get('Authorization'),
+    ).map((result) => ({
+      ...result,
+      rating:
+        typeof result.rating === 'number'
+          ? Number(result.rating.toFixed(1))
+          : toMockRecommendationRating(result.rating),
+    }));
     const startIndex = Number.isNaN(cursor) ? 0 : cursor;
     const nextIndex = startIndex + pageSize;
     const next = nextIndex < results.length ? String(nextIndex) : null;


### PR DESCRIPTION
## 관련 이슈

- closes #192 

## 변경 내용

- 매칭 추천 결과 mock이 평가한 5개 게임을 그대로 재사용하지 않도록 구조를 수정
- 게임 mock 카탈로그를 추천 풀로 사용해 매칭 결과용 15개 추천 목록을 생성하도록 변경
- mock 내부에서 장르 적합도, 별점, 좋아요 여부, 장르 겹침, 기본 평점을 조합해 추천 순서를 계산하도록 정리
- 추천 결과의 `is_liked` 값이 현재 좋아요 상태 기준으로 반영되도록 auth mock liked 상태를 참조
- 기존 응답 shape는 유지
  - `count`
  - `next`
  - `results`

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 매칭 추천 결과 mock이 “평가한 후보 재노출”처럼 보이던 문제를 정리하는 데 집중했습니다.
- 실서비스와 동일한 계산식을 재현하는 것이 아니라, 사용자가 기대하는 추천 결과 흐름에 맞는 mock 동작으로 정리한 작업입니다.