### PR TITLE
refactor(auth): 쿠키 기반 세션 복구 부트스트랩 도입 및 인증 가드 정합화

### DIFF
--- a/docs/ai/api-contract.md
+++ b/docs/ai/api-contract.md
@@ -11,11 +11,13 @@
 
 - **Access Token**: 클라이언트 메모리(Zustand State) 내에서 관리하여 XSS 공격 방어.
 - **Refresh Token**: 브라우저 **HttpOnly, Secure 쿠키** 기반으로 관리하여 보안 강화.
-- **Legacy Cleanup**: 기존 `localStorage`에 `refresh_token`을 저장하던 방식은 완전히 폐기하며, 관련 데이터를 일괄 삭제함.
+- **Startup Bootstrap**: 앱 최초 진입 시 `POST /api/v1/accounts/token/refresh`로 세션 복구를 시도하고, 성공 시 `/me` 조회로 사용자 정보를 hydrate함.
+- **Legacy Cleanup**: 기존 `localStorage` 인증 키(`auth-storage`, `access_token`, `refresh_token` 등)는 앱 시작 시 1회 정리함.
 
 ### 2. 인증 관련 API 엔드포인트
 
 - **소셜 로그인 진입**: `GET /api/v1/accounts/social-login/{google|kakao|naver}` (백엔드 제공 OAuth 시작점)
+- **소셜 로그인 콜백 경로**: 정식 경로는 `/callback`이며, 기존 `/auth/callback`은 하위 호환 redirect 경로로 유지함.
 - **토큰 갱신**: `POST /api/v1/accounts/token/refresh` (쿠키의 리프레시 토큰을 사용하여 액세스 토큰 재발급)
 - **주의**: API 명세서 표에 `refresh_token` body 예시가 있어도, 실서버 동작 기준은 HttpOnly 쿠키 인증이며 프론트는 `withCredentials` 요청으로 맞춥니다.
 - **로그아웃**: `POST /api/v1/accounts/logout` (액세스 토큰 무효화 및 서버측 쿠키 삭제 요청)
@@ -34,6 +36,7 @@
 
 - **Axios Interceptor**: 모든 API 요청에서 `401 Unauthorized` 발생 시 `/token/refresh`를 자동 호출하여 세션 연장 시도.
 - **세션 만료 처리**: 리프레시 토큰 만료로 갱신 실패 시, '세션 만료' 안내 후 강제 로그아웃 및 로그인 페이지로 유도.
+- **초기 진입 예외 처리**: 콜백 라우트(`/callback`, `/auth/callback`)에서는 중복 refresh를 피하기 위해 앱 시작 bootstrap을 건너뜀.
 
 ### 5. 마이페이지 프로필 표시 필드
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,11 @@ import {
   AUTH_SESSION_EXPIRED_NOTICE_MESSAGE,
   type AuthSessionExpiredDetail,
 } from './features/auth/constants/session';
+import useAuthBootstrap from './features/auth/hooks/useAuthBootstrap';
 import SupportChatWidget from './components/support-chat/SupportChatWidget';
 
 function App() {
+  useAuthBootstrap();
   const navigate = useNavigate();
   const location = useLocation();
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from 'react-router';
 import { ROUTES } from '../../constants/routes';
-import { useAuthStore } from '../../store/useAuthStore';
+import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
 import HeaderProfileMenu from './HeaderProfileMenu';
 
 type HeaderProps = {
@@ -17,7 +17,7 @@ const HIDDEN_GUEST_ACTION_PATHS = new Set([
 
 const Header = ({ fixed = true }: HeaderProps) => {
   const location = useLocation();
-  const isLoggedIn = useAuthStore((state) => Boolean(state.accessToken));
+  const { isAuthReady, canAccessAuthenticatedRoute } = useAuthGuardState();
   const shouldHideGuestActions = HIDDEN_GUEST_ACTION_PATHS.has(
     location.pathname,
   );
@@ -40,7 +40,9 @@ const Header = ({ fixed = true }: HeaderProps) => {
         </Link>
 
         <div className="flex items-center gap-2 sm:gap-3">
-          {!isLoggedIn ? (
+          {!isAuthReady ? (
+            <div aria-hidden className="h-9 w-44" />
+          ) : !canAccessAuthenticatedRoute ? (
             shouldHideGuestActions ? null : (
               <>
                 <Link

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router';
+
+import { ROUTES } from '../../../constants/routes';
+import {
+  clearLegacyAuthStorage,
+  useAuthStore,
+} from '../../../store/useAuthStore';
+import { getCurrentUserProfile, refreshAccessToken } from '../api/auth';
+
+const AUTH_BOOTSTRAP_SKIP_PATHS = new Set([
+  `/${ROUTES.AUTH_CALLBACK}`,
+  `/${ROUTES.LEGACY_AUTH_CALLBACK}`,
+]);
+
+function useAuthBootstrap() {
+  const location = useLocation();
+  const authBootstrapStatus = useAuthStore(
+    (state) => state.authBootstrapStatus,
+  );
+  const hasBootstrappedRef = useRef(false);
+
+  useEffect(() => {
+    clearLegacyAuthStorage();
+  }, []);
+
+  useEffect(() => {
+    if (hasBootstrappedRef.current) {
+      return;
+    }
+
+    hasBootstrappedRef.current = true;
+
+    const store = useAuthStore.getState();
+
+    if (AUTH_BOOTSTRAP_SKIP_PATHS.has(location.pathname)) {
+      store.setAuthBootstrapStatus('ready');
+      return;
+    }
+
+    let isMounted = true;
+    store.setAuthBootstrapStatus('loading');
+
+    const bootstrapAuth = async () => {
+      try {
+        const { access_token: accessToken } = await refreshAccessToken();
+
+        if (!isMounted) {
+          return;
+        }
+
+        useAuthStore.getState().setAccessToken(accessToken);
+        const profile = await getCurrentUserProfile();
+
+        if (!isMounted) {
+          return;
+        }
+
+        useAuthStore.getState().setAccount(profile);
+      } catch {
+        if (!isMounted) {
+          return;
+        }
+
+        useAuthStore.getState().clearAuth();
+      } finally {
+        if (isMounted) {
+          useAuthStore.getState().setAuthBootstrapStatus('ready');
+        }
+      }
+    };
+
+    void bootstrapAuth();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [location.pathname]);
+
+  return {
+    authBootstrapStatus,
+    isAuthReady: authBootstrapStatus === 'ready',
+  };
+}
+
+export default useAuthBootstrap;

--- a/src/features/auth/hooks/useAuthGuardState.ts
+++ b/src/features/auth/hooks/useAuthGuardState.ts
@@ -1,0 +1,18 @@
+import { useAuthStore } from '../../../store/useAuthStore';
+
+function useAuthGuardState() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const authBootstrapStatus = useAuthStore(
+    (state) => state.authBootstrapStatus,
+  );
+  const isAuthReady = authBootstrapStatus === 'ready';
+
+  return {
+    isAuthenticated,
+    isAuthReady,
+    authBootstrapStatus,
+    canAccessAuthenticatedRoute: isAuthReady && isAuthenticated,
+  };
+}
+
+export default useAuthGuardState;

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -6,6 +6,7 @@ import { Link, useNavigate, useParams } from 'react-router';
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
 import { authKeys } from '../../features/auth/api/queryKeys';
+import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
 import type { LikedGamesResponse } from '../../features/auth/types/auth';
 import {
   useMatchCandidatesQuery,
@@ -21,7 +22,6 @@ import {
 import { useMatchingStore } from '../../features/matching/store/useMatchingStore';
 import { extractApiErrorMessage } from '../../features/survey/api/survey';
 import { isMockServiceWorkerEnabled } from '../../lib/env';
-import { getAccessToken } from '../../utils/auth';
 
 const formatMatchingCandidateRating = (rating: number | null) => {
   if (typeof rating !== 'number') {
@@ -45,9 +45,9 @@ function MatchingGenreDetailPage() {
   const { genreSlug } = useParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const hasAccessToken = Boolean(getAccessToken());
+  const { canAccessAuthenticatedRoute, isAuthReady } = useAuthGuardState();
   const isMockMode = isMockServiceWorkerEnabled();
-  const canAccessPage = isMockMode || hasAccessToken;
+  const canAccessPage = isMockMode || canAccessAuthenticatedRoute;
   const isValidGenreSlug = genreSlug ? isMatchingGenreSlug(genreSlug) : false;
   const genre = genreSlug ? getMatchingGenreBySlug(genreSlug) : undefined;
 
@@ -228,6 +228,10 @@ function MatchingGenreDetailPage() {
               <ChevronLeft size={16} />
               장르 선택으로 돌아가기
             </Link>
+          </section>
+        ) : !isMockMode && !isAuthReady ? (
+          <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 text-center text-white/68 sm:px-8 sm:py-12">
+            인증 상태를 확인하는 중입니다...
           </section>
         ) : !canAccessPage ? (
           <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 sm:px-8 sm:py-12">

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -4,16 +4,16 @@ import { Link } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
+import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
 import { useMatchingGenreImageQueries } from '../../features/matching/api/useMatchingApi';
 import { MATCHING_GENRES } from '../../features/matching/genres';
 import { useMatchingStore } from '../../features/matching/store/useMatchingStore';
 import { isMockServiceWorkerEnabled } from '../../lib/env';
-import { getAccessToken } from '../../utils/auth';
 
 function MatchingListPage() {
-  const hasAccessToken = Boolean(getAccessToken());
+  const { canAccessAuthenticatedRoute } = useAuthGuardState();
   const isMockMode = isMockServiceWorkerEnabled();
-  const canFetchGenreImages = isMockMode || hasAccessToken;
+  const canFetchGenreImages = isMockMode || canAccessAuthenticatedRoute;
   const resetFlow = useMatchingStore((state) => state.resetFlow);
   const genreImageQueries = useMatchingGenreImageQueries(
     MATCHING_GENRES.map((genre) => genre.genreId),

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -35,6 +35,7 @@ import {
   useUploadFileToS3Mutation,
 } from '../../features/auth/api/useAuthApi';
 import { authKeys } from '../../features/auth/api/queryKeys';
+import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
 import type {
   AuthGender,
@@ -44,11 +45,7 @@ import type {
 import GameDetailModal from '../../features/games/components/GameDetailModal';
 import type { GameListItem } from '../../features/games/types';
 import type { FavoriteGamePreview } from '../../features/mypage/types';
-import {
-  clearAuthTokens,
-  getAccessToken,
-  setAuthAccount,
-} from '../../utils/auth';
+import { clearAuthTokens, setAuthAccount } from '../../utils/auth';
 import { useAuthStore } from '../../store/useAuthStore';
 
 type PasswordTouchedState = Record<PasswordChangeFieldName, boolean>;
@@ -171,7 +168,7 @@ const toGenderLabel = (gender?: AuthGender) => {
 function MyPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const hasAccessToken = Boolean(getAccessToken());
+  const { canAccessAuthenticatedRoute, isAuthReady } = useAuthGuardState();
   const { logout, isPending: isLogoutPending } = useLogoutAction();
   const changePasswordMutation = useChangePasswordMutation();
   const deleteAccountMutation = useDeleteAccountMutation();
@@ -181,9 +178,9 @@ function MyPage() {
     useProfileImagePresignedUrlMutation();
   const uploadFileToS3Mutation = useUploadFileToS3Mutation();
   const confirmProfileImageMutation = useConfirmProfileImageMutation();
-  const profileQuery = useCurrentUserProfileQuery(hasAccessToken);
+  const profileQuery = useCurrentUserProfileQuery(canAccessAuthenticatedRoute);
   const likedGamesQuery = useLikedGamesInfiniteQuery(
-    hasAccessToken,
+    canAccessAuthenticatedRoute,
     DEFAULT_LIKED_GAMES_PAGE_SIZE,
   );
   const storedAccount = useAuthStore((state) => state.account);
@@ -321,7 +318,20 @@ function MyPage() {
     isFavoriteGamesFetchingNextPage,
   ]);
 
-  if (!hasAccessToken) {
+  if (!isAuthReady) {
+    return (
+      <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+        <Header fixed />
+        <main className="mx-auto flex min-h-screen w-full max-w-[1240px] px-4 pt-[6.1rem] pb-12 sm:px-6 md:px-8 md:pt-[6.4rem]">
+          <section className="survey-panel mx-auto w-full max-w-[920px] px-8 py-12 text-center text-white/68">
+            인증 상태를 확인하는 중입니다...
+          </section>
+        </main>
+      </div>
+    );
+  }
+
+  if (!canAccessAuthenticatedRoute) {
     return (
       <Navigate
         to={`/${ROUTES.LOGIN}`}

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -9,6 +9,7 @@ import ActionButton from '../../components/common/ActionButton';
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
 import { authKeys } from '../../features/auth/api/queryKeys';
+import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
 import type { LikedGamesResponse } from '../../features/auth/types/auth';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
 import {
@@ -30,7 +31,6 @@ import type {
   SurveyResultResponse,
 } from '../../features/survey/types/survey';
 import { isMockServiceWorkerEnabled } from '../../lib/env';
-import { getAccessToken } from '../../utils/auth';
 
 const FALLBACK_BACKDROP_ITEMS = [
   {
@@ -275,8 +275,8 @@ function RecommendationListPage() {
   const isSurveySource =
     source === 'survey' || (!source && Boolean(legacySessionId));
   const isMockMode = isMockServiceWorkerEnabled();
-  const hasAccessToken = Boolean(getAccessToken());
-  const canAccessPage = isMockMode || hasAccessToken;
+  const { canAccessAuthenticatedRoute, isAuthReady } = useAuthGuardState();
+  const canAccessPage = isMockMode || canAccessAuthenticatedRoute;
 
   const surveyResultsQuery = useSurveyResultsInfinite(
     !isMatchSource && isSurveySource && canAccessPage,
@@ -595,7 +595,16 @@ function RecommendationListPage() {
             </aside>
           </div>
 
-          {!canAccessPage ? (
+          {!isMockMode && !isAuthReady ? (
+            <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
+              <h2 className="text-2xl font-bold text-white">
+                인증 상태를 확인하는 중입니다.
+              </h2>
+              <p className="mt-4 text-base leading-7 break-keep text-white/60">
+                잠시만 기다려 주세요. 세션 확인 후 추천 결과를 불러옵니다.
+              </p>
+            </section>
+          ) : !canAccessPage ? (
             <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
               <h2 className="text-2xl font-bold text-white">
                 로그인 후 추천 결과를 볼 수 있어요.

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -1,21 +1,21 @@
 import { useEffect } from 'react';
 
 import Header from '../../components/common/Header';
+import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
 import SurveyChatPanel from '../../features/survey/components/SurveyChatPanel';
 import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
 import { isMockServiceWorkerEnabled } from '../../lib/env';
 import { useAuthStore } from '../../store/useAuthStore';
-import { getAccessToken } from '../../utils/auth';
 
 function SurveyPage() {
-  const hasAccessToken = Boolean(getAccessToken());
+  const { canAccessAuthenticatedRoute, isAuthReady } = useAuthGuardState();
   const isMockMode = isMockServiceWorkerEnabled();
-  const canAccessSurvey = isMockMode || hasAccessToken;
+  const canAccessSurvey = isMockMode || canAccessAuthenticatedRoute;
   const account = useAuthStore((state) => state.account);
   const syncOwnerKey = useSurveyStore((state) => state.syncOwnerKey);
   const surveyOwnerKey = account?.login_id
     ? `survey-user:${account.login_id}`
-    : hasAccessToken
+    : canAccessAuthenticatedRoute
       ? 'survey-user:authenticated'
       : isMockMode
         ? 'survey-user:mock'
@@ -31,7 +31,17 @@ function SurveyPage() {
       <Header fixed />
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-[100dvh] md:max-h-[100dvh] md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
-        {canAccessSurvey ? (
+        {!isMockMode && !isAuthReady ? (
+          <section className="survey-panel max-w-2xl px-8 py-10">
+            <h2 className="text-2xl font-bold text-white">
+              인증 상태를 확인하는 중입니다.
+            </h2>
+            <p className="mt-4 text-base leading-7 text-white/60">
+              잠시만 기다려 주세요. 세션 확인 후 설문 화면을 이어서
+              보여드릴게요.
+            </p>
+          </section>
+        ) : canAccessSurvey ? (
           <SurveyChatPanel />
         ) : (
           <section className="survey-panel max-w-2xl px-8 py-10">

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,68 +1,62 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
 import type { CurrentUserProfileResponse } from '../features/auth/types/auth';
 
 /**
- * [Auth] 새로고침 로그인 유지 업데이트
- * - Access Token: 로컬 개발/테스트 흐름에 맞춰 localStorage 기반으로 유지합니다.
+ * [Auth] 쿠키 기반 세션 복구 업데이트
+ * - Access Token: 클라이언트 메모리(Zustand State)에서만 유지합니다.
  * - Refresh Token: 브라우저 HttpOnly Cookie 기반 관리 (백엔드 주도)
- * - 로그아웃/세션 만료 시 localStorage 인증 데이터를 즉시 제거합니다.
+ * - 레거시 localStorage 인증 키는 앱 시작 시 1회 정리합니다.
  */
+
+export type AuthBootstrapStatus = 'idle' | 'loading' | 'ready';
 
 interface AuthState {
   accessToken: string | null;
   account: CurrentUserProfileResponse | null;
   isAuthenticated: boolean;
+  authBootstrapStatus: AuthBootstrapStatus;
   setAccessToken: (token: string) => void;
   setAccount: (account: CurrentUserProfileResponse | null) => void;
   setAuth: (token: string, account: CurrentUserProfileResponse) => void;
   clearAuth: () => void;
+  setAuthBootstrapStatus: (status: AuthBootstrapStatus) => void;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
+export const useAuthStore = create<AuthState>((set) => ({
+  accessToken: null,
+  account: null,
+  isAuthenticated: false,
+  authBootstrapStatus: 'idle',
+
+  setAccessToken: (token) =>
+    set({
+      accessToken: token,
+      isAuthenticated: !!token,
+    }),
+
+  setAccount: (account) => set({ account }),
+
+  setAuth: (token, account) =>
+    set({
+      accessToken: token,
+      account: account,
+      isAuthenticated: true,
+    }),
+
+  clearAuth: () => {
+    set({
       accessToken: null,
       account: null,
       isAuthenticated: false,
+    });
+  },
 
-      setAccessToken: (token) =>
-        set({
-          accessToken: token,
-          isAuthenticated: !!token,
-        }),
-
-      setAccount: (account) => set({ account }),
-
-      setAuth: (token, account) =>
-        set({
-          accessToken: token,
-          account: account,
-          isAuthenticated: true,
-        }),
-
-      clearAuth: () => {
-        set({
-          accessToken: null,
-          account: null,
-          isAuthenticated: false,
-        });
-
-        // 기존 localStorage 기반 레거시 데이터 완전 삭제
-        clearLegacyAuthStorage();
-      },
-    }),
-    {
-      name: 'auth-storage',
-      storage: createJSONStorage(() => window.localStorage),
-      partialize: (state) => ({
-        accessToken: state.accessToken,
-        account: state.account,
-        isAuthenticated: state.isAuthenticated,
-      }),
-    },
-  ),
-);
+  setAuthBootstrapStatus: (status) => {
+    set({
+      authBootstrapStatus: status,
+    });
+  },
+}));
 
 /**
  * 기존 localStorage에 저장되던 모든 인증 관련 레거시 키를 삭제합니다.


### PR DESCRIPTION
## 관련 이슈

- closes #

## 변경 내용

-useAuthStore에서 persist/localStorage 제거, Access Token을 메모리 전용으로 전환했습니다.
-앱 최초 진입 시 POST /api/v1/accounts/token/refresh로 세션 복구 후 /me hydrate 하는 useAuthBootstrap 훅을 추가했습니다.
-authBootstrapStatus/useAuthGuardState를 도입하고, MyPage/Survey/Matching/Recommendation/Header 인증 판별을 -   authReady + isAuthenticated 기준으로 통일했습니다.
-콜백 경로 정책(/{callback} 정식, /{auth/callback} 하위호환)과 쿠키 기반 refresh 계약을 문서(docs/ai/api-contract.md)에 동기화했습니다.
-앱 시작 시 레거시 인증 키(auth-storage, access_token, refresh_token 등) 1회 정리 로직을 유지했습니다.


## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-소셜 로그인 성공 redirect 권장 경로: /callback?social_login=success
-refresh는 실서버 동작 기준으로 HttpOnly 쿠키 인증(withCredentials)을 사용하며 body는 사용하지 않습니다.
-백엔드 CORS credentials 설정(Allow-Credentials: true, 허용 Origin 명시)이 전제됩니다.
