### PR TITLE
[Feat] 설문 채팅 UX, 상태 유지 및 추천 리스트 더보기 흐름 개선

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -4,6 +4,7 @@ import {
   type KeyboardEvent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -12,7 +13,6 @@ import {
   ChevronRight,
   RotateCcw,
   SendHorizontal,
-  Sparkles,
   TriangleAlert,
 } from 'lucide-react';
 
@@ -28,13 +28,71 @@ import { useSurveyStore } from '../store/useSurveyStore';
 import SurveyMessageBubble from './SurveyMessageBubble';
 import SurveyProgress from './SurveyProgress';
 
+const NON_GAME_CHAT_MAX_STRIKES = 3;
+const NON_GAME_CHAT_BLOCK_DURATION_MS = 5 * 60 * 1000;
+
+const GAME_RELATED_KEYWORDS = [
+  '게임',
+  '장르',
+  '스토리',
+  '전투',
+  '보스',
+  '탐험',
+  '수집',
+  '성장',
+  '플레이',
+  '플레이스타일',
+  '멀티',
+  '싱글',
+  '협동',
+  '그래픽',
+  '분위기',
+  '손맛',
+  'rpg',
+  'fps',
+  '액션',
+  '어드벤처',
+  '슈팅',
+  '전략',
+  '시뮬레이션',
+  '레이싱',
+  '스포츠',
+  '퍼즐',
+  '플랫폼',
+  '격투',
+  '리듬',
+  '비주얼 노벨',
+];
+
+const isLikelyGameRelatedMessage = (content: string) => {
+  const normalized = content.trim().toLowerCase();
+
+  if (!normalized) {
+    return true;
+  }
+
+  return GAME_RELATED_KEYWORDS.some((keyword) =>
+    normalized.includes(keyword.toLowerCase()),
+  );
+};
+
+const formatRemainingBlockTime = (remainingMs: number) => {
+  const totalSeconds = Math.max(0, Math.ceil(remainingMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${String(minutes).padStart(1, '0')}:${String(seconds).padStart(2, '0')}`;
+};
+
 function SurveyChatPanel() {
   const navigate = useNavigate();
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const formRef = useRef<HTMLFormElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const shouldRestoreFocusRef = useRef(false);
+  const lastMessageCountRef = useRef(0);
   const [inputValue, setInputValue] = useState('');
+  const [currentTime, setCurrentTime] = useState(() => Date.now());
 
   const {
     sessionId,
@@ -45,11 +103,16 @@ function SurveyChatPanel() {
     error,
     recommendationReady,
     lastSubmittedMessage,
+    nonGameStrikeCount,
+    chatBlockedUntil,
     setHasBootstrapped,
     setSubmitting,
     setError,
     clearError,
     setLastSubmittedMessage,
+    setNonGameStrikeCount,
+    setChatBlockedUntil,
+    clearModerationState,
     addUserMessage,
     hydrateInitialSession,
     applyChatResponse,
@@ -67,11 +130,66 @@ function SurveyChatPanel() {
       (message.includes('해당 세션') || message.includes('설문 세션이 만료')),
     );
 
+  const remainingBlockTimeMs = chatBlockedUntil
+    ? Math.max(chatBlockedUntil - currentTime, 0)
+    : 0;
+  const isChatTemporarilyBlocked = Boolean(
+    chatBlockedUntil && remainingBlockTimeMs > 0,
+  );
+  const hasExpiredChatBlock = Boolean(
+    chatBlockedUntil && remainingBlockTimeMs <= 0,
+  );
+  const isTextareaDisabled =
+    isSubmitting ||
+    recommendationReady ||
+    isChatTemporarilyBlocked ||
+    hasExpiredChatBlock;
+  const inputPlaceholder = useMemo(() => {
+    if (isChatTemporarilyBlocked) {
+      return '반복된 이상행동으로 인해 5분간 채팅이 정지됩니다.';
+    }
+
+    if (hasExpiredChatBlock) {
+      return '제한 시간이 종료되었습니다. 설문 초기화를 누르고 다시 진행해 주세요.';
+    }
+
+    if (recommendationReady) {
+      return "추천 결과가 준비되었어요. 우측 상단의 '추천 결과 보기' 버튼을 눌러 다음 단계로 이동해 주세요.";
+    }
+
+    return '취향과 관련된 게임 이야기를 입력해 주세요.';
+  }, [hasExpiredChatBlock, isChatTemporarilyBlocked, recommendationReady]);
+
   useEffect(() => {
-    viewportRef.current?.scrollTo({
-      top: viewportRef.current.scrollHeight,
-      behavior: 'smooth',
+    if (!isChatTemporarilyBlocked) {
+      return undefined;
+    }
+
+    const timer = window.setInterval(() => {
+      setCurrentTime(Date.now());
+    }, 1000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [isChatTemporarilyBlocked]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+
+    if (!viewport) {
+      return;
+    }
+
+    const shouldJumpToBottom =
+      lastMessageCountRef.current === 0 && messages.length > 0;
+
+    viewport.scrollTo({
+      top: viewport.scrollHeight,
+      behavior: shouldJumpToBottom ? 'auto' : 'smooth',
     });
+
+    lastMessageCountRef.current = messages.length;
   }, [messages, error]);
 
   const restoreTextareaFocus = useCallback(() => {
@@ -92,12 +210,20 @@ function SurveyChatPanel() {
     if (
       !isSubmitting &&
       !recommendationReady &&
+      !isChatTemporarilyBlocked &&
+      !hasExpiredChatBlock &&
       shouldRestoreFocusRef.current
     ) {
       shouldRestoreFocusRef.current = false;
       restoreTextareaFocus();
     }
-  }, [isSubmitting, recommendationReady, restoreTextareaFocus]);
+  }, [
+    hasExpiredChatBlock,
+    isChatTemporarilyBlocked,
+    isSubmitting,
+    recommendationReady,
+    restoreTextareaFocus,
+  ]);
 
   const bootstrapSurvey = useCallback(
     async (force = false) => {
@@ -200,8 +326,28 @@ function SurveyChatPanel() {
 
     const nextMessage = inputValue.trim();
 
-    if (!nextMessage) {
+    if (
+      !nextMessage ||
+      isChatTemporarilyBlocked ||
+      hasExpiredChatBlock ||
+      recommendationReady
+    ) {
       return;
+    }
+
+    const isGameRelatedMessage = isLikelyGameRelatedMessage(nextMessage);
+
+    if (!isGameRelatedMessage) {
+      const nextStrikeCount = nonGameStrikeCount + 1;
+      setNonGameStrikeCount(nextStrikeCount);
+
+      if (nextStrikeCount >= NON_GAME_CHAT_MAX_STRIKES) {
+        setCurrentTime(Date.now());
+        setChatBlockedUntil(Date.now() + NON_GAME_CHAT_BLOCK_DURATION_MS);
+        setInputValue('');
+        shouldRestoreFocusRef.current = false;
+        return;
+      }
     }
 
     shouldRestoreFocusRef.current = true;
@@ -262,6 +408,7 @@ function SurveyChatPanel() {
     if (!sessionId) {
       shouldRestoreFocusRef.current = true;
       setInputValue('');
+      clearModerationState();
       resetSurveyState();
       await bootstrapSurvey();
       return;
@@ -276,6 +423,7 @@ function SurveyChatPanel() {
       });
 
       setInputValue('');
+      clearModerationState();
       hydrateInitialSession(response);
     } catch (requestError) {
       const errorMessage = extractApiErrorMessage(requestError);
@@ -309,25 +457,16 @@ function SurveyChatPanel() {
 
   return (
     <section className="survey-panel flex min-h-0 flex-1 flex-col overflow-hidden">
-      <div className="border-b border-white/8 px-4 py-3.5 sm:px-5 md:px-6 md:py-4">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div className="max-w-2xl">
-            <div className="mb-2.5 inline-flex items-center gap-2 rounded-full border border-[#6c2323] bg-[#1a0a0a] px-3 py-1 text-[11px] font-semibold tracking-[0.2em] text-[#ff8f8f] uppercase">
-              <Sparkles size={14} />
-              {isMockServiceWorkerEnabled() ? '체험 모드' : '개인화 설문'}
-            </div>
+      <div className="border-b border-white/8 px-4 py-2.5 sm:px-5 md:px-6">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="min-w-0">
             <h2 className="text-[22px] font-bold text-white sm:text-2xl md:text-[28px]">
-              AI 취향 설문
+              설문 조사
             </h2>
-            <p className="mt-1.5 text-sm leading-6 break-keep text-white/58 md:text-[15px]">
-              최근 재미있었던 게임 경험, 선호 장르, 원하는 플레이 감각을 편하게
-              말해주시면 추천 결과로 자연스럽게 이어져요.
+            <p className="mt-1 text-sm leading-6 break-keep text-white/58 md:text-[15px]">
+              대화형 AI 설문으로 플레이 스타일을 빠르게 파악하고, 이어지는 추천
+              리스트까지 자연스럽게 연결합니다.
             </p>
-            {isMockServiceWorkerEnabled() ? (
-              <p className="mt-2 text-[13px] leading-5 text-[#ffb0b0]">
-                체험 모드에서 설문 흐름을 먼저 확인할 수 있어요.
-              </p>
-            ) : null}
           </div>
 
           <div className="flex flex-wrap items-center gap-2.5">
@@ -354,25 +493,20 @@ function SurveyChatPanel() {
         </div>
       </div>
 
-      <div className="survey-grid min-h-0 flex-1 gap-3 px-3 py-3 sm:px-4 sm:py-4 md:gap-4 md:px-6 md:py-5">
-        <div className="min-h-0 space-y-3">
+      <div className="survey-grid min-h-0 flex-1 gap-2.5 px-3 py-3 sm:px-4 sm:py-4 md:gap-3 md:px-5 md:py-4">
+        <div className="min-h-0 space-y-2.5">
           <SurveyProgress progress={progress} />
 
-          <section className="survey-panel px-4 py-4 sm:px-5 md:py-4">
-            <h3 className="text-[13px] font-semibold tracking-[0.18em] text-white/42 uppercase">
+          <section className="survey-panel px-4 py-3.5 sm:px-5 md:py-3.5">
+            <h3 className="text-[12px] font-semibold tracking-[0.16em] text-white/42 uppercase">
               안내사항
             </h3>
-            <div className="mt-2.5 space-y-2.5 text-sm leading-6 text-white/60">
+            <div className="mt-2 space-y-2 text-sm leading-[1.35rem] text-white/56">
+              <p>게임 취향, 플레이 스타일, 선호 장르 중심으로 답변해 주세요.</p>
+              <p>구체적으로 적을수록 설문 흐름이 더 빠르게 정리될 수 있어요.</p>
               <p>
-                답변은 게임 취향, 플레이 스타일, 선호 장르처럼 게임과 관련된
-                내용 위주로 작성해 주세요.
-              </p>
-              <p>
-                최대한 자세히 답변을 적어주시면 빠르게 설문이 끝날 수 있습니다.
-              </p>
-              <p>
-                게임과 관련없는 질문을 반복할시 일시적으로 계정이 정지될 수
-                있습니다.
+                게임과 관련없는 질문을 3회 이상 반복할 시 5분 동안 설문 기능을
+                사용할 수 없습니다.
               </p>
             </div>
           </section>
@@ -381,7 +515,7 @@ function SurveyChatPanel() {
         <div className="survey-panel flex min-h-0 flex-col">
           <div
             ref={viewportRef}
-            className="survey-message-scroll flex-1 space-y-4 px-4 py-4 sm:px-5 sm:py-4 md:px-6"
+            className="survey-message-scroll flex-1 space-y-3.5 px-4 py-4 sm:px-5 sm:py-4 md:px-6"
           >
             {!messages.length && isSubmitting ? (
               <div className="flex w-full justify-start">
@@ -423,49 +557,44 @@ function SurveyChatPanel() {
             ) : null}
           </div>
 
-          <div className="border-t border-white/8 px-4 py-3.5 sm:px-5 sm:py-4 md:px-6">
-            <form ref={formRef} onSubmit={handleSubmit} className="space-y-3">
-              <label className="block">
-                <span className="mb-2.5 block text-sm font-semibold text-white/65">
-                  {recommendationReady
-                    ? '설문이 완료되었습니다.'
-                    : '지금 떠오르는 취향이나 최근 즐긴 게임 이야기를 적어보세요.'}
-                </span>
+          <div className="border-t border-white/8 px-4 py-3 sm:px-5 sm:py-3.5 md:px-6">
+            <form ref={formRef} onSubmit={handleSubmit}>
+              <label className="relative block h-[58px] overflow-hidden rounded-full border border-white/10 bg-[#0e0e10] transition focus-within:border-[#b42525] focus-within:bg-[#121214]">
                 <textarea
                   ref={textareaRef}
+                  rows={1}
                   value={inputValue}
                   onChange={(event) => setInputValue(event.target.value)}
                   onKeyDown={handleTextareaKeyDown}
-                  placeholder={
-                    recommendationReady
-                      ? "추천 결과가 준비되었어요. 우측 상단의 '추천 결과 보기' 버튼을 눌러 다음 단계로 이동해 주세요."
-                      : '예: 도전적인 보스전은 좋아하지만, 분위기는 너무 어둡지 않고 탐험하는 재미가 있는 게임이 좋아요.'
-                  }
-                  className="min-h-[104px] w-full resize-none rounded-[22px] border border-white/10 bg-[#0e0e10] px-4 py-3.5 text-[15px] leading-6 text-white transition outline-none placeholder:text-white/26 focus:border-[#b42525] focus:bg-[#121214] sm:px-5 md:min-h-[88px]"
-                  disabled={isSubmitting || recommendationReady}
+                  placeholder={inputPlaceholder}
+                  className="h-full min-h-full w-full resize-none overflow-hidden bg-transparent py-4 pr-[5.9rem] pl-4 text-[15px] leading-6 text-white outline-none placeholder:text-white/26 sm:pl-5"
+                  disabled={isTextareaDisabled}
                 />
+                {isChatTemporarilyBlocked ? (
+                  <div className="absolute inset-y-0 right-0 flex items-center pr-2">
+                    <div className="inline-flex h-[46px] min-w-[62px] items-center justify-center rounded-full border border-[#6f2525] bg-[#170b0b] px-2.5 text-sm font-semibold text-[#ffb4b4]">
+                      {formatRemainingBlockTime(remainingBlockTimeMs)}
+                    </div>
+                  </div>
+                ) : hasExpiredChatBlock ? null : (
+                  <div className="absolute inset-y-0 right-0 flex items-center pr-2">
+                    <button
+                      type="submit"
+                      disabled={isSubmitting || recommendationReady}
+                      aria-label={
+                        recommendationReady
+                          ? '설문 완료'
+                          : isSubmitting
+                            ? '응답 생성 중'
+                            : '메시지 보내기'
+                      }
+                      className="inline-flex h-[46px] w-[46px] items-center justify-center rounded-full bg-[linear-gradient(135deg,#ff3535,#9f1212)] text-white shadow-[0_14px_30px_rgba(139,0,0,0.28)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
+                    >
+                      <SendHorizontal size={16} />
+                    </button>
+                  </div>
+                )}
               </label>
-
-              <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center sm:justify-between">
-                <p className="text-[13px] leading-5 text-white/40">
-                  {recommendationReady
-                    ? "설문이 끝났습니다. 우측 상단의 '추천 결과 보기' 버튼을 누르면 바로 추천 리스트로 이동합니다."
-                    : 'Enter 키로 전송하고, Shift + Enter로 줄바꿈할 수 있습니다.'}
-                </p>
-
-                <button
-                  type="submit"
-                  disabled={isSubmitting || recommendationReady}
-                  className="inline-flex items-center justify-center gap-2 rounded-2xl bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(139,0,0,0.28)] transition hover:translate-y-[-1px] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
-                >
-                  <SendHorizontal size={16} />
-                  {recommendationReady
-                    ? '설문 완료'
-                    : isSubmitting
-                      ? '응답 생성 중...'
-                      : '메시지 보내기'}
-                </button>
-              </div>
             </form>
           </div>
         </div>

--- a/src/features/survey/components/SurveyProgress.tsx
+++ b/src/features/survey/components/SurveyProgress.tsx
@@ -10,20 +10,17 @@ function SurveyProgress({ progress }: SurveyProgressProps) {
   const percentage = Math.max(0, Math.min(progress.completion_rate * 100, 100));
 
   return (
-    <section className="survey-panel p-4">
-      <div className="mb-2.5 flex items-start justify-between gap-3">
-        <div className="flex items-start gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/[0.05] text-[#ff4d4d]">
-            <Activity size={18} />
+    <section className="survey-panel p-3.5">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-white/[0.05] text-[#ff4d4d]">
+            <Activity size={16} />
           </div>
           <div className="space-y-0.5">
             <p className="text-sm font-semibold text-white">진행률</p>
-            <p className="text-[13px] leading-5 text-white/55">
-              답변이 구체적일수록 남은 질문 수가 줄어들 수 있습니다.
-            </p>
           </div>
         </div>
-        <p className="pt-0.5 text-sm font-semibold text-[#ff7a7a]">
+        <p className="text-sm font-semibold text-[#ff7a7a]">
           {Math.round(percentage)}%
         </p>
       </div>

--- a/src/features/survey/store/useSurveyStore.ts
+++ b/src/features/survey/store/useSurveyStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 import {
   DEFAULT_SURVEY_PROGRESS,
@@ -11,6 +12,7 @@ import {
 } from '../types/survey';
 
 interface SurveyStoreState {
+  ownerKey: string | null;
   sessionId: string | null;
   messages: SurveyMessage[];
   status: SurveySessionStatus;
@@ -20,11 +22,17 @@ interface SurveyStoreState {
   error: string | null;
   recommendationReady: boolean;
   lastSubmittedMessage: string | null;
+  nonGameStrikeCount: number;
+  chatBlockedUntil: number | null;
+  syncOwnerKey: (ownerKey: string) => void;
   setHasBootstrapped: (hasBootstrapped: boolean) => void;
   setSubmitting: (isSubmitting: boolean) => void;
   setError: (error: string | null) => void;
   clearError: () => void;
   setLastSubmittedMessage: (message: string | null) => void;
+  setNonGameStrikeCount: (count: number) => void;
+  setChatBlockedUntil: (timestamp: number | null) => void;
+  clearModerationState: () => void;
   addUserMessage: (content: string) => void;
   hydrateInitialSession: (payload: SurveySessionStartResponse) => void;
   beginSession: (payload: SurveySessionStartResponse) => void;
@@ -45,106 +53,147 @@ const createMessage = (
 const COMPLETION_GUIDE_MESSAGE =
   "추천 결과가 준비되었어요. 우측 상단의 '추천 결과 보기' 버튼을 눌러 바로 확인해 보세요.";
 
-const initialState = {
+const createInitialState = (ownerKey: string | null = null) => ({
+  ownerKey,
   sessionId: null,
   messages: [] as SurveyMessage[],
   status: 'IDLE' as SurveySessionStatus,
-  progress: DEFAULT_SURVEY_PROGRESS,
+  progress: { ...DEFAULT_SURVEY_PROGRESS },
   hasBootstrapped: false,
   isSubmitting: false,
   error: null,
   recommendationReady: false,
   lastSubmittedMessage: null,
-};
+  nonGameStrikeCount: 0,
+  chatBlockedUntil: null,
+});
 
-export const useSurveyStore = create<SurveyStoreState>((set) => ({
-  ...initialState,
-  setHasBootstrapped: (hasBootstrapped) => set({ hasBootstrapped }),
-  setSubmitting: (isSubmitting) => set({ isSubmitting }),
-  setError: (error) => set({ error }),
-  clearError: () => set({ error: null }),
-  setLastSubmittedMessage: (message) => set({ lastSubmittedMessage: message }),
-  addUserMessage: (content) =>
-    set((state) => ({
-      messages: [...state.messages, createMessage('user', content)],
-    })),
-  hydrateInitialSession: (payload) =>
-    set(() => ({
-      sessionId: payload.session_id,
-      status: payload.status,
-      progress: payload.progress ?? { ...DEFAULT_SURVEY_PROGRESS },
-      isSubmitting: false,
-      hasBootstrapped: true,
-      error: null,
-      recommendationReady: payload.recommendation_ready,
-      lastSubmittedMessage: null,
-      messages: payload.assistant_message
-        ? [createMessage('assistant', payload.assistant_message)]
-        : payload.recommendation_ready
-          ? [createMessage('assistant', COMPLETION_GUIDE_MESSAGE)]
-          : [],
-    })),
-  beginSession: (payload) =>
-    set((state) => ({
-      sessionId: payload.session_id,
-      status: payload.status,
-      progress: payload.progress ?? state.progress,
-      hasBootstrapped: true,
-      isSubmitting: false,
-      error: null,
-      recommendationReady: payload.recommendation_ready,
-      messages: payload.assistant_message
-        ? state.messages.at(-1)?.role === 'assistant' &&
-          state.messages.at(-1)?.content === payload.assistant_message
-          ? state.messages
-          : [
-              ...state.messages,
-              createMessage('assistant', payload.assistant_message),
-            ]
-        : payload.recommendation_ready
-          ? state.messages.at(-1)?.role === 'assistant' &&
-            state.messages.at(-1)?.content === COMPLETION_GUIDE_MESSAGE
-            ? state.messages
-            : [
-                ...state.messages,
-                createMessage('assistant', COMPLETION_GUIDE_MESSAGE),
-              ]
-          : state.messages,
-    })),
-  applyChatResponse: (payload) =>
-    set((state) => ({
-      status: payload.status,
-      progress: payload.progress,
-      recommendationReady: payload.recommendation_ready,
-      isSubmitting: false,
-      error: null,
-      messages: (() => {
-        if (payload.assistant_message) {
-          return state.messages.at(-1)?.role === 'assistant' &&
-            state.messages.at(-1)?.content === payload.assistant_message
-            ? state.messages
-            : [
-                ...state.messages,
-                createMessage('assistant', payload.assistant_message),
-              ];
-        }
+export const useSurveyStore = create<SurveyStoreState>()(
+  persist(
+    (set) => ({
+      ...createInitialState(),
+      syncOwnerKey: (ownerKey) =>
+        set((state) =>
+          state.ownerKey === ownerKey
+            ? state
+            : {
+                ...createInitialState(ownerKey),
+              },
+        ),
+      setHasBootstrapped: (hasBootstrapped) => set({ hasBootstrapped }),
+      setSubmitting: (isSubmitting) => set({ isSubmitting }),
+      setError: (error) => set({ error }),
+      clearError: () => set({ error: null }),
+      setLastSubmittedMessage: (message) =>
+        set({ lastSubmittedMessage: message }),
+      setNonGameStrikeCount: (count) => set({ nonGameStrikeCount: count }),
+      setChatBlockedUntil: (timestamp) => set({ chatBlockedUntil: timestamp }),
+      clearModerationState: () =>
+        set({
+          nonGameStrikeCount: 0,
+          chatBlockedUntil: null,
+        }),
+      addUserMessage: (content) =>
+        set((state) => ({
+          messages: [...state.messages, createMessage('user', content)],
+        })),
+      hydrateInitialSession: (payload) =>
+        set((state) => ({
+          sessionId: payload.session_id,
+          status: payload.status,
+          progress: payload.progress ?? { ...DEFAULT_SURVEY_PROGRESS },
+          isSubmitting: false,
+          hasBootstrapped: true,
+          error: null,
+          recommendationReady: payload.recommendation_ready,
+          lastSubmittedMessage: null,
+          nonGameStrikeCount: 0,
+          chatBlockedUntil: null,
+          messages: payload.assistant_message
+            ? [createMessage('assistant', payload.assistant_message)]
+            : payload.recommendation_ready
+              ? [createMessage('assistant', COMPLETION_GUIDE_MESSAGE)]
+              : [],
+          ownerKey: state.ownerKey,
+        })),
+      beginSession: (payload) =>
+        set((state) => ({
+          sessionId: payload.session_id,
+          status: payload.status,
+          progress: payload.progress ?? state.progress,
+          hasBootstrapped: true,
+          isSubmitting: false,
+          error: null,
+          recommendationReady: payload.recommendation_ready,
+          messages: payload.assistant_message
+            ? state.messages.at(-1)?.role === 'assistant' &&
+              state.messages.at(-1)?.content === payload.assistant_message
+              ? state.messages
+              : [
+                  ...state.messages,
+                  createMessage('assistant', payload.assistant_message),
+                ]
+            : payload.recommendation_ready
+              ? state.messages.at(-1)?.role === 'assistant' &&
+                state.messages.at(-1)?.content === COMPLETION_GUIDE_MESSAGE
+                ? state.messages
+                : [
+                    ...state.messages,
+                    createMessage('assistant', COMPLETION_GUIDE_MESSAGE),
+                  ]
+              : state.messages,
+        })),
+      applyChatResponse: (payload) =>
+        set((state) => ({
+          status: payload.status,
+          progress: payload.progress,
+          recommendationReady: payload.recommendation_ready,
+          isSubmitting: false,
+          error: null,
+          messages: (() => {
+            if (payload.assistant_message) {
+              return state.messages.at(-1)?.role === 'assistant' &&
+                state.messages.at(-1)?.content === payload.assistant_message
+                ? state.messages
+                : [
+                    ...state.messages,
+                    createMessage('assistant', payload.assistant_message),
+                  ];
+            }
 
-        if (payload.recommendation_ready) {
-          return state.messages.at(-1)?.role === 'assistant' &&
-            state.messages.at(-1)?.content === COMPLETION_GUIDE_MESSAGE
-            ? state.messages
-            : [
-                ...state.messages,
-                createMessage('assistant', COMPLETION_GUIDE_MESSAGE),
-              ];
-        }
+            if (payload.recommendation_ready) {
+              return state.messages.at(-1)?.role === 'assistant' &&
+                state.messages.at(-1)?.content === COMPLETION_GUIDE_MESSAGE
+                ? state.messages
+                : [
+                    ...state.messages,
+                    createMessage('assistant', COMPLETION_GUIDE_MESSAGE),
+                  ];
+            }
 
-        return state.messages;
-      })(),
-    })),
-  resetSurveyState: () => ({
-    ...initialState,
-    messages: [...initialState.messages],
-    progress: { ...DEFAULT_SURVEY_PROGRESS },
-  }),
-}));
+            return state.messages;
+          })(),
+        })),
+      resetSurveyState: () =>
+        set((state) => ({
+          ...createInitialState(state.ownerKey),
+        })),
+    }),
+    {
+      name: 'survey-storage',
+      storage: createJSONStorage(() => window.localStorage),
+      partialize: (state) => ({
+        ownerKey: state.ownerKey,
+        sessionId: state.sessionId,
+        messages: state.messages,
+        status: state.status,
+        progress: state.progress,
+        hasBootstrapped: state.hasBootstrapped,
+        recommendationReady: state.recommendationReady,
+        lastSubmittedMessage: state.lastSubmittedMessage,
+        nonGameStrikeCount: state.nonGameStrikeCount,
+        chatBlockedUntil: state.chatBlockedUntil,
+      }),
+    },
+  ),
+);

--- a/src/index.css
+++ b/src/index.css
@@ -149,12 +149,12 @@
   .survey-grid {
     display: grid;
     min-height: 0;
-    grid-template-columns: minmax(0, 300px) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 248px) minmax(0, 1fr);
   }
 
   .survey-message-scroll {
     min-height: 0;
-    max-height: min(54vh, 560px);
+    max-height: min(64vh, 700px);
     overflow-y: auto;
     scrollbar-width: thin;
     scrollbar-color: rgba(255, 255, 255, 0.18) transparent;

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { InfiniteData } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { ChevronRight, Heart, Sparkles, Star } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { ChevronDown, ChevronRight, Heart, Sparkles, Star } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 
 import ActionButton from '../../components/common/ActionButton';
@@ -266,6 +266,8 @@ function RecommendationListPage() {
   const [likeFeedbackMessage, setLikeFeedbackMessage] = useState<string | null>(
     null,
   );
+  const recommendationScrollRef = useRef<HTMLDivElement | null>(null);
+  const loadMoreAnchorOffsetRef = useRef<number | null>(null);
   const queryClient = useQueryClient();
   const source = searchParams.get('source');
   const legacySessionId = searchParams.get('session_id');
@@ -315,8 +317,38 @@ function RecommendationListPage() {
       errorMessage?.includes('매칭 추천 결과를 찾을 수 없습니다') ||
       recommendationItems.length === 0,
     );
+
+  useEffect(() => {
+    if (loadMoreAnchorOffsetRef.current === null) {
+      return;
+    }
+
+    const scrollContainer = recommendationScrollRef.current;
+
+    if (!scrollContainer) {
+      loadMoreAnchorOffsetRef.current = null;
+      return;
+    }
+
+    const nextScrollTop =
+      scrollContainer.scrollHeight - loadMoreAnchorOffsetRef.current;
+    scrollContainer.scrollTop = Math.max(0, nextScrollTop);
+    loadMoreAnchorOffsetRef.current = null;
+  }, [recommendationItems.length]);
+
   const handleOpenDetail = (item: RecommendationDisplayItem) => {
     setSelectedGame(toGameListItem(item));
+  };
+
+  const handleLoadMore = () => {
+    const scrollContainer = recommendationScrollRef.current;
+
+    if (scrollContainer) {
+      loadMoreAnchorOffsetRef.current =
+        scrollContainer.scrollHeight - scrollContainer.scrollTop;
+    }
+
+    void fetchNextPage();
   };
 
   useEffect(() => {
@@ -648,7 +680,10 @@ function RecommendationListPage() {
                 </div>
               ) : (
                 <>
-                  <div className="recommendation-scroll max-h-[62vh] overflow-y-auto">
+                  <div
+                    ref={recommendationScrollRef}
+                    className="recommendation-scroll max-h-[62vh] overflow-y-auto"
+                  >
                     <div className="divide-y divide-white/8">
                       {recommendationItems.map((item) => (
                         <RecommendationRow
@@ -663,19 +698,24 @@ function RecommendationListPage() {
                   </div>
 
                   {hasNextPage || isFetchingNextPage ? (
-                    <div className="flex justify-end border-t border-white/8 px-4 py-4 sm:px-6 lg:px-7">
-                      <button
-                        type="button"
-                        onClick={() => void fetchNextPage()}
-                        disabled={isFetchingNextPage}
-                        className="inline-flex min-w-[120px] items-center justify-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white/82 transition hover:border-[#6f2525] hover:bg-[#160b0b] hover:text-white disabled:cursor-not-allowed disabled:opacity-45"
-                      >
-                        {isFetchingNextPage ? '불러오는 중...' : '더보기'}
-                        {!isFetchingNextPage ? (
-                          <ChevronRight size={16} />
-                        ) : null}
-                      </button>
-                    </div>
+                    <button
+                      type="button"
+                      onClick={handleLoadMore}
+                      disabled={isFetchingNextPage}
+                      className="flex w-full flex-col items-center justify-center gap-1 border-t border-white/8 px-4 py-3 text-sm font-medium text-white/82 transition hover:bg-white/[0.03] hover:text-white disabled:cursor-not-allowed disabled:opacity-45 sm:px-6 lg:px-7"
+                    >
+                      <span>
+                        {isFetchingNextPage
+                          ? '추천 결과를 불러오는 중입니다...'
+                          : '더보기'}
+                      </span>
+                      {!isFetchingNextPage ? (
+                        <ChevronDown
+                          size={18}
+                          className="translate-y-[1px] text-white/56"
+                        />
+                      ) : null}
+                    </button>
                   ) : null}
                 </>
               )}

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -1,42 +1,36 @@
-import { useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 
 import Header from '../../components/common/Header';
 import SurveyChatPanel from '../../features/survey/components/SurveyChatPanel';
 import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
 import { isMockServiceWorkerEnabled } from '../../lib/env';
+import { useAuthStore } from '../../store/useAuthStore';
 import { getAccessToken } from '../../utils/auth';
 
 function SurveyPage() {
   const hasAccessToken = Boolean(getAccessToken());
   const isMockMode = isMockServiceWorkerEnabled();
   const canAccessSurvey = isMockMode || hasAccessToken;
-  const resetSurveyState = useSurveyStore((state) => state.resetSurveyState);
+  const account = useAuthStore((state) => state.account);
+  const syncOwnerKey = useSurveyStore((state) => state.syncOwnerKey);
+  const surveyOwnerKey = account?.login_id
+    ? `survey-user:${account.login_id}`
+    : hasAccessToken
+      ? 'survey-user:authenticated'
+      : isMockMode
+        ? 'survey-user:mock'
+        : 'survey-user:guest';
 
-  useLayoutEffect(() => {
-    resetSurveyState();
-  }, [resetSurveyState]);
+  useEffect(() => {
+    syncOwnerKey(surveyOwnerKey);
+  }, [surveyOwnerKey, syncOwnerKey]);
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <div className="app-aurora pointer-events-none absolute inset-0 opacity-90" />
       <Header fixed />
 
-      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-3 pt-[5.5rem] pb-8 sm:px-4 sm:pt-24 sm:pb-10 md:h-[100dvh] md:max-h-[100dvh] md:overflow-hidden md:px-8 md:pt-[6.5rem] md:pb-8">
-        <section className="mb-5 flex shrink-0 flex-col gap-3 md:mb-4 md:gap-2.5">
-          <div className="inline-flex w-fit items-center rounded-full border border-[#5e1717] bg-[#150707] px-3.5 py-1.5 text-[11px] font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
-            개인화 설문
-          </div>
-          <div className="max-w-3xl">
-            <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl md:text-[44px]">
-              설문 조사
-            </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-white/62 sm:text-base md:mt-2.5">
-              대화형 AI 설문으로 플레이 스타일을 빠르게 파악하고, 이어지는 추천
-              리스트까지 자연스럽게 연결합니다.
-            </p>
-          </div>
-        </section>
-
+      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-[100dvh] md:max-h-[100dvh] md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
         {canAccessSurvey ? (
           <SurveyChatPanel />
         ) : (


### PR DESCRIPTION
## 관련 이슈

- closes #200 

## 변경 내용

- 설문 페이지 상단의 불필요한 소개 영역을 정리하고 챗봇 중심 레이아웃으로 재구성
- `설문 초기화` 라인에 설문 제목과 서비스 설명을 다시 배치해 정보는 유지하면서도 챗봇 영역이 더 크게 보이도록 조정
- 진행률 카드와 안내사항 카드의 세로 밀도를 줄이고, 메시지 영역이 더 넓게 보이도록 레이아웃 최적화
- 설문 입력창을 한 줄 중심 구조로 변경하고, 전송 버튼을 입력창 내부에 배치하도록 수정
- 입력창 내부 전송 버튼과 제한 타이머의 크기/위치/여백을 반복 조정해 입력창 안에서 안정적으로 보이도록 정리
- `Enter 키로 전송` 안내 문구 등 불필요한 보조 문구 제거
- 안내사항에 게임과 관련없는 질문 반복 시 이용 제한 안내 문구 추가
- 게임과 관련없는 채팅을 3회 이상 반복하면 5분 동안 설문 채팅이 제한되도록 구현
- 제한 중에는 텍스트 에어리어를 비활성화하고, 입력창 안에서 5분 카운트다운이 보이도록 수정
- 제한 시간이 종료된 뒤에는 바로 재입력하지 않고 `설문 초기화 후 다시 진행` 흐름으로 유도
- 로그인 사용자 기준으로 설문 대화/진행률이 재진입 후에도 유지되도록 store 보존 구조를 정리
- 이미 설문을 완료한 사용자는 기존 대화 내용을 유지한 채 입력창이 비활성화되도록 정리
- `설문 초기화` 클릭 시 기존 대화, 진행률, 이용 제한 상태까지 함께 초기화하고 처음부터 다시 시작하도록 수정
- 저장된 설문 대화를 다시 불러올 때 상단에서 아래로 스크롤되는 애니메이션 없이 바로 마지막 대화 위치로 이동하도록 수정
- 추천 결과 페이지의 작은 `더보기` 버튼을 제거하고, 하단 전체 영역을 클릭 가능한 더보기 영역으로 변경
- 더보기 이후에도 스크롤이 처음으로 돌아가지 않고, 기존에 보던 하단 위치를 기준으로 자연스럽게 이어서 확인할 수 있도록 보정 로직 추가
- 추천 리스트 하단 더보기 영역의 세로 여백도 축소해 더 가볍게 보이도록 정리

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="1728" height="897" alt="스크린샷 2026-04-22 오후 7 24 16" src="https://github.com/user-attachments/assets/72393dac-daa3-42a6-ab61-c170028bec71" />


## 참고사항

- 이번 PR은 설문 채팅 사용성, 로그인 사용자 기준 상태 유지, 이용 제한 흐름, 추천 리스트 더보기 UX 개선에 집중했습니다.
- 게임과 무관한 질문 판별은 현재 프론트 기준의 키워드 휴리스틱으로 동작합니다.
- 빌드 시 chunk size warning은 남아 있지만 기능 오류는 아닙니다.
