### PR TITLE
refactor(auth): 개발용 로그인 계정 패널 단일화 및 설명 문구 제거

### DIFF
--- a/src/components/auth/AuthInputActionButton.tsx
+++ b/src/components/auth/AuthInputActionButton.tsx
@@ -16,7 +16,7 @@ function AuthInputActionButton({
     <AuthButton
       type={type}
       variant="secondary"
-      className={`bg-login-field text-login-label w-full border border-white/16 text-sm font-semibold hover:border-[#ff6b6e]/60 hover:bg-[#261216] hover:text-[#ffd7d8] focus-visible:ring-[#ff5c60]/25 sm:w-[5.75rem] sm:shrink-0 ${className}`}
+      className={`w-full border border-[#5b3035] bg-[#1d1215] text-sm font-semibold text-[#f2d8d9] hover:border-[#ff6b6e]/65 hover:bg-[#29161a] hover:text-white focus-visible:ring-[#ff5c60]/25 active:scale-[0.99] sm:w-[5.75rem] sm:shrink-0 ${className}`}
       {...props}
     >
       {children}

--- a/src/components/auth/AuthInputActionButton.tsx
+++ b/src/components/auth/AuthInputActionButton.tsx
@@ -16,7 +16,7 @@ function AuthInputActionButton({
     <AuthButton
       type={type}
       variant="secondary"
-      className={`w-full border-2 border-[#ff9a57] bg-[#fff4ea] text-sm font-semibold text-[#9a4316] shadow-[0_10px_24px_rgba(255,154,87,0.18)] hover:border-[#ff8a3d] hover:bg-[#ffead9] hover:text-[#7a2f08] sm:w-[5.75rem] sm:shrink-0 ${className}`}
+      className={`bg-login-field text-login-label w-full border border-white/16 text-sm font-semibold hover:border-[#ff6b6e]/60 hover:bg-[#261216] hover:text-[#ffd7d8] focus-visible:ring-[#ff5c60]/25 sm:w-[5.75rem] sm:shrink-0 ${className}`}
       {...props}
     >
       {children}

--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -37,14 +37,14 @@ function AuthInputField({
   const shouldRenderMessage = Boolean(resolvedMessage) || reserveMessageSpace;
 
   return (
-    <div className={`space-y-1.5 ${containerClassName} sm:space-y-2`}>
+    <div className={`space-y-2 ${containerClassName} sm:space-y-2.5`}>
       <label
         htmlFor={id}
         className="text-login-label block text-sm font-medium"
       >
         {label}
       </label>
-      <div className="relative flex flex-col gap-2.5 sm:flex-row sm:items-stretch">
+      <div className="relative flex flex-col gap-3 sm:flex-row sm:items-stretch">
         <InputControl
           id={id}
           {...inputProps}
@@ -58,7 +58,7 @@ function AuthInputField({
         <p
           role={errorMessage ? 'alert' : undefined}
           aria-hidden={!resolvedMessage}
-          className={`${reserveMessageSpace ? 'min-h-5' : ''} pl-1 text-sm/5 font-medium ${resolvedMessage ? resolvedMessageClassName : 'text-transparent'}`}
+          className={`${reserveMessageSpace ? 'min-h-5' : ''} pt-0.5 pl-1 text-sm/5 font-medium ${resolvedMessage ? resolvedMessageClassName : 'text-transparent'}`}
         >
           {resolvedMessage ?? ''}
         </p>

--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -34,16 +34,17 @@ function AuthInputField({
     : helperMessageTone === 'success'
       ? 'text-emerald-400'
       : 'text-login-helper';
+  const shouldRenderMessage = Boolean(resolvedMessage) || reserveMessageSpace;
 
   return (
-    <div className={`space-y-2 ${containerClassName} sm:space-y-2.5`}>
+    <div className={`space-y-1.5 ${containerClassName} sm:space-y-2`}>
       <label
         htmlFor={id}
         className="text-login-label block text-sm font-medium"
       >
         {label}
       </label>
-      <div className="relative flex flex-col gap-3 sm:flex-row sm:items-stretch">
+      <div className="relative flex flex-col gap-2.5 sm:flex-row sm:items-stretch">
         <InputControl
           id={id}
           {...inputProps}
@@ -53,11 +54,11 @@ function AuthInputField({
         {action}
         {toast}
       </div>
-      {resolvedMessage || reserveMessageSpace ? (
+      {shouldRenderMessage ? (
         <p
           role={errorMessage ? 'alert' : undefined}
           aria-hidden={!resolvedMessage}
-          className={`min-h-5 pl-1 text-sm/5 font-medium ${resolvedMessage ? resolvedMessageClassName : 'text-transparent'}`}
+          className={`${reserveMessageSpace ? 'min-h-5' : ''} pl-1 text-sm/5 font-medium ${resolvedMessage ? resolvedMessageClassName : 'text-transparent'}`}
         >
           {resolvedMessage ?? ''}
         </p>

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -32,8 +32,10 @@ function AuthRadioGroup({
   required = false,
   disabled = false,
 }: AuthRadioGroupProps) {
+  const shouldRenderMessage = Boolean(errorMessage) || reserveMessageSpace;
+
   return (
-    <fieldset className="space-y-3">
+    <fieldset className="space-y-2.5">
       <legend className="text-login-label block text-sm font-medium">
         {label}
       </legend>
@@ -65,10 +67,10 @@ function AuthRadioGroup({
                 className="peer sr-only"
               />
               <span
-                className={`flex h-14 items-center justify-center rounded-2xl border px-4 text-sm font-semibold transition-all group-hover:border-white/20 group-hover:text-white/85 peer-checked:border-[#ff8a3d] peer-checked:bg-[linear-gradient(135deg,rgba(255,138,61,0.24),rgba(255,110,48,0.1))] peer-checked:text-white peer-checked:shadow-[0_14px_32px_rgba(255,138,61,0.18)] peer-disabled:opacity-60 ${
+                className={`bg-login-field text-login-label flex h-14 items-center justify-center rounded-xl border px-4 text-sm font-semibold transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-[#ff5c60]/25 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-black peer-disabled:opacity-60 ${
                   errorMessage
-                    ? 'border-red-500/80 bg-white/[0.03] text-red-200'
-                    : 'border-login-field text-login-helper bg-white/[0.03]'
+                    ? 'border-red-500/80 text-red-200 group-hover:border-red-400/90 group-hover:bg-[#2f1519] group-hover:text-red-100'
+                    : 'border-white/16 group-hover:border-[#ff6b6e]/60 group-hover:bg-[#261216] group-hover:text-[#ffd7d8] peer-checked:border-[#ff6b6e]/70 peer-checked:bg-[#261216] peer-checked:text-[#ffd7d8]'
                 }`}
               >
                 {option.label}
@@ -77,11 +79,11 @@ function AuthRadioGroup({
           );
         })}
       </div>
-      {errorMessage || reserveMessageSpace ? (
+      {shouldRenderMessage ? (
         <p
           role={errorMessage ? 'alert' : undefined}
           aria-hidden={!errorMessage}
-          className={`min-h-5 pl-1 text-sm/5 font-medium ${errorMessage ? 'text-red-400' : 'text-transparent'}`}
+          className={`${reserveMessageSpace ? 'min-h-5' : ''} pl-1 text-sm/5 font-medium ${errorMessage ? 'text-red-400' : 'text-transparent'}`}
         >
           {errorMessage ?? ''}
         </p>

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -67,10 +67,10 @@ function AuthRadioGroup({
                 className="peer sr-only"
               />
               <span
-                className={`bg-login-field text-login-label flex h-14 items-center justify-center rounded-xl border px-4 text-sm font-semibold transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-[#ff5c60]/25 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-black peer-disabled:opacity-60 ${
+                className={`flex h-14 items-center justify-center rounded-xl border px-4 text-sm font-semibold transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-[#ff5c60]/25 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-black peer-disabled:opacity-60 ${
                   errorMessage
-                    ? 'border-red-500/80 text-red-200 group-hover:border-red-400/90 group-hover:bg-[#2f1519] group-hover:text-red-100'
-                    : 'border-white/16 group-hover:border-[#ff6b6e]/60 group-hover:bg-[#261216] group-hover:text-[#ffd7d8] peer-checked:border-[#ff6b6e]/70 peer-checked:bg-[#261216] peer-checked:text-[#ffd7d8]'
+                    ? 'border-red-500/80 bg-[#1d1215] text-red-200 group-hover:border-red-400/90 group-hover:bg-[#2f1519] group-hover:text-red-100'
+                    : 'bg-login-field text-login-label border-white/16 group-hover:border-white/24 group-hover:bg-[#1d1e22] group-hover:text-white/90 peer-checked:border-[#ff6b6e]/70 peer-checked:bg-[#29161a] peer-checked:text-white'
                 }`}
               >
                 {option.label}

--- a/src/components/auth/authSharedStyles.ts
+++ b/src/components/auth/authSharedStyles.ts
@@ -6,7 +6,7 @@ export const AUTH_SHARED_LAYOUT_CLASS_NAMES = {
 export const AUTH_SHARED_FORM_CLASS_NAMES = {
   socialGroup: 'mt-6 sm:mt-7',
   divider: 'my-5 sm:my-6',
-  form: 'space-y-3 sm:space-y-3.5',
+  form: 'space-y-2.5 sm:space-y-3',
   feedbackMessage: 'text-sm/5',
   submitButton: 'mt-1 h-14 w-full text-base/6 sm:mt-2',
   auxiliaryLink:

--- a/src/components/auth/authSharedStyles.ts
+++ b/src/components/auth/authSharedStyles.ts
@@ -6,12 +6,12 @@ export const AUTH_SHARED_LAYOUT_CLASS_NAMES = {
 export const AUTH_SHARED_FORM_CLASS_NAMES = {
   socialGroup: 'mt-6 sm:mt-7',
   divider: 'my-5 sm:my-6',
-  form: 'space-y-2.5 sm:space-y-3',
+  form: 'space-y-3 sm:space-y-3.5',
   feedbackMessage: 'text-sm/5',
-  submitButton: 'mt-1 h-14 w-full text-base/6 sm:mt-2',
+  submitButton: 'mt-2 h-14 w-full text-base/6 sm:mt-2.5',
   auxiliaryLink:
     'text-login-muted text-sm font-medium transition-colors hover:text-white/80',
-  footerSection: 'border-login-divider mt-5 border-t pt-4 sm:mt-6 sm:pt-5',
+  footerSection: 'border-login-divider mt-4 border-t pt-4 sm:mt-5 sm:pt-5',
   footerHelperText: 'text-login-helper text-center text-sm/5 font-normal',
   footerLinkButton: 'mt-3 h-14 w-full text-base/6',
 } as const;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -315,11 +315,9 @@ function LoginPage() {
         panelClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.panel}
         contentClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.content}
       >
-        <AuthSocialLoginGroup
-          className={AUTH_SHARED_FORM_CLASS_NAMES.socialGroup}
-        />
+        <AuthSocialLoginGroup className="mt-2 sm:mt-2.5" />
 
-        <AuthDivider className={AUTH_SHARED_FORM_CLASS_NAMES.divider} />
+        <AuthDivider className="my-4 sm:my-5" />
 
         <form
           className={AUTH_SHARED_FORM_CLASS_NAMES.form}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -126,10 +126,12 @@ function LoginPage() {
     !feedbackVisibility.hasFieldError &&
     !feedbackVisibility.showFormMessage &&
     Boolean(noticeMessage.trim());
+  const primaryMockAccount =
+    mockAccounts.find((account) => account.loginId === 'pgti-demo') ??
+    mockAccounts[0];
+  const visibleMockAccounts = primaryMockAccount ? [primaryMockAccount] : [];
   const showMockAccounts =
-    mockServiceWorkerEnabled &&
-    Array.isArray(mockAccounts) &&
-    mockAccounts.length > 0;
+    mockServiceWorkerEnabled && visibleMockAccounts.length > 0;
 
   useEffect(() => {
     setFormMessage(
@@ -434,7 +436,7 @@ function LoginPage() {
 
             <div className="support-chat-scrollbar max-h-[min(60vh,28rem)] overflow-y-auto px-4 py-4">
               <ul className="space-y-2.5">
-                {mockAccounts.map((account) => (
+                {visibleMockAccounts.map((account) => (
                   <li
                     key={account.loginId}
                     className="border-login-outline rounded-2xl border bg-black/20 p-3"
@@ -443,9 +445,6 @@ function LoginPage() {
                       <div className="min-w-0">
                         <p className="text-sm font-semibold text-white">
                           {account.name}
-                        </p>
-                        <p className="text-login-helper mt-1 text-xs/5">
-                          {account.note}
                         </p>
                       </div>
                       <button

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -77,6 +77,10 @@ const LOGIN_FIELD_ELEMENT_IDS: Record<LoginFieldName, string> = {
   password: 'login-password',
 };
 
+const resolveMockAccounts = (
+  accounts: DevMockLoginAccountsResponse['accounts'] | undefined,
+) => (Array.isArray(accounts) ? accounts : []);
+
 function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -122,7 +126,10 @@ function LoginPage() {
     !feedbackVisibility.hasFieldError &&
     !feedbackVisibility.showFormMessage &&
     Boolean(noticeMessage.trim());
-  const showMockAccounts = mockServiceWorkerEnabled && mockAccounts.length > 0;
+  const showMockAccounts =
+    mockServiceWorkerEnabled &&
+    Array.isArray(mockAccounts) &&
+    mockAccounts.length > 0;
 
   useEffect(() => {
     setFormMessage(
@@ -150,7 +157,7 @@ function LoginPage() {
           return;
         }
 
-        setMockAccounts(data.accounts);
+        setMockAccounts(resolveMockAccounts(data?.accounts));
       })
       .catch(async () => {
         try {
@@ -303,6 +310,7 @@ function LoginPage() {
     <>
       <AuthLayout
         title="로그인"
+        titleClassName="sr-only"
         withPanel
         panelClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.panel}
         contentClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.content}
@@ -334,7 +342,6 @@ function LoginPage() {
             }
             errorMessage={resolvedFieldErrors.login_id}
             disabled={loginMutation.isPending}
-            reserveMessageSpace
           />
 
           <AuthInputField
@@ -354,7 +361,6 @@ function LoginPage() {
             }
             errorMessage={resolvedFieldErrors.password}
             disabled={loginMutation.isPending}
-            reserveMessageSpace
           />
 
           {showNoticeMessage ? (
@@ -373,15 +379,6 @@ function LoginPage() {
               {formMessage}
             </AuthFormMessage>
           ) : null}
-
-          <div className="flex justify-end">
-            <button
-              type="button"
-              className={AUTH_SHARED_FORM_CLASS_NAMES.auxiliaryLink}
-            >
-              아이디/비밀번호를 잊어버리셨나요?
-            </button>
-          </div>
 
           <AuthButton
             type="submit"

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -482,7 +482,7 @@ function SignupPage() {
       contentClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.content}
     >
       <form
-        className={AUTH_SHARED_FORM_CLASS_NAMES.form}
+        className={`${AUTH_SHARED_FORM_CLASS_NAMES.form} pt-1 sm:pt-1.5`}
         autoComplete="on"
         onSubmit={handleSubmit}
       >
@@ -512,7 +512,6 @@ function SignupPage() {
           }
           errorMessage={resolvedFieldErrors.name}
           disabled={isSubmitting}
-          containerClassName="pt-1"
         />
 
         <AuthInputField

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -3,12 +3,10 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import AuthButton from '../components/auth/AuthButton';
-import AuthDivider from '../components/auth/AuthDivider';
 import AuthFormMessage from '../components/auth/AuthFormMessage';
 import AuthInputActionButton from '../components/auth/AuthInputActionButton';
 import AuthInputField from '../components/auth/AuthInputField';
 import AuthRadioGroup from '../components/auth/AuthRadioGroup';
-import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
 import {
   AUTH_SHARED_FORM_CLASS_NAMES,
   AUTH_SHARED_LAYOUT_CLASS_NAMES,
@@ -478,18 +476,11 @@ function SignupPage() {
   return (
     <AuthLayout
       title="회원가입"
-      subtitle="회원가입 후 취향 기반 게임 추천을 시작해보세요"
+      titleClassName="sr-only"
       withPanel
       panelClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.panel}
       contentClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.content}
-      subtitleClassName="mx-auto max-w-[290px] sm:max-w-[320px]"
     >
-      <AuthSocialLoginGroup
-        className={AUTH_SHARED_FORM_CLASS_NAMES.socialGroup}
-      />
-
-      <AuthDivider className={AUTH_SHARED_FORM_CLASS_NAMES.divider} />
-
       <form
         className={AUTH_SHARED_FORM_CLASS_NAMES.form}
         autoComplete="on"
@@ -520,13 +511,7 @@ function SignupPage() {
             }))
           }
           errorMessage={resolvedFieldErrors.name}
-          helperMessage={
-            !resolvedFieldErrors.name
-              ? `이름은 ${NAME_MAX_LENGTH}자 이하로 입력해주세요.`
-              : ''
-          }
           disabled={isSubmitting}
-          reserveMessageSpace
           containerClassName="pt-1"
         />
 
@@ -550,17 +535,15 @@ function SignupPage() {
           }
           errorMessage={resolvedFieldErrors.login_id}
           helperMessage={
-            !resolvedFieldErrors.login_id
-              ? loginIdCheckState.tone === 'success'
-                ? loginIdCheckState.message
-                : `아이디는 ${LOGIN_ID_MAX_LENGTH}자 이하로 입력해주세요.`
+            !resolvedFieldErrors.login_id &&
+            loginIdCheckState.tone === 'success'
+              ? loginIdCheckState.message
               : ''
           }
           helperMessageTone={
             loginIdCheckState.tone === 'success' ? 'success' : 'muted'
           }
           disabled={isSubmitting}
-          reserveMessageSpace
           action={
             <AuthInputActionButton
               onClick={handleCheckLoginIdDuplicate}
@@ -617,7 +600,6 @@ function SignupPage() {
           }
           helperMessageTone="success"
           disabled={isSubmitting}
-          reserveMessageSpace
           action={
             <AuthInputActionButton
               onClick={handleCheckNicknameDuplicate}
@@ -666,7 +648,6 @@ function SignupPage() {
           }
           errorMessage={resolvedFieldErrors.password}
           disabled={isSubmitting}
-          reserveMessageSpace
         />
 
         <AuthInputField
@@ -688,7 +669,6 @@ function SignupPage() {
           }
           errorMessage={resolvedFieldErrors.password_check}
           disabled={isSubmitting}
-          reserveMessageSpace
         />
 
         <AuthRadioGroup
@@ -702,7 +682,6 @@ function SignupPage() {
           }
           errorMessage={resolvedFieldErrors.gender}
           disabled={isSubmitting}
-          reserveMessageSpace
         />
 
         {feedbackVisibility.showFormMessage ? (


### PR DESCRIPTION
## 관련 이슈

- closes #210

## 변경 내용

-로그인/회원가입 UI에서 불필요 요소를 정리했습니다.
-로그인 페이지는 타이틀을 시각적으로 숨기고, 아이디/비밀번호 찾기 링크를 제거했으며, 소셜 로그인/디바이더 간격을 자연스럽게 보정했습니다.
-회원가입 페이지는 타이틀을 시각적으로 숨기고 소셜 로그인 영역을 제거했으며, 폼 시작 여백과 필드 간 간격을 정리했습니다.

-입력/에러 메시지 레이아웃을 동적으로 정리해 에러가 있을 때만 메시지 영역이 확장되도록 수정했습니다.
-중복확인 버튼과 성별 선택 버튼의 톤을 통일하고, 성별은 기본 중립 상태 + 선택 시 강조 상태로 동작하도록 보정했습니다.
-로그인 DEV 계정 응답 가드를 추가해 Cannot read properties of undefined (reading 'length') 런타임 에러를 방지했습니다.

개발용 로그인 계정 패널은 단일 계정 노출로 단순화했고, 계정 설명 문구(note)를 제거했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

https://github.com/user-attachments/assets/55099738-82c6-45f1-a444-5276ce4eb106





## 참고사항

-
