### PR TITLE
fix(auth,header,chat): 인증 부트스트랩 고정 이슈 해결 및 헤더/고객센터 UI 원복

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from 'react-router';
 import { ROUTES } from '../../constants/routes';
-import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
+import { useAuthStore } from '../../store/useAuthStore';
 import HeaderProfileMenu from './HeaderProfileMenu';
 
 type HeaderProps = {
@@ -17,7 +17,7 @@ const HIDDEN_GUEST_ACTION_PATHS = new Set([
 
 const Header = ({ fixed = true }: HeaderProps) => {
   const location = useLocation();
-  const { isAuthReady, canAccessAuthenticatedRoute } = useAuthGuardState();
+  const isLoggedIn = useAuthStore((state) => Boolean(state.accessToken));
   const shouldHideGuestActions = HIDDEN_GUEST_ACTION_PATHS.has(
     location.pathname,
   );
@@ -40,9 +40,7 @@ const Header = ({ fixed = true }: HeaderProps) => {
         </Link>
 
         <div className="flex items-center gap-2 sm:gap-3">
-          {!isAuthReady ? (
-            <div aria-hidden className="h-9 w-44" />
-          ) : !canAccessAuthenticatedRoute ? (
+          {!isLoggedIn ? (
             shouldHideGuestActions ? null : (
               <>
                 <Link

--- a/src/components/support-chat/SupportChatHeader.tsx
+++ b/src/components/support-chat/SupportChatHeader.tsx
@@ -14,21 +14,18 @@ function SupportChatHeader({
   onClose,
 }: SupportChatHeaderProps) {
   return (
-    <div className="border-b border-[#641312] px-4 py-4 sm:px-5">
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex items-start gap-3">
-          <div className="support-chat-header-badge">
-            <Bot size={20} />
-          </div>
-          <div className="min-w-0">
-            <p className="text-lg font-semibold tracking-[0.02em] text-white sm:text-xl">
-              고객센터
-            </p>
-            <p className="mt-1 truncate text-sm leading-5 whitespace-nowrap text-white/70">
-              {routeContext.pageLabel} 화면에서도 바로 문의하실 수 있어요.
-            </p>
-          </div>
+    <div
+      className="border-b border-[#641312] px-4 py-3.5 sm:px-5"
+      data-route-context={routeContext.pageLabel}
+    >
+      <div className="relative flex items-center justify-between gap-3">
+        <div className="support-chat-header-badge">
+          <Bot size={20} />
         </div>
+
+        <p className="pointer-events-none absolute left-1/2 -translate-x-1/2 text-[1.35rem] leading-none font-semibold tracking-[0.01em] text-white sm:text-[1.45rem]">
+          고객센터
+        </p>
 
         <div className="flex items-center gap-1.5">
           <button

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -31,6 +31,7 @@ import type {
 
 const normalizeApiBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
 const authApiUrl = `${normalizeApiBaseUrl(apiBaseUrl)}${AUTH_BASE_PATH}`;
+const AUTH_REFRESH_TIMEOUT_MS = 7000;
 const DEFAULT_API_ERROR_MESSAGE =
   '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
 
@@ -100,6 +101,7 @@ export const refreshAccessToken = async () => {
     {},
     {
       withCredentials: true,
+      timeout: AUTH_REFRESH_TIMEOUT_MS,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -33,6 +33,11 @@ function useAuthBootstrap() {
 
     const store = useAuthStore.getState();
 
+    if (store.accessToken) {
+      store.setAuthBootstrapStatus('ready');
+      return;
+    }
+
     if (AUTH_BOOTSTRAP_SKIP_PATHS.has(location.pathname)) {
       store.setAuthBootstrapStatus('ready');
       return;

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -32,6 +32,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({
       accessToken: token,
       isAuthenticated: !!token,
+      authBootstrapStatus: 'ready',
     }),
 
   setAccount: (account) => set({ account }),
@@ -41,6 +42,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       accessToken: token,
       account: account,
       isAuthenticated: true,
+      authBootstrapStatus: 'ready',
     }),
 
   clearAuth: () => {


### PR DESCRIPTION
## 관련 이슈

- closes #206

## 변경 내용

- 인증 부트스트랩이 loading에 고정되는 케이스를 방지하기 위해 refresh 타임아웃(7초)과 상태 전환 보강을 적용했습니다.
- 헤더 우측 인증 버튼 영역을 기존 동작(즉시 로그인/회원가입 또는 프로필 노출)으로 원복했습니다.
- 고객센터 챗봇 헤더의 안내 문구를 제거하고, 고객센터 타이틀을 중앙 정렬로 보정했습니다.


## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="736" height="1442" alt="image" src="https://github.com/user-attachments/assets/e5fbadfe-35d8-41c3-b752-a1d2f8763430" />

## 참고사항

-
