### PR TITLE
refactor(chat): 고객센터 챗봇 스크롤/abort/접근성 최적화

### DIFF
--- a/src/components/support-chat/SupportChatComposer.tsx
+++ b/src/components/support-chat/SupportChatComposer.tsx
@@ -58,6 +58,7 @@ function SupportChatComposer({
           className="mt-1 text-xs text-[#ff8b84]"
           role="alert"
           aria-live="assertive"
+          aria-atomic="true"
         >
           {error}
         </p>

--- a/src/components/support-chat/SupportChatLauncherButton.tsx
+++ b/src/components/support-chat/SupportChatLauncherButton.tsx
@@ -14,12 +14,12 @@ function SupportChatLauncherButton({
       type="button"
       onClick={onClick}
       aria-label={isOpen ? '고객센터 챗봇 닫기' : '고객센터 챗봇 열기'}
-      className="support-chat-fab group fixed right-4 bottom-4 z-[95] flex h-16 w-16 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none sm:right-6 sm:bottom-6"
+      className="support-chat-fab group fixed right-4 bottom-4 z-[95] flex h-16 w-16 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none motion-reduce:transition-none motion-reduce:hover:translate-y-0 sm:right-6 sm:bottom-6"
     >
       <span className="support-chat-fab-glow" />
       <Bot
         size={24}
-        className={`relative z-10 transition-transform ${
+        className={`relative z-10 transition-transform motion-reduce:transition-none ${
           isOpen ? 'scale-95 rotate-6' : 'scale-100'
         }`}
       />

--- a/src/components/support-chat/SupportChatPanel.tsx
+++ b/src/components/support-chat/SupportChatPanel.tsx
@@ -19,10 +19,14 @@ type SupportChatPanelProps = {
   quickActions: SupportChatQuickAction[];
   showQuickActions: boolean;
   isSubmitting: boolean;
+  isViewportNearBottom: boolean;
+  showJumpToLatestButton: boolean;
+  liveStatusMessage: string | null;
   error: string | null;
   inputValue: string;
   onReset: () => void;
   onClose: () => void;
+  onJumpToLatest: () => void;
   onQuickActionSelect: (label: string) => void;
   onInputChange: (value: string) => void;
   onSubmit: () => void;
@@ -37,10 +41,14 @@ function SupportChatPanel({
   quickActions,
   showQuickActions,
   isSubmitting,
+  isViewportNearBottom,
+  showJumpToLatestButton,
+  liveStatusMessage,
   error,
   inputValue,
   onReset,
   onClose,
+  onJumpToLatest,
   onQuickActionSelect,
   onInputChange,
   onSubmit,
@@ -48,7 +56,7 @@ function SupportChatPanel({
   return (
     <div
       ref={panelRef}
-      className={`support-chat-panel fixed right-4 bottom-24 z-[90] flex h-[min(78vh,46rem)] w-[min(94vw,27rem)] origin-bottom-right flex-col overflow-hidden transition-all duration-300 ease-out sm:right-6 sm:bottom-26 ${
+      className={`support-chat-panel fixed right-4 bottom-24 z-[90] flex h-[min(78vh,46rem)] w-[min(94vw,27rem)] origin-bottom-right flex-col overflow-hidden transition-all duration-300 ease-out motion-reduce:transition-none sm:right-6 sm:bottom-26 ${
         isOpen
           ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
           : 'pointer-events-none translate-y-4 scale-95 opacity-0'
@@ -67,7 +75,7 @@ function SupportChatPanel({
         ref={viewportRef}
         className="support-chat-scrollbar flex-1 overflow-y-auto px-4 py-4"
         role="log"
-        aria-live="polite"
+        aria-live={isViewportNearBottom ? 'polite' : 'off'}
         aria-relevant="additions text"
         aria-label="고객센터 챗봇 대화 내역"
       >
@@ -85,6 +93,27 @@ function SupportChatPanel({
           ) : null}
         </div>
       </div>
+
+      {showJumpToLatestButton ? (
+        <div className="pointer-events-none absolute right-4 bottom-[5.75rem] z-20 flex justify-end">
+          <button
+            type="button"
+            onClick={onJumpToLatest}
+            className="pointer-events-auto inline-flex items-center rounded-full border border-[#cf4a44]/75 bg-[#2a0f0f]/95 px-3.5 py-2 text-xs font-semibold text-white shadow-[0_16px_30px_rgba(0,0,0,0.35)] transition hover:border-[#e05f58] hover:bg-[#371413] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#df3b33] motion-reduce:transition-none"
+          >
+            새 메시지 확인
+          </button>
+        </div>
+      ) : null}
+
+      <p
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {liveStatusMessage}
+      </p>
 
       <SupportChatComposer
         value={inputValue}

--- a/src/components/support-chat/SupportChatWidget.tsx
+++ b/src/components/support-chat/SupportChatWidget.tsx
@@ -1,5 +1,6 @@
 import {
   type MutableRefObject,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -58,12 +59,17 @@ const getRouteContext = (pathname: string): SupportChatRouteContext => ({
   pageLabel: getPageLabel(pathname),
 });
 
+const AUTO_SCROLL_NEAR_BOTTOM_THRESHOLD_PX = 72;
+
 function SupportChatWidget() {
   const location = useLocation();
   const [inputValue, setInputValue] = useState('');
+  const [isViewportNearBottom, setIsViewportNearBottom] = useState(true);
+  const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const streamAbortRef = useRef<AbortController | null>(null);
+  const lastHandledMessageCursorRef = useRef<string | null>(null);
 
   const routeContext = useMemo(
     () => getRouteContext(location.pathname),
@@ -95,11 +101,66 @@ function SupportChatWidget() {
     finalizeAssistantMessage,
     removeMessage,
   } = useSupportChatStore();
+  const messageUpdateCursor = useMemo(() => {
+    const latestMessage = messages.at(-1);
+
+    return `${messages.length}:${latestMessage?.id ?? 'none'}:${latestMessage?.content.length ?? 0}:${isSubmitting ? 1 : 0}:${showQuickActions ? 1 : 0}`;
+  }, [isSubmitting, messages, showQuickActions]);
 
   const sendMessageMutation = useSendChatbotMessageMutation();
 
   const isRecoverableSessionError = (message: string) =>
     message.includes('session_id') || message.includes('유효하지 않은');
+
+  const abortStreamingResponse = useCallback(
+    (resetSubmitting = false) => {
+      if (streamAbortRef.current) {
+        streamAbortRef.current.abort();
+        streamAbortRef.current = null;
+      }
+
+      if (resetSubmitting) {
+        setSubmitting(false);
+      }
+    },
+    [setSubmitting],
+  );
+
+  const isNearBottom = useCallback((viewport: HTMLDivElement) => {
+    const distanceFromBottom =
+      viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop;
+
+    return distanceFromBottom <= AUTO_SCROLL_NEAR_BOTTOM_THRESHOLD_PX;
+  }, []);
+
+  const scrollViewportToBottom = useCallback((behavior: ScrollBehavior) => {
+    const viewport = viewportRef.current;
+
+    if (!viewport) {
+      return;
+    }
+
+    viewport.scrollTo({
+      top: viewport.scrollHeight,
+      behavior,
+    });
+    setIsViewportNearBottom(true);
+    setHasUnreadMessages(false);
+  }, []);
+
+  const handleClosePanel = useCallback(() => {
+    abortStreamingResponse(true);
+    closePanel();
+  }, [abortStreamingResponse, closePanel]);
+
+  const handleTogglePanel = useCallback(() => {
+    if (isOpen) {
+      handleClosePanel();
+      return;
+    }
+
+    togglePanel();
+  }, [handleClosePanel, isOpen, togglePanel]);
 
   useEffect(() => {
     if (!hasBootstrapped) {
@@ -117,7 +178,7 @@ function SupportChatWidget() {
 
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        closePanel();
+        handleClosePanel();
       }
     };
 
@@ -127,7 +188,7 @@ function SupportChatWidget() {
         !panelRef.current.contains(event.target as Node) &&
         !(event.target as HTMLElement)?.closest('.support-chat-fab')
       ) {
-        closePanel();
+        handleClosePanel();
       }
     };
 
@@ -138,41 +199,102 @@ function SupportChatWidget() {
       window.removeEventListener('keydown', handleEscape);
       window.removeEventListener('mousedown', handleOutsideClick);
     };
-  }, [closePanel, isOpen]);
+  }, [handleClosePanel, isOpen]);
 
   useEffect(
     () => () => {
-      streamAbortRef.current?.abort();
+      abortStreamingResponse(true);
     },
-    [],
+    [abortStreamingResponse],
   );
 
   useEffect(() => {
-    if (!isOpen || !viewportRef.current) {
+    if (!isOpen) {
+      if (streamAbortRef.current) {
+        abortStreamingResponse(true);
+      }
+
+      setHasUnreadMessages(false);
+      setIsViewportNearBottom(true);
       return;
     }
 
     const frameId = window.requestAnimationFrame(() => {
-      const viewport = viewportRef.current;
-
-      if (!viewport) {
-        return;
-      }
-
-      viewport.scrollTo({
-        top: viewport.scrollHeight,
-        behavior: 'auto',
-      });
+      scrollViewportToBottom('auto');
     });
 
     return () => {
       window.cancelAnimationFrame(frameId);
     };
-  }, [isOpen, isSubmitting, messages, showQuickActions]);
+  }, [abortStreamingResponse, isOpen, scrollViewportToBottom]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const viewport = viewportRef.current;
+
+    if (!viewport) {
+      return;
+    }
+
+    const handleViewportScroll = () => {
+      const nearBottom = isNearBottom(viewport);
+      setIsViewportNearBottom(nearBottom);
+
+      if (nearBottom) {
+        setHasUnreadMessages(false);
+      }
+    };
+
+    handleViewportScroll();
+    viewport.addEventListener('scroll', handleViewportScroll, {
+      passive: true,
+    });
+
+    return () => {
+      viewport.removeEventListener('scroll', handleViewportScroll);
+    };
+  }, [isNearBottom, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      lastHandledMessageCursorRef.current = messageUpdateCursor;
+      return;
+    }
+
+    const hasNewIncomingUpdate =
+      lastHandledMessageCursorRef.current !== messageUpdateCursor;
+    lastHandledMessageCursorRef.current = messageUpdateCursor;
+
+    if (!hasNewIncomingUpdate) {
+      return;
+    }
+
+    if (isViewportNearBottom) {
+      const frameId = window.requestAnimationFrame(() => {
+        scrollViewportToBottom('auto');
+      });
+
+      return () => {
+        window.cancelAnimationFrame(frameId);
+      };
+    }
+
+    setHasUnreadMessages(true);
+  }, [
+    isOpen,
+    isViewportNearBottom,
+    messageUpdateCursor,
+    scrollViewportToBottom,
+  ]);
 
   const handleReset = () => {
-    streamAbortRef.current?.abort();
+    abortStreamingResponse(true);
     setInputValue('');
+    setHasUnreadMessages(false);
+    setIsViewportNearBottom(true);
     resetConversation(routeContext);
   };
 
@@ -263,6 +385,14 @@ function SupportChatWidget() {
     await submitMessage(label);
   };
 
+  const showJumpToLatestButton =
+    isOpen && hasUnreadMessages && !isViewportNearBottom;
+  const liveStatusMessage = showJumpToLatestButton
+    ? '새 메시지가 도착했습니다. 새 메시지 확인 버튼을 누르면 최신 메시지로 이동합니다.'
+    : isSubmitting
+      ? '챗봇이 응답을 작성 중입니다.'
+      : null;
+
   return (
     <>
       <SupportChatPanel
@@ -276,10 +406,16 @@ function SupportChatWidget() {
         }
         showQuickActions={showQuickActions}
         isSubmitting={isSubmitting}
+        isViewportNearBottom={isViewportNearBottom}
+        showJumpToLatestButton={showJumpToLatestButton}
+        liveStatusMessage={liveStatusMessage}
         error={error}
         inputValue={inputValue}
         onReset={handleReset}
-        onClose={closePanel}
+        onClose={handleClosePanel}
+        onJumpToLatest={() => {
+          scrollViewportToBottom('smooth');
+        }}
         onQuickActionSelect={handleQuickActionSelect}
         onInputChange={(value) => {
           if (error) {
@@ -290,7 +426,7 @@ function SupportChatWidget() {
         }}
         onSubmit={handleSubmit}
       />
-      <SupportChatLauncherButton isOpen={isOpen} onClick={togglePanel} />
+      <SupportChatLauncherButton isOpen={isOpen} onClick={handleTogglePanel} />
     </>
   );
 }

--- a/src/features/support-chat/store/useSupportChatStore.ts
+++ b/src/features/support-chat/store/useSupportChatStore.ts
@@ -39,6 +39,8 @@ type SupportChatStoreState = {
   removeMessage: (messageId: string) => void;
 };
 
+const SUPPORT_CHAT_MESSAGE_CAP = 100;
+
 const createMessage = (
   role: SupportChatMessage['role'],
   content: string,
@@ -56,25 +58,32 @@ const createInitialMessages = () => [
   createMessage('assistant', SUPPORT_CHAT_WELCOME_MESSAGE),
 ];
 
+const capMessages = (messages: SupportChatMessage[]) =>
+  messages.length > SUPPORT_CHAT_MESSAGE_CAP
+    ? messages.slice(-SUPPORT_CHAT_MESSAGE_CAP)
+    : messages;
+
 const initialState = {
   sessionId: null as number | null,
   messages: createInitialMessages(),
   quickActions: SUPPORT_CHAT_QUICK_ACTIONS,
   showQuickActions: true,
-  hasBootstrapped: true,
+  hasBootstrapped: false,
   isOpen: false,
   isSubmitting: false,
   error: null as string | null,
   routeContext: createDefaultRouteContext(),
 };
 
+// 고객센터 챗봇 대화는 화면 한정 임시 상태로만 유지한다.
+// 보안 정책상 persist/sessionStorage/localStorage를 사용하지 않는다.
 export const useSupportChatStore = create<SupportChatStoreState>()(
   (set, get) => ({
     ...initialState,
     bootstrapConversation: (routeContext = get().routeContext) => {
       const state = get();
 
-      if (state.hasBootstrapped && state.messages.length > 0) {
+      if (state.hasBootstrapped) {
         if (routeContext.pathname !== state.routeContext.pathname) {
           set({ routeContext });
         }
@@ -84,12 +93,14 @@ export const useSupportChatStore = create<SupportChatStoreState>()(
 
       set({
         ...initialState,
+        hasBootstrapped: true,
         routeContext,
       });
     },
     resetConversation: (routeContext = get().routeContext) =>
       set({
         ...initialState,
+        hasBootstrapped: true,
         isOpen: true,
         routeContext,
       }),
@@ -104,14 +115,17 @@ export const useSupportChatStore = create<SupportChatStoreState>()(
     hideQuickActions: () => set({ showQuickActions: false }),
     appendUserMessage: (content) =>
       set((state) => ({
-        messages: [...state.messages, createMessage('user', content)],
+        messages: capMessages([
+          ...state.messages,
+          createMessage('user', content),
+        ]),
       })),
     beginAssistantMessage: (messageId) =>
       set((state) => ({
-        messages: [
+        messages: capMessages([
           ...state.messages,
           createMessage('assistant', '', 'streaming', messageId),
-        ],
+        ]),
       })),
     appendAssistantChunk: (messageId, chunk) =>
       set((state) => ({

--- a/src/index.css
+++ b/src/index.css
@@ -503,6 +503,30 @@
     }
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    .support-chat-panel,
+    .support-chat-fab,
+    .support-chat-fab *,
+    .support-chat-icon-btn,
+    .support-chat-quick-action,
+    .support-chat-input,
+    .support-chat-send-btn {
+      transition-duration: 0ms !important;
+      animation-duration: 0ms !important;
+      animation-iteration-count: 1 !important;
+    }
+
+    .support-chat-quick-action:hover,
+    .support-chat-send-btn:hover {
+      transform: none;
+    }
+
+    .support-chat-dot {
+      animation: none;
+      opacity: 0.72;
+    }
+  }
+
   .auth-input-autofill:-webkit-autofill,
   .auth-input-autofill:-webkit-autofill:hover,
   .auth-input-autofill:-webkit-autofill:focus,


### PR DESCRIPTION
## 관련 이슈

- closes #196

## 변경 내용

-고객센터 챗봇 자동 스크롤을 하단 근접 시에만 동작하도록 수정했습니다. (사용자가 이전 메시지 확인 중일 때 강제 점프 방지)
-하단 미고정 상태에서 새 응답 도착 시 새 메시지 확인 플로팅 버튼을 노출하고, 클릭 시 최하단으로 이동하도록 추가했습니다.
-챗봇 패널 닫기(닫기 버튼/ESC/외부 클릭/토글) 시 진행 중인 스트림 요청을 AbortController로 즉시 중단하도록 정리했습니다.
-useSupportChatStore에 메시지 상한(최근 100개 cap)을 적용했습니다.
-hasBootstrapped 전이를 단순화했습니다. (초기화/재시작 흐름 명확화)
-고객센터 챗봇 저장 정책은 기존대로 non-persist를 유지하고, 외부 저장소(session/local storage) 미사용 상태를 유지했습니다.
-접근성 보강:
  * 대화 로그 aria-live를 하단 고정 여부에 따라 제어
  * 스트리밍/새 메시지 상태를 role="status"로 분리 안내
  * 에러 안내 aria-live="assertive" + aria-atomic 보강
  * prefers-reduced-motion 환경에서 챗봇 애니메이션/전환 효과를 최소화했습니다.


## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
