### PR TITLE
[Fix] 설문 추천 결과 상세 연결 및 채팅 제한 흐름 수정

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -133,6 +133,8 @@ function SurveyChatPanel() {
   const remainingBlockTimeMs = chatBlockedUntil
     ? Math.max(chatBlockedUntil - currentTime, 0)
     : 0;
+  const hasReachedNonGameChatLimit =
+    nonGameStrikeCount >= NON_GAME_CHAT_MAX_STRIKES;
   const isChatTemporarilyBlocked = Boolean(
     chatBlockedUntil && remainingBlockTimeMs > 0,
   );
@@ -144,6 +146,12 @@ function SurveyChatPanel() {
     recommendationReady ||
     isChatTemporarilyBlocked ||
     hasExpiredChatBlock;
+  const isRecommendationButtonDisabled =
+    !recommendationReady ||
+    isSubmitting ||
+    isChatTemporarilyBlocked ||
+    hasExpiredChatBlock ||
+    hasReachedNonGameChatLimit;
   const inputPlaceholder = useMemo(() => {
     if (isChatTemporarilyBlocked) {
       return '반복된 이상행동으로 인해 5분간 채팅이 정지됩니다.';
@@ -277,7 +285,7 @@ function SurveyChatPanel() {
     const trimmed = content.trim();
 
     if (!trimmed || isSubmitting) {
-      return;
+      return false;
     }
 
     clearError();
@@ -314,8 +322,11 @@ function SurveyChatPanel() {
 
         applyChatResponse(response);
       }
+
+      return true;
     } catch (requestError) {
       setError(extractApiErrorMessage(requestError));
+      return false;
     } finally {
       setSubmitting(false);
     }
@@ -336,23 +347,32 @@ function SurveyChatPanel() {
     }
 
     const isGameRelatedMessage = isLikelyGameRelatedMessage(nextMessage);
-
-    if (!isGameRelatedMessage) {
-      const nextStrikeCount = nonGameStrikeCount + 1;
-      setNonGameStrikeCount(nextStrikeCount);
-
-      if (nextStrikeCount >= NON_GAME_CHAT_MAX_STRIKES) {
-        setCurrentTime(Date.now());
-        setChatBlockedUntil(Date.now() + NON_GAME_CHAT_BLOCK_DURATION_MS);
-        setInputValue('');
-        shouldRestoreFocusRef.current = false;
-        return;
-      }
-    }
+    const nextStrikeCount = isGameRelatedMessage
+      ? nonGameStrikeCount
+      : nonGameStrikeCount + 1;
+    const shouldBlockAfterResponse =
+      !isGameRelatedMessage && nextStrikeCount >= NON_GAME_CHAT_MAX_STRIKES;
 
     shouldRestoreFocusRef.current = true;
     setInputValue('');
-    await submitMessage({ content: nextMessage, appendUserMessage: true });
+    const didSubmitSucceed = await submitMessage({
+      content: nextMessage,
+      appendUserMessage: true,
+    });
+
+    if (!didSubmitSucceed) {
+      return;
+    }
+
+    if (!isGameRelatedMessage) {
+      setNonGameStrikeCount(nextStrikeCount);
+    }
+
+    if (shouldBlockAfterResponse) {
+      setCurrentTime(Date.now());
+      setChatBlockedUntil(Date.now() + NON_GAME_CHAT_BLOCK_DURATION_MS);
+      shouldRestoreFocusRef.current = false;
+    }
   };
 
   const handleRetry = async () => {
@@ -443,6 +463,10 @@ function SurveyChatPanel() {
   };
 
   const handleMoveToRecommendation = () => {
+    if (isRecommendationButtonDisabled) {
+      return;
+    }
+
     startTransition(() => {
       navigate(`/${ROUTES.RECOMMENDATION_LIST}?source=survey`);
     });
@@ -483,7 +507,7 @@ function SurveyChatPanel() {
             <button
               type="button"
               onClick={handleMoveToRecommendation}
-              disabled={!recommendationReady || isSubmitting}
+              disabled={isRecommendationButtonDisabled}
               className="inline-flex items-center gap-2 rounded-xl bg-[linear-gradient(135deg,#ee2525,#9b1010)] px-4 py-2.5 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(150,0,0,0.32)] transition hover:translate-y-[-1px] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
             >
               추천 결과 보기

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -1,5 +1,7 @@
 import { delay, http, HttpResponse } from 'msw';
 
+import { getMockLikedGameIdsForAuthorization } from '../../auth/mocks/handlers';
+import { mockTopGames } from '../../games/mockGames';
 import type {
   SurveyApiChatRequest,
   SurveyApiResultItem,
@@ -19,80 +21,32 @@ const surveyQuestions = [
   '플레이 타임은 짧고 강렬한 편이 좋으신가요, 아니면 오래 파고들며 성장하는 흐름이 좋으신가요?',
 ];
 
-const recommendations: SurveyApiResultItem[] = [
-  {
-    game_id: 501,
-    title: '호랑나비 어드벤처',
-    genres: ['RPG', '어드벤처'],
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=800&q=80',
-    rating: 95.8,
-    is_liked: false,
-  },
-  {
-    game_id: 502,
-    title: '이터널 오딧세이',
-    genres: ['액션', 'RPG'],
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1542751371-adc38448a05e?auto=format&fit=crop&w=800&q=80',
-    rating: 91.6,
-    is_liked: true,
-  },
-  {
-    game_id: 503,
-    title: '스타폴 택틱스',
-    genres: ['전략', '시뮬레이션'],
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1493711662062-fa541adb3fc8?auto=format&fit=crop&w=800&q=80',
-    rating: 88.4,
-    is_liked: false,
-  },
-  {
-    game_id: 504,
-    title: '크림슨 서킷',
-    genres: ['슈팅', '로그라이트'],
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1511882150382-421056c89033?auto=format&fit=crop&w=800&q=80',
-    rating: 86.9,
-    is_liked: false,
-  },
-  {
-    game_id: 505,
-    title: '문라이트 캔버스',
-    genres: ['비주얼 노벨', '퍼즐'],
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1518709268805-4e9042af2176?auto=format&fit=crop&w=800&q=80',
-    rating: 93.7,
-    is_liked: true,
-  },
-  {
-    game_id: 506,
-    title: '드리프트 네온',
-    genres: ['레이싱', '스포츠'],
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1486572788966-cfd3df1f5b42?auto=format&fit=crop&w=800&q=80',
-    rating: 82.4,
-    is_liked: false,
-  },
-  {
-    game_id: 507,
-    title: '노던 랩소디',
-    genres: ['어드벤처', '스토리'],
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1493711662062-fa541adb3fc8?auto=format&fit=crop&w=800&q=80',
-    rating: 89.8,
-    is_liked: false,
-  },
-  {
-    game_id: 508,
-    title: '제로아워 레이드',
-    genres: ['FPS', '협동'],
-    thumbnail_url:
-      'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=800&q=80',
-    rating: 84.6,
-    is_liked: true,
-  },
-];
+const SURVEY_RECOMMENDATION_GAME_IDS = [
+  1086940, 1245620, 292030, 1091500, 814380, 2050650, 1868140, 367520, 646570,
+  1551360, 1364780, 1003590, 412830, 620, 553850,
+] as const;
+
+const mockTopGameById = new Map(
+  mockTopGames.map((game) => [game.gameId, game]),
+);
+
+const buildSurveyRecommendations = (authorization: string | null) => {
+  const likedGameIds = getMockLikedGameIdsForAuthorization(authorization);
+
+  return SURVEY_RECOMMENDATION_GAME_IDS.map((gameId) =>
+    mockTopGameById.get(gameId),
+  )
+    .filter((game): game is (typeof mockTopGames)[number] => Boolean(game))
+    .map<SurveyApiResultItem>((game) => ({
+      game_id: game.gameId,
+      title: game.name,
+      genres: game.genres,
+      thumbnail_url: game.thumbnailUrl,
+      rating:
+        typeof game.rating === 'number' ? Number(game.rating.toFixed(1)) : null,
+      is_liked: likedGameIds.has(game.gameId),
+    }));
+};
 
 interface MockSurveySession {
   askedQuestions: number;
@@ -251,6 +205,9 @@ export const surveyHandlers = [
     const cursor = Number(url.searchParams.get('cursor') ?? '0');
     const pageSize = Number(
       url.searchParams.get('page_size') ?? DEFAULT_RECOMMENDATION_PAGE_SIZE,
+    );
+    const recommendations = buildSurveyRecommendations(
+      request.headers.get('authorization'),
     );
 
     if (!latestCompletedSurveySessionId) {


### PR DESCRIPTION
## 관련 이슈

- closes #202 

## 변경 내용

- 설문에서 게임과 관련없는 질문을 3회째 입력했을 때 즉시 차단하지 않고, 질문 전송 및 AI 응답 수신 후 5분 제한이 적용되도록 수정
- 5분 제한 상태에 들어가면 `추천 결과 보기` 버튼이 활성화되지 않도록 수정
- 설문 추천 결과 mock이 고정 임시 게임 데이터를 사용하지 않고, 실제 게임 mock 카탈로그와 같은 `game_id`를 사용하도록 정리
- 설문 추천 결과 리스트에서도 게임 상세 모달이 정상 연결되도록 데이터 정합성 수정
- 추천 결과의 `is_liked` 값도 현재 좋아요 상태 기준으로 반영되도록 정리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
