### PR TITLE
[Fix] 찜 상태 동기화 및 비밀번호 변경 계약 정리

### DIFF
--- a/docs/ai/api-contract.md
+++ b/docs/ai/api-contract.md
@@ -26,6 +26,39 @@
 - **마이페이지 찜 목록 조회**: `GET /api/v1/accounts/me/game-like`
 - **마이페이지 찜 해제**: `DELETE /api/v1/accounts/me/game-like/{game_id}`
 
+#### 비밀번호 변경 필드 계약
+
+비밀번호 변경은 현재 프론트 구현 기준으로 아래 필드명을 canonical contract로 사용합니다.
+백엔드 명세가 다시 조정되더라도, 프론트는 이 문서를 먼저 갱신한 뒤 타입과 mock을 함께 수정합니다.
+
+```json
+{
+  "old_password": "string",
+  "new_password": "string",
+  "new_password_check": "string"
+}
+```
+
+- `old_password`: 현재 비밀번호
+- `new_password`: 새 비밀번호
+- `new_password_check`: 새 비밀번호 확인
+- 필드 검증 에러는 `detail` 또는 `error_detail` 안에 위 3개 키로 내려오는 것을 기준으로 처리합니다.
+- 현재 비밀번호 불일치는 field error가 아니라 일반 에러 메시지로 처리하며, 응답 예시는 아래와 같습니다.
+
+```json
+{
+  "error_detail": "현재 비밀번호가 올바르지 않습니다."
+}
+```
+
+- 성공 응답은 아래 형태를 기준으로 사용합니다.
+
+```json
+{
+  "detail": "비밀번호가 변경되었습니다."
+}
+```
+
 ### 3. 로그아웃 및 세션 초기화 규정
 
 - **상태 초기화**: 로그아웃 실행 시 `useAuthStore`의 토큰 및 사용자 프로필 정보를 즉시 `null`로 초기화.

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -30,6 +30,7 @@ import type {
   UpdateUserInfoRequest,
   UploadFileToS3Request,
 } from '../types/auth';
+import { syncGameLikeStateInQueryCache } from '../../games/queryCache';
 import { setAuthAccount } from '../../../utils/auth';
 
 export const DEFAULT_LIKED_GAMES_PAGE_SIZE = 20;
@@ -132,11 +133,12 @@ export const useUnlikeLikedGameMutation = () => {
           };
         },
       );
-      void queryClient.invalidateQueries({
-        queryKey: authKeys.likedGames(),
+      syncGameLikeStateInQueryCache(queryClient, {
+        gameId,
+        isLiked: false,
       });
       void queryClient.invalidateQueries({
-        queryKey: ['games', 'detail', gameId],
+        queryKey: authKeys.likedGames(),
       });
     },
   });

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { delay, http, HttpResponse } from 'msw';
 
 import { AUTH_BASE_PATH } from '../constants/auth';
+import { mockGameDetails } from '../../games/mockGameDetails';
 import { mockTopGames } from '../../games/mockGames';
 import type { RawGameLikeResponse } from '../../games/types';
 import type {
@@ -40,7 +41,12 @@ let pendingSocialLoginId: string | null = null;
 const mockLikedGamesByLoginId = new Map<string, LikedGameItemResponse[]>(
   [...mockUsers.keys()].map((loginId) => [loginId, []]),
 );
-const mockGameLikeCountByGameId = new Map<number, number>();
+const mockGameLikeCountByGameId = new Map<number, number>(
+  Object.values(mockGameDetails).map((detail) => [
+    detail.gameId,
+    detail.likeCount,
+  ]),
+);
 const mockUploadedProfileImagesByPath = new Map<
   string,
   { contentType: string; bytes: ArrayBuffer }
@@ -161,8 +167,8 @@ const getOrCreateLikedGames = (loginId: string) => {
   return nextLikedGames;
 };
 
-const getCurrentLikeCount = (gameId: number) =>
-  Math.max(0, mockGameLikeCountByGameId.get(gameId) ?? 0);
+const getCurrentLikeCount = (gameId: number, fallbackLikeCount = 0) =>
+  Math.max(0, mockGameLikeCountByGameId.get(gameId) ?? fallbackLikeCount);
 
 const increaseLikeCount = (gameId: number) => {
   const nextLikeCount = getCurrentLikeCount(gameId) + 1;
@@ -256,6 +262,23 @@ export const getMockLikedGameIdsForAuthorization = (
   return new Set(
     getOrCreateLikedGames(user.loginId).map((game) => game.game_id),
   );
+};
+
+export const getMockGameLikeStateForAuthorization = (
+  authorization: string | null,
+  gameId: number,
+  fallbackLikeCount = 0,
+) => {
+  const user = getAuthorizedUser(authorization);
+
+  return {
+    is_liked: user
+      ? getOrCreateLikedGames(user.loginId).some(
+          (game) => game.game_id === gameId,
+        )
+      : null,
+    like_count: getCurrentLikeCount(gameId, fallbackLikeCount),
+  };
 };
 
 const loginHandlers = [

--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -7,6 +7,7 @@ import { authKeys } from '../../auth/api/queryKeys';
 import type { LikedGamesResponse } from '../../auth/types/auth';
 import { useAuthStore } from '../../../store/useAuthStore';
 import { getGameDetail, likeGame, unlikeGame } from '../gameApi';
+import { gamesKeys, syncGameLikeStateInQueryCache } from '../queryCache';
 import type { GameDetail, GameListItem } from '../types';
 
 type GameDetailModalProps = {
@@ -86,7 +87,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
   >({});
 
   const detailQuery = useQuery({
-    queryKey: ['games', 'detail', game.gameId],
+    queryKey: gamesKeys.detail(game.gameId),
     queryFn: () => getGameDetail(game.gameId),
     staleTime: 0,
     refetchOnMount: 'always',
@@ -109,17 +110,11 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
       };
 
       setLikeState(nextLikeState);
-      queryClient.setQueryData<GameDetail>(
-        ['games', 'detail', game.gameId],
-        (currentDetail) =>
-          currentDetail
-            ? {
-                ...currentDetail,
-                isLiked: response.isLiked,
-                likeCount: response.likeCount,
-              }
-            : currentDetail,
-      );
+      syncGameLikeStateInQueryCache(queryClient, {
+        gameId: response.gameId,
+        isLiked: response.isLiked,
+        likeCount: response.likeCount,
+      });
 
       queryClient.setQueriesData<LikedGamesResponse>(
         { queryKey: authKeys.likedGames() },
@@ -171,9 +166,6 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
       );
       void queryClient.invalidateQueries({
         queryKey: authKeys.likedGames(),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: ['games', 'detail', game.gameId],
       });
     },
     onError: (error) => {

--- a/src/features/games/mocks/handlers.ts
+++ b/src/features/games/mocks/handlers.ts
@@ -1,18 +1,16 @@
 import { delay, http, HttpResponse } from 'msw';
 
+import { getMockGameLikeStateForAuthorization } from '../../auth/mocks/handlers';
 import { GAME_GENRE_ID_MAP } from '../genres';
 import {
   getStoredGameDetail,
   getStoredTop100Games,
   searchStoredGames,
-  updateStoredGameLike,
 } from './state';
 import type {
   GameDetail,
-  GameLikeResponse,
   GameListItem,
   RawGameDetailResponse,
-  RawGameLikeResponse,
   RawGameListItem,
 } from '../types';
 
@@ -31,14 +29,6 @@ const getErrorResponse = (status: number, message: string) =>
       error_detail: message,
     },
     { status },
-  );
-
-const getUnauthorizedResponse = () =>
-  HttpResponse.json(
-    {
-      error_detail: '로그인이 필요합니다.',
-    },
-    { status: 401 },
   );
 
 const parsePositiveInteger = (value: string | null, fallback: number) => {
@@ -88,25 +78,32 @@ const toRawGameDetail = (detail: GameDetail): RawGameDetailResponse => ({
   is_liked: detail.isLiked,
 });
 
-const toRawGameLikeResponse = (
-  response: GameLikeResponse,
-): RawGameLikeResponse => ({
-  game_id: response.gameId,
-  is_liked: response.isLiked,
-  like_count: response.likeCount,
-});
-
 export const gamesHandlers = [
   http.get('/api/v1/games/list/top100', async ({ request }) => {
     const url = new URL(request.url);
     const genreIdValue = url.searchParams.get('genre_id');
     const genreId = parseGenreId(url.searchParams.get('genre_id'));
+    const resolveStoredGameLikeState = (
+      gameId: number,
+      fallback: { isLiked: boolean | null; likeCount: number },
+    ) => {
+      const likeState = getMockGameLikeStateForAuthorization(
+        request.headers.get('authorization'),
+        gameId,
+        fallback.likeCount,
+      );
+
+      return {
+        isLiked: likeState.is_liked,
+        likeCount: likeState.like_count,
+      };
+    };
 
     if (genreIdValue && (!genreId || !validGenreIds.has(genreId))) {
       return getErrorResponse(400, '유효하지 않은 genre_id 입니다. (1~14)');
     }
 
-    const games = getStoredTop100Games({ genreId });
+    const games = getStoredTop100Games({ genreId, resolveStoredGameLikeState });
 
     await delay(250);
 
@@ -128,6 +125,21 @@ export const gamesHandlers = [
       url.searchParams.get('page_size'),
       DEFAULT_GAME_PAGE_SIZE,
     );
+    const resolveStoredGameLikeState = (
+      gameId: number,
+      fallback: { isLiked: boolean | null; likeCount: number },
+    ) => {
+      const likeState = getMockGameLikeStateForAuthorization(
+        request.headers.get('authorization'),
+        gameId,
+        fallback.likeCount,
+      );
+
+      return {
+        isLiked: likeState.is_liked,
+        likeCount: likeState.like_count,
+      };
+    };
 
     if (genreIdValue && (!genreId || !validGenreIds.has(genreId))) {
       return getErrorResponse(400, '유효하지 않은 genre_id 입니다. (1~14)');
@@ -149,6 +161,7 @@ export const gamesHandlers = [
         DEFAULT_GAME_SORT,
       page,
       pageSize,
+      resolveStoredGameLikeState,
     });
 
     await delay(300);
@@ -159,14 +172,25 @@ export const gamesHandlers = [
     });
   }),
 
-  http.get('/api/v1/games/list/:gameId', async ({ params }) => {
+  http.get('/api/v1/games/list/:gameId', async ({ params, request }) => {
     const gameId = Number(params.gameId);
 
     if (!Number.isInteger(gameId) || gameId <= 0) {
       return getErrorResponse(400, '유효하지 않은 game_id 입니다.');
     }
 
-    const detail = getStoredGameDetail(gameId);
+    const detail = getStoredGameDetail(gameId, (resolvedGameId, fallback) => {
+      const likeState = getMockGameLikeStateForAuthorization(
+        request.headers.get('authorization'),
+        resolvedGameId,
+        fallback.likeCount,
+      );
+
+      return {
+        isLiked: likeState.is_liked,
+        likeCount: likeState.like_count,
+      };
+    });
 
     if (!detail) {
       return getErrorResponse(404, '해당 게임을 찾을 수 없습니다.');
@@ -175,49 +199,5 @@ export const gamesHandlers = [
     await delay(220);
 
     return HttpResponse.json(toRawGameDetail(detail));
-  }),
-
-  http.post('/api/v1/games/:gameId/like', async ({ params, request }) => {
-    if (!request.headers.get('authorization')?.startsWith('Bearer ')) {
-      return getUnauthorizedResponse();
-    }
-
-    const gameId = Number(params.gameId);
-
-    if (!Number.isInteger(gameId) || gameId <= 0) {
-      return getErrorResponse(400, '유효하지 않은 game_id 입니다.');
-    }
-
-    const response = updateStoredGameLike(gameId, true);
-
-    if (!response) {
-      return getErrorResponse(404, '해당 게임을 찾을 수 없습니다.');
-    }
-
-    await delay(180);
-
-    return HttpResponse.json(toRawGameLikeResponse(response));
-  }),
-
-  http.delete('/api/v1/games/:gameId/like', async ({ params, request }) => {
-    if (!request.headers.get('authorization')?.startsWith('Bearer ')) {
-      return getUnauthorizedResponse();
-    }
-
-    const gameId = Number(params.gameId);
-
-    if (!Number.isInteger(gameId) || gameId <= 0) {
-      return getErrorResponse(400, '유효하지 않은 game_id 입니다.');
-    }
-
-    const response = updateStoredGameLike(gameId, false);
-
-    if (!response) {
-      return getErrorResponse(404, '해당 게임을 찾을 수 없습니다.');
-    }
-
-    await delay(180);
-
-    return HttpResponse.json(toRawGameLikeResponse(response));
   }),
 ];

--- a/src/features/games/mocks/state.ts
+++ b/src/features/games/mocks/state.ts
@@ -6,7 +6,7 @@ import {
 import { mockGameDetails } from '../mockGameDetails';
 import { mockTopGames } from '../mockGames';
 import { createSearchKeyword, type SearchKeyword } from '../search';
-import type { GameDetail, GameListItem, GameLikeResponse } from '../types';
+import type { GameDetail, GameListItem } from '../types';
 
 const steamStoreUrl = (gameId: number) =>
   `https://store.steampowered.com/app/${gameId}`;
@@ -17,6 +17,16 @@ const genreIdToFilterMap = new Map<number, GameGenreFilter>(
     genre as Exclude<GameGenreFilter, '전체'>,
   ]),
 );
+
+type StoredGameLikeState = {
+  isLiked: boolean | null;
+  likeCount: number;
+};
+
+type ResolveStoredGameLikeState = (
+  gameId: number,
+  fallback: StoredGameLikeState,
+) => StoredGameLikeState;
 
 const getFuzzySearchDistance = (value: string) => {
   if (value.length < 3) {
@@ -223,15 +233,33 @@ const ensureStoredDetail = (gameId: number) => {
 const getGenreFilterById = (genreId?: number) =>
   genreId ? (genreIdToFilterMap.get(genreId) ?? null) : '전체';
 
-const getEffectiveLikeCount = (gameId: number) =>
-  ensureStoredDetail(gameId)?.likeCount ?? 0;
+const getStoredLikeFallback = (gameId: number): StoredGameLikeState => ({
+  isLiked:
+    ensureStoredDetail(gameId)?.isLiked ??
+    getStoredTopGame(gameId)?.isLiked ??
+    null,
+  likeCount: ensureStoredDetail(gameId)?.likeCount ?? 0,
+});
 
-const getEffectiveIsLiked = (gameId: number) =>
-  ensureStoredDetail(gameId)?.isLiked ?? getStoredTopGame(gameId)?.isLiked;
+const getResolvedGameLikeState = (
+  gameId: number,
+  resolveStoredGameLikeState?: ResolveStoredGameLikeState,
+) => {
+  const fallback = getStoredLikeFallback(gameId);
 
-const getHydratedTopGames = () =>
+  return resolveStoredGameLikeState
+    ? resolveStoredGameLikeState(gameId, fallback)
+    : fallback;
+};
+
+const getHydratedTopGames = (
+  resolveStoredGameLikeState?: ResolveStoredGameLikeState,
+) =>
   storedTopGames.map((game) => {
-    const isLiked = getEffectiveIsLiked(game.gameId);
+    const { isLiked } = getResolvedGameLikeState(
+      game.gameId,
+      resolveStoredGameLikeState,
+    );
 
     return typeof isLiked === 'boolean' ? { ...game, isLiked } : { ...game };
   });
@@ -239,6 +267,7 @@ const getHydratedTopGames = () =>
 const sortGames = (
   games: GameListItem[],
   sort: 'rating_desc' | 'like_desc' | 'created_at',
+  resolveStoredGameLikeState?: ResolveStoredGameLikeState,
 ) =>
   [...games].sort((left, right) => {
     if (sort === 'created_at') {
@@ -250,8 +279,10 @@ const sortGames = (
 
     if (sort === 'like_desc') {
       const likeCountDiff =
-        getEffectiveLikeCount(right.gameId) -
-        getEffectiveLikeCount(left.gameId);
+        getResolvedGameLikeState(right.gameId, resolveStoredGameLikeState)
+          .likeCount -
+        getResolvedGameLikeState(left.gameId, resolveStoredGameLikeState)
+          .likeCount;
 
       if (likeCountDiff !== 0) {
         return likeCountDiff;
@@ -276,15 +307,17 @@ const filterGames = ({
   search = '',
   fuzzy = true,
   genreId,
+  resolveStoredGameLikeState,
 }: {
   search?: string;
   fuzzy?: boolean;
   genreId?: number;
+  resolveStoredGameLikeState?: ResolveStoredGameLikeState;
 }) => {
   const searchKeyword = createSearchKeyword(search);
   const selectedGenre = getGenreFilterById(genreId);
 
-  return getHydratedTopGames().filter((game) => {
+  return getHydratedTopGames(resolveStoredGameLikeState).filter((game) => {
     const matchesSearch =
       !searchKeyword.normalized ||
       matchesSearchKeyword(
@@ -300,8 +333,13 @@ const filterGames = ({
   });
 };
 
-export const getStoredTop100Games = ({ genreId }: { genreId?: number } = {}) =>
-  filterGames({ genreId }).slice(0, 100);
+export const getStoredTop100Games = ({
+  genreId,
+  resolveStoredGameLikeState,
+}: {
+  genreId?: number;
+  resolveStoredGameLikeState?: ResolveStoredGameLikeState;
+} = {}) => filterGames({ genreId, resolveStoredGameLikeState }).slice(0, 100);
 
 export const searchStoredGames = ({
   search = '',
@@ -310,6 +348,7 @@ export const searchStoredGames = ({
   sort = 'rating_desc',
   page = 1,
   pageSize = 20,
+  resolveStoredGameLikeState,
 }: {
   search?: string;
   fuzzy?: boolean;
@@ -317,10 +356,12 @@ export const searchStoredGames = ({
   sort?: 'rating_desc' | 'like_desc' | 'created_at';
   page?: number;
   pageSize?: number;
+  resolveStoredGameLikeState?: ResolveStoredGameLikeState;
 }) => {
   const filteredGames = sortGames(
-    filterGames({ search, fuzzy, genreId }),
+    filterGames({ search, fuzzy, genreId, resolveStoredGameLikeState }),
     sort,
+    resolveStoredGameLikeState,
   );
   const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
   const safePageSize =
@@ -334,37 +375,24 @@ export const searchStoredGames = ({
   };
 };
 
-export const getStoredGameDetail = (gameId: number) => {
-  const detail = ensureStoredDetail(gameId);
-
-  return detail ? cloneGameDetail(detail) : null;
-};
-
-export const updateStoredGameLike = (
+export const getStoredGameDetail = (
   gameId: number,
-  isLiked: boolean,
-): GameLikeResponse | null => {
+  resolveStoredGameLikeState?: ResolveStoredGameLikeState,
+) => {
   const detail = ensureStoredDetail(gameId);
 
   if (!detail) {
     return null;
   }
 
-  const currentLiked = detail.isLiked === true;
-  const likeCountAdjustment = currentLiked === isLiked ? 0 : isLiked ? 1 : -1;
-
-  detail.isLiked = isLiked;
-  detail.likeCount = Math.max(0, detail.likeCount + likeCountAdjustment);
-
-  const topGame = getStoredTopGame(gameId);
-
-  if (topGame) {
-    topGame.isLiked = isLiked;
-  }
+  const resolvedLikeState = getResolvedGameLikeState(
+    gameId,
+    resolveStoredGameLikeState,
+  );
 
   return {
-    gameId,
-    isLiked,
-    likeCount: detail.likeCount,
+    ...cloneGameDetail(detail),
+    isLiked: resolvedLikeState.isLiked,
+    likeCount: resolvedLikeState.likeCount,
   };
 };

--- a/src/features/games/queryCache.ts
+++ b/src/features/games/queryCache.ts
@@ -1,0 +1,124 @@
+import type { InfiniteData, QueryClient } from '@tanstack/react-query';
+
+import type { GameGenreFilter } from './genres';
+import type { GameDetail, GameListItem, SearchGamesResult } from './types';
+
+const gamesRootKey = ['games'] as const;
+const gamesTop100RootKey = [...gamesRootKey, 'top100'] as const;
+const gamesSearchRootKey = [...gamesRootKey, 'search'] as const;
+
+export const gamesKeys = {
+  all: gamesRootKey,
+  top100Root: () => gamesTop100RootKey,
+  top100: (genre: GameGenreFilter) => [...gamesTop100RootKey, genre] as const,
+  searchRoot: () => gamesSearchRootKey,
+  search: (searchText: string, genre: GameGenreFilter) =>
+    [...gamesSearchRootKey, searchText, genre] as const,
+  detail: (gameId: number) => [...gamesRootKey, 'detail', gameId] as const,
+};
+
+type GameLikeCacheUpdate = {
+  gameId: number;
+  isLiked: boolean;
+  likeCount?: number;
+};
+
+type LikeableResultPage = {
+  results: Array<{
+    game_id: number;
+    is_liked: boolean;
+  }>;
+};
+
+const getNextLikeCount = (
+  currentLikeCount: number,
+  currentIsLiked: boolean | null,
+  update: GameLikeCacheUpdate,
+) => {
+  if (typeof update.likeCount === 'number') {
+    return update.likeCount;
+  }
+
+  if (currentIsLiked === update.isLiked) {
+    return currentLikeCount;
+  }
+
+  return Math.max(0, currentLikeCount + (update.isLiked ? 1 : -1));
+};
+
+const updateGameListItem = (
+  item: GameListItem,
+  update: GameLikeCacheUpdate,
+): GameListItem =>
+  item.gameId === update.gameId ? { ...item, isLiked: update.isLiked } : item;
+
+export const syncGameLikeStateInQueryCache = (
+  queryClient: QueryClient,
+  update: GameLikeCacheUpdate,
+) => {
+  queryClient.setQueryData<GameDetail>(
+    gamesKeys.detail(update.gameId),
+    (currentDetail) =>
+      currentDetail
+        ? {
+            ...currentDetail,
+            isLiked: update.isLiked,
+            likeCount: getNextLikeCount(
+              currentDetail.likeCount,
+              currentDetail.isLiked,
+              update,
+            ),
+          }
+        : currentDetail,
+  );
+
+  queryClient.setQueriesData<GameListItem[]>(
+    { queryKey: gamesKeys.top100Root() },
+    (currentGames) =>
+      Array.isArray(currentGames)
+        ? currentGames.map((game) => updateGameListItem(game, update))
+        : currentGames,
+  );
+
+  queryClient.setQueriesData<InfiniteData<SearchGamesResult>>(
+    { queryKey: gamesKeys.searchRoot() },
+    (currentData) =>
+      currentData && Array.isArray(currentData.pages)
+        ? {
+            ...currentData,
+            pages: currentData.pages.map((page) => ({
+              ...page,
+              results: page.results.map((game) =>
+                updateGameListItem(game, update),
+              ),
+            })),
+          }
+        : currentData,
+  );
+
+  const updateRecommendationPages = <TPage extends LikeableResultPage>(
+    currentData: InfiniteData<TPage> | undefined,
+  ) =>
+    currentData && Array.isArray(currentData.pages)
+      ? {
+          ...currentData,
+          pages: currentData.pages.map((page) => ({
+            ...page,
+            results: page.results.map((result) =>
+              result.game_id === update.gameId
+                ? { ...result, is_liked: update.isLiked }
+                : result,
+            ),
+          })),
+        }
+      : currentData;
+
+  queryClient.setQueryData<InfiniteData<LikeableResultPage>>(
+    ['survey-results'],
+    updateRecommendationPages,
+  );
+  queryClient.setQueryData<InfiniteData<LikeableResultPage>>(
+    ['match-results'],
+    updateRecommendationPages,
+  );
+};

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -23,6 +23,7 @@ import {
 import { getTopGames, searchGames } from '../../features/games/gameApi';
 import { GAME_GENRE_FILTERS } from '../../features/games/genres';
 import { useDebouncedValue } from '../../features/games/hooks/useDebouncedValue';
+import { gamesKeys } from '../../features/games/queryCache';
 import { normalizeSearchText } from '../../features/games/search';
 import type { GameListItem } from '../../features/games/types';
 import type { GameGenreFilter } from '../../features/games/genres';
@@ -72,7 +73,7 @@ const MainPage = () => {
   const isSearchMode = debouncedSearchText.length > 0;
 
   const topGamesQuery = useQuery({
-    queryKey: ['games', 'top100', selectedGenre],
+    queryKey: gamesKeys.top100(selectedGenre),
     enabled: !isSearchMode,
     queryFn: () => getTopGames({ genre: selectedGenre }),
     staleTime: 60_000,
@@ -80,7 +81,7 @@ const MainPage = () => {
   });
 
   const searchGamesQuery = useInfiniteQuery({
-    queryKey: ['games', 'search', debouncedSearchText, selectedGenre],
+    queryKey: gamesKeys.search(debouncedSearchText, selectedGenre),
     enabled: isSearchMode,
     initialPageParam: 1,
     queryFn: ({ pageParam }) =>

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import type { InfiniteData } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { ChevronDown, ChevronRight, Heart, Sparkles, Star } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
@@ -17,19 +16,16 @@ import {
   likeGame,
   unlikeGame,
 } from '../../features/games/gameApi';
-import type { GameDetail } from '../../features/games/types';
+import {
+  gamesKeys,
+  syncGameLikeStateInQueryCache,
+} from '../../features/games/queryCache';
 import type { GameListItem } from '../../features/games/types';
 import { useMatchResultsInfinite } from '../../features/matching/api/useMatchingApi';
-import type {
-  MatchResultItem,
-  MatchResultResponse,
-} from '../../features/matching/types';
+import type { MatchResultItem } from '../../features/matching/types';
 import { useSurveyResultsInfinite } from '../../features/survey/api/useSurveyApi';
 import { extractApiErrorMessage } from '../../features/survey/api/survey';
-import type {
-  SurveyResultItem,
-  SurveyResultResponse,
-} from '../../features/survey/types/survey';
+import type { SurveyResultItem } from '../../features/survey/types/survey';
 import { isMockServiceWorkerEnabled } from '../../lib/env';
 
 const FALLBACK_BACKDROP_ITEMS = [
@@ -149,21 +145,21 @@ function RecommendationRow({
   isLikePending,
 }: RecommendationRowProps) {
   return (
-    <article className="group grid gap-4 px-4 py-5 transition-colors duration-200 hover:bg-white/[0.025] sm:grid-cols-[118px_minmax(0,1fr)] sm:items-center sm:px-6 sm:py-6 lg:grid-cols-[118px_minmax(0,1fr)_auto] lg:gap-6 lg:px-7">
+    <article className="group grid gap-4 px-4 py-5 transition-colors duration-200 hover:bg-white/2.5 sm:grid-cols-[118px_minmax(0,1fr)] sm:items-center sm:px-6 sm:py-6 lg:grid-cols-[118px_minmax(0,1fr)_auto] lg:gap-6 lg:px-7">
       <button
         type="button"
         onClick={() => onOpenDetail(item)}
         aria-label={`${item.title} 상세 보기`}
-        className="overflow-hidden rounded-[20px] border border-white/6 bg-[#111111] text-left shadow-[0_14px_32px_rgba(0,0,0,0.18)] transition hover:border-white/12 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]"
+        className="bg-auth-panel overflow-hidden rounded-[20px] border border-white/6 text-left shadow-[0_14px_32px_rgba(0,0,0,0.18)] transition hover:border-white/12 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12]"
       >
         {item.thumbnail_url ? (
           <img
             src={item.thumbnail_url}
             alt={item.title}
-            className="h-[94px] w-full object-cover transition-transform duration-300 group-hover:scale-[1.02] sm:h-[88px]"
+            className="h-23.5 w-full object-cover transition-transform duration-300 group-hover:scale-[1.02] sm:h-22"
           />
         ) : (
-          <div className="flex h-[94px] w-full items-center justify-center bg-[#151515] text-sm text-white/35 sm:h-[88px]">
+          <div className="flex h-23.5 w-full items-center justify-center bg-[#151515] text-sm text-white/35 sm:h-22">
             이미지 준비 중
           </div>
         )}
@@ -186,7 +182,7 @@ function RecommendationRow({
         </p>
       </div>
 
-      <div className="flex items-center justify-end gap-3 lg:min-w-[96px]">
+      <div className="flex items-center justify-end gap-3 lg:min-w-24">
         <ActionButton
           type="button"
           variant="icon"
@@ -195,7 +191,7 @@ function RecommendationRow({
           className={`${
             item.is_liked
               ? 'border-[#6f2525] bg-[#170b0b] text-[#f07373]'
-              : 'border-white/10 bg-white/[0.02] text-white/60 hover:border-white/18 hover:text-white/86'
+              : 'border-white/10 bg-white/2 text-white/60 hover:border-white/18 hover:text-white/86'
           } ${isLikePending ? 'cursor-not-allowed opacity-55' : ''}`}
           aria-label={item.is_liked ? '좋아요 해제' : '좋아요 추가'}
         >
@@ -207,7 +203,7 @@ function RecommendationRow({
           variant="icon"
           onClick={() => onOpenDetail(item)}
           aria-label={`${item.title} 상세 보기`}
-          className="border-transparent text-white/42 group-hover:border-white/8 group-hover:bg-white/[0.03] group-hover:text-white/82"
+          className="border-transparent text-white/42 group-hover:border-white/8 group-hover:bg-white/3 group-hover:text-white/82"
         >
           <ChevronRight size={18} />
         </ActionButton>
@@ -236,7 +232,7 @@ function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
         {backdropItems.map((item) => (
           <div
             key={item.id}
-            className="overflow-hidden rounded-[20px] border border-white/6 bg-white/[0.02] shadow-[0_18px_34px_rgba(0,0,0,0.18)]"
+            className="overflow-hidden rounded-[20px] border border-white/6 bg-white/2 shadow-[0_18px_34px_rgba(0,0,0,0.18)]"
           >
             {item.thumbnail ? (
               <img
@@ -245,7 +241,7 @@ function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
                 className="h-full w-full object-cover"
               />
             ) : (
-              <div className="flex h-full min-h-[160px] items-center justify-center bg-[#161616] text-sm text-white/25">
+              <div className="flex h-full min-h-40 items-center justify-center bg-[#161616] text-sm text-white/25">
                 PGTI
               </div>
             )}
@@ -365,39 +361,6 @@ function RecommendationListPage() {
     };
   }, [likeFeedbackMessage]);
 
-  const updateRecommendationResultsCache = (
-    gameId: number,
-    nextIsLiked: boolean,
-  ) => {
-    const updatePages = <
-      TPage extends { results: Array<{ game_id: number; is_liked: boolean }> },
-    >(
-      data: InfiniteData<TPage> | undefined,
-    ) =>
-      data
-        ? {
-            ...data,
-            pages: data.pages.map((page) => ({
-              ...page,
-              results: page.results.map((result) =>
-                result.game_id === gameId
-                  ? { ...result, is_liked: nextIsLiked }
-                  : result,
-              ),
-            })),
-          }
-        : data;
-
-    queryClient.setQueryData<InfiniteData<SurveyResultResponse>>(
-      ['survey-results'],
-      updatePages,
-    );
-    queryClient.setQueryData<InfiniteData<MatchResultResponse>>(
-      ['match-results'],
-      updatePages,
-    );
-  };
-
   const updateLikedGamesCache = (
     item: RecommendationDisplayItem,
     nextIsLiked: boolean,
@@ -464,29 +427,21 @@ function RecommendationListPage() {
       setLikeFeedbackMessage(null);
     },
     onSuccess: async (response, variables) => {
-      updateRecommendationResultsCache(response.gameId, response.isLiked);
       updateLikedGamesCache(variables.item, response.isLiked);
       setSelectedGame((current) =>
         current?.gameId === response.gameId
           ? { ...current, isLiked: response.isLiked }
           : current,
       );
-
-      queryClient.setQueryData<GameDetail>(
-        ['games', 'detail', response.gameId],
-        (currentDetail) =>
-          currentDetail
-            ? {
-                ...currentDetail,
-                isLiked: response.isLiked,
-                likeCount: response.likeCount,
-              }
-            : currentDetail,
-      );
+      syncGameLikeStateInQueryCache(queryClient, {
+        gameId: response.gameId,
+        isLiked: response.isLiked,
+        likeCount: response.likeCount,
+      });
 
       try {
         const detail = await queryClient.fetchQuery({
-          queryKey: ['games', 'detail', response.gameId],
+          queryKey: gamesKeys.detail(response.gameId),
           queryFn: () => getGameDetail(response.gameId),
           staleTime: 60_000,
         });
@@ -552,18 +507,18 @@ function RecommendationListPage() {
       <RecommendationBackdrop items={recommendationItems} />
       <Header fixed />
 
-      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1200px] flex-col px-3 pt-24 pb-10 sm:px-4 sm:pt-28 sm:pb-12 md:px-8 md:pt-32 md:pb-16">
-        <section className="mx-auto w-full max-w-[980px]">
+      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-300 flex-col px-3 pt-24 pb-10 sm:px-4 sm:pt-28 sm:pb-12 md:px-8 md:pt-32 md:pb-16">
+        <section className="mx-auto w-full max-w-245">
           <div className="mb-8 grid gap-4 lg:grid-cols-[minmax(0,1fr)_240px] lg:items-end">
             <div>
-              <div className="inline-flex w-fit items-center gap-2 rounded-full border border-white/8 bg-white/[0.03] px-4 py-1.5 text-[11px] font-semibold tracking-[0.22em] text-white/45 uppercase backdrop-blur-md">
+              <div className="inline-flex w-fit items-center gap-2 rounded-full border border-white/8 bg-white/3 px-4 py-1.5 text-[11px] font-semibold tracking-[0.22em] text-white/45 uppercase backdrop-blur-md">
                 <Sparkles size={13} />
                 AI Curated
               </div>
               <h1 className="mt-5 text-3xl font-semibold tracking-[-0.04em] text-white sm:text-4xl md:text-[52px]">
                 게임 추천 리스트
               </h1>
-              <p className="mt-4 max-w-[620px] text-sm leading-7 break-keep text-white/58 sm:text-base">
+              <p className="mt-4 max-w-155 text-sm leading-7 break-keep text-white/58 sm:text-base">
                 {isMatchSource
                   ? '장르별 매칭에서 남긴 별점과 좋아요를 바탕으로 정리된 추천 결과예요. 마음에 드는 게임은 좋아요로 표시해 두고 마이페이지에서도 다시 확인할 수 있어요.'
                   : '설문에서 드러난 취향을 바탕으로, 지금 바로 플레이하고 싶어질 만한 게임들을 차분하게 정리해뒀어요.'}
@@ -572,7 +527,7 @@ function RecommendationListPage() {
                 {recommendationHighlights.map((highlight) => (
                   <span
                     key={highlight}
-                    className="inline-flex items-center rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5 text-xs font-medium text-white/68 backdrop-blur-sm"
+                    className="inline-flex items-center rounded-full border border-white/8 bg-white/3 px-3 py-1.5 text-xs font-medium text-white/68 backdrop-blur-sm"
                   >
                     {highlight}
                   </span>
@@ -646,7 +601,7 @@ function RecommendationListPage() {
               </Link>
             </section>
           ) : (
-            <section className="overflow-hidden rounded-[32px] border border-white/8 bg-[linear-gradient(180deg,rgba(16,16,18,0.92),rgba(9,9,10,0.98))] shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-2xl">
+            <section className="overflow-hidden rounded-4xl border border-white/8 bg-[linear-gradient(180deg,rgba(16,16,18,0.92),rgba(9,9,10,0.98))] shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-2xl">
               <div className="px-4 py-5 sm:px-6 lg:px-7 lg:py-6">
                 <div className="flex flex-col gap-3 border-b border-white/8 pb-5 sm:flex-row sm:items-end sm:justify-between">
                   <div>
@@ -660,7 +615,7 @@ function RecommendationListPage() {
                     </p>
                   </div>
 
-                  <div className="inline-flex w-fit items-center rounded-full border border-white/8 bg-white/[0.03] px-4 py-2 text-xs text-white/48">
+                  <div className="inline-flex w-fit items-center rounded-full border border-white/8 bg-white/3 px-4 py-2 text-xs text-white/48">
                     {cappedTotalCount > 0
                       ? `${cappedTotalCount}개의 추천 결과`
                       : '추천 결과를 정리하고 있어요'}
@@ -711,7 +666,7 @@ function RecommendationListPage() {
                       type="button"
                       onClick={handleLoadMore}
                       disabled={isFetchingNextPage}
-                      className="flex w-full flex-col items-center justify-center gap-1 border-t border-white/8 px-4 py-3 text-sm font-medium text-white/82 transition hover:bg-white/[0.03] hover:text-white disabled:cursor-not-allowed disabled:opacity-45 sm:px-6 lg:px-7"
+                      className="flex w-full flex-col items-center justify-center gap-1 border-t border-white/8 px-4 py-3 text-sm font-medium text-white/82 transition hover:bg-white/3 hover:text-white disabled:cursor-not-allowed disabled:opacity-45 sm:px-6 lg:px-7"
                     >
                       <span>
                         {isFetchingNextPage
@@ -721,7 +676,7 @@ function RecommendationListPage() {
                       {!isFetchingNextPage ? (
                         <ChevronDown
                           size={18}
-                          className="translate-y-[1px] text-white/56"
+                          className="translate-y-px text-white/56"
                         />
                       ) : null}
                     </button>


### PR DESCRIPTION
## 관련 이슈

- closes #211

## 변경 내용

- MSW에서 게임 찜 상태의 source-of-truth를 `auth mock`으로 단일화했습니다.
- `games mock`의 중복 좋아요 핸들러를 제거하고, 목록/검색/상세 응답이 인증 사용자 기준 `is_liked`, `like_count`를 반영하도록 정리했습니다.
- 게임 공통 query key와 좋아요 캐시 동기화 helper를 추가해 메인, 상세 모달, 추천 리스트, 마이페이지가 같은 찜 상태를 보도록 맞췄습니다.
- 마이페이지 찜 해제와 상세 모달 좋아요 변경 시 게임 관련 캐시가 함께 갱신되도록 수정했습니다.
- 추천 리스트 페이지는 공통 캐시 helper를 사용하도록 정리했고, 함께 canonical Tailwind class 정리도 반영했습니다.
- `docs/ai/api-contract.md`에 현재 FE 기준 비밀번호 변경 계약(`old_password`, `new_password`, `new_password_check`)을 문서화했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷


https://github.com/user-attachments/assets/a10af3f1-7994-4696-8d7c-7a30f6b20fbe



## 참고사항

- 비밀번호 변경 계약은 팀 합의에 따라 현재 FE 기준을 canonical contract로 문서화했습니다.
- 이번 PR은 런타임 수정과 문서 정리가 함께 포함되어 있습니다.
- 브라우저 확인 시 아래 시나리오를 우선 확인하면 됩니다.
- 메인에서 상세 모달로 찜 후 닫아도 카드 상태가 유지되는지
- 마이페이지에서 찜 해제 후 메인/상세/추천에서 동일하게 반영되는지
- 추천 리스트에서 찜 상태 변경 시 상세/마이페이지와 일관되게 보이는지
