### PR TITLE
refactor(chat): 고객센터 챗봇 헤더/아바타/에러표시 UX 정리

### DIFF
--- a/src/components/support-chat/SupportChatComposer.tsx
+++ b/src/components/support-chat/SupportChatComposer.tsx
@@ -1,11 +1,9 @@
 import type { FormEvent, KeyboardEvent } from 'react';
 import { SendHorizontal } from 'lucide-react';
-import StatusMessage from '../common/StatusMessage';
 
 type SupportChatComposerProps = {
   value: string;
   disabled?: boolean;
-  error?: string | null;
   onChange: (value: string) => void;
   onSubmit: () => void;
 };
@@ -13,7 +11,6 @@ type SupportChatComposerProps = {
 function SupportChatComposer({
   value,
   disabled = false,
-  error = null,
   onChange,
   onSubmit,
 }: SupportChatComposerProps) {
@@ -54,15 +51,6 @@ function SupportChatComposer({
           <SendHorizontal size={16} />
         </button>
       </form>
-      {error ? (
-        <StatusMessage
-          tone="error"
-          variant="inline"
-          className="mt-1 text-xs text-[#ff8b84]"
-        >
-          {error}
-        </StatusMessage>
-      ) : null}
     </div>
   );
 }

--- a/src/components/support-chat/SupportChatHeader.tsx
+++ b/src/components/support-chat/SupportChatHeader.tsx
@@ -24,7 +24,7 @@ function SupportChatHeader({
         </div>
 
         <p className="pointer-events-none absolute left-1/2 -translate-x-1/2 text-[1.35rem] leading-none font-semibold tracking-[0.01em] text-white sm:text-[1.45rem]">
-          고객센터
+          고객센터 챗봇
         </p>
 
         <div className="flex items-center gap-1.5">

--- a/src/components/support-chat/SupportChatMessageBubble.tsx
+++ b/src/components/support-chat/SupportChatMessageBubble.tsx
@@ -1,6 +1,8 @@
-import { Bot, UserRound } from 'lucide-react';
+import { Bot } from 'lucide-react';
 
 import type { SupportChatMessage } from '@/features/support-chat/types/supportChat';
+import { useAuthStore } from '@/store/useAuthStore';
+import defaultProfileImage from '@/assets/프로필 이미지.png';
 import SupportChatTypingIndicator from './SupportChatTypingIndicator';
 
 type SupportChatMessageBubbleProps = {
@@ -16,7 +18,6 @@ const roleMeta = {
       'border border-[#7a1715]/70 bg-[#2a0e0d] text-[#ff6b62] shadow-[0_0_24px_rgba(201,41,35,0.16)]',
   },
   user: {
-    Icon: UserRound,
     wrapperClassName: 'justify-end',
     bodyClassName: 'support-chat-bubble-user',
     badgeClassName:
@@ -26,7 +27,10 @@ const roleMeta = {
 
 function SupportChatMessageBubble({ message }: SupportChatMessageBubbleProps) {
   const meta = roleMeta[message.role];
-  const Icon = meta.Icon;
+  const AssistantIcon = roleMeta.assistant.Icon;
+  const account = useAuthStore((state) => state.account);
+  const isAuthenticatedUser = useAuthStore((state) => state.isAuthenticated);
+  const userAvatarUrl = account?.profile_img_url?.trim() || defaultProfileImage;
   const isTyping =
     message.role === 'assistant' &&
     message.status === 'streaming' &&
@@ -39,7 +43,7 @@ function SupportChatMessageBubble({ message }: SupportChatMessageBubbleProps) {
           <div
             className={`mt-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl ${meta.badgeClassName}`}
           >
-            <Icon size={18} />
+            <AssistantIcon size={18} />
           </div>
         ) : null}
 
@@ -59,7 +63,20 @@ function SupportChatMessageBubble({ message }: SupportChatMessageBubbleProps) {
           <div
             className={`mt-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl ${meta.badgeClassName}`}
           >
-            <Icon size={18} />
+            <img
+              src={userAvatarUrl}
+              alt={
+                isAuthenticatedUser
+                  ? '회원 프로필 이미지'
+                  : '비회원 프로필 이미지'
+              }
+              className="h-full w-full rounded-2xl object-cover"
+              onError={(event) => {
+                if (event.currentTarget.src !== defaultProfileImage) {
+                  event.currentTarget.src = defaultProfileImage;
+                }
+              }}
+            />
           </div>
         ) : null}
       </div>

--- a/src/components/support-chat/SupportChatPanel.tsx
+++ b/src/components/support-chat/SupportChatPanel.tsx
@@ -22,7 +22,6 @@ type SupportChatPanelProps = {
   isPinnedToBottom: boolean;
   showJumpToLatestButton: boolean;
   liveStatusMessage: string | null;
-  error: string | null;
   inputValue: string;
   onReset: () => void;
   onClose: () => void;
@@ -44,7 +43,6 @@ function SupportChatPanel({
   isPinnedToBottom,
   showJumpToLatestButton,
   liveStatusMessage,
-  error,
   inputValue,
   onReset,
   onClose,
@@ -118,7 +116,6 @@ function SupportChatPanel({
       <SupportChatComposer
         value={inputValue}
         disabled={isSubmitting}
-        error={error}
         onChange={onInputChange}
         onSubmit={onSubmit}
       />

--- a/src/components/support-chat/SupportChatWidget.tsx
+++ b/src/components/support-chat/SupportChatWidget.tsx
@@ -60,6 +60,8 @@ const getRouteContext = (pathname: string): SupportChatRouteContext => ({
 });
 
 const AUTO_SCROLL_NEAR_BOTTOM_THRESHOLD_PX = 72;
+const SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE =
+  '메시지는 공백일 수 없고 2자 이상이어야 합니다.';
 
 function SupportChatWidget() {
   const location = useLocation();
@@ -84,7 +86,6 @@ function SupportChatWidget() {
     isPinnedToBottom,
     isOpen,
     isSubmitting,
-    error,
     bootstrapConversation,
     resetConversation,
     closePanel,
@@ -93,10 +94,9 @@ function SupportChatWidget() {
     setSessionId,
     setPinnedToBottom,
     setSubmitting,
-    setError,
-    clearError,
     hideQuickActions,
     appendUserMessage,
+    appendAssistantMessage,
     beginAssistantMessage,
     appendAssistantChunk,
     finalizeAssistantMessage,
@@ -150,6 +150,20 @@ function SupportChatWidget() {
       setHasUnreadMessages(false);
     },
     [setPinnedToBottom],
+  );
+
+  const appendAssistantErrorMessage = useCallback(
+    (message: string) => {
+      const trimmedMessage = message.trim();
+
+      if (!trimmedMessage) {
+        return;
+      }
+
+      hideQuickActions();
+      appendAssistantMessage(trimmedMessage);
+    },
+    [appendAssistantMessage, hideQuickActions],
   );
 
   const handleClosePanel = useCallback(() => {
@@ -305,14 +319,17 @@ function SupportChatWidget() {
   const submitMessage = async (message: string) => {
     const trimmedMessage = message.trim();
 
-    if (trimmedMessage.length < 2 || isSubmitting) {
-      setError('메시지는 공백일 수 없고 2자 이상이어야 합니다.');
+    if (trimmedMessage.length < 2) {
+      appendAssistantErrorMessage(SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE);
+      return;
+    }
+
+    if (isSubmitting) {
       return;
     }
 
     const assistantPlaceholderMessageId = crypto.randomUUID();
 
-    clearError();
     hideQuickActions();
     appendUserMessage(trimmedMessage);
     beginAssistantMessage(assistantPlaceholderMessageId);
@@ -365,7 +382,7 @@ function SupportChatWidget() {
       const errorMessage = extractSupportChatErrorMessage(requestError);
 
       if (errorMessage) {
-        setError(errorMessage);
+        appendAssistantErrorMessage(errorMessage);
       }
 
       setSubmitting(false);
@@ -376,7 +393,7 @@ function SupportChatWidget() {
 
   const handleSubmit = async () => {
     if (!inputValue.trim()) {
-      setError('메시지는 공백일 수 없고 2자 이상이어야 합니다.');
+      appendAssistantErrorMessage(SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE);
       return;
     }
 
@@ -413,7 +430,6 @@ function SupportChatWidget() {
         isPinnedToBottom={isPinnedToBottom}
         showJumpToLatestButton={showJumpToLatestButton}
         liveStatusMessage={liveStatusMessage}
-        error={error}
         inputValue={inputValue}
         onReset={handleReset}
         onClose={handleClosePanel}
@@ -422,10 +438,6 @@ function SupportChatWidget() {
         }}
         onQuickActionSelect={handleQuickActionSelect}
         onInputChange={(value) => {
-          if (error) {
-            clearError();
-          }
-
           setInputValue(value);
         }}
         onSubmit={handleSubmit}

--- a/src/features/support-chat/store/useSupportChatStore.ts
+++ b/src/features/support-chat/store/useSupportChatStore.ts
@@ -20,7 +20,6 @@ type SupportChatStoreState = {
   isPinnedToBottom: boolean;
   isOpen: boolean;
   isSubmitting: boolean;
-  error: string | null;
   routeContext: SupportChatRouteContext;
   bootstrapConversation: (routeContext?: SupportChatRouteContext) => void;
   resetConversation: (routeContext?: SupportChatRouteContext) => void;
@@ -31,10 +30,9 @@ type SupportChatStoreState = {
   setSessionId: (sessionId: number | null) => void;
   setPinnedToBottom: (isPinnedToBottom: boolean) => void;
   setSubmitting: (isSubmitting: boolean) => void;
-  setError: (error: string | null) => void;
-  clearError: () => void;
   hideQuickActions: () => void;
   appendUserMessage: (content: string) => void;
+  appendAssistantMessage: (content: string) => void;
   beginAssistantMessage: (messageId: string) => void;
   appendAssistantChunk: (messageId: string, chunk: string) => void;
   finalizeAssistantMessage: (messageId: string) => void;
@@ -74,7 +72,6 @@ const initialState = {
   isPinnedToBottom: true,
   isOpen: false,
   isSubmitting: false,
-  error: null as string | null,
   routeContext: createDefaultRouteContext(),
 };
 
@@ -114,14 +111,19 @@ export const useSupportChatStore = create<SupportChatStoreState>()(
     setSessionId: (sessionId) => set({ sessionId }),
     setPinnedToBottom: (isPinnedToBottom) => set({ isPinnedToBottom }),
     setSubmitting: (isSubmitting) => set({ isSubmitting }),
-    setError: (error) => set({ error }),
-    clearError: () => set({ error: null }),
     hideQuickActions: () => set({ showQuickActions: false }),
     appendUserMessage: (content) =>
       set((state) => ({
         messages: capMessages([
           ...state.messages,
           createMessage('user', content),
+        ]),
+      })),
+    appendAssistantMessage: (content) =>
+      set((state) => ({
+        messages: capMessages([
+          ...state.messages,
+          createMessage('assistant', content),
         ]),
       })),
     beginAssistantMessage: (messageId) =>


### PR DESCRIPTION
## 관련 이슈

- closes #208 

## 변경 내용

-고객센터 챗봇 헤더 타이틀을 고객센터 챗봇으로 변경했습니다.
-채팅 사용자 아바타를 회원/비회원 모두 이미지 기반으로 통일했습니다.
-회원은 account.profile_img_url을 우선 사용하고, 비회원/미설정/이미지 로드 실패 시 기본 프로필 이미지로 폴백되도록 처리했습니다.
-입력창 하단 에러 문구(StatusMessage)를 제거하고, 입력 검증/API/스트림 실패 에러를 챗봇(assistant) 말풍선으로 노출하도록 전환했습니다.
-챗봇 스토어에서 하단 에러 UI 전용 상태(error, setError, clearError)를 정리하고, assistant 완성 메시지 추가 액션으로 통일했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="640" height="1792" alt="image" src="https://github.com/user-attachments/assets/18f46dd7-2a3f-4a85-be9b-f514481857c3" />

## 참고사항

-
