### PR TITLE
design(auth): 로그인/회원가입 배경·카드 레이아웃 및 폼 비주얼 리파인먼트

### DIFF
--- a/src/components/auth/AuthInputActionButton.tsx
+++ b/src/components/auth/AuthInputActionButton.tsx
@@ -16,7 +16,7 @@ function AuthInputActionButton({
     <AuthButton
       type={type}
       variant="secondary"
-      className={`w-full border border-[#5b3035] bg-[#1d1215] text-sm font-semibold text-[#f2d8d9] hover:border-[#ff6b6e]/65 hover:bg-[#29161a] hover:text-white focus-visible:ring-[#ff5c60]/25 active:scale-[0.99] sm:w-[5.75rem] sm:shrink-0 ${className}`}
+      className={`h-12 w-full border border-[#5b3035] bg-[#1d1215] text-sm font-semibold text-[#f2d8d9] hover:border-[#ff6b6e]/65 hover:bg-[#29161a] hover:text-white focus-visible:ring-[#ff5c60]/25 active:scale-[0.99] sm:h-[3.2rem] sm:w-[5.75rem] sm:shrink-0 ${className}`}
       {...props}
     >
       {children}

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -67,7 +67,7 @@ function AuthRadioGroup({
                 className="peer sr-only"
               />
               <span
-                className={`flex h-14 items-center justify-center rounded-xl border px-4 text-sm font-semibold transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-[#ff5c60]/25 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-black peer-disabled:opacity-60 ${
+                className={`flex h-12 items-center justify-center rounded-xl border px-4 text-sm font-semibold transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-[#ff5c60]/25 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-black peer-disabled:opacity-60 sm:h-[3.2rem] ${
                   errorMessage
                     ? 'border-red-500/80 bg-[#1d1215] text-red-200 group-hover:border-red-400/90 group-hover:bg-[#2f1519] group-hover:text-red-100'
                     : 'bg-login-field text-login-label border-white/16 group-hover:border-white/24 group-hover:bg-[#1d1e22] group-hover:text-white/90 peer-checked:border-[#ff6b6e]/70 peer-checked:bg-[#29161a] peer-checked:text-white'

--- a/src/components/auth/AuthSocialLoginGroup.tsx
+++ b/src/components/auth/AuthSocialLoginGroup.tsx
@@ -21,9 +21,9 @@ const GROUP_SIZE_CLASS_NAMES = {
 
 const BUTTON_SIZE_CLASS_NAMES = {
   default: {
-    google: 'h-14',
-    kakao: 'h-14',
-    naver: 'h-14',
+    google: 'h-12 sm:h-[3.2rem]',
+    kakao: 'h-12 sm:h-[3.2rem]',
+    naver: 'h-12 sm:h-[3.2rem]',
     label: '',
   },
   compact: {

--- a/src/components/auth/authSharedStyles.ts
+++ b/src/components/auth/authSharedStyles.ts
@@ -1,17 +1,18 @@
 export const AUTH_SHARED_LAYOUT_CLASS_NAMES = {
-  panel: 'max-w-[560px] px-5 py-6 sm:px-9 sm:py-9',
-  content: 'max-w-[420px]',
+  panel: 'max-w-[560px] px-5 py-6 sm:px-9 sm:py-8',
+  content: 'max-w-[428px]',
 } as const;
 
 export const AUTH_SHARED_FORM_CLASS_NAMES = {
-  socialGroup: 'mt-6 sm:mt-7',
-  divider: 'my-5 sm:my-6',
-  form: 'space-y-3 sm:space-y-3.5',
+  socialGroup: 'mt-4 sm:mt-5',
+  divider: 'my-3 sm:my-4',
+  form: 'space-y-2.5 sm:space-y-3',
   feedbackMessage: 'text-sm/5',
-  submitButton: 'mt-2 h-14 w-full text-base/6 sm:mt-2.5',
+  submitButton:
+    'mt-1.5 h-12 w-full text-sm/6 sm:mt-2 sm:h-[3.2rem] sm:text-base/6',
   auxiliaryLink:
     'text-login-muted text-sm font-medium transition-colors hover:text-white/80',
-  footerSection: 'border-login-divider mt-4 border-t pt-4 sm:mt-5 sm:pt-5',
+  footerSection: 'border-login-divider mt-3 border-t pt-3 sm:mt-4 sm:pt-4',
   footerHelperText: 'text-login-helper text-center text-sm/5 font-normal',
-  footerLinkButton: 'mt-3 h-14 w-full text-base/6',
+  footerLinkButton: 'mt-2.5 h-12 w-full text-sm/6 sm:h-[3.2rem] sm:text-base/6',
 } as const;

--- a/src/components/common/InputControl.tsx
+++ b/src/components/common/InputControl.tsx
@@ -6,7 +6,7 @@ type InputControlProps = {
 } & InputHTMLAttributes<HTMLInputElement>;
 
 const inputBaseClassName =
-  'auth-input-autofill placeholder-login-muted bg-login-field h-14 min-w-0 w-full rounded-xl border px-4 text-base text-white transition outline-none focus-visible:ring-2';
+  'auth-input-autofill placeholder-login-muted bg-login-field h-12 min-w-0 w-full rounded-xl border px-3.5 text-[0.95rem] text-white transition outline-none focus-visible:ring-2 sm:h-[3.2rem] sm:px-4 sm:text-base';
 
 function InputControl({
   hasError = false,

--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -27,7 +27,7 @@ function AuthLayout({
   const content = (
     <>
       <h1
-        className={`text-center text-[clamp(2rem,4.8vw,3rem)] leading-none font-semibold ${titleClassName}`}
+        className={`text-center text-[clamp(1.8rem,4.3vw,2.65rem)] leading-[1.05] font-semibold tracking-[-0.02em] text-white ${titleClassName}`}
       >
         {title}
       </h1>
@@ -47,11 +47,14 @@ function AuthLayout({
       <Header fixed={false} />
 
       <main
-        className={`flex flex-1 items-center justify-center px-4 py-6 sm:px-6 sm:py-8 lg:px-8 ${mainClassName}`}
+        className={`auth-layout-main relative isolate flex flex-1 items-center justify-center overflow-hidden px-4 py-6 sm:px-6 sm:py-8 lg:px-8 ${mainClassName}`}
       >
+        <div aria-hidden="true" className="auth-layout-backdrop" />
+        <div aria-hidden="true" className="auth-layout-grid" />
+
         {withPanel ? (
           <section
-            className={`bg-auth-panel border-auth-panel shadow-auth-panel w-full max-w-[520px] rounded-[28px] border px-4 py-5 backdrop-blur-sm sm:rounded-3xl sm:px-8 sm:py-8 ${panelClassName}`}
+            className={`auth-layout-panel w-full max-w-[520px] rounded-[28px] border px-4 py-5 backdrop-blur-sm sm:rounded-3xl sm:px-8 sm:py-8 ${panelClassName}`}
           >
             <div className={`mx-auto w-full max-w-[440px] ${contentClassName}`}>
               {content}

--- a/src/index.css
+++ b/src/index.css
@@ -33,9 +33,14 @@
   --color-login-naver: #03c75a;
   --color-login-primary: #f20f17;
   --color-login-primary-hover: #dd0d14;
-  --color-auth-panel: #111111;
-  --color-auth-panel-border: rgba(255, 255, 255, 0.08);
-  --shadow-auth-panel: rgba(0, 0, 0, 0.34);
+  --color-auth-panel: rgba(12, 12, 14, 0.88);
+  --color-auth-panel-border: rgba(255, 255, 255, 0.13);
+  --shadow-auth-panel: rgba(0, 0, 0, 0.5);
+  --color-auth-backdrop-grid: rgba(255, 255, 255, 0.045);
+  --color-auth-backdrop-red-glow: rgba(242, 15, 23, 0.2);
+  --color-auth-backdrop-white-glow: rgba(255, 255, 255, 0.08);
+  --color-auth-panel-top: rgba(255, 255, 255, 0.06);
+  --color-auth-panel-bottom: rgba(255, 255, 255, 0.02);
   --shadow-login-primary: rgba(242, 15, 23, 0.42);
   --color-support-chat-panel: rgba(8, 8, 9, 0.92);
   --color-support-chat-panel-border: rgba(153, 25, 20, 0.8);
@@ -127,6 +132,70 @@
         transparent 24%
       ),
       linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 32%);
+  }
+
+  .auth-layout-main {
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.025),
+      transparent 35%
+    );
+  }
+
+  .auth-layout-backdrop {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: -2;
+    background:
+      radial-gradient(
+        circle at 14% 14%,
+        var(--color-auth-backdrop-red-glow),
+        transparent 34%
+      ),
+      radial-gradient(
+        circle at 86% 8%,
+        var(--color-auth-backdrop-white-glow),
+        transparent 30%
+      ),
+      radial-gradient(
+        circle at 52% 86%,
+        rgba(150, 20, 20, 0.14),
+        transparent 42%
+      );
+  }
+
+  .auth-layout-grid {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: -1;
+    opacity: 0.32;
+    background-image:
+      linear-gradient(var(--color-auth-backdrop-grid) 1px, transparent 1px),
+      linear-gradient(
+        90deg,
+        var(--color-auth-backdrop-grid) 1px,
+        transparent 1px
+      );
+    background-size: 42px 42px;
+    mask-image: radial-gradient(ellipse at center, black 32%, transparent 78%);
+  }
+
+  .auth-layout-panel {
+    border-color: var(--color-auth-panel-border);
+    background:
+      linear-gradient(
+        180deg,
+        var(--color-auth-panel-top),
+        var(--color-auth-panel-bottom)
+      ),
+      var(--color-auth-panel);
+    box-shadow:
+      0 36px 70px -28px var(--shadow-auth-panel),
+      0 0 0 1px rgba(255, 255, 255, 0.035),
+      0 0 44px rgba(242, 15, 23, 0.14);
+    backdrop-filter: blur(18px);
   }
 
   .survey-panel {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -322,14 +322,16 @@ function LoginPage() {
     <>
       <AuthLayout
         title="로그인"
-        titleClassName="sr-only"
+        titleClassName="text-[clamp(1.68rem,4vw,2.45rem)]"
         withPanel
         panelClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.panel}
         contentClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.content}
       >
-        <AuthSocialLoginGroup className="mt-2 sm:mt-2.5" />
+        <AuthSocialLoginGroup
+          className={AUTH_SHARED_FORM_CLASS_NAMES.socialGroup}
+        />
 
-        <AuthDivider className="my-4 sm:my-5" />
+        <AuthDivider className={AUTH_SHARED_FORM_CLASS_NAMES.divider} />
 
         <form
           className={AUTH_SHARED_FORM_CLASS_NAMES.form}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -476,13 +476,13 @@ function SignupPage() {
   return (
     <AuthLayout
       title="회원가입"
-      titleClassName="sr-only"
+      titleClassName="text-[clamp(1.68rem,4vw,2.45rem)]"
       withPanel
       panelClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.panel}
       contentClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.content}
     >
       <form
-        className={`${AUTH_SHARED_FORM_CLASS_NAMES.form} pt-1 sm:pt-1.5`}
+        className={`${AUTH_SHARED_FORM_CLASS_NAMES.form} mt-5 sm:mt-6`}
         autoComplete="on"
         onSubmit={handleSubmit}
       >


### PR DESCRIPTION
## 관련 이슈

- closes #218

## 변경 내용

- 로그인/회원가입 공통 레이아웃에 은은한 그라데이션 + 기하학 패턴 배경 적용
- 카드형 컨테이너(패널) 대비 강화(보더/그림자/블러)로 폼 집중도 개선
- 로그인/회원가입 타이틀 재도입 및 타이틀 크기 미세 조정
-공통 입력/버튼 높이 및 간격 리듬 조정
  * InputControl 높이/패딩 최적화
  * 제출 버튼/푸터 버튼 높이 조정
  * 중복확인 버튼, 소셜 버튼, 성별 선택 버튼 높이 정렬
- 기존 “에러 메시지 발생 시에만 간격 확장” 동작 유지

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

https://github.com/user-attachments/assets/24c3beb5-2e7e-4508-a342-1abb899b2132

## 참고사항

- API/라우트/상태 타입 변경은 없고, UI 레이아웃 및 스타일만 조정했습니다.
