### PR TITLE
refactor(mypage): 마이페이지 API 명세 정합 및 프로필/찜 UI 개선

### DIFF
--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -14,8 +14,8 @@ function FavoriteGameCard({
   onFavoriteClick,
 }: FavoriteGameCardProps) {
   return (
-    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover flex h-full flex-col overflow-hidden rounded-[24px] border transition duration-200">
-      <div className="bg-mypage-soft relative aspect-[16/10] overflow-hidden">
+    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover flex h-full flex-col overflow-hidden rounded-[22px] border transition duration-200">
+      <div className="bg-mypage-soft relative aspect-[3/4] overflow-hidden">
         <button
           type="button"
           onClick={() => onClick?.(game)}
@@ -25,7 +25,7 @@ function FavoriteGameCard({
             <img
               src={game.thumbnailUrl}
               alt={`${game.title} 썸네일`}
-              className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
+              className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.04]"
               loading="lazy"
             />
           ) : (
@@ -33,15 +33,16 @@ function FavoriteGameCard({
               이미지 준비 중
             </div>
           )}
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/70 via-black/18 to-transparent" />
         </button>
-        <div className="absolute inset-x-0 bottom-0 flex justify-end p-3">
+        <div className="absolute top-3 right-3">
           <button
             type="button"
             aria-label={`${game.title} 찜 삭제`}
             onClick={() => onFavoriteClick?.(game)}
-            className="bg-login-primary inline-flex h-10 w-10 items-center justify-center rounded-full text-white shadow-[0_12px_28px_rgba(242,15,23,0.25)] transition hover:scale-105"
+            className="bg-login-primary inline-flex h-9 w-9 items-center justify-center rounded-full text-white shadow-[0_12px_28px_rgba(242,15,23,0.25)] transition hover:scale-105"
           >
-            <Heart size={16} fill="currentColor" />
+            <Heart size={15} fill="currentColor" />
           </button>
         </div>
       </div>
@@ -49,10 +50,14 @@ function FavoriteGameCard({
       <button
         type="button"
         onClick={() => onClick?.(game)}
-        className="flex flex-1 flex-col gap-2 px-4 py-4 text-left sm:px-5"
+        className="flex flex-1 flex-col gap-2 px-4 py-4 text-left"
       >
-        <h3 className="text-lg/7 font-semibold text-white">{game.title}</h3>
-        <p className="text-mypage-muted text-sm/6">{game.summary}</p>
+        <h3 className="line-clamp-1 text-base/6 font-semibold text-white sm:text-lg/7">
+          {game.title}
+        </h3>
+        <p className="text-mypage-muted line-clamp-2 text-xs/5 sm:text-sm/6">
+          {game.summary}
+        </p>
       </button>
     </article>
   );

--- a/src/components/mypage/FavoriteGameCardSkeleton.tsx
+++ b/src/components/mypage/FavoriteGameCardSkeleton.tsx
@@ -1,0 +1,31 @@
+type FavoriteGameCardSkeletonProps = {
+  count?: number;
+};
+
+function FavoriteGameCardSkeleton({
+  count = 8,
+}: FavoriteGameCardSkeletonProps) {
+  return (
+    <div
+      className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <article
+          key={index}
+          className="border-mypage-card bg-mypage-card overflow-hidden rounded-[22px] border"
+        >
+          <div className="aspect-[3/4] animate-pulse bg-white/8" />
+          <div className="space-y-2 px-4 py-4">
+            <div className="h-5 w-3/4 animate-pulse rounded-full bg-white/10" />
+            <div className="h-4 w-full animate-pulse rounded-full bg-white/8" />
+            <div className="h-4 w-2/3 animate-pulse rounded-full bg-white/8" />
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export default FavoriteGameCardSkeleton;

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -43,38 +43,50 @@ function MyPageProfileSection({
       </h1>
 
       <div className="mt-8 flex justify-center">
-        <div className="border-mypage-panel bg-mypage-card relative flex h-28 w-28 items-center justify-center overflow-hidden rounded-full border">
-          {hasProfileImage ? (
-            <img
-              src={profileImageUrl!}
-              alt={`${nickname} 프로필 이미지`}
-              className="h-full w-full object-cover"
+        <div className="relative h-32 w-32 sm:h-36 sm:w-36">
+          <div className="border-mypage-panel bg-mypage-card relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border shadow-[0_24px_50px_rgba(0,0,0,0.46),0_0_0_1px_rgba(255,255,255,0.03)]">
+            {hasProfileImage ? (
+              <img
+                src={profileImageUrl!}
+                alt={`${nickname} 프로필 이미지`}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <CircleUserRound size={48} className="text-white/85" />
+            )}
+          </div>
+          <label className="border-mypage-panel bg-mypage-card text-mypage-muted focus-within:ring-mypage-panel absolute -right-1 -bottom-1 inline-flex cursor-pointer items-center rounded-full border px-3 py-1.5 text-xs font-semibold transition focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-[#050505] hover:text-white">
+            <input
+              type="file"
+              accept="image/*"
+              className="sr-only"
+              disabled={isProfileLoading || isProfileImageUploading}
+              onChange={(event) => {
+                onProfileImageSelect?.(event.target.files?.[0] ?? null);
+                event.currentTarget.value = '';
+              }}
             />
-          ) : (
-            <CircleUserRound size={42} className="text-white/85" />
-          )}
+            {isProfileImageUploading ? '업로드 중...' : '프로필 변경'}
+          </label>
         </div>
-      </div>
-      <div className="mt-3 flex justify-center">
-        <label className="border-mypage-panel bg-mypage-card text-mypage-muted focus-within:ring-mypage-panel relative inline-flex cursor-pointer items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-[#050505] hover:text-white">
-          <input
-            type="file"
-            accept="image/*"
-            className="sr-only"
-            disabled={isProfileLoading || isProfileImageUploading}
-            onChange={(event) => {
-              onProfileImageSelect?.(event.target.files?.[0] ?? null);
-              event.currentTarget.value = '';
-            }}
-          />
-          {isProfileImageUploading ? '업로드 중...' : '프로필 변경'}
-        </label>
       </div>
 
       {isProfileLoading ? (
-        <div className="mt-5 flex flex-col items-center gap-3">
-          <div className="h-8 w-32 animate-pulse rounded-full bg-white/8" />
-          <div className="h-4 w-full max-w-sm animate-pulse rounded-full bg-white/6" />
+        <div
+          className="mt-5 flex flex-col items-center gap-3"
+          aria-live="polite"
+          aria-busy="true"
+        >
+          <div className="h-8 w-36 animate-pulse rounded-full bg-white/10" />
+          <div className="h-4 w-full max-w-sm animate-pulse rounded-full bg-white/8" />
+          <div className="border-mypage-panel bg-mypage-card mt-1 grid w-full max-w-[640px] gap-3 rounded-2xl border px-4 py-4 sm:grid-cols-3 sm:gap-4 sm:px-5">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="space-y-2">
+                <div className="h-3 w-10 animate-pulse rounded-full bg-white/8" />
+                <div className="h-5 w-full animate-pulse rounded-full bg-white/10" />
+              </div>
+            ))}
+          </div>
         </div>
       ) : (
         <>

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -1,5 +1,5 @@
 import { CircleUserRound } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import AuthButton from '../auth/AuthButton';
 
@@ -11,10 +11,12 @@ type MyPageProfileSectionProps = {
   profileImageUrl?: string | null;
   isProfileLoading?: boolean;
   isProfileImageUploading?: boolean;
+  isProfileUpdating?: boolean;
   isLoggingOut: boolean;
   isPasswordPanelOpen: boolean;
   onPasswordToggle: () => void;
   onLogout: () => void;
+  onNicknameSave?: (nickname: string) => Promise<boolean>;
   onProfileImageSelect?: (file: File | null) => void;
   children?: ReactNode;
 };
@@ -27,14 +29,47 @@ function MyPageProfileSection({
   profileImageUrl = null,
   isProfileLoading = false,
   isProfileImageUploading = false,
+  isProfileUpdating = false,
   isLoggingOut,
   isPasswordPanelOpen,
   onPasswordToggle,
   onLogout,
+  onNicknameSave,
   onProfileImageSelect,
   children,
 }: MyPageProfileSectionProps) {
   const hasProfileImage = Boolean(profileImageUrl?.trim());
+  const [isNicknameEditMode, setIsNicknameEditMode] = useState(false);
+  const [nextNickname, setNextNickname] = useState(nickname);
+  const [nicknameFieldError, setNicknameFieldError] = useState('');
+
+  const handleNicknameSave = async () => {
+    const trimmedNickname = nextNickname.trim();
+
+    if (!trimmedNickname) {
+      setNicknameFieldError('닉네임을 입력해주세요.');
+      return;
+    }
+
+    if (trimmedNickname === nickname.trim()) {
+      setIsNicknameEditMode(false);
+      setNicknameFieldError('');
+      return;
+    }
+
+    if (!onNicknameSave) {
+      setIsNicknameEditMode(false);
+      setNicknameFieldError('');
+      return;
+    }
+
+    const isSuccess = await onNicknameSave(trimmedNickname);
+
+    if (isSuccess) {
+      setIsNicknameEditMode(false);
+      setNicknameFieldError('');
+    }
+  };
 
   return (
     <section className="border-mypage-panel bg-mypage-panel shadow-mypage-float rounded-[28px] border px-5 py-8 text-center backdrop-blur-xl sm:px-8 sm:py-10">
@@ -43,7 +78,7 @@ function MyPageProfileSection({
       </h1>
 
       <div className="mt-8 flex justify-center">
-        <div className="relative h-32 w-32 sm:h-36 sm:w-36">
+        <div className="h-32 w-32 sm:h-36 sm:w-36">
           <div className="border-mypage-panel bg-mypage-card relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border shadow-[0_24px_50px_rgba(0,0,0,0.46),0_0_0_1px_rgba(255,255,255,0.03)]">
             {hasProfileImage ? (
               <img
@@ -55,20 +90,22 @@ function MyPageProfileSection({
               <CircleUserRound size={48} className="text-white/85" />
             )}
           </div>
-          <label className="border-mypage-panel bg-mypage-card text-mypage-muted focus-within:ring-mypage-panel absolute -right-1 -bottom-1 inline-flex cursor-pointer items-center rounded-full border px-3 py-1.5 text-xs font-semibold transition focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-[#050505] hover:text-white">
-            <input
-              type="file"
-              accept="image/*"
-              className="sr-only"
-              disabled={isProfileLoading || isProfileImageUploading}
-              onChange={(event) => {
-                onProfileImageSelect?.(event.target.files?.[0] ?? null);
-                event.currentTarget.value = '';
-              }}
-            />
-            {isProfileImageUploading ? '업로드 중...' : '프로필 변경'}
-          </label>
         </div>
+      </div>
+      <div className="mt-3 flex justify-center">
+        <label className="border-mypage-panel bg-mypage-card text-mypage-muted focus-within:ring-mypage-panel inline-flex h-9 cursor-pointer items-center justify-center rounded-full border px-3 py-1.5 text-xs leading-none font-semibold whitespace-nowrap transition focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-[#050505] hover:text-white">
+          <input
+            type="file"
+            accept="image/*"
+            className="sr-only"
+            disabled={isProfileLoading || isProfileImageUploading}
+            onChange={(event) => {
+              onProfileImageSelect?.(event.target.files?.[0] ?? null);
+              event.currentTarget.value = '';
+            }}
+          />
+          {isProfileImageUploading ? '업로드 중...' : '프로필 변경'}
+        </label>
       </div>
 
       {isProfileLoading ? (
@@ -90,7 +127,75 @@ function MyPageProfileSection({
         </div>
       ) : (
         <>
-          <p className="mt-5 text-2xl font-semibold text-white">{nickname}</p>
+          <div className="mt-5 flex justify-center">
+            {isNicknameEditMode ? (
+              <div className="w-full max-w-sm space-y-2">
+                <label htmlFor="profile-nickname" className="sr-only">
+                  닉네임
+                </label>
+                <input
+                  id="profile-nickname"
+                  type="text"
+                  value={nextNickname}
+                  onChange={(event) => {
+                    setNextNickname(event.target.value);
+
+                    if (nicknameFieldError) {
+                      setNicknameFieldError('');
+                    }
+                  }}
+                  maxLength={20}
+                  disabled={isProfileUpdating}
+                  className="auth-input-autofill placeholder-login-muted bg-login-field border-login-field h-12 w-full rounded-xl border px-4 text-base text-white transition outline-none hover:border-white/15 focus-visible:ring-2 focus-visible:ring-white/20"
+                  placeholder="닉네임을 입력하세요"
+                />
+                {nicknameFieldError ? (
+                  <p className="pl-1 text-left text-sm/5 font-medium text-red-400">
+                    {nicknameFieldError}
+                  </p>
+                ) : null}
+                <div className="flex justify-end gap-2">
+                  <button
+                    type="button"
+                    className="border-mypage-panel bg-mypage-card text-mypage-muted rounded-full border px-3 py-1.5 text-xs font-semibold transition hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => {
+                      setIsNicknameEditMode(false);
+                      setNextNickname(nickname);
+                      setNicknameFieldError('');
+                    }}
+                    disabled={isProfileUpdating}
+                  >
+                    취소
+                  </button>
+                  <button
+                    type="button"
+                    className="bg-login-primary rounded-full px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-[#dd0d14] disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => {
+                      void handleNicknameSave();
+                    }}
+                    disabled={isProfileUpdating}
+                  >
+                    {isProfileUpdating ? '저장 중...' : '저장'}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col items-center gap-2">
+                <p className="text-2xl font-semibold text-white">{nickname}</p>
+                <button
+                  type="button"
+                  className="border-mypage-panel bg-mypage-card text-mypage-muted rounded-full border px-3 py-1.5 text-xs font-semibold transition hover:text-white"
+                  onClick={() => {
+                    setIsNicknameEditMode(true);
+                    setNextNickname(nickname);
+                    setNicknameFieldError('');
+                  }}
+                >
+                  닉네임 변경
+                </button>
+              </div>
+            )}
+          </div>
           <p className="text-mypage-muted mt-2 text-sm/6">
             계정 정보와 찜한 게임 목록을 한곳에서 관리할 수 있습니다.
           </p>

--- a/src/components/mypage/PasswordChangePanel.tsx
+++ b/src/components/mypage/PasswordChangePanel.tsx
@@ -47,7 +47,7 @@ function PasswordChangePanel({
       <form className="space-y-4" onSubmit={onSubmit}>
         <AuthInputField
           id="current-password"
-          name="current_password"
+          name="old_password"
           type="password"
           label="현재 비밀번호"
           placeholder="현재 비밀번호를 입력하세요"
@@ -75,7 +75,7 @@ function PasswordChangePanel({
 
         <AuthInputField
           id="new-password-confirm"
-          name="new_password_confirm"
+          name="new_password_check"
           type="password"
           label="새 비밀번호 확인"
           placeholder="새 비밀번호를 한번 더 입력하세요"

--- a/src/components/mypage/ToastMessage.tsx
+++ b/src/components/mypage/ToastMessage.tsx
@@ -24,7 +24,8 @@ function ToastMessage({
   className = '',
 }: ToastMessageProps) {
   const Icon = tone === 'success' ? CheckCircle2 : AlertCircle;
-  let positioningClass = 'fixed top-20 right-[clamp(1rem,5vw,20rem)]';
+  let positioningClass =
+    'fixed top-20 right-4 sm:right-6 lg:right-10 xl:right-14';
 
   if (variant === 'absoluteCenter') {
     positioningClass =

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -8,9 +8,10 @@ import type {
   CheckNicknameDuplicateRequest,
   ChangePasswordRequest,
   ChangePasswordResponse,
+  ConfirmProfileImageRequest,
+  ConfirmProfileImageResponse,
   CurrentUserProfileResponse,
   DeleteAccountRequest,
-  DeleteAccountResponse,
   DeleteLikedGameResponse,
   DuplicateCheckResponse,
   ErrorResponseBody,
@@ -140,6 +141,17 @@ export const uploadFileToS3 = async ({
   });
 };
 
+export const confirmProfileImage = async (
+  payload: ConfirmProfileImageRequest,
+) => {
+  const response = await api.patch<ConfirmProfileImageResponse>(
+    `${AUTH_BASE_PATH}/me/profile-image`,
+    payload,
+  );
+
+  return response.data;
+};
+
 export const changePassword = async (payload: ChangePasswordRequest) => {
   const response = await api.post<ChangePasswordResponse>(
     `${AUTH_BASE_PATH}/me/change-password`,
@@ -150,14 +162,9 @@ export const changePassword = async (payload: ChangePasswordRequest) => {
 };
 
 export const deleteAccount = async (payload: DeleteAccountRequest) => {
-  const response = await api.delete<DeleteAccountResponse>(
-    `${AUTH_BASE_PATH}/me`,
-    {
-      data: payload,
-    },
-  );
-
-  return response.data;
+  await api.delete(`${AUTH_BASE_PATH}/me`, {
+    data: payload,
+  });
 };
 
 export const signup = async (payload: SignupRequest) => {

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -25,6 +25,7 @@ import type {
   RefreshAccessTokenResponse,
   SignupRequest,
   SignupResponse,
+  UpdateUserInfoRequest,
   UploadFileToS3Request,
 } from '../types/auth';
 
@@ -89,6 +90,15 @@ export const refreshAccessToken = async () => {
 export const getCurrentUserProfile = async () => {
   const response = await api.get<CurrentUserProfileResponse>(
     `${AUTH_BASE_PATH}/me`,
+  );
+
+  return response.data;
+};
+
+export const updateUserInfo = async (payload: UpdateUserInfoRequest) => {
+  const response = await api.patch<CurrentUserProfileResponse>(
+    `${AUTH_BASE_PATH}/me`,
+    payload,
   );
 
   return response.data;

--- a/src/features/auth/api/queryKeys.ts
+++ b/src/features/auth/api/queryKeys.ts
@@ -15,6 +15,7 @@ export const authKeys = {
   signup: () => [...authRootKey, 'signup'] as const,
   logout: () => [...authRootKey, 'logout'] as const,
   me: () => authMeKey,
+  updateUserInfo: () => [...authMeKey, 'update'] as const,
   likedGames: () => authLikedGamesKey,
   likedGamesList: (payload: LikedGamesRequest = {}) =>
     [

--- a/src/features/auth/api/queryKeys.ts
+++ b/src/features/auth/api/queryKeys.ts
@@ -1,0 +1,42 @@
+import type { LikedGamesRequest } from '../types/auth';
+
+const authRootKey = ['auth'] as const;
+const authMeKey = [...authRootKey, 'me'] as const;
+const authLikedGamesKey = [...authMeKey, 'game-like'] as const;
+
+const resolveLikedGamesPage = (payload: LikedGamesRequest = {}) =>
+  payload.page ?? 1;
+const resolveLikedGamesPageSize = (payload: LikedGamesRequest = {}) =>
+  payload.page_size;
+
+export const authKeys = {
+  all: authRootKey,
+  login: () => [...authRootKey, 'login'] as const,
+  signup: () => [...authRootKey, 'signup'] as const,
+  logout: () => [...authRootKey, 'logout'] as const,
+  me: () => authMeKey,
+  likedGames: () => authLikedGamesKey,
+  likedGamesList: (payload: LikedGamesRequest = {}) =>
+    [
+      ...authLikedGamesKey,
+      resolveLikedGamesPage(payload),
+      resolveLikedGamesPageSize(payload),
+    ] as const,
+  likedGamesInfinite: (payload: Pick<LikedGamesRequest, 'page_size'> = {}) =>
+    [
+      ...authLikedGamesKey,
+      'infinite',
+      resolveLikedGamesPageSize(payload),
+    ] as const,
+  unlikeLikedGame: () => [...authLikedGamesKey, 'unlike'] as const,
+  profileImagePresignedUrl: () =>
+    [...authMeKey, 'profile-image', 'presigned-url'] as const,
+  profileImageUpload: () => [...authMeKey, 'profile-image', 'upload'] as const,
+  profileImageConfirm: () =>
+    [...authMeKey, 'profile-image', 'confirm'] as const,
+  changePassword: () => [...authRootKey, 'change-password'] as const,
+  deleteAccount: () => [...authRootKey, 'delete-account'] as const,
+  checkIdDuplicate: () => [...authRootKey, 'check-id-duplicate'] as const,
+  checkNicknameDuplicate: () =>
+    [...authRootKey, 'check-nickname-duplicate'] as const,
+};

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -18,6 +18,7 @@ import {
   logout,
   signup,
   unlikeLikedGame,
+  updateUserInfo,
   uploadFileToS3,
 } from './auth';
 import { authKeys } from './queryKeys';
@@ -26,8 +27,10 @@ import type {
   LikedGamesResponse,
   LikedGamesRequest,
   ProfileImagePresignedUrlRequest,
+  UpdateUserInfoRequest,
   UploadFileToS3Request,
 } from '../types/auth';
+import { setAuthAccount } from '../../../utils/auth';
 
 export const DEFAULT_LIKED_GAMES_PAGE_SIZE = 20;
 
@@ -170,6 +173,19 @@ export const useDeleteAccountMutation = () =>
     mutationKey: authKeys.deleteAccount(),
     mutationFn: deleteAccount,
   });
+
+export const useUpdateUserInfoMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: authKeys.updateUserInfo(),
+    mutationFn: (payload: UpdateUserInfoRequest) => updateUserInfo(payload),
+    onSuccess: (data) => {
+      queryClient.setQueryData(authKeys.me(), data);
+      setAuthAccount(data);
+    },
+  });
+};
 
 export const useCheckIdDuplicateMutation = () =>
   useMutation({

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -1,9 +1,15 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import {
   checkIdDuplicate,
   checkNicknameDuplicate,
   changePassword,
+  confirmProfileImage,
   deleteAccount,
   getProfileImagePresignedUrl,
   getCurrentUserProfile,
@@ -14,34 +20,38 @@ import {
   unlikeLikedGame,
   uploadFileToS3,
 } from './auth';
+import { authKeys } from './queryKeys';
 import type {
+  ConfirmProfileImageRequest,
   LikedGamesResponse,
   LikedGamesRequest,
   ProfileImagePresignedUrlRequest,
   UploadFileToS3Request,
 } from '../types/auth';
 
+export const DEFAULT_LIKED_GAMES_PAGE_SIZE = 20;
+
 export const useLoginMutation = () =>
   useMutation({
-    mutationKey: ['auth', 'login'],
+    mutationKey: authKeys.login(),
     mutationFn: login,
   });
 
 export const useSignupMutation = () =>
   useMutation({
-    mutationKey: ['auth', 'signup'],
+    mutationKey: authKeys.signup(),
     mutationFn: signup,
   });
 
 export const useLogoutMutation = () =>
   useMutation({
-    mutationKey: ['auth', 'logout'],
+    mutationKey: authKeys.logout(),
     mutationFn: logout,
   });
 
 export const useCurrentUserProfileQuery = (enabled = true) =>
   useQuery({
-    queryKey: ['auth', 'me'],
+    queryKey: authKeys.me(),
     queryFn: getCurrentUserProfile,
     enabled,
     staleTime: 60_000,
@@ -52,43 +62,75 @@ export const useLikedGamesQuery = (
   payload: LikedGamesRequest = {},
 ) =>
   useQuery({
-    queryKey: ['auth', 'me', 'game-like', payload.page ?? 1, payload.page_size],
+    queryKey: authKeys.likedGamesList(payload),
     queryFn: () => getLikedGames(payload),
     enabled,
     staleTime: 60_000,
+  });
+
+export const useLikedGamesInfiniteQuery = (
+  enabled = true,
+  pageSize = DEFAULT_LIKED_GAMES_PAGE_SIZE,
+) =>
+  useInfiniteQuery({
+    queryKey: authKeys.likedGamesInfinite({ page_size: pageSize }),
+    queryFn: ({ pageParam }) =>
+      getLikedGames({
+        page: pageParam,
+        page_size: pageSize,
+      }),
+    enabled,
+    staleTime: 60_000,
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      const loadedGameCount = allPages.reduce(
+        (count, page) => count + page.results.length,
+        0,
+      );
+
+      if (loadedGameCount >= lastPage.count) {
+        return undefined;
+      }
+
+      return allPages.length + 1;
+    },
   });
 
 export const useUnlikeLikedGameMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationKey: ['auth', 'me', 'game-like', 'unlike'],
+    mutationKey: authKeys.unlikeLikedGame(),
     mutationFn: unlikeLikedGame,
     onSuccess: (_, gameId) => {
       queryClient.setQueriesData<LikedGamesResponse>(
-        { queryKey: ['auth', 'me', 'game-like'] },
+        { queryKey: authKeys.likedGames() },
         (current) => {
-          if (!current) {
+          if (
+            !current ||
+            !Array.isArray((current as Partial<LikedGamesResponse>).results)
+          ) {
             return current;
           }
 
-          const nextResults = current.results.filter(
+          const currentLikedGames = current as LikedGamesResponse;
+          const nextResults = currentLikedGames.results.filter(
             (likedGame) => likedGame.game_id !== gameId,
           );
 
-          if (nextResults.length === current.results.length) {
+          if (nextResults.length === currentLikedGames.results.length) {
             return current;
           }
 
           return {
-            ...current,
-            count: Math.max(0, current.count - 1),
+            ...currentLikedGames,
+            count: Math.max(0, currentLikedGames.count - 1),
             results: nextResults,
           };
         },
       );
       void queryClient.invalidateQueries({
-        queryKey: ['auth', 'me', 'game-like'],
+        queryKey: authKeys.likedGames(),
       });
       void queryClient.invalidateQueries({
         queryKey: ['games', 'detail', gameId],
@@ -99,37 +141,44 @@ export const useUnlikeLikedGameMutation = () => {
 
 export const useProfileImagePresignedUrlMutation = () =>
   useMutation({
-    mutationKey: ['auth', 'me', 'profile-image', 'presigned-url'],
+    mutationKey: authKeys.profileImagePresignedUrl(),
     mutationFn: (payload: ProfileImagePresignedUrlRequest) =>
       getProfileImagePresignedUrl(payload),
   });
 
 export const useUploadFileToS3Mutation = () =>
   useMutation({
-    mutationKey: ['auth', 'me', 'profile-image', 'upload'],
+    mutationKey: authKeys.profileImageUpload(),
     mutationFn: (payload: UploadFileToS3Request) => uploadFileToS3(payload),
+  });
+
+export const useConfirmProfileImageMutation = () =>
+  useMutation({
+    mutationKey: authKeys.profileImageConfirm(),
+    mutationFn: (payload: ConfirmProfileImageRequest) =>
+      confirmProfileImage(payload),
   });
 
 export const useChangePasswordMutation = () =>
   useMutation({
-    mutationKey: ['auth', 'change-password'],
+    mutationKey: authKeys.changePassword(),
     mutationFn: changePassword,
   });
 
 export const useDeleteAccountMutation = () =>
   useMutation({
-    mutationKey: ['auth', 'delete-account'],
+    mutationKey: authKeys.deleteAccount(),
     mutationFn: deleteAccount,
   });
 
 export const useCheckIdDuplicateMutation = () =>
   useMutation({
-    mutationKey: ['auth', 'check-id-duplicate'],
+    mutationKey: authKeys.checkIdDuplicate(),
     mutationFn: checkIdDuplicate,
   });
 
 export const useCheckNicknameDuplicateMutation = () =>
   useMutation({
-    mutationKey: ['auth', 'check-nickname-duplicate'],
+    mutationKey: authKeys.checkNicknameDuplicate(),
     mutationFn: checkNicknameDuplicate,
   });

--- a/src/features/auth/hooks/useLogoutAction.ts
+++ b/src/features/auth/hooks/useLogoutAction.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 
 import { ROUTES } from '../../../constants/routes';
 import { clearAuthTokens } from '../../../utils/auth';
+import { authKeys } from '../api/queryKeys';
 import { useLogoutMutation } from '../api/useAuthApi';
 
 function useLogoutAction() {
@@ -18,8 +19,8 @@ function useLogoutAction() {
     }
 
     clearAuthTokens();
-    await queryClient.cancelQueries({ queryKey: ['auth'] });
-    queryClient.removeQueries({ queryKey: ['auth'] });
+    await queryClient.cancelQueries({ queryKey: authKeys.all });
+    queryClient.removeQueries({ queryKey: authKeys.all });
     navigate(ROUTES.HOME, { replace: true });
   };
 

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -22,6 +22,7 @@ import type {
   ProfileImagePresignedUrlResponse,
   SocialAuthProvider,
   SignupRequest,
+  UpdateUserInfoRequest,
 } from '../types/auth';
 import { createMockUserMap, type MockUserRecord } from './mockUsers';
 
@@ -91,6 +92,14 @@ const getUnauthorizedError = (message: string) =>
 
 const findUserByNickname = (nickname: string) =>
   [...mockUsers.values()].find((user) => user.nickname === nickname);
+
+const findUserByNicknameExcludingLoginId = (
+  nickname: string,
+  loginId: string,
+) =>
+  [...mockUsers.values()].find(
+    (user) => user.nickname === nickname && user.loginId !== loginId,
+  );
 
 const getDevLoginAccounts = () =>
   [...mockUsers.values()]
@@ -504,6 +513,78 @@ const accountHandlers = [
     };
 
     return HttpResponse.json(responseBody);
+  }),
+
+  http.patch(`${AUTH_BASE_PATH}/me`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+    const user = getAuthorizedUser(authorization);
+
+    if (!user) {
+      return getUnauthorizedError('로그인이 필요합니다.');
+    }
+
+    const body = (await request
+      .json()
+      .catch(() => null)) as UpdateUserInfoRequest | null;
+    const hasNickname = typeof body?.nickname === 'string';
+    const hasProfileImage = typeof body?.profile_img_url === 'string';
+
+    if (!hasNickname && !hasProfileImage) {
+      return HttpResponse.json(
+        {
+          error_detail: '수정할 정보를 전달해주세요.',
+        },
+        { status: 400 },
+      );
+    }
+
+    if (hasNickname) {
+      const nickname = body!.nickname!.trim();
+
+      if (!nickname) {
+        return getFieldValidationError(
+          'nickname',
+          '"nickname"이 필드는 필수 항목입니다.',
+        );
+      }
+
+      if (nickname.length < 2 || nickname.length > 20) {
+        return getFieldValidationError(
+          'nickname',
+          '닉네임은 2자 이상 20자 이하로 입력해주세요.',
+        );
+      }
+
+      if (findUserByNicknameExcludingLoginId(nickname, user.loginId)) {
+        return getDuplicateError('이미 사용 중인 닉네임입니다.');
+      }
+
+      user.nickname = nickname;
+    }
+
+    if (hasProfileImage) {
+      const profileImageUrl = body!.profile_img_url!.trim();
+
+      if (!profileImageUrl) {
+        return getFieldValidationError(
+          'profile_img_url',
+          '"profile_img_url"이 필드는 필수 항목입니다.',
+        );
+      }
+
+      user.profileImageUrl = profileImageUrl;
+    }
+
+    await delay(180);
+
+    return HttpResponse.json({
+      login_id: user.loginId,
+      name: user.name,
+      nickname: user.nickname,
+      gender: user.gender,
+      email: user.email,
+      profile_img_url: user.profileImageUrl,
+    } satisfies CurrentUserProfileResponse);
   }),
 
   http.post(

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -9,9 +9,10 @@ import type {
   CheckNicknameDuplicateRequest,
   ChangePasswordRequest,
   ChangePasswordResponse,
+  ConfirmProfileImageRequest,
+  ConfirmProfileImageResponse,
   CurrentUserProfileResponse,
   DeleteAccountRequest,
-  DeleteAccountResponse,
   DeleteLikedGameResponse,
   LikedGameItemResponse,
   LikedGamesResponse,
@@ -534,9 +535,11 @@ const accountHandlers = [
       }
 
       const uploadFileName = `${Date.now()}-${sanitizeFileName(fileName)}`;
+      const fileKey = getProfileImagePathKey(user.loginId, uploadFileName);
       const responseBody: ProfileImagePresignedUrlResponse = {
         presigned_url: `${MOCK_S3_HOST}/upload/${user.loginId}/${uploadFileName}`,
-        file_url: `${MOCK_S3_HOST}/public/${user.loginId}/${uploadFileName}`,
+        img_url: `${MOCK_S3_HOST}/public/${user.loginId}/${uploadFileName}`,
+        key: fileKey,
       };
 
       await delay(100);
@@ -555,8 +558,8 @@ const accountHandlers = [
 
     const requestUrl = new URL(request.url);
     const page = parsePositiveInteger(requestUrl.searchParams.get('page'), 1);
-    const pageSize = parsePositiveInteger(
-      requestUrl.searchParams.get('page_size'),
+    const pageSize = Math.min(
+      parsePositiveInteger(requestUrl.searchParams.get('page_size'), 20),
       20,
     );
     const likedGames = getOrCreateLikedGames(user.loginId);
@@ -589,7 +592,6 @@ const accountHandlers = [
           bytes,
           contentType,
         });
-        user.profileImageUrl = `${MOCK_S3_HOST}/public/${loginId}/${fileName}`;
       }
 
       await delay(120);
@@ -597,6 +599,58 @@ const accountHandlers = [
       return new HttpResponse(null, { status: 200 });
     },
   ),
+
+  http.patch(`${AUTH_BASE_PATH}/me/profile-image`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+    const user = getAuthorizedUser(authorization);
+
+    if (!user) {
+      return getUnauthorizedError('로그인이 필요합니다.');
+    }
+
+    const body = (await request.json()) as ConfirmProfileImageRequest;
+    const profileImageUrl = body.profile_img_url.trim();
+
+    if (!profileImageUrl) {
+      return getFieldValidationError(
+        'profile_img_url',
+        '"profile_img_url"이 필드는 필수 항목입니다.',
+      );
+    }
+
+    const urlPrefix = `${MOCK_S3_HOST}/public/${user.loginId}/`;
+
+    if (!profileImageUrl.startsWith(urlPrefix)) {
+      return getFieldValidationError(
+        'profile_img_url',
+        '유효한 프로필 이미지 경로를 전달해주세요.',
+      );
+    }
+
+    const uploadedFileName = profileImageUrl.slice(urlPrefix.length);
+    const uploadedImageKey = getProfileImagePathKey(
+      user.loginId,
+      uploadedFileName,
+    );
+
+    if (!mockUploadedProfileImagesByPath.has(uploadedImageKey)) {
+      return HttpResponse.json(
+        {
+          error_detail: '업로드된 프로필 이미지를 찾을 수 없습니다.',
+        },
+        { status: 404 },
+      );
+    }
+
+    user.profileImageUrl = profileImageUrl;
+
+    await delay(120);
+
+    return HttpResponse.json({
+      detail: '프로필 이미지가 변경되었습니다.',
+      profile_img_url: profileImageUrl,
+    } satisfies ConfirmProfileImageResponse);
+  }),
 
   http.get(`${MOCK_S3_HOST}/public/:loginId/:fileName`, async ({ params }) => {
     const loginId = typeof params.loginId === 'string' ? params.loginId : '';
@@ -671,14 +725,14 @@ const accountHandlers = [
     }
 
     const body = (await request.json()) as ChangePasswordRequest;
-    const currentPassword = body.current_password.trim();
+    const currentPassword = body.old_password.trim();
     const nextPassword = body.new_password.trim();
-    const nextPasswordConfirm = body.new_password_confirm.trim();
+    const nextPasswordConfirm = body.new_password_check.trim();
 
     if (!currentPassword) {
       return getFieldValidationError(
-        'current_password',
-        '"current_password"이 필드는 필수 항목입니다.',
+        'old_password',
+        '"old_password"이 필드는 필수 항목입니다.',
       );
     }
 
@@ -691,8 +745,8 @@ const accountHandlers = [
 
     if (!nextPasswordConfirm) {
       return getFieldValidationError(
-        'new_password_confirm',
-        '"new_password_confirm"이 필드는 필수 항목입니다.',
+        'new_password_check',
+        '"new_password_check"이 필드는 필수 항목입니다.',
       );
     }
 
@@ -714,7 +768,7 @@ const accountHandlers = [
 
     if (nextPassword !== nextPasswordConfirm) {
       return getFieldValidationError(
-        'new_password_confirm',
+        'new_password_check',
         '비밀번호가 일치하지 않습니다.',
       );
     }
@@ -768,9 +822,7 @@ const accountHandlers = [
 
     await delay(220);
 
-    return HttpResponse.json({
-      detail: '회원 탈퇴가 완료되었습니다.',
-    } satisfies DeleteAccountResponse);
+    return new HttpResponse(null, { status: 204 });
   }),
 ];
 

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -20,16 +20,12 @@ export interface LogoutResponse {
 }
 
 export interface ChangePasswordRequest {
-  current_password: string;
+  old_password: string;
   new_password: string;
-  new_password_confirm: string;
+  new_password_check: string;
 }
 
 export interface ChangePasswordResponse {
-  detail: string;
-}
-
-export interface DeleteAccountResponse {
   detail: string;
 }
 
@@ -75,7 +71,17 @@ export interface ProfileImagePresignedUrlRequest {
 
 export interface ProfileImagePresignedUrlResponse {
   presigned_url: string;
-  file_url: string;
+  img_url: string;
+  key: string;
+}
+
+export interface ConfirmProfileImageRequest {
+  profile_img_url: string;
+}
+
+export interface ConfirmProfileImageResponse {
+  detail?: string;
+  profile_img_url?: string;
 }
 
 export interface UploadFileToS3Request {

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -64,6 +64,11 @@ export interface CurrentUserProfileResponse {
   profile_img_url?: string | null;
 }
 
+export interface UpdateUserInfoRequest {
+  nickname?: string;
+  profile_img_url?: string;
+}
+
 export interface ProfileImagePresignedUrlRequest {
   file_name: string;
   content_type: string;

--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -3,6 +3,7 @@ import { AxiosError } from 'axios';
 import { ExternalLink, Heart, PlayCircle, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import ToastMessage from '../../../components/mypage/ToastMessage';
+import { authKeys } from '../../auth/api/queryKeys';
 import type { LikedGamesResponse } from '../../auth/types/auth';
 import { useAuthStore } from '../../../store/useAuthStore';
 import { getGameDetail, likeGame, unlikeGame } from '../gameApi';
@@ -47,7 +48,13 @@ const resolveEmbedUrl = (
   embedUrl: string | null,
   videoUrl: string | null,
 ): string | null => embedUrl ?? (videoUrl ? toYouTubeEmbedUrl(videoUrl) : null);
+const isLikedGamesResponse = (value: unknown): value is LikedGamesResponse => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
 
+  return Array.isArray((value as Partial<LikedGamesResponse>).results);
+};
 const getLikeErrorMessage = (error: unknown) => {
   if (error instanceof AxiosError) {
     if (error.response?.status === 401) {
@@ -115,14 +122,16 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
       );
 
       queryClient.setQueriesData<LikedGamesResponse>(
-        { queryKey: ['auth', 'me', 'game-like'] },
+        { queryKey: authKeys.likedGames() },
         (current) => {
-          if (!current) {
+          if (!isLikedGamesResponse(current)) {
             return current;
           }
 
+          const currentLikedGames = current as LikedGamesResponse;
+
           if (response.isLiked) {
-            const alreadyExists = current.results.some(
+            const alreadyExists = currentLikedGames.results.some(
               (likedGame) => likedGame.game_id === response.gameId,
             );
 
@@ -139,29 +148,29 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
             };
 
             return {
-              ...current,
-              count: current.count + 1,
-              results: [nextLikedGame, ...current.results],
+              ...currentLikedGames,
+              count: currentLikedGames.count + 1,
+              results: [nextLikedGame, ...currentLikedGames.results],
             };
           }
 
-          const nextResults = current.results.filter(
+          const nextResults = currentLikedGames.results.filter(
             (likedGame) => likedGame.game_id !== response.gameId,
           );
 
-          if (nextResults.length === current.results.length) {
+          if (nextResults.length === currentLikedGames.results.length) {
             return current;
           }
 
           return {
-            ...current,
-            count: Math.max(0, current.count - 1),
+            ...currentLikedGames,
+            count: Math.max(0, currentLikedGames.count - 1),
             results: nextResults,
           };
         },
       );
       void queryClient.invalidateQueries({
-        queryKey: ['auth', 'me', 'game-like'],
+        queryKey: authKeys.likedGames(),
       });
       void queryClient.invalidateQueries({
         queryKey: ['games', 'detail', game.gameId],

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate, useParams } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
+import { authKeys } from '../../features/auth/api/queryKeys';
 import type { LikedGamesResponse } from '../../features/auth/types/auth';
 import {
   useMatchCandidatesQuery,
@@ -30,6 +31,14 @@ const formatMatchingCandidateRating = (rating: number | null) => {
   const normalizedRating = rating <= 5 ? rating * 20 : rating;
 
   return `${normalizedRating.toFixed(1)}점`;
+};
+
+const isLikedGamesResponse = (value: unknown): value is LikedGamesResponse => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  return Array.isArray((value as Partial<LikedGamesResponse>).results);
 };
 
 function MatchingGenreDetailPage() {
@@ -119,15 +128,19 @@ function MatchingGenreDetailPage() {
 
   const syncLikedGamesCache = () => {
     queryClient.setQueriesData<LikedGamesResponse>(
-      { queryKey: ['auth', 'me', 'game-like'] },
+      { queryKey: authKeys.likedGames() },
       (current) => {
-        if (!current) {
+        if (!isLikedGamesResponse(current)) {
           return current;
         }
 
+        const currentLikedGames = current as LikedGamesResponse;
         const likedAt = new Date().toISOString();
         const nextLikedGamesById = new Map(
-          current.results.map((likedGame) => [likedGame.game_id, likedGame]),
+          currentLikedGames.results.map((likedGame) => [
+            likedGame.game_id,
+            likedGame,
+          ]),
         );
 
         displayCandidates.forEach((candidate) => {
@@ -158,7 +171,7 @@ function MatchingGenreDetailPage() {
         );
 
         return {
-          ...current,
+          ...currentLikedGames,
           count: nextResults.length,
           results: nextResults,
         };
@@ -166,7 +179,7 @@ function MatchingGenreDetailPage() {
     );
 
     void queryClient.invalidateQueries({
-      queryKey: ['auth', 'me', 'game-like'],
+      queryKey: authKeys.likedGames(),
     });
   };
 

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -8,6 +8,7 @@ import AuthButton from '../../components/auth/AuthButton';
 import Header from '../../components/common/Header';
 import ConfirmModal from '../../components/mypage/ConfirmModal';
 import FavoriteGameCard from '../../components/mypage/FavoriteGameCard';
+import FavoriteGameCardSkeleton from '../../components/mypage/FavoriteGameCardSkeleton';
 import FavoriteGamesEmptyState from '../../components/mypage/FavoriteGamesEmptyState';
 import MyPageProfileSection from '../../components/mypage/MyPageProfileSection';
 import PasswordChangePanel, {
@@ -21,14 +22,17 @@ import {
   extractAuthApiFieldErrors,
 } from '../../features/auth/api/auth';
 import {
+  DEFAULT_LIKED_GAMES_PAGE_SIZE,
   useChangePasswordMutation,
+  useConfirmProfileImageMutation,
   useCurrentUserProfileQuery,
   useDeleteAccountMutation,
-  useLikedGamesQuery,
+  useLikedGamesInfiniteQuery,
   useProfileImagePresignedUrlMutation,
   useUnlikeLikedGameMutation,
   useUploadFileToS3Mutation,
 } from '../../features/auth/api/useAuthApi';
+import { authKeys } from '../../features/auth/api/queryKeys';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
 import type {
   AuthGender,
@@ -104,9 +108,9 @@ const getPasswordFieldErrors = (
 const mapPasswordApiFieldErrors = (
   fieldErrors: Record<string, string>,
 ): PasswordFieldErrors => ({
-  currentPassword: fieldErrors.current_password,
+  currentPassword: fieldErrors.old_password,
   newPassword: fieldErrors.new_password,
-  newPasswordConfirm: fieldErrors.new_password_confirm,
+  newPasswordConfirm: fieldErrors.new_password_check,
 });
 
 const formatLikedAt = (likedAt: string) => {
@@ -173,11 +177,12 @@ function MyPage() {
   const profileImagePresignedUrlMutation =
     useProfileImagePresignedUrlMutation();
   const uploadFileToS3Mutation = useUploadFileToS3Mutation();
+  const confirmProfileImageMutation = useConfirmProfileImageMutation();
   const profileQuery = useCurrentUserProfileQuery(hasAccessToken);
-  const likedGamesQuery = useLikedGamesQuery(hasAccessToken, {
-    page: 1,
-    page_size: 100,
-  });
+  const likedGamesQuery = useLikedGamesInfiniteQuery(
+    hasAccessToken,
+    DEFAULT_LIKED_GAMES_PAGE_SIZE,
+  );
   const storedAccount = useAuthStore((state) => state.account);
 
   const [isPasswordPanelOpen, setIsPasswordPanelOpen] = useState(false);
@@ -210,9 +215,21 @@ function MyPage() {
     newPasswordConfirm:
       apiFieldErrors.newPasswordConfirm ?? localFieldErrors.newPasswordConfirm,
   };
-  const favoriteGames = useMemo(() => {
-    return (likedGamesQuery.data?.results ?? []).map(toFavoriteGamePreview);
+  const likedGameResults = useMemo(() => {
+    const pages = likedGamesQuery.data?.pages ?? [];
+
+    return pages.flatMap((page) => page.results);
   }, [likedGamesQuery.data]);
+
+  const favoriteGames = useMemo(() => {
+    const deduplicatedGames = new Map<number, LikedGameItemResponse>();
+
+    likedGameResults.forEach((game) => {
+      deduplicatedGames.set(game.game_id, game);
+    });
+
+    return [...deduplicatedGames.values()].map(toFavoriteGamePreview);
+  }, [likedGameResults]);
 
   useEffect(() => {
     if (!toast) {
@@ -262,18 +279,22 @@ function MyPage() {
     );
   }
 
-  const favoriteCount = favoriteGames.length;
+  const favoriteCount =
+    likedGamesQuery.data?.pages?.[0]?.count ?? favoriteGames.length;
   const resolvedProfile = profileQuery.data ?? storedAccount;
   const isProfileLoading = profileQuery.isLoading && !resolvedProfile;
-  const isFavoriteGamesLoading = likedGamesQuery.isLoading && !favoriteCount;
-  const isFavoriteGamesError = likedGamesQuery.isError && !favoriteCount;
+  const isFavoriteGamesLoading =
+    likedGamesQuery.isLoading && !favoriteGames.length;
+  const isFavoriteGamesError = likedGamesQuery.isError && !favoriteGames.length;
+  const hasFavoriteGamesNextPage = Boolean(likedGamesQuery.hasNextPage);
   const profileName = resolvedProfile?.name || 'N/A';
   const profileEmail = resolvedProfile?.email || null;
   const profileGenderLabel = toGenderLabel(resolvedProfile?.gender);
   const profileImageUrl = resolvedProfile?.profile_img_url ?? null;
   const isProfileImageUploading =
     profileImagePresignedUrlMutation.isPending ||
-    uploadFileToS3Mutation.isPending;
+    uploadFileToS3Mutation.isPending ||
+    confirmProfileImageMutation.isPending;
 
   const resetPasswordPanel = () => {
     setPasswordValues(initialPasswordValues);
@@ -342,9 +363,9 @@ function MyPage() {
 
     try {
       const response = await changePasswordMutation.mutateAsync({
-        current_password: passwordValues.currentPassword.trim(),
+        old_password: passwordValues.currentPassword.trim(),
         new_password: passwordValues.newPassword.trim(),
-        new_password_confirm: passwordValues.newPasswordConfirm.trim(),
+        new_password_check: passwordValues.newPasswordConfirm.trim(),
       });
 
       setPasswordValues(initialPasswordValues);
@@ -380,7 +401,7 @@ function MyPage() {
     }
 
     try {
-      const response = await deleteAccountMutation.mutateAsync({
+      await deleteAccountMutation.mutateAsync({
         password: trimmedPassword,
       });
 
@@ -388,7 +409,7 @@ function MyPage() {
       navigate(`/${ROUTES.LOGIN}`, {
         replace: true,
         state: {
-          noticeMessage: response.detail,
+          noticeMessage: '회원 탈퇴가 완료되었습니다.',
         },
       });
     } catch (error) {
@@ -426,6 +447,12 @@ function MyPage() {
       return;
     }
 
+    const previousProfile =
+      queryClient.getQueryData<CurrentUserProfileResponse>(authKeys.me()) ??
+      resolvedProfile ??
+      null;
+    let hasOptimisticProfileUpdate = false;
+
     try {
       const presignedResponse =
         await profileImagePresignedUrlMutation.mutateAsync({
@@ -440,29 +467,64 @@ function MyPage() {
       });
 
       queryClient.setQueryData<CurrentUserProfileResponse>(
-        ['auth', 'me'],
+        authKeys.me(),
         (currentProfile) =>
           currentProfile
             ? {
                 ...currentProfile,
-                profile_img_url: presignedResponse.file_url,
+                profile_img_url: presignedResponse.img_url,
               }
             : currentProfile,
       );
 
-      if (resolvedProfile) {
+      if (previousProfile) {
         setAuthAccount({
-          ...resolvedProfile,
-          profile_img_url: presignedResponse.file_url,
+          ...previousProfile,
+          profile_img_url: presignedResponse.img_url,
         });
       }
 
-      void queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
+      hasOptimisticProfileUpdate = true;
+
+      const confirmResponse = await confirmProfileImageMutation.mutateAsync({
+        profile_img_url: presignedResponse.img_url,
+      });
+      const confirmedProfileImageUrl =
+        confirmResponse.profile_img_url ?? presignedResponse.img_url;
+
+      queryClient.setQueryData<CurrentUserProfileResponse>(
+        authKeys.me(),
+        (currentProfile) =>
+          currentProfile
+            ? {
+                ...currentProfile,
+                profile_img_url: confirmedProfileImageUrl,
+              }
+            : currentProfile,
+      );
+
+      if (previousProfile) {
+        setAuthAccount({
+          ...previousProfile,
+          profile_img_url: confirmedProfileImageUrl,
+        });
+      }
+
+      void queryClient.invalidateQueries({ queryKey: authKeys.me() });
       setToast({
         tone: 'success',
         message: '프로필이 변경되었습니다.',
       });
     } catch (error) {
+      if (hasOptimisticProfileUpdate && previousProfile) {
+        queryClient.setQueryData<CurrentUserProfileResponse>(
+          authKeys.me(),
+          previousProfile,
+        );
+        setAuthAccount(previousProfile);
+        void queryClient.invalidateQueries({ queryKey: authKeys.me() });
+      }
+
       setToast({
         tone: 'error',
         message: extractAuthApiErrorMessage(error),
@@ -502,7 +564,7 @@ function MyPage() {
       <div className="app-aurora pointer-events-none absolute inset-0 opacity-70" />
       <Header fixed />
 
-      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-[clamp(1rem,5vw,20rem)] pt-24 pb-14 sm:pt-28 sm:pb-16 lg:pt-32">
+      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-4 pt-24 pb-14 sm:px-6 sm:pt-28 sm:pb-16 lg:px-10 lg:pt-32 xl:px-14">
         <MyPageProfileSection
           nickname={resolvedProfile?.nickname ?? '회원'}
           name={profileName}
@@ -558,34 +620,74 @@ function MyPage() {
             </p>
           </div>
 
-          <div className="mypage-scrollbar mt-5 max-h-[720px] overflow-y-auto pr-1">
+          <div className="mypage-scrollbar mt-5 max-h-[760px] overflow-y-auto pr-1">
             {isFavoriteGamesLoading ? (
-              <p
-                role="status"
-                aria-live="polite"
-                className="text-mypage-muted py-8 text-center text-sm"
-              >
-                찜 목록을 불러오는 중입니다...
-              </p>
+              <FavoriteGameCardSkeleton />
             ) : favoriteCount > 0 ? (
-              <div className="grid gap-4 md:grid-cols-2">
-                {favoriteGames.map((game) => (
-                  <FavoriteGameCard
-                    key={game.gameId}
-                    game={game}
-                    onClick={handleFavoriteGameCardClick}
-                    onFavoriteClick={setSelectedFavoriteGame}
-                  />
-                ))}
+              <div>
+                <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
+                  {favoriteGames.map((game) => (
+                    <FavoriteGameCard
+                      key={game.gameId}
+                      game={game}
+                      onClick={handleFavoriteGameCardClick}
+                      onFavoriteClick={setSelectedFavoriteGame}
+                    />
+                  ))}
+                </div>
+                {hasFavoriteGamesNextPage ||
+                likedGamesQuery.isFetchingNextPage ||
+                likedGamesQuery.isFetchNextPageError ? (
+                  <div className="mt-5 flex flex-col items-center gap-2">
+                    {likedGamesQuery.isFetchNextPageError ? (
+                      <p className="text-sm text-red-300">
+                        추가 찜 목록을 불러오지 못했습니다.
+                      </p>
+                    ) : null}
+                    <AuthButton
+                      type="button"
+                      variant="secondary"
+                      className="w-full max-w-40"
+                      onClick={() => void likedGamesQuery.fetchNextPage()}
+                      disabled={
+                        likedGamesQuery.isFetchingNextPage ||
+                        !hasFavoriteGamesNextPage
+                      }
+                    >
+                      {likedGamesQuery.isFetchingNextPage
+                        ? '더 불러오는 중...'
+                        : hasFavoriteGamesNextPage
+                          ? '찜 목록 더보기'
+                          : '모두 불러왔어요'}
+                    </AuthButton>
+                  </div>
+                ) : null}
               </div>
             ) : isFavoriteGamesError ? (
-              <p
+              <div
                 role="status"
                 aria-live="polite"
-                className="py-8 text-center text-sm text-red-300"
+                className="border-mypage-divider bg-mypage-card flex min-h-56 flex-col items-center justify-center gap-4 rounded-[24px] border border-dashed px-6 py-10 text-center"
               >
-                찜 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
-              </p>
+                <p className="text-sm text-red-300">
+                  찜 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+                </p>
+                <AuthButton
+                  type="button"
+                  variant="secondary"
+                  className="w-full max-w-36"
+                  onClick={() => void likedGamesQuery.refetch()}
+                  disabled={
+                    likedGamesQuery.isFetching ||
+                    likedGamesQuery.isFetchingNextPage
+                  }
+                >
+                  {likedGamesQuery.isFetching ||
+                  likedGamesQuery.isFetchingNextPage
+                    ? '다시 불러오는 중...'
+                    : '다시 시도'}
+                </AuthButton>
+              </div>
             ) : (
               <FavoriteGamesEmptyState />
             )}

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -1,6 +1,6 @@
 import type { FormEvent } from 'react';
 import { Heart, ShieldAlert } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -204,6 +204,8 @@ function MyPage() {
     useState<FavoriteGamePreview | null>(null);
   const [selectedDetailGame, setSelectedDetailGame] =
     useState<GameListItem | null>(null);
+  const favoriteGamesScrollRef = useRef<HTMLDivElement | null>(null);
+  const favoriteGamesLoadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const localFieldErrors = useMemo(
     () => getPasswordFieldErrors(passwordValues, touchedState),
@@ -232,6 +234,11 @@ function MyPage() {
 
     return [...deduplicatedGames.values()].map(toFavoriteGamePreview);
   }, [likedGameResults]);
+  const hasFavoriteGamesNextPage = Boolean(likedGamesQuery.hasNextPage);
+  const isFavoriteGamesFetchNextPageError =
+    likedGamesQuery.isFetchNextPageError;
+  const isFavoriteGamesFetchingNextPage = likedGamesQuery.isFetchingNextPage;
+  const fetchNextFavoriteGamesPage = likedGamesQuery.fetchNextPage;
 
   useEffect(() => {
     if (!toast) {
@@ -271,6 +278,48 @@ function MyPage() {
     };
   }, [isPasswordPanelOpen, passwordPanelMessage]);
 
+  useEffect(() => {
+    if (isFavoriteGamesFetchNextPageError || !hasFavoriteGamesNextPage) {
+      return undefined;
+    }
+
+    const rootElement = favoriteGamesScrollRef.current;
+    const targetElement = favoriteGamesLoadMoreRef.current;
+
+    if (!rootElement || !targetElement) {
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+
+        if (!entry?.isIntersecting || isFavoriteGamesFetchingNextPage) {
+          return;
+        }
+
+        void fetchNextFavoriteGamesPage();
+      },
+      {
+        root: rootElement,
+        rootMargin: '0px 0px 160px 0px',
+        threshold: 0.1,
+      },
+    );
+
+    observer.observe(targetElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    favoriteGames.length,
+    fetchNextFavoriteGamesPage,
+    hasFavoriteGamesNextPage,
+    isFavoriteGamesFetchNextPageError,
+    isFavoriteGamesFetchingNextPage,
+  ]);
+
   if (!hasAccessToken) {
     return (
       <Navigate
@@ -288,7 +337,6 @@ function MyPage() {
   const isFavoriteGamesLoading =
     likedGamesQuery.isLoading && !favoriteGames.length;
   const isFavoriteGamesError = likedGamesQuery.isError && !favoriteGames.length;
-  const hasFavoriteGamesNextPage = Boolean(likedGamesQuery.hasNextPage);
   const profileName = resolvedProfile?.name || 'N/A';
   const profileEmail = resolvedProfile?.email || null;
   const profileGenderLabel = toGenderLabel(resolvedProfile?.gender);
@@ -649,7 +697,10 @@ function MyPage() {
             </p>
           </div>
 
-          <div className="mypage-scrollbar mt-5 max-h-[760px] overflow-y-auto pr-1">
+          <div
+            ref={favoriteGamesScrollRef}
+            className="mypage-scrollbar mt-5 max-h-[760px] overflow-y-auto pr-1"
+          >
             {isFavoriteGamesLoading ? (
               <FavoriteGameCardSkeleton />
             ) : favoriteCount > 0 ? (
@@ -664,33 +715,39 @@ function MyPage() {
                     />
                   ))}
                 </div>
-                {hasFavoriteGamesNextPage ||
-                likedGamesQuery.isFetchingNextPage ||
-                likedGamesQuery.isFetchNextPageError ? (
-                  <div className="mt-5 flex flex-col items-center gap-2">
-                    {likedGamesQuery.isFetchNextPageError ? (
+                <div className="mt-5 flex flex-col items-center gap-2">
+                  <div
+                    ref={favoriteGamesLoadMoreRef}
+                    aria-hidden="true"
+                    className="h-0.5 w-full"
+                  />
+                  {likedGamesQuery.isFetchNextPageError ? (
+                    <>
                       <p className="text-sm text-red-300">
                         추가 찜 목록을 불러오지 못했습니다.
                       </p>
-                    ) : null}
-                    <AuthButton
-                      type="button"
-                      variant="secondary"
-                      className="w-full max-w-40"
-                      onClick={() => void likedGamesQuery.fetchNextPage()}
-                      disabled={
-                        likedGamesQuery.isFetchingNextPage ||
-                        !hasFavoriteGamesNextPage
-                      }
-                    >
-                      {likedGamesQuery.isFetchingNextPage
-                        ? '더 불러오는 중...'
-                        : hasFavoriteGamesNextPage
-                          ? '찜 목록 더보기'
-                          : '모두 불러왔어요'}
-                    </AuthButton>
-                  </div>
-                ) : null}
+                      <AuthButton
+                        type="button"
+                        variant="secondary"
+                        className="w-full max-w-40"
+                        onClick={() => void likedGamesQuery.fetchNextPage()}
+                        disabled={likedGamesQuery.isFetchingNextPage}
+                      >
+                        {likedGamesQuery.isFetchingNextPage
+                          ? '다시 불러오는 중...'
+                          : '다시 시도'}
+                      </AuthButton>
+                    </>
+                  ) : likedGamesQuery.isFetchingNextPage ? (
+                    <p className="text-mypage-muted text-sm">
+                      찜 목록을 더 불러오는 중입니다...
+                    </p>
+                  ) : hasFavoriteGamesNextPage ? (
+                    <p className="text-mypage-muted text-sm">
+                      아래로 스크롤하면 찜 목록을 더 볼 수 있어요.
+                    </p>
+                  ) : null}
+                </div>
               </div>
             ) : isFavoriteGamesError ? (
               <div

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -29,6 +29,7 @@ import {
   useDeleteAccountMutation,
   useLikedGamesInfiniteQuery,
   useProfileImagePresignedUrlMutation,
+  useUpdateUserInfoMutation,
   useUnlikeLikedGameMutation,
   useUploadFileToS3Mutation,
 } from '../../features/auth/api/useAuthApi';
@@ -173,6 +174,7 @@ function MyPage() {
   const { logout, isPending: isLogoutPending } = useLogoutAction();
   const changePasswordMutation = useChangePasswordMutation();
   const deleteAccountMutation = useDeleteAccountMutation();
+  const updateUserInfoMutation = useUpdateUserInfoMutation();
   const unlikeLikedGameMutation = useUnlikeLikedGameMutation();
   const profileImagePresignedUrlMutation =
     useProfileImagePresignedUrlMutation();
@@ -532,6 +534,31 @@ function MyPage() {
     }
   };
 
+  const handleNicknameSave = async (nextNickname: string) => {
+    try {
+      await updateUserInfoMutation.mutateAsync({
+        nickname: nextNickname,
+      });
+      setToast({
+        tone: 'success',
+        message: '프로필이 변경되었습니다.',
+      });
+
+      return true;
+    } catch (error) {
+      const fieldErrors = extractAuthApiFieldErrors(error);
+      const nicknameErrorMessage =
+        fieldErrors.nickname || extractAuthApiErrorMessage(error);
+
+      setToast({
+        tone: 'error',
+        message: nicknameErrorMessage,
+      });
+
+      return false;
+    }
+  };
+
   const handleFavoriteGameCardClick = (game: FavoriteGamePreview) => {
     setSelectedDetailGame(toFavoriteGameListItem(game));
   };
@@ -573,12 +600,14 @@ function MyPage() {
           profileImageUrl={profileImageUrl}
           isProfileLoading={isProfileLoading}
           isProfileImageUploading={isProfileImageUploading}
+          isProfileUpdating={updateUserInfoMutation.isPending}
           isLoggingOut={isLogoutPending}
           isPasswordPanelOpen={isPasswordPanelOpen}
           onPasswordToggle={() => setIsPasswordPanelOpen((current) => !current)}
           onLogout={() => {
             void logout();
           }}
+          onNicknameSave={handleNicknameSave}
           onProfileImageSelect={(file) => {
             void handleProfileImageSelect(file);
           }}

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -7,6 +7,7 @@ import { Link, useSearchParams } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
+import { authKeys } from '../../features/auth/api/queryKeys';
 import type { LikedGamesResponse } from '../../features/auth/types/auth';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
 import {
@@ -78,6 +79,14 @@ const LIKE_ERROR_MESSAGE =
   '좋아요 상태를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.';
 const LIKE_LOGIN_REQUIRED_MESSAGE = '로그인 후 좋아요를 사용할 수 있어요.';
 const FEEDBACK_MESSAGE_DURATION_MS = 3000;
+
+const isLikedGamesResponse = (value: unknown): value is LikedGamesResponse => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  return Array.isArray((value as Partial<LikedGamesResponse>).results);
+};
 
 const normalizeResultItem = (
   item: SurveyResultItem | MatchResultItem,
@@ -359,14 +368,16 @@ function RecommendationListPage() {
     nextIsLiked: boolean,
   ) => {
     queryClient.setQueriesData<LikedGamesResponse>(
-      { queryKey: ['auth', 'me', 'game-like'] },
+      { queryKey: authKeys.likedGames() },
       (current) => {
-        if (!current) {
+        if (!isLikedGamesResponse(current)) {
           return current;
         }
 
+        const currentLikedGames = current as LikedGamesResponse;
+
         if (nextIsLiked) {
-          const alreadyExists = current.results.some(
+          const alreadyExists = currentLikedGames.results.some(
             (likedGame) => likedGame.game_id === item.game_id,
           );
 
@@ -375,8 +386,8 @@ function RecommendationListPage() {
           }
 
           return {
-            ...current,
-            count: current.count + 1,
+            ...currentLikedGames,
+            count: currentLikedGames.count + 1,
             results: [
               {
                 game_id: item.game_id,
@@ -385,22 +396,22 @@ function RecommendationListPage() {
                 genres: item.genres,
                 liked_at: new Date().toISOString(),
               },
-              ...current.results,
+              ...currentLikedGames.results,
             ],
           };
         }
 
-        const nextResults = current.results.filter(
+        const nextResults = currentLikedGames.results.filter(
           (likedGame) => likedGame.game_id !== item.game_id,
         );
 
-        if (nextResults.length === current.results.length) {
+        if (nextResults.length === currentLikedGames.results.length) {
           return current;
         }
 
         return {
-          ...current,
-          count: Math.max(0, current.count - 1),
+          ...currentLikedGames,
+          count: Math.max(0, currentLikedGames.count - 1),
           results: nextResults,
         };
       },
@@ -446,15 +457,17 @@ function RecommendationListPage() {
         });
 
         queryClient.setQueriesData<LikedGamesResponse>(
-          { queryKey: ['auth', 'me', 'game-like'] },
+          { queryKey: authKeys.likedGames() },
           (current) => {
-            if (!current || !response.isLiked) {
+            if (!isLikedGamesResponse(current) || !response.isLiked) {
               return current;
             }
 
+            const currentLikedGames = current as LikedGamesResponse;
+
             return {
-              ...current,
-              results: current.results.map((likedGame) =>
+              ...currentLikedGames,
+              results: currentLikedGames.results.map((likedGame) =>
                 likedGame.game_id === response.gameId
                   ? {
                       ...likedGame,
@@ -475,7 +488,7 @@ function RecommendationListPage() {
       }
 
       void queryClient.invalidateQueries({
-        queryKey: ['auth', 'me', 'game-like'],
+        queryKey: authKeys.likedGames(),
       });
     },
     onError: (error) => {


### PR DESCRIPTION
## 관련 이슈

- closes #185

## 변경 내용

- 마이페이지 비밀번호 변경 요청 필드명을 명세 기준으로 정합화했습니다. (old_password, new_password, new_password_check)
- 프로필 이미지 업로드 흐름을 명세에 맞게 수정했습니다. (Presigned 응답 img_url, key 반영 + S3 PUT 후 PATCH /api/v1/accounts/me/profile-image 확정 호출)
- 회원탈퇴 성공 응답을 204 No Content 기준으로 처리하도록 정리했습니다.
- 찜 목록 조회를 page_size=20 기준으로 맞추고, 페이지 단위 로딩 구조를 적용했습니다.
- 찜 목록 UI를 더보기 버튼 방식에서 무한스크롤 방식으로 전환했습니다.
- authKeys 쿼리 키 팩토리를 도입해 마이페이지/상세/추천/매칭의 찜 캐시 동기화를 일관화했습니다.
- 마이페이지 프로필/찜 UI를 개선했습니다. (세로형 포스터 카드, 스켈레톤 로딩, 에러 재시도, 프로필 섹션 편집 UX 보강)
- 사용자 정보 수정 API (PATCH /api/v1/accounts/me) 연동 및 닉네임 편집 UI를 추가했습니다.
- MSW 핸들러도 위 API 계약과 동일하게 맞췄습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3436" height="1826" alt="image" src="https://github.com/user-attachments/assets/0212d423-6a28-4393-8058-e73dd5b2e7da" />

## 참고사항

-
