### PR TITLE
refactor(auth,mypage): 헤더 프로필 동기화 및 마이페이지 프로필/찜 UI 개선

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import { Link, useLocation } from 'react-router';
 import { ROUTES } from '../../constants/routes';
+import { useCurrentUserProfileQuery } from '../../features/auth/api/useAuthApi';
 import { useAuthStore } from '../../store/useAuthStore';
 import HeaderProfileMenu from './HeaderProfileMenu';
 
@@ -18,9 +20,22 @@ const HIDDEN_GUEST_ACTION_PATHS = new Set([
 const Header = ({ fixed = true }: HeaderProps) => {
   const location = useLocation();
   const isLoggedIn = useAuthStore((state) => Boolean(state.accessToken));
+  const account = useAuthStore((state) => state.account);
+  const setAccount = useAuthStore((state) => state.setAccount);
+  const profileHydrationQuery = useCurrentUserProfileQuery(
+    isLoggedIn && !account,
+  );
   const shouldHideGuestActions = HIDDEN_GUEST_ACTION_PATHS.has(
     location.pathname,
   );
+  const resolvedProfileImageUrl =
+    account?.profile_img_url ?? profileHydrationQuery.data?.profile_img_url;
+
+  useEffect(() => {
+    if (profileHydrationQuery.data) {
+      setAccount(profileHydrationQuery.data);
+    }
+  }, [profileHydrationQuery.data, setAccount]);
 
   return (
     <header
@@ -62,7 +77,7 @@ const Header = ({ fixed = true }: HeaderProps) => {
               </>
             )
           ) : (
-            <HeaderProfileMenu />
+            <HeaderProfileMenu profileImageUrl={resolvedProfileImageUrl} />
           )}
         </div>
       </div>

--- a/src/components/common/HeaderProfileMenu.tsx
+++ b/src/components/common/HeaderProfileMenu.tsx
@@ -7,12 +7,18 @@ import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
 
 const PROFILE_MENU_ID = 'header-profile-menu';
 
-function HeaderProfileMenu() {
+type HeaderProfileMenuProps = {
+  profileImageUrl?: string | null;
+};
+
+function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const { logout, isPending } = useLogoutAction();
   const location = useLocation();
   const isMyPage = location.pathname === `/${ROUTES.MY_PAGE}`;
+  const trimmedProfileImageUrl = profileImageUrl?.trim() || null;
+  const resolvedProfileImageUrl = trimmedProfileImageUrl || profileImg;
 
   useEffect(() => {
     if (!isOpen) {
@@ -63,9 +69,13 @@ function HeaderProfileMenu() {
         className="hover:border-header-accent h-10 w-10 cursor-pointer overflow-hidden rounded-full border-2 border-transparent transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
       >
         <img
-          src={profileImg}
+          src={resolvedProfileImageUrl}
           alt="프로필 이미지"
           className="h-full w-full object-cover"
+          onError={(event) => {
+            event.currentTarget.onerror = null;
+            event.currentTarget.src = profileImg;
+          }}
         />
       </button>
 

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -42,9 +42,9 @@ function FavoriteGameCard({
             variant="icon"
             aria-label={`${game.title} 찜 해제`}
             onClick={() => onFavoriteClick?.(game)}
-            className="border-white/18 bg-black/55 text-white/90 shadow-[0_10px_24px_rgba(0,0,0,0.35)] hover:border-white/32 hover:bg-black/70 hover:text-white focus-visible:ring-white/25"
+            className="hover:!border-login-primary hover:!bg-login-primary-hover !border-login-primary !bg-login-primary !text-white shadow-[0_10px_24px_rgba(0,0,0,0.38)] hover:!text-white focus-visible:ring-red-300/45"
           >
-            <X size={15} />
+            <X size={15} strokeWidth={2.25} />
           </ActionButton>
         </div>
       </div>

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -1,4 +1,4 @@
-import { Heart } from 'lucide-react';
+import { X } from 'lucide-react';
 
 import type { FavoriteGamePreview } from '../../features/mypage/types';
 import ActionButton from '../common/ActionButton';
@@ -40,11 +40,11 @@ function FavoriteGameCard({
           <ActionButton
             type="button"
             variant="icon"
-            aria-label={`${game.title} 찜 삭제`}
+            aria-label={`${game.title} 찜 해제`}
             onClick={() => onFavoriteClick?.(game)}
-            className="bg-login-primary hover:bg-login-primary-hover border-transparent text-white shadow-[0_12px_28px_rgba(242,15,23,0.25)] hover:text-white focus-visible:ring-red-500/35"
+            className="border-white/18 bg-black/55 text-white/90 shadow-[0_10px_24px_rgba(0,0,0,0.35)] hover:border-white/32 hover:bg-black/70 hover:text-white focus-visible:ring-white/25"
           >
-            <Heart size={15} fill="currentColor" />
+            <X size={15} />
           </ActionButton>
         </div>
       </div>
@@ -57,7 +57,7 @@ function FavoriteGameCard({
         <h3 className="line-clamp-1 text-base/6 font-semibold text-white sm:text-lg/7">
           {game.title}
         </h3>
-        <p className="text-mypage-muted line-clamp-2 text-xs/5 sm:text-sm/6">
+        <p className="text-mypage-muted line-clamp-1 text-xs/5 sm:text-sm/6">
           {game.summary}
         </p>
       </button>

--- a/src/components/mypage/FavoriteGameCardSkeleton.tsx
+++ b/src/components/mypage/FavoriteGameCardSkeleton.tsx
@@ -7,7 +7,7 @@ function FavoriteGameCardSkeleton({
 }: FavoriteGameCardSkeletonProps) {
   return (
     <div
-      className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4"
+      className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 2xl:grid-cols-4"
       aria-live="polite"
       aria-busy="true"
     >

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -1,4 +1,4 @@
-import { CircleUserRound } from 'lucide-react';
+import { Camera, CircleUserRound, LoaderCircle } from 'lucide-react';
 import { useState, type ReactNode } from 'react';
 
 import AuthButton from '../auth/AuthButton';
@@ -73,64 +73,89 @@ function MyPageProfileSection({
   };
 
   return (
-    <section className="border-mypage-panel bg-mypage-panel shadow-mypage-float rounded-[28px] border px-5 py-8 text-center backdrop-blur-xl sm:px-8 sm:py-10">
-      <h1 className="text-[clamp(2rem,4.8vw,2.75rem)] font-semibold text-white">
+    <section className="border-mypage-panel bg-mypage-panel shadow-mypage-float rounded-[28px] border px-5 py-7 text-center backdrop-blur-xl sm:px-8 sm:py-9">
+      <h1 className="text-[clamp(1.75rem,4vw,2.3rem)] font-semibold text-white">
         마이페이지
       </h1>
 
-      <div className="mt-8 flex justify-center">
-        <div className="h-32 w-32 sm:h-36 sm:w-36">
-          <div className="border-mypage-panel bg-mypage-card relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border shadow-[0_24px_50px_rgba(0,0,0,0.46),0_0_0_1px_rgba(255,255,255,0.03)]">
-            {hasProfileImage ? (
-              <img
-                src={profileImageUrl!}
-                alt={`${nickname} 프로필 이미지`}
-                className="h-full w-full object-cover"
+      <div className="mt-7 grid gap-6 lg:grid-cols-[10.5rem_minmax(0,1fr)] lg:items-start lg:gap-8">
+        <div className="flex flex-col items-center">
+          <div className="group relative h-32 w-32 sm:h-36 sm:w-36">
+            <label className="absolute inset-0 block cursor-pointer">
+              <input
+                type="file"
+                accept="image/*"
+                className="sr-only"
+                disabled={isProfileLoading || isProfileImageUploading}
+                onChange={(event) => {
+                  onProfileImageSelect?.(event.target.files?.[0] ?? null);
+                  event.currentTarget.value = '';
+                  event.currentTarget.blur();
+                }}
               />
-            ) : (
-              <CircleUserRound size={48} className="text-white/85" />
-            )}
-          </div>
-        </div>
-      </div>
-      <div className="mt-3 flex justify-center">
-        <label className="border-mypage-panel bg-mypage-card text-mypage-muted focus-within:ring-mypage-panel inline-flex h-9 cursor-pointer items-center justify-center rounded-full border px-3 py-1.5 text-xs leading-none font-semibold whitespace-nowrap transition focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-[#050505] hover:text-white">
-          <input
-            type="file"
-            accept="image/*"
-            className="sr-only"
-            disabled={isProfileLoading || isProfileImageUploading}
-            onChange={(event) => {
-              onProfileImageSelect?.(event.target.files?.[0] ?? null);
-              event.currentTarget.value = '';
-            }}
-          />
-          {isProfileImageUploading ? '업로드 중...' : '프로필 변경'}
-        </label>
-      </div>
-
-      {isProfileLoading ? (
-        <div
-          className="mt-5 flex flex-col items-center gap-3"
-          aria-live="polite"
-          aria-busy="true"
-        >
-          <div className="h-8 w-36 animate-pulse rounded-full bg-white/10" />
-          <div className="h-4 w-full max-w-sm animate-pulse rounded-full bg-white/8" />
-          <div className="border-mypage-panel bg-mypage-card mt-1 grid w-full max-w-[640px] gap-3 rounded-2xl border px-4 py-4 sm:grid-cols-3 sm:gap-4 sm:px-5">
-            {Array.from({ length: 3 }).map((_, index) => (
-              <div key={index} className="space-y-2">
-                <div className="h-3 w-10 animate-pulse rounded-full bg-white/8" />
-                <div className="h-5 w-full animate-pulse rounded-full bg-white/10" />
+              <span className="sr-only">
+                {isProfileImageUploading
+                  ? '프로필 이미지 업로드 중'
+                  : '프로필 변경'}
+              </span>
+              <div className="border-mypage-panel bg-mypage-card relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border shadow-[0_24px_50px_rgba(0,0,0,0.46),0_0_0_1px_rgba(255,255,255,0.03)]">
+                {hasProfileImage ? (
+                  <img
+                    src={profileImageUrl!}
+                    alt={`${nickname} 프로필 이미지`}
+                    className={`h-full w-full object-cover transition duration-200 ${
+                      isProfileImageUploading
+                        ? 'blur-[1.8px] brightness-[0.62]'
+                        : 'group-hover:blur-[1.8px] group-hover:brightness-[0.62]'
+                    }`}
+                  />
+                ) : (
+                  <CircleUserRound
+                    size={48}
+                    className="text-white/85 transition duration-200 group-hover:opacity-70"
+                  />
+                )}
+                <span
+                  className={`pointer-events-none absolute inset-0 flex items-center justify-center rounded-full transition ${
+                    isProfileImageUploading
+                      ? 'bg-black/55 opacity-100'
+                      : 'bg-black/0 opacity-0 group-hover:bg-black/45 group-hover:opacity-100'
+                  }`}
+                >
+                  <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/35 bg-black/45 text-white">
+                    {isProfileImageUploading ? (
+                      <LoaderCircle size={14} className="animate-spin" />
+                    ) : (
+                      <Camera size={14} />
+                    )}
+                  </span>
+                </span>
               </div>
-            ))}
+            </label>
           </div>
         </div>
-      ) : (
-        <>
-          <div className="mt-5 flex justify-center">
+
+        {isProfileLoading ? (
+          <div
+            className="flex flex-col items-center gap-3 lg:items-start"
+            aria-live="polite"
+            aria-busy="true"
+          >
+            <div className="h-8 w-36 animate-pulse rounded-full bg-white/10" />
+            <div className="h-4 w-full max-w-sm animate-pulse rounded-full bg-white/8" />
+            <div className="border-mypage-panel bg-mypage-card mt-1 grid w-full gap-3 rounded-2xl border px-4 py-4 text-left sm:grid-cols-3 sm:gap-4 sm:px-5">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div key={index} className="space-y-2">
+                  <div className="h-3 w-10 animate-pulse rounded-full bg-white/8" />
+                  <div className="h-5 w-full animate-pulse rounded-full bg-white/10" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-3 lg:items-start">
             {isNicknameEditMode ? (
-              <div className="w-full max-w-sm space-y-2">
+              <div className="w-full max-w-sm space-y-2 lg:max-w-md">
                 <label htmlFor="profile-nickname" className="sr-only">
                   닉네임
                 </label>
@@ -182,11 +207,13 @@ function MyPageProfileSection({
                 </div>
               </div>
             ) : (
-              <div className="flex flex-col items-center gap-2">
-                <p className="text-2xl font-semibold text-white">{nickname}</p>
+              <div className="flex items-center gap-3">
+                <p className="max-w-[18rem] truncate text-2xl font-semibold text-white">
+                  {nickname}
+                </p>
                 <button
                   type="button"
-                  className="border-mypage-panel bg-mypage-card text-mypage-muted rounded-full border px-3 py-1.5 text-xs font-semibold transition hover:text-white"
+                  className="border-mypage-panel bg-mypage-card text-mypage-muted shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold transition hover:text-white"
                   onClick={() => {
                     setIsNicknameEditMode(true);
                     setNextNickname(nickname);
@@ -197,50 +224,49 @@ function MyPageProfileSection({
                 </button>
               </div>
             )}
+            <p className="text-mypage-muted mt-1 text-sm/6">
+              계정 정보와 찜한 게임 목록을 한곳에서 관리할 수 있습니다.
+            </p>
+            <dl className="border-mypage-panel bg-mypage-card mt-3 grid w-full gap-3 rounded-2xl border px-4 py-4 text-left text-sm/6 sm:grid-cols-3 sm:gap-4 sm:px-5">
+              <div>
+                <dt className="text-mypage-muted text-xs/5">이름</dt>
+                <dd className="mt-1 font-medium text-white">{name}</dd>
+              </div>
+              <div>
+                <dt className="text-mypage-muted text-xs/5">이메일</dt>
+                <dd className="mt-1 truncate font-medium text-white">
+                  {email || 'N/A'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-mypage-muted text-xs/5">성별</dt>
+                <dd className="mt-1 font-medium text-white">{genderLabel}</dd>
+              </div>
+            </dl>
+            <div className="mt-1 flex w-full flex-col gap-3 sm:flex-row sm:justify-center lg:justify-start">
+              <AuthButton
+                type="button"
+                variant="secondary"
+                className="w-full sm:w-auto sm:min-w-36"
+                onClick={onPasswordToggle}
+              >
+                {isPasswordPanelOpen ? '비밀번호 변경 닫기' : '비밀번호 변경'}
+              </AuthButton>
+              <AuthButton
+                type="button"
+                variant="secondary"
+                className="w-full sm:w-auto sm:min-w-28"
+                onClick={onLogout}
+                disabled={isLoggingOut}
+              >
+                {isLoggingOut ? '로그아웃 중...' : '로그아웃'}
+              </AuthButton>
+            </div>
           </div>
-          <p className="text-mypage-muted mt-2 text-sm/6">
-            계정 정보와 찜한 게임 목록을 한곳에서 관리할 수 있습니다.
-          </p>
-          <dl className="border-mypage-panel bg-mypage-card mt-5 grid gap-3 rounded-2xl border px-4 py-4 text-left text-sm/6 sm:grid-cols-3 sm:gap-4 sm:px-5">
-            <div>
-              <dt className="text-mypage-muted text-xs/5">이름</dt>
-              <dd className="mt-1 font-medium text-white">{name}</dd>
-            </div>
-            <div>
-              <dt className="text-mypage-muted text-xs/5">이메일</dt>
-              <dd className="mt-1 truncate font-medium text-white">
-                {email || 'N/A'}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-mypage-muted text-xs/5">성별</dt>
-              <dd className="mt-1 font-medium text-white">{genderLabel}</dd>
-            </div>
-          </dl>
-        </>
-      )}
-
-      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:justify-center">
-        <AuthButton
-          type="button"
-          variant="secondary"
-          className="w-full sm:w-auto sm:min-w-36"
-          onClick={onPasswordToggle}
-        >
-          {isPasswordPanelOpen ? '비밀번호 변경 닫기' : '비밀번호 변경'}
-        </AuthButton>
-        <AuthButton
-          type="button"
-          variant="secondary"
-          className="w-full sm:w-auto sm:min-w-28"
-          onClick={onLogout}
-          disabled={isLoggingOut}
-        >
-          {isLoggingOut ? '로그아웃 중...' : '로그아웃'}
-        </AuthButton>
+        )}
       </div>
 
-      {children}
+      {children ? <div className="mt-6">{children}</div> : null}
     </section>
   );
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -84,7 +84,9 @@ const resolveMockAccounts = (
 function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const setAuth = useAuthStore((state) => state.setAuth);
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+  const setAccount = useAuthStore((state) => state.setAccount);
+  const clearAuth = useAuthStore((state) => state.clearAuth);
   const loginMutation = useLoginMutation();
   const [mockAccounts, setMockAccounts] = useState<DevMockLoginAccount[]>([]);
   const [isMockPanelOpen, setIsMockPanelOpen] = useState(false);
@@ -293,18 +295,26 @@ function LoginPage() {
 
     try {
       const response = await loginMutation.mutateAsync(payload);
-
-      // [Refactor] #94: Access Token 메모리 저장, Refresh Token은 HttpOnly 쿠키로 관리됨
-      const profile = await getCurrentUserProfile();
-      setAuth(response.access_token, profile);
-
-      navigate(ROUTES.HOME);
+      setAccessToken(response.access_token);
     } catch (error) {
       const resolvedError = resolveLoginApiError(error, payload);
 
       setApiFieldErrors(resolvedError.fieldErrors);
       setFormMessage(resolvedError.message);
       focusFieldByName(resolvedError.focusField, LOGIN_FIELD_ELEMENT_IDS);
+      return;
+    }
+
+    try {
+      // [Refactor] #94: Access Token 메모리 저장 후 현재 사용자 프로필을 동기화합니다.
+      const profile = await getCurrentUserProfile();
+      setAccount(profile);
+      navigate(ROUTES.HOME);
+    } catch {
+      clearAuth();
+      setFormMessage(
+        '로그인 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      );
     }
   };
 

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -112,33 +112,15 @@ const mapPasswordApiFieldErrors = (
   newPasswordConfirm: fieldErrors.new_password_check,
 });
 
-const formatLikedAt = (likedAt: string) => {
-  const date = new Date(likedAt);
-
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-
-  return date.toLocaleDateString('ko-KR');
-};
-
 const toFavoriteGamePreview = (
   game: LikedGameItemResponse,
 ): FavoriteGamePreview => {
   const normalizedGenres = game.genres.filter((genre) => genre.trim());
-  const likedAtLabel = formatLikedAt(game.liked_at);
-
-  const summaryParts = [
-    normalizedGenres.length > 0
-      ? `장르: ${normalizedGenres.join(', ')}`
-      : '장르 정보 없음',
-    likedAtLabel ? `찜한 날짜: ${likedAtLabel}` : null,
-  ].filter(Boolean);
 
   return {
     gameId: game.game_id,
     title: game.game_title.trim() || 'N/A',
-    summary: summaryParts.join(' · '),
+    summary: normalizedGenres.length > 0 ? normalizedGenres.join(', ') : 'N/A',
     thumbnailUrl: game.thumbnail_url,
     genres: normalizedGenres,
   };
@@ -710,13 +692,13 @@ function MyPage() {
 
           <div
             ref={favoriteGamesScrollRef}
-            className="mypage-scrollbar mt-5 max-h-[760px] overflow-y-auto pr-1"
+            className="mypage-scrollbar mt-5 h-[23rem] overflow-y-auto pr-1 sm:h-[25rem] lg:h-[25rem]"
           >
             {isFavoriteGamesLoading ? (
               <FavoriteGameCardSkeleton />
             ) : favoriteCount > 0 ? (
               <div>
-                <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
+                <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 2xl:grid-cols-4">
                   {favoriteGames.map((game) => (
                     <FavoriteGameCard
                       key={game.gameId}


### PR DESCRIPTION
## 관련 이슈

- closes #216

## 변경 내용

-로그인 성공 직후 토큰 반영 → /me hydrate 순서로 정리해 헤더/마이페이지 사용자 정보 표시 불일치 수정
-헤더 프로필 메뉴 아바타를 account.profile_img_url 기반으로 연동하고, 실패 시 기본 이미지 폴백 처리
-마이페이지 찜 카드 UI 정리
  * 하트 액션을 X 아이콘(찜 해제)로 변경
  * 카드 보조 텍스트를 장르명 중심으로 단순화
  * 목록 영역 높이를 조정해 1줄 중심으로 보이도록 수정
-프로필 이미지 변경 UX 개선
  * 기본 상태: 프로필 이미지 그대로 노출
  * hover/focus 상태: 이미지 dim/blur + 중앙 카메라 액션 노출
  * 파일 선택 취소 후 오버레이 잔상 문제 수정
  * 우하단 보조 카메라 배지 제거, 중앙 액션은 카메라 아이콘만 유지

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

https://github.com/user-attachments/assets/290293df-632d-4d57-8e3d-f3c97865178f

## 참고사항

-
