### PR TITLE
refactor(auth,mypage,route): 인증 게이트 통합 및 마이페이지 구조 분리

### DIFF
--- a/src/components/auth/AuthGateStatusPanel.tsx
+++ b/src/components/auth/AuthGateStatusPanel.tsx
@@ -1,0 +1,28 @@
+type AuthGateStatusPanelProps = {
+  title: string;
+  description: string;
+  align?: 'left' | 'center';
+  className?: string;
+};
+
+function AuthGateStatusPanel({
+  title,
+  description,
+  align = 'left',
+  className = '',
+}: AuthGateStatusPanelProps) {
+  return (
+    <section
+      className={`survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10 ${
+        align === 'center' ? 'text-center' : ''
+      } ${className}`.trim()}
+    >
+      <h2 className="text-2xl font-bold text-white">{title}</h2>
+      <p className="mt-4 text-base leading-7 break-keep text-white/60">
+        {description}
+      </p>
+    </section>
+  );
+}
+
+export default AuthGateStatusPanel;

--- a/src/components/auth/AuthWrapper.tsx
+++ b/src/components/auth/AuthWrapper.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react';
+
+import useAuthGate, {
+  type UseAuthGateResult,
+} from '../../features/auth/hooks/useAuthGate';
+
+type AuthWrapperProps = {
+  children: ReactNode;
+  gate?: UseAuthGateResult;
+  allowMockBypass?: boolean;
+  loadingFallback?: ReactNode;
+  unauthorizedFallback?: ReactNode;
+};
+
+function AuthWrapper({
+  children,
+  gate,
+  allowMockBypass = false,
+  loadingFallback = null,
+  unauthorizedFallback = null,
+}: AuthWrapperProps) {
+  const fallbackGate = useAuthGate({ allowMockBypass });
+  const resolvedGate = gate ?? fallbackGate;
+
+  if (resolvedGate.needsAuthCheck) {
+    return <>{loadingFallback}</>;
+  }
+
+  if (resolvedGate.shouldRedirectToLogin) {
+    return <>{unauthorizedFallback}</>;
+  }
+
+  return <>{children}</>;
+}
+
+export default AuthWrapper;

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -39,7 +39,13 @@ function MyPageProfileSection({
   onProfileImageSelect,
   children,
 }: MyPageProfileSectionProps) {
-  const hasProfileImage = Boolean(profileImageUrl?.trim());
+  const normalizedProfileImageUrl = profileImageUrl?.trim() ?? '';
+  const [failedProfileImageUrl, setFailedProfileImageUrl] = useState<
+    string | null
+  >(null);
+  const hasProfileImage =
+    Boolean(normalizedProfileImageUrl) &&
+    failedProfileImageUrl !== normalizedProfileImageUrl;
   const [isNicknameEditMode, setIsNicknameEditMode] = useState(false);
   const [nextNickname, setNextNickname] = useState(nickname);
   const [nicknameFieldError, setNicknameFieldError] = useState('');
@@ -101,8 +107,11 @@ function MyPageProfileSection({
               <div className="border-mypage-panel bg-mypage-card relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border shadow-[0_24px_50px_rgba(0,0,0,0.46),0_0_0_1px_rgba(255,255,255,0.03)]">
                 {hasProfileImage ? (
                   <img
-                    src={profileImageUrl!}
+                    src={normalizedProfileImageUrl}
                     alt={`${nickname} 프로필 이미지`}
+                    onError={() =>
+                      setFailedProfileImageUrl(normalizedProfileImageUrl)
+                    }
                     className={`h-full w-full object-cover transition duration-200 ${
                       isProfileImageUploading
                         ? 'blur-[1.8px] brightness-[0.62]'

--- a/src/features/auth/hooks/useAuthGate.ts
+++ b/src/features/auth/hooks/useAuthGate.ts
@@ -1,0 +1,52 @@
+import { isMockServiceWorkerEnabled } from '../../../lib/env';
+import { useAuthStore } from '../../../store/useAuthStore';
+
+type UseAuthGateOptions = {
+  allowMockBypass?: boolean;
+};
+
+export type UseAuthGateResult = {
+  isAuthenticated: boolean;
+  isAuthReady: boolean;
+  authBootstrapStatus: 'idle' | 'loading' | 'ready';
+  isMockMode: boolean;
+  canBypassAuth: boolean;
+  canAccessAuthenticatedRoute: boolean;
+  needsAuthCheck: boolean;
+  shouldRedirectToLogin: boolean;
+  accessStatus: 'loading' | 'authorized' | 'unauthorized';
+};
+
+function useAuthGate(options: UseAuthGateOptions = {}): UseAuthGateResult {
+  const { allowMockBypass = false } = options;
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const authBootstrapStatus = useAuthStore(
+    (state) => state.authBootstrapStatus,
+  );
+  const isAuthReady = authBootstrapStatus === 'ready';
+  const isMockMode = isMockServiceWorkerEnabled();
+  const canBypassAuth = allowMockBypass && isMockMode;
+  const canAccessAuthenticatedRoute =
+    canBypassAuth || (isAuthReady && isAuthenticated);
+  const needsAuthCheck = !canBypassAuth && !isAuthReady;
+  const shouldRedirectToLogin = !needsAuthCheck && !canAccessAuthenticatedRoute;
+  const accessStatus = needsAuthCheck
+    ? 'loading'
+    : canAccessAuthenticatedRoute
+      ? 'authorized'
+      : 'unauthorized';
+
+  return {
+    isAuthenticated,
+    isAuthReady,
+    authBootstrapStatus,
+    isMockMode,
+    canBypassAuth,
+    canAccessAuthenticatedRoute,
+    needsAuthCheck,
+    shouldRedirectToLogin,
+    accessStatus,
+  };
+}
+
+export default useAuthGate;

--- a/src/features/auth/hooks/useAuthGuardState.ts
+++ b/src/features/auth/hooks/useAuthGuardState.ts
@@ -1,17 +1,13 @@
-import { useAuthStore } from '../../../store/useAuthStore';
+import useAuthGate from './useAuthGate';
 
 function useAuthGuardState() {
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const authBootstrapStatus = useAuthStore(
-    (state) => state.authBootstrapStatus,
-  );
-  const isAuthReady = authBootstrapStatus === 'ready';
+  const gate = useAuthGate();
 
   return {
-    isAuthenticated,
-    isAuthReady,
-    authBootstrapStatus,
-    canAccessAuthenticatedRoute: isAuthReady && isAuthenticated,
+    isAuthenticated: gate.isAuthenticated,
+    isAuthReady: gate.isAuthReady,
+    authBootstrapStatus: gate.authBootstrapStatus,
+    canAccessAuthenticatedRoute: gate.canAccessAuthenticatedRoute,
   };
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -14,11 +14,12 @@ import RecommendationListPage from './pages/recommendation/RecommendationListPag
 import SurveyPage from './pages/survey/SurveyPage';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
-import MyPage from './pages/mypage/MyPage';
 import AuthCallbackPage from './pages/AuthCallbackPage';
 import './index.css';
 
 const queryClient = new QueryClient();
+// eslint-disable-next-line react-refresh/only-export-components
+const LazyMyPage = lazy(() => import('./pages/mypage/MyPage'));
 
 const router = createBrowserRouter([
   {
@@ -67,7 +68,20 @@ const router = createBrowserRouter([
       },
       {
         path: ROUTES.MY_PAGE,
-        element: <MyPage />,
+        element: (
+          <Suspense
+            fallback={
+              <div className="relative min-h-screen overflow-hidden bg-[#050505] text-white">
+                <div className="app-aurora pointer-events-none absolute inset-0 opacity-70" />
+                <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1240px] items-center justify-center px-4 text-center text-white/70 sm:px-6 md:px-8">
+                  마이페이지를 불러오는 중입니다...
+                </main>
+              </div>
+            }
+          >
+            <LazyMyPage />
+          </Suspense>
+        ),
       },
     ],
   },

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -3,10 +3,11 @@ import { ChevronLeft, ChevronRight, Heart } from 'lucide-react';
 import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
 
+import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
 import { authKeys } from '../../features/auth/api/queryKeys';
-import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
+import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import type { LikedGamesResponse } from '../../features/auth/types/auth';
 import {
   useMatchCandidatesQuery,
@@ -21,7 +22,6 @@ import {
 } from '../../features/matching/genres';
 import { useMatchingStore } from '../../features/matching/store/useMatchingStore';
 import { extractApiErrorMessage } from '../../features/survey/api/survey';
-import { isMockServiceWorkerEnabled } from '../../lib/env';
 
 const formatMatchingCandidateRating = (rating: number | null) => {
   if (typeof rating !== 'number') {
@@ -45,9 +45,8 @@ function MatchingGenreDetailPage() {
   const { genreSlug } = useParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { canAccessAuthenticatedRoute, isAuthReady } = useAuthGuardState();
-  const isMockMode = isMockServiceWorkerEnabled();
-  const canAccessPage = isMockMode || canAccessAuthenticatedRoute;
+  const authGate = useAuthGate({ allowMockBypass: true });
+  const canAccessPage = authGate.accessStatus === 'authorized';
   const isValidGenreSlug = genreSlug ? isMatchingGenreSlug(genreSlug) : false;
   const genre = genreSlug ? getMatchingGenreBySlug(genreSlug) : undefined;
 
@@ -229,23 +228,19 @@ function MatchingGenreDetailPage() {
               장르 선택으로 돌아가기
             </Link>
           </section>
-        ) : !isMockMode && !isAuthReady ? (
-          <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 text-center text-white/68 sm:px-8 sm:py-12">
-            인증 상태를 확인하는 중입니다...
-          </section>
+        ) : authGate.accessStatus === 'loading' ? (
+          <AuthGateStatusPanel
+            title="인증 상태를 확인하는 중입니다."
+            description="잠시만 기다려 주세요. 세션 확인 후 매칭 화면을 불러옵니다."
+            align="center"
+            className="mx-auto max-w-[760px] sm:py-12"
+          />
         ) : !canAccessPage ? (
-          <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 sm:px-8 sm:py-12">
-            <p className="text-sm font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
-              Matching
-            </p>
-            <h1 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl">
-              로그인 후 매칭을 진행할 수 있어요.
-            </h1>
-            <p className="mt-4 max-w-[52ch] text-sm leading-7 break-keep text-white/60 sm:text-base">
-              실제 API 모드에서는 인증 토큰이 필요합니다. 개발 환경에서 MSW를
-              켜두면 로그인 없이도 매칭 흐름을 확인할 수 있어요.
-            </p>
-          </section>
+          <AuthGateStatusPanel
+            title="로그인 후 매칭을 진행할 수 있어요."
+            description="실제 API 모드에서는 인증 토큰이 필요합니다. 개발 환경에서 MSW를 켜두면 로그인 없이도 매칭 흐름을 확인할 수 있어요."
+            className="mx-auto max-w-[760px] sm:py-12"
+          />
         ) : matchCandidatesQuery.isLoading ? (
           <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 text-center text-white/68 sm:px-8 sm:py-12">
             매칭 후보 게임을 불러오는 중입니다...

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -4,16 +4,14 @@ import { Link } from 'react-router';
 
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
-import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
+import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import { useMatchingGenreImageQueries } from '../../features/matching/api/useMatchingApi';
 import { MATCHING_GENRES } from '../../features/matching/genres';
 import { useMatchingStore } from '../../features/matching/store/useMatchingStore';
-import { isMockServiceWorkerEnabled } from '../../lib/env';
 
 function MatchingListPage() {
-  const { canAccessAuthenticatedRoute } = useAuthGuardState();
-  const isMockMode = isMockServiceWorkerEnabled();
-  const canFetchGenreImages = isMockMode || canAccessAuthenticatedRoute;
+  const authGate = useAuthGate({ allowMockBypass: true });
+  const canFetchGenreImages = authGate.accessStatus === 'authorized';
   const resetFlow = useMatchingStore((state) => state.resetFlow);
   const genreImageQueries = useMatchingGenreImageQueries(
     MATCHING_GENRES.map((genre) => genre.genreId),

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -1,880 +1,131 @@
-import type { FormEvent } from 'react';
-import { Heart, ShieldAlert } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router';
-import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { Navigate } from 'react-router';
 
-import AuthButton from '../../components/auth/AuthButton';
+import AuthWrapper from '../../components/auth/AuthWrapper';
 import Header from '../../components/common/Header';
-import InputControl from '../../components/common/InputControl';
-import ConfirmModal from '../../components/mypage/ConfirmModal';
-import FavoriteGameCard from '../../components/mypage/FavoriteGameCard';
-import FavoriteGameCardSkeleton from '../../components/mypage/FavoriteGameCardSkeleton';
-import FavoriteGamesEmptyState from '../../components/mypage/FavoriteGamesEmptyState';
-import MyPageProfileSection from '../../components/mypage/MyPageProfileSection';
-import PasswordChangePanel, {
-  type PasswordChangeFieldName,
-  type PasswordChangeValues,
-} from '../../components/mypage/PasswordChangePanel';
 import ToastMessage from '../../components/mypage/ToastMessage';
 import { ROUTES } from '../../constants/routes';
-import {
-  extractAuthApiErrorMessage,
-  extractAuthApiFieldErrors,
-} from '../../features/auth/api/auth';
-import {
-  DEFAULT_LIKED_GAMES_PAGE_SIZE,
-  useChangePasswordMutation,
-  useConfirmProfileImageMutation,
-  useCurrentUserProfileQuery,
-  useDeleteAccountMutation,
-  useLikedGamesInfiniteQuery,
-  useProfileImagePresignedUrlMutation,
-  useUpdateUserInfoMutation,
-  useUnlikeLikedGameMutation,
-  useUploadFileToS3Mutation,
-} from '../../features/auth/api/useAuthApi';
-import { authKeys } from '../../features/auth/api/queryKeys';
-import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
+import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
-import type {
-  AuthGender,
-  CurrentUserProfileResponse,
-  LikedGameItemResponse,
-} from '../../features/auth/types/auth';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
 import type { GameListItem } from '../../features/games/types';
-import type { FavoriteGamePreview } from '../../features/mypage/types';
-import { clearAuthTokens, setAuthAccount } from '../../utils/auth';
-import { useAuthStore } from '../../store/useAuthStore';
+import MyPageAccountDangerZone from './components/MyPageAccountDangerZone';
+import MyPageLikedGamesSection from './components/MyPageLikedGamesSection';
+import MyPageProfileContainer from './components/MyPageProfileContainer';
+import useMyPageProfile from './hooks/useMyPageProfile';
+import useMyPageSecurity from './hooks/useMyPageSecurity';
+import type { MyPageToast } from './types';
 
-type PasswordTouchedState = Record<PasswordChangeFieldName, boolean>;
-type PasswordFieldErrors = Partial<Record<PasswordChangeFieldName, string>>;
-type ToastState = {
-  tone: 'success' | 'error';
-  message: string;
-} | null;
-type PasswordPanelMessage = {
-  tone: 'success' | 'error';
-  message: string;
-} | null;
+const loadingFallback = (
+  <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+    <Header fixed />
+    <main className="mx-auto flex min-h-screen w-full max-w-[1240px] px-4 pt-[6.1rem] pb-12 sm:px-6 md:px-8 md:pt-[6.4rem]">
+      <section className="survey-panel mx-auto w-full max-w-[920px] px-8 py-12 text-center text-white/68">
+        인증 상태를 확인하는 중입니다...
+      </section>
+    </main>
+  </div>
+);
 
-const initialPasswordValues: PasswordChangeValues = {
-  currentPassword: '',
-  newPassword: '',
-  newPasswordConfirm: '',
-};
-
-const initialTouchedState: PasswordTouchedState = {
-  currentPassword: false,
-  newPassword: false,
-  newPasswordConfirm: false,
-};
-
-const getPasswordFieldErrors = (
-  values: PasswordChangeValues,
-  touchedState: PasswordTouchedState,
-) => {
-  const trimmedCurrentPassword = values.currentPassword.trim();
-  const trimmedNewPassword = values.newPassword.trim();
-  const trimmedNewPasswordConfirm = values.newPasswordConfirm.trim();
-
-  return {
-    currentPassword:
-      touchedState.currentPassword && !trimmedCurrentPassword
-        ? '현재 비밀번호를 입력해주세요.'
-        : '',
-    newPassword:
-      touchedState.newPassword && !trimmedNewPassword
-        ? '새 비밀번호를 입력해주세요.'
-        : touchedState.newPassword &&
-            trimmedNewPassword.length > 0 &&
-            trimmedNewPassword.length < 8
-          ? '비밀번호는 8자 이상이어야 합니다.'
-          : '',
-    newPasswordConfirm:
-      touchedState.newPasswordConfirm && !trimmedNewPasswordConfirm
-        ? '새 비밀번호를 한번 더 입력해주세요.'
-        : touchedState.newPasswordConfirm &&
-            trimmedNewPassword.length > 0 &&
-            trimmedNewPasswordConfirm.length > 0 &&
-            trimmedNewPassword !== trimmedNewPasswordConfirm
-          ? '비밀번호와 일치하지 않습니다.'
-          : '',
-  } satisfies Record<PasswordChangeFieldName, string>;
-};
-
-const mapPasswordApiFieldErrors = (
-  fieldErrors: Record<string, string>,
-): PasswordFieldErrors => ({
-  currentPassword: fieldErrors.old_password,
-  newPassword: fieldErrors.new_password,
-  newPasswordConfirm: fieldErrors.new_password_check,
-});
-
-const toFavoriteGamePreview = (
-  game: LikedGameItemResponse,
-): FavoriteGamePreview => {
-  const normalizedGenres = game.genres.filter((genre) => genre.trim());
-
-  return {
-    gameId: game.game_id,
-    title: game.game_title.trim() || 'N/A',
-    summary: normalizedGenres.length > 0 ? normalizedGenres.join(', ') : 'N/A',
-    thumbnailUrl: game.thumbnail_url,
-    genres: normalizedGenres,
-  };
-};
-
-const toFavoriteGameListItem = (game: FavoriteGamePreview): GameListItem => ({
-  gameId: game.gameId,
-  name: game.title,
-  genres: game.genres.length > 0 ? game.genres : ['N/A'],
-  thumbnailUrl: game.thumbnailUrl,
-  rating: null,
-  isLiked: true,
-});
-
-const toGenderLabel = (gender?: AuthGender) => {
-  if (gender === 'M') {
-    return '남성';
-  }
-
-  if (gender === 'W') {
-    return '여성';
-  }
-
-  return 'N/A';
-};
+const unauthorizedFallback = (
+  <Navigate
+    to={`/${ROUTES.LOGIN}`}
+    replace
+    state={{ noticeMessage: '로그인 후 마이페이지를 이용할 수 있습니다.' }}
+  />
+);
 
 function MyPage() {
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const { canAccessAuthenticatedRoute, isAuthReady } = useAuthGuardState();
+  const authGate = useAuthGate();
   const { logout, isPending: isLogoutPending } = useLogoutAction();
-  const changePasswordMutation = useChangePasswordMutation();
-  const deleteAccountMutation = useDeleteAccountMutation();
-  const updateUserInfoMutation = useUpdateUserInfoMutation();
-  const unlikeLikedGameMutation = useUnlikeLikedGameMutation();
-  const profileImagePresignedUrlMutation =
-    useProfileImagePresignedUrlMutation();
-  const uploadFileToS3Mutation = useUploadFileToS3Mutation();
-  const confirmProfileImageMutation = useConfirmProfileImageMutation();
-  const profileQuery = useCurrentUserProfileQuery(canAccessAuthenticatedRoute);
-  const likedGamesQuery = useLikedGamesInfiniteQuery(
-    canAccessAuthenticatedRoute,
-    DEFAULT_LIKED_GAMES_PAGE_SIZE,
-  );
-  const storedAccount = useAuthStore((state) => state.account);
-
-  const [isPasswordPanelOpen, setIsPasswordPanelOpen] = useState(false);
-  const [passwordValues, setPasswordValues] = useState<PasswordChangeValues>(
-    initialPasswordValues,
-  );
-  const [touchedState, setTouchedState] =
-    useState<PasswordTouchedState>(initialTouchedState);
-  const [apiFieldErrors, setApiFieldErrors] = useState<PasswordFieldErrors>({});
-  const [toast, setToast] = useState<ToastState>(null);
-  const [passwordPanelMessage, setPasswordPanelMessage] =
-    useState<PasswordPanelMessage>(null);
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [deletePassword, setDeletePassword] = useState('');
-  const [deletePasswordError, setDeletePasswordError] = useState('');
-  const [selectedFavoriteGame, setSelectedFavoriteGame] =
-    useState<FavoriteGamePreview | null>(null);
+  const [toast, setToast] = useState<MyPageToast>(null);
   const [selectedDetailGame, setSelectedDetailGame] =
     useState<GameListItem | null>(null);
-  const favoriteGamesScrollRef = useRef<HTMLDivElement | null>(null);
-  const favoriteGamesLoadMoreRef = useRef<HTMLDivElement | null>(null);
-
-  const localFieldErrors = useMemo(
-    () => getPasswordFieldErrors(passwordValues, touchedState),
-    [passwordValues, touchedState],
-  );
-
-  const resolvedFieldErrors: Record<PasswordChangeFieldName, string> = {
-    currentPassword:
-      apiFieldErrors.currentPassword ?? localFieldErrors.currentPassword,
-    newPassword: apiFieldErrors.newPassword ?? localFieldErrors.newPassword,
-    newPasswordConfirm:
-      apiFieldErrors.newPasswordConfirm ?? localFieldErrors.newPasswordConfirm,
-  };
-  const likedGameResults = useMemo(() => {
-    const pages = likedGamesQuery.data?.pages ?? [];
-
-    return pages.flatMap((page) => page.results);
-  }, [likedGamesQuery.data]);
-
-  const favoriteGames = useMemo(() => {
-    const deduplicatedGames = new Map<number, LikedGameItemResponse>();
-
-    likedGameResults.forEach((game) => {
-      deduplicatedGames.set(game.game_id, game);
-    });
-
-    return [...deduplicatedGames.values()].map(toFavoriteGamePreview);
-  }, [likedGameResults]);
-  const hasFavoriteGamesNextPage = Boolean(likedGamesQuery.hasNextPage);
-  const isFavoriteGamesFetchNextPageError =
-    likedGamesQuery.isFetchNextPageError;
-  const isFavoriteGamesFetchingNextPage = likedGamesQuery.isFetchingNextPage;
-  const fetchNextFavoriteGamesPage = likedGamesQuery.fetchNextPage;
-
-  useEffect(() => {
-    if (!toast) {
-      return undefined;
-    }
-
-    const timeout = window.setTimeout(() => {
-      setToast(null);
-    }, 3000);
-
-    return () => {
-      window.clearTimeout(timeout);
-    };
-  }, [toast]);
-
-  useEffect(() => {
-    if (profileQuery.data) {
-      setAuthAccount(profileQuery.data);
-    }
-  }, [profileQuery.data]);
-
-  useEffect(() => {
-    if (!isPasswordPanelOpen || passwordPanelMessage?.tone !== 'success') {
-      return undefined;
-    }
-
-    const timeout = window.setTimeout(() => {
-      setIsPasswordPanelOpen(false);
-      setPasswordValues(initialPasswordValues);
-      setTouchedState(initialTouchedState);
-      setApiFieldErrors({});
-      setPasswordPanelMessage(null);
-    }, 2000);
-
-    return () => {
-      window.clearTimeout(timeout);
-    };
-  }, [isPasswordPanelOpen, passwordPanelMessage]);
-
-  useEffect(() => {
-    if (isFavoriteGamesFetchNextPageError || !hasFavoriteGamesNextPage) {
-      return undefined;
-    }
-
-    const rootElement = favoriteGamesScrollRef.current;
-    const targetElement = favoriteGamesLoadMoreRef.current;
-
-    if (!rootElement || !targetElement) {
-      return undefined;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const [entry] = entries;
-
-        if (!entry?.isIntersecting || isFavoriteGamesFetchingNextPage) {
-          return;
-        }
-
-        void fetchNextFavoriteGamesPage();
-      },
-      {
-        root: rootElement,
-        rootMargin: '0px 0px 160px 0px',
-        threshold: 0.1,
-      },
-    );
-
-    observer.observe(targetElement);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [
-    favoriteGames.length,
-    fetchNextFavoriteGamesPage,
-    hasFavoriteGamesNextPage,
-    isFavoriteGamesFetchNextPageError,
-    isFavoriteGamesFetchingNextPage,
-  ]);
-
-  if (!isAuthReady) {
-    return (
-      <div className="relative min-h-screen overflow-hidden bg-[#050505]">
-        <Header fixed />
-        <main className="mx-auto flex min-h-screen w-full max-w-[1240px] px-4 pt-[6.1rem] pb-12 sm:px-6 md:px-8 md:pt-[6.4rem]">
-          <section className="survey-panel mx-auto w-full max-w-[920px] px-8 py-12 text-center text-white/68">
-            인증 상태를 확인하는 중입니다...
-          </section>
-        </main>
-      </div>
-    );
-  }
-
-  if (!canAccessAuthenticatedRoute) {
-    return (
-      <Navigate
-        to={`/${ROUTES.LOGIN}`}
-        replace
-        state={{ noticeMessage: '로그인 후 마이페이지를 이용할 수 있습니다.' }}
-      />
-    );
-  }
-
-  const favoriteCount =
-    likedGamesQuery.data?.pages?.[0]?.count ?? favoriteGames.length;
-  const resolvedProfile = profileQuery.data ?? storedAccount;
-  const isProfileLoading = profileQuery.isLoading && !resolvedProfile;
-  const isFavoriteGamesLoading =
-    likedGamesQuery.isLoading && !favoriteGames.length;
-  const isFavoriteGamesError = likedGamesQuery.isError && !favoriteGames.length;
-  const profileName = resolvedProfile?.name || 'N/A';
-  const profileEmail = resolvedProfile?.email || null;
-  const profileGenderLabel = toGenderLabel(resolvedProfile?.gender);
-  const profileImageUrl = resolvedProfile?.profile_img_url ?? null;
-  const isProfileImageUploading =
-    profileImagePresignedUrlMutation.isPending ||
-    uploadFileToS3Mutation.isPending ||
-    confirmProfileImageMutation.isPending;
-
-  const resetPasswordPanel = () => {
-    setPasswordValues(initialPasswordValues);
-    setTouchedState(initialTouchedState);
-    setApiFieldErrors({});
-    setPasswordPanelMessage(null);
-  };
-
-  const closePasswordPanel = () => {
-    setIsPasswordPanelOpen(false);
-    resetPasswordPanel();
-  };
-
-  const handlePasswordValueChange = (
-    fieldName: PasswordChangeFieldName,
-    value: string,
-  ) => {
-    setPasswordValues((previous) => ({
-      ...previous,
-      [fieldName]: value,
-    }));
-
-    setApiFieldErrors((previous) => {
-      if (!previous[fieldName]) {
-        return previous;
-      }
-
-      return {
-        ...previous,
-        [fieldName]: '',
-      };
-    });
-
-    setPasswordPanelMessage(null);
-  };
-
-  const handlePasswordBlur = (fieldName: PasswordChangeFieldName) => {
-    setTouchedState((previous) => ({
-      ...previous,
-      [fieldName]: true,
-    }));
-  };
-
-  const handlePasswordSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    const nextTouchedState = {
-      currentPassword: true,
-      newPassword: true,
-      newPasswordConfirm: true,
-    } satisfies PasswordTouchedState;
-
-    setTouchedState(nextTouchedState);
-    setApiFieldErrors({});
-    setPasswordPanelMessage(null);
-
-    const nextFieldErrors = getPasswordFieldErrors(
-      passwordValues,
-      nextTouchedState,
-    );
-    const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
-
-    if (hasLocalError) {
-      return;
-    }
-
-    try {
-      const response = await changePasswordMutation.mutateAsync({
-        old_password: passwordValues.currentPassword.trim(),
-        new_password: passwordValues.newPassword.trim(),
-        new_password_check: passwordValues.newPasswordConfirm.trim(),
-      });
-
-      setPasswordValues(initialPasswordValues);
-      setTouchedState(initialTouchedState);
-      setApiFieldErrors({});
-      setPasswordPanelMessage({
-        tone: 'success',
-        message: response.detail,
-      });
-    } catch (error) {
-      const nextApiFieldErrors = mapPasswordApiFieldErrors(
-        extractAuthApiFieldErrors(error),
-      );
-
-      if (Object.values(nextApiFieldErrors).some(Boolean)) {
-        setApiFieldErrors(nextApiFieldErrors);
-        return;
-      }
-
-      setPasswordPanelMessage({
-        tone: 'error',
-        message: extractAuthApiErrorMessage(error),
-      });
-    }
-  };
-
-  const handleDeleteAccount = async () => {
-    const trimmedPassword = deletePassword.trim();
-
-    if (!trimmedPassword) {
-      setDeletePasswordError('현재 비밀번호를 입력해주세요.');
-      return;
-    }
-
-    try {
-      await deleteAccountMutation.mutateAsync({
-        password: trimmedPassword,
-      });
-
-      clearAuthTokens();
-      navigate(`/${ROUTES.LOGIN}`, {
-        replace: true,
-        state: {
-          noticeMessage: '회원 탈퇴가 완료되었습니다.',
-        },
-      });
-    } catch (error) {
-      const fieldErrors = extractAuthApiFieldErrors(error);
-
-      if (fieldErrors.password) {
-        setDeletePasswordError(fieldErrors.password);
-        return;
-      }
-
-      const errorMessage = extractAuthApiErrorMessage(error);
-
-      if (errorMessage.includes('비밀번호')) {
-        setDeletePasswordError(errorMessage);
-        return;
-      }
-
-      setToast({
-        tone: 'error',
-        message: errorMessage,
-      });
-    }
-  };
-
-  const handleProfileImageSelect = async (file: File | null) => {
-    if (!file) {
-      return;
-    }
-
-    if (!file.type.startsWith('image/')) {
-      setToast({
-        tone: 'error',
-        message: '이미지 파일만 업로드할 수 있습니다.',
-      });
-      return;
-    }
-
-    const previousProfile =
-      queryClient.getQueryData<CurrentUserProfileResponse>(authKeys.me()) ??
-      resolvedProfile ??
-      null;
-    let hasOptimisticProfileUpdate = false;
-
-    try {
-      const presignedResponse =
-        await profileImagePresignedUrlMutation.mutateAsync({
-          file_name: file.name,
-          content_type: file.type || 'application/octet-stream',
-        });
-
-      await uploadFileToS3Mutation.mutateAsync({
-        presigned_url: presignedResponse.presigned_url,
-        file,
-        content_type: file.type || 'application/octet-stream',
-      });
-
-      queryClient.setQueryData<CurrentUserProfileResponse>(
-        authKeys.me(),
-        (currentProfile) =>
-          currentProfile
-            ? {
-                ...currentProfile,
-                profile_img_url: presignedResponse.img_url,
-              }
-            : currentProfile,
-      );
-
-      if (previousProfile) {
-        setAuthAccount({
-          ...previousProfile,
-          profile_img_url: presignedResponse.img_url,
-        });
-      }
-
-      hasOptimisticProfileUpdate = true;
-
-      const confirmResponse = await confirmProfileImageMutation.mutateAsync({
-        profile_img_url: presignedResponse.img_url,
-      });
-      const confirmedProfileImageUrl =
-        confirmResponse.profile_img_url ?? presignedResponse.img_url;
-
-      queryClient.setQueryData<CurrentUserProfileResponse>(
-        authKeys.me(),
-        (currentProfile) =>
-          currentProfile
-            ? {
-                ...currentProfile,
-                profile_img_url: confirmedProfileImageUrl,
-              }
-            : currentProfile,
-      );
-
-      if (previousProfile) {
-        setAuthAccount({
-          ...previousProfile,
-          profile_img_url: confirmedProfileImageUrl,
-        });
-      }
-
-      void queryClient.invalidateQueries({ queryKey: authKeys.me() });
-      setToast({
-        tone: 'success',
-        message: '프로필이 변경되었습니다.',
-      });
-    } catch (error) {
-      if (hasOptimisticProfileUpdate && previousProfile) {
-        queryClient.setQueryData<CurrentUserProfileResponse>(
-          authKeys.me(),
-          previousProfile,
-        );
-        setAuthAccount(previousProfile);
-        void queryClient.invalidateQueries({ queryKey: authKeys.me() });
-      }
-
-      setToast({
-        tone: 'error',
-        message: extractAuthApiErrorMessage(error),
-      });
-    }
-  };
-
-  const handleNicknameSave = async (nextNickname: string) => {
-    try {
-      await updateUserInfoMutation.mutateAsync({
-        nickname: nextNickname,
-      });
-      setToast({
-        tone: 'success',
-        message: '프로필이 변경되었습니다.',
-      });
-
-      return true;
-    } catch (error) {
-      const fieldErrors = extractAuthApiFieldErrors(error);
-      const nicknameErrorMessage =
-        fieldErrors.nickname || extractAuthApiErrorMessage(error);
-
-      setToast({
-        tone: 'error',
-        message: nicknameErrorMessage,
-      });
-
-      return false;
-    }
-  };
-
-  const handleFavoriteGameCardClick = (game: FavoriteGamePreview) => {
-    setSelectedDetailGame(toFavoriteGameListItem(game));
-  };
-
-  const handleFavoriteGameDeleteConfirm = async () => {
-    if (!selectedFavoriteGame) {
-      return;
-    }
-
-    try {
-      const response = await unlikeLikedGameMutation.mutateAsync(
-        selectedFavoriteGame.gameId,
-      );
-
-      setSelectedFavoriteGame(null);
-      setToast({
-        tone: 'success',
-        message: response.detail || '찜한 게임이 목록에서 삭제되었습니다.',
-      });
-    } catch (error) {
-      setToast({
-        tone: 'error',
-        message: extractAuthApiErrorMessage(error),
-      });
-    }
-  };
+  const myPageProfile = useMyPageProfile({
+    enabled: authGate.canAccessAuthenticatedRoute,
+    onToast: setToast,
+  });
+  const myPageSecurity = useMyPageSecurity({
+    onToast: setToast,
+  });
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
-      <div className="app-aurora pointer-events-none absolute inset-0 opacity-70" />
-      <Header fixed />
+    <AuthWrapper
+      gate={authGate}
+      loadingFallback={loadingFallback}
+      unauthorizedFallback={unauthorizedFallback}
+    >
+      <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+        <div className="app-aurora pointer-events-none absolute inset-0 opacity-70" />
+        <Header fixed />
 
-      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-4 pt-24 pb-14 sm:px-6 sm:pt-28 sm:pb-16 lg:px-10 lg:pt-32 xl:px-14">
-        <MyPageProfileSection
-          nickname={resolvedProfile?.nickname ?? '회원'}
-          name={profileName}
-          email={profileEmail}
-          genderLabel={profileGenderLabel}
-          profileImageUrl={profileImageUrl}
-          isProfileLoading={isProfileLoading}
-          isProfileImageUploading={isProfileImageUploading}
-          isProfileUpdating={updateUserInfoMutation.isPending}
-          isLoggingOut={isLogoutPending}
-          isPasswordPanelOpen={isPasswordPanelOpen}
-          onPasswordToggle={() => setIsPasswordPanelOpen((current) => !current)}
-          onLogout={() => {
-            void logout();
-          }}
-          onNicknameSave={handleNicknameSave}
-          onProfileImageSelect={(file) => {
-            void handleProfileImageSelect(file);
-          }}
-        >
-          {isPasswordPanelOpen ? (
-            <PasswordChangePanel
-              values={passwordValues}
-              errors={resolvedFieldErrors}
-              message={passwordPanelMessage?.message}
-              messageTone={passwordPanelMessage?.tone ?? 'error'}
-              isPending={changePasswordMutation.isPending}
-              onValueChange={handlePasswordValueChange}
-              onFieldBlur={handlePasswordBlur}
-              onCancel={closePasswordPanel}
-              onSubmit={handlePasswordSubmit}
-            />
-          ) : null}
-        </MyPageProfileSection>
-
-        <section className="bg-mypage-panel border-mypage-panel shadow-mypage-float mt-8 rounded-[28px] border px-4 py-5 backdrop-blur-xl sm:mt-10 sm:px-6 sm:py-6">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-3">
-              <span className="bg-mypage-accent-soft text-login-primary inline-flex h-11 w-11 items-center justify-center rounded-full">
-                <Heart size={18} fill="currentColor" />
-              </span>
-              <div>
-                <h2 className="text-2xl font-semibold text-white">찜한 목록</h2>
-                <p className="text-mypage-muted mt-1 text-sm/6">
-                  내가 저장한 게임들을 한눈에 다시 확인할 수 있어요.
-                </p>
-              </div>
-            </div>
-            <p className="text-mypage-muted text-sm">
-              {isFavoriteGamesLoading
-                ? '찜 목록을 불러오는 중입니다.'
-                : favoriteCount > 0
-                  ? `총 ${favoriteCount}개의 게임이 저장되어 있어요`
-                  : '아직 저장된 게임이 없어요'}
-            </p>
-          </div>
-
-          <div
-            ref={favoriteGamesScrollRef}
-            className="mypage-scrollbar mt-5 h-[23rem] overflow-y-auto pr-1 sm:h-[25rem] lg:h-[25rem]"
-          >
-            {isFavoriteGamesLoading ? (
-              <FavoriteGameCardSkeleton />
-            ) : favoriteCount > 0 ? (
-              <div>
-                <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 2xl:grid-cols-4">
-                  {favoriteGames.map((game) => (
-                    <FavoriteGameCard
-                      key={game.gameId}
-                      game={game}
-                      onClick={handleFavoriteGameCardClick}
-                      onFavoriteClick={setSelectedFavoriteGame}
-                    />
-                  ))}
-                </div>
-                <div className="mt-5 flex flex-col items-center gap-2">
-                  <div
-                    ref={favoriteGamesLoadMoreRef}
-                    aria-hidden="true"
-                    className="h-0.5 w-full"
-                  />
-                  {likedGamesQuery.isFetchNextPageError ? (
-                    <>
-                      <p className="text-sm text-red-300">
-                        추가 찜 목록을 불러오지 못했습니다.
-                      </p>
-                      <AuthButton
-                        type="button"
-                        variant="secondary"
-                        className="w-full max-w-40"
-                        onClick={() => void likedGamesQuery.fetchNextPage()}
-                        disabled={likedGamesQuery.isFetchingNextPage}
-                      >
-                        {likedGamesQuery.isFetchingNextPage
-                          ? '다시 불러오는 중...'
-                          : '다시 시도'}
-                      </AuthButton>
-                    </>
-                  ) : likedGamesQuery.isFetchingNextPage ? (
-                    <p className="text-mypage-muted text-sm">
-                      찜 목록을 더 불러오는 중입니다...
-                    </p>
-                  ) : hasFavoriteGamesNextPage ? (
-                    <p className="text-mypage-muted text-sm">
-                      아래로 스크롤하면 찜 목록을 더 볼 수 있어요.
-                    </p>
-                  ) : null}
-                </div>
-              </div>
-            ) : isFavoriteGamesError ? (
-              <div
-                role="status"
-                aria-live="polite"
-                className="border-mypage-divider bg-mypage-card flex min-h-56 flex-col items-center justify-center gap-4 rounded-[24px] border border-dashed px-6 py-10 text-center"
-              >
-                <p className="text-sm text-red-300">
-                  찜 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
-                </p>
-                <AuthButton
-                  type="button"
-                  variant="secondary"
-                  className="w-full max-w-36"
-                  onClick={() => void likedGamesQuery.refetch()}
-                  disabled={
-                    likedGamesQuery.isFetching ||
-                    likedGamesQuery.isFetchingNextPage
-                  }
-                >
-                  {likedGamesQuery.isFetching ||
-                  likedGamesQuery.isFetchingNextPage
-                    ? '다시 불러오는 중...'
-                    : '다시 시도'}
-                </AuthButton>
-              </div>
-            ) : (
-              <FavoriteGamesEmptyState />
-            )}
-          </div>
-        </section>
-
-        <section className="mt-8 flex flex-col items-center justify-center gap-3 pb-2 text-center">
-          <div className="text-mypage-muted flex items-center gap-2 text-sm/6">
-            <ShieldAlert size={16} />
-            <span>
-              더 이상 서비스를 이용하지 않으려면 회원탈퇴를 진행할 수 있습니다.
-            </span>
-          </div>
-          <AuthButton
-            type="button"
-            variant="secondary"
-            className="border-mypage-divider text-mypage-muted w-full max-w-44 hover:text-white"
-            onClick={() => {
-              setDeletePassword('');
-              setDeletePasswordError('');
-              setIsDeleteModalOpen(true);
+        <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-4 pt-24 pb-14 sm:px-6 sm:pt-28 sm:pb-16 lg:px-10 lg:pt-32 xl:px-14">
+          <MyPageProfileContainer
+            nickname={myPageProfile.profileNickname}
+            name={myPageProfile.profileName}
+            email={myPageProfile.profileEmail}
+            genderLabel={myPageProfile.profileGenderLabel}
+            profileImageUrl={myPageProfile.profileImageUrl}
+            isProfileLoading={myPageProfile.isProfileLoading}
+            isProfileImageUploading={myPageProfile.isProfileImageUploading}
+            isProfileUpdating={myPageProfile.isProfileUpdating}
+            isLoggingOut={isLogoutPending}
+            onLogout={() => {
+              void logout();
             }}
-          >
-            회원탈퇴
-          </AuthButton>
-        </section>
-      </main>
+            onNicknameSave={myPageProfile.handleNicknameSave}
+            onProfileImageSelect={myPageProfile.handleProfileImageSelect}
+            isPasswordPanelOpen={myPageSecurity.isPasswordPanelOpen}
+            onPasswordToggle={myPageSecurity.togglePasswordPanel}
+            passwordValues={myPageSecurity.passwordValues}
+            passwordErrors={myPageSecurity.resolvedPasswordErrors}
+            passwordPanelMessage={myPageSecurity.passwordPanelMessage?.message}
+            passwordPanelMessageTone={
+              myPageSecurity.passwordPanelMessage?.tone ?? 'error'
+            }
+            isPasswordChangePending={myPageSecurity.isChangePasswordPending}
+            onPasswordValueChange={myPageSecurity.handlePasswordValueChange}
+            onPasswordBlur={myPageSecurity.handlePasswordBlur}
+            onPasswordCancel={myPageSecurity.closePasswordPanel}
+            onPasswordSubmit={myPageSecurity.handlePasswordSubmit}
+          />
 
-      {toast ? (
-        <ToastMessage
-          message={toast.message}
-          tone={toast.tone}
-          onClose={() => setToast(null)}
-          variant="fixedCenter"
-        />
-      ) : null}
+          <MyPageLikedGamesSection
+            enabled={authGate.canAccessAuthenticatedRoute}
+            onOpenGameDetail={setSelectedDetailGame}
+            onToast={setToast}
+          />
 
-      <ConfirmModal
-        open={isDeleteModalOpen}
-        title="회원탈퇴 하시겠습니까?"
-        description={
-          <div className="space-y-3">
-            <p>
-              탈퇴를 진행하면 현재 로그인 세션이 종료되고, 로그인 화면으로
-              이동합니다.
-            </p>
-            <div className="space-y-2">
-              <label
-                htmlFor="delete-account-password"
-                className="block text-sm font-medium text-white"
-              >
-                현재 비밀번호
-              </label>
-              <InputControl
-                id="delete-account-password"
-                type="password"
-                autoComplete="current-password"
-                value={deletePassword}
-                onChange={(event) => {
-                  setDeletePassword(event.target.value);
+          <MyPageAccountDangerZone
+            isDeleteModalOpen={myPageSecurity.isDeleteModalOpen}
+            deletePassword={myPageSecurity.deletePassword}
+            deletePasswordError={myPageSecurity.deletePasswordError}
+            isDeletePending={myPageSecurity.isDeleteAccountPending}
+            onOpenDeleteModal={myPageSecurity.openDeleteModal}
+            onCloseDeleteModal={myPageSecurity.closeDeleteModal}
+            onDeletePasswordChange={myPageSecurity.handleDeletePasswordChange}
+            onConfirmDeleteAccount={myPageSecurity.handleDeleteAccount}
+          />
+        </main>
 
-                  if (deletePasswordError) {
-                    setDeletePasswordError('');
-                  }
-                }}
-                hasError={Boolean(deletePasswordError)}
-                className="h-12"
-                placeholder="현재 비밀번호를 입력하세요"
-              />
-              {deletePasswordError ? (
-                <p className="pl-1 text-sm/5 font-medium text-red-400">
-                  {deletePasswordError}
-                </p>
-              ) : null}
-            </div>
-          </div>
-        }
-        confirmLabel="회원탈퇴"
-        isPending={deleteAccountMutation.isPending}
-        onClose={() => {
-          setIsDeleteModalOpen(false);
-          setDeletePassword('');
-          setDeletePasswordError('');
-        }}
-        onConfirm={() => {
-          void handleDeleteAccount();
-        }}
-      />
-      <ConfirmModal
-        open={Boolean(selectedFavoriteGame)}
-        title="찜한 게임을 삭제할까요?"
-        description={`'${selectedFavoriteGame?.title ?? ''}'을(를) 찜한 목록에서 삭제하시겠습니까?`}
-        confirmLabel="예"
-        cancelLabel="아니오"
-        isPending={unlikeLikedGameMutation.isPending}
-        onClose={() => setSelectedFavoriteGame(null)}
-        onConfirm={() => {
-          void handleFavoriteGameDeleteConfirm();
-        }}
-      />
-      {selectedDetailGame ? (
-        <GameDetailModal
-          key={selectedDetailGame.gameId}
-          game={selectedDetailGame}
-          onClose={() => setSelectedDetailGame(null)}
-        />
-      ) : null}
-    </div>
+        {toast ? (
+          <ToastMessage
+            message={toast.message}
+            tone={toast.tone}
+            onClose={() => setToast(null)}
+            variant="fixedCenter"
+          />
+        ) : null}
+
+        {selectedDetailGame ? (
+          <GameDetailModal
+            key={selectedDetailGame.gameId}
+            game={selectedDetailGame}
+            onClose={() => setSelectedDetailGame(null)}
+          />
+        ) : null}
+      </div>
+    </AuthWrapper>
   );
 }
 

--- a/src/pages/mypage/components/MyPageAccountDangerZone.tsx
+++ b/src/pages/mypage/components/MyPageAccountDangerZone.tsx
@@ -1,0 +1,94 @@
+import { ShieldAlert } from 'lucide-react';
+
+import AuthButton from '../../../components/auth/AuthButton';
+import InputControl from '../../../components/common/InputControl';
+import ConfirmModal from '../../../components/mypage/ConfirmModal';
+
+type MyPageAccountDangerZoneProps = {
+  isDeleteModalOpen: boolean;
+  deletePassword: string;
+  deletePasswordError: string;
+  isDeletePending: boolean;
+  onOpenDeleteModal: () => void;
+  onCloseDeleteModal: () => void;
+  onDeletePasswordChange: (value: string) => void;
+  onConfirmDeleteAccount: () => Promise<void>;
+};
+
+function MyPageAccountDangerZone({
+  isDeleteModalOpen,
+  deletePassword,
+  deletePasswordError,
+  isDeletePending,
+  onOpenDeleteModal,
+  onCloseDeleteModal,
+  onDeletePasswordChange,
+  onConfirmDeleteAccount,
+}: MyPageAccountDangerZoneProps) {
+  return (
+    <>
+      <section className="mt-8 flex flex-col items-center justify-center gap-3 pb-2 text-center">
+        <div className="text-mypage-muted flex items-center gap-2 text-sm/6">
+          <ShieldAlert size={16} />
+          <span>
+            더 이상 서비스를 이용하지 않으려면 회원탈퇴를 진행할 수 있습니다.
+          </span>
+        </div>
+        <AuthButton
+          type="button"
+          variant="secondary"
+          className="border-mypage-divider text-mypage-muted w-full max-w-44 hover:text-white"
+          onClick={onOpenDeleteModal}
+        >
+          회원탈퇴
+        </AuthButton>
+      </section>
+
+      <ConfirmModal
+        open={isDeleteModalOpen}
+        title="회원탈퇴 하시겠습니까?"
+        description={
+          <div className="space-y-3">
+            <p>
+              탈퇴를 진행하면 현재 로그인 세션이 종료되고, 로그인 화면으로
+              이동합니다.
+            </p>
+            <div className="space-y-2">
+              <label
+                htmlFor="delete-account-password"
+                className="block text-sm font-medium text-white"
+              >
+                현재 비밀번호
+              </label>
+              <InputControl
+                id="delete-account-password"
+                type="password"
+                autoComplete="current-password"
+                value={deletePassword}
+                onChange={(event) => {
+                  onDeletePasswordChange(event.target.value);
+                }}
+                hasError={Boolean(deletePasswordError)}
+                className="h-12"
+                placeholder="현재 비밀번호를 입력하세요"
+              />
+              {deletePasswordError ? (
+                <p className="pl-1 text-sm/5 font-medium text-red-400">
+                  {deletePasswordError}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        }
+        confirmLabel="회원탈퇴"
+        isPending={isDeletePending}
+        onClose={onCloseDeleteModal}
+        onConfirm={() => {
+          void onConfirmDeleteAccount();
+        }}
+      />
+    </>
+  );
+}
+
+export default MyPageAccountDangerZone;

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -1,0 +1,258 @@
+import { Heart } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import AuthButton from '../../../components/auth/AuthButton';
+import ConfirmModal from '../../../components/mypage/ConfirmModal';
+import FavoriteGameCard from '../../../components/mypage/FavoriteGameCard';
+import FavoriteGameCardSkeleton from '../../../components/mypage/FavoriteGameCardSkeleton';
+import FavoriteGamesEmptyState from '../../../components/mypage/FavoriteGamesEmptyState';
+import { extractAuthApiErrorMessage } from '../../../features/auth/api/auth';
+import {
+  DEFAULT_LIKED_GAMES_PAGE_SIZE,
+  useLikedGamesInfiniteQuery,
+  useUnlikeLikedGameMutation,
+} from '../../../features/auth/api/useAuthApi';
+import type { GameListItem } from '../../../features/games/types';
+import type { FavoriteGamePreview } from '../../../features/mypage/types';
+import type { LikedGameItemResponse } from '../../../features/auth/types/auth';
+import type { MyPageToastPayload } from '../types';
+import { toFavoriteGameListItem, toFavoriteGamePreview } from '../utils';
+
+type MyPageLikedGamesSectionProps = {
+  enabled: boolean;
+  onOpenGameDetail: (game: GameListItem) => void;
+  onToast: (toast: MyPageToastPayload) => void;
+};
+
+function MyPageLikedGamesSection({
+  enabled,
+  onOpenGameDetail,
+  onToast,
+}: MyPageLikedGamesSectionProps) {
+  const likedGamesQuery = useLikedGamesInfiniteQuery(
+    enabled,
+    DEFAULT_LIKED_GAMES_PAGE_SIZE,
+  );
+  const unlikeLikedGameMutation = useUnlikeLikedGameMutation();
+  const [selectedFavoriteGame, setSelectedFavoriteGame] =
+    useState<FavoriteGamePreview | null>(null);
+  const favoriteGamesScrollRef = useRef<HTMLDivElement | null>(null);
+  const favoriteGamesLoadMoreRef = useRef<HTMLDivElement | null>(null);
+  const likedGameResults = useMemo(() => {
+    const pages = likedGamesQuery.data?.pages ?? [];
+
+    return pages.flatMap((page) => page.results);
+  }, [likedGamesQuery.data]);
+  const favoriteGames = useMemo(() => {
+    const deduplicatedGames = new Map<number, LikedGameItemResponse>();
+
+    likedGameResults.forEach((game) => {
+      deduplicatedGames.set(game.game_id, game);
+    });
+
+    return [...deduplicatedGames.values()].map(toFavoriteGamePreview);
+  }, [likedGameResults]);
+  const hasFavoriteGamesNextPage = Boolean(likedGamesQuery.hasNextPage);
+  const isFavoriteGamesFetchNextPageError =
+    likedGamesQuery.isFetchNextPageError;
+  const isFavoriteGamesFetchingNextPage = likedGamesQuery.isFetchingNextPage;
+  const fetchNextFavoriteGamesPage = likedGamesQuery.fetchNextPage;
+  const favoriteCount =
+    likedGamesQuery.data?.pages?.[0]?.count ?? favoriteGames.length;
+  const isFavoriteGamesLoading =
+    likedGamesQuery.isLoading && !favoriteGames.length;
+  const isFavoriteGamesError = likedGamesQuery.isError && !favoriteGames.length;
+
+  useEffect(() => {
+    if (isFavoriteGamesFetchNextPageError || !hasFavoriteGamesNextPage) {
+      return undefined;
+    }
+
+    const rootElement = favoriteGamesScrollRef.current;
+    const targetElement = favoriteGamesLoadMoreRef.current;
+
+    if (!rootElement || !targetElement) {
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+
+        if (!entry?.isIntersecting || isFavoriteGamesFetchingNextPage) {
+          return;
+        }
+
+        void fetchNextFavoriteGamesPage();
+      },
+      {
+        root: rootElement,
+        rootMargin: '0px 0px 160px 0px',
+        threshold: 0.1,
+      },
+    );
+
+    observer.observe(targetElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    favoriteGames.length,
+    fetchNextFavoriteGamesPage,
+    hasFavoriteGamesNextPage,
+    isFavoriteGamesFetchNextPageError,
+    isFavoriteGamesFetchingNextPage,
+  ]);
+
+  const handleFavoriteGameCardClick = (game: FavoriteGamePreview) => {
+    onOpenGameDetail(toFavoriteGameListItem(game));
+  };
+
+  const handleFavoriteGameDeleteConfirm = async () => {
+    if (!selectedFavoriteGame) {
+      return;
+    }
+
+    try {
+      const response = await unlikeLikedGameMutation.mutateAsync(
+        selectedFavoriteGame.gameId,
+      );
+
+      setSelectedFavoriteGame(null);
+      onToast({
+        tone: 'success',
+        message: response.detail || '찜한 게임이 목록에서 삭제되었습니다.',
+      });
+    } catch (error) {
+      onToast({
+        tone: 'error',
+        message: extractAuthApiErrorMessage(error),
+      });
+    }
+  };
+
+  return (
+    <>
+      <section className="bg-mypage-panel border-mypage-panel shadow-mypage-float mt-8 rounded-[28px] border px-4 py-5 backdrop-blur-xl sm:mt-10 sm:px-6 sm:py-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <span className="bg-mypage-accent-soft text-login-primary inline-flex h-11 w-11 items-center justify-center rounded-full">
+              <Heart size={18} fill="currentColor" />
+            </span>
+            <div>
+              <h2 className="text-2xl font-semibold text-white">찜한 목록</h2>
+              <p className="text-mypage-muted mt-1 text-sm/6">
+                내가 저장한 게임들을 한눈에 다시 확인할 수 있어요.
+              </p>
+            </div>
+          </div>
+          <p className="text-mypage-muted text-sm">
+            {isFavoriteGamesLoading
+              ? '찜 목록을 불러오는 중입니다.'
+              : favoriteCount > 0
+                ? `총 ${favoriteCount}개의 게임이 저장되어 있어요`
+                : '아직 저장된 게임이 없어요'}
+          </p>
+        </div>
+
+        <div
+          ref={favoriteGamesScrollRef}
+          className="mypage-scrollbar mt-5 h-[23rem] overflow-y-auto pr-1 sm:h-[25rem] lg:h-[25rem]"
+        >
+          {isFavoriteGamesLoading ? (
+            <FavoriteGameCardSkeleton />
+          ) : favoriteCount > 0 ? (
+            <div>
+              <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 2xl:grid-cols-4">
+                {favoriteGames.map((game) => (
+                  <FavoriteGameCard
+                    key={game.gameId}
+                    game={game}
+                    onClick={handleFavoriteGameCardClick}
+                    onFavoriteClick={setSelectedFavoriteGame}
+                  />
+                ))}
+              </div>
+              <div className="mt-5 flex flex-col items-center gap-2">
+                <div
+                  ref={favoriteGamesLoadMoreRef}
+                  aria-hidden="true"
+                  className="h-0.5 w-full"
+                />
+                {likedGamesQuery.isFetchNextPageError ? (
+                  <>
+                    <p className="text-sm text-red-300">
+                      추가 찜 목록을 불러오지 못했습니다.
+                    </p>
+                    <AuthButton
+                      type="button"
+                      variant="secondary"
+                      className="w-full max-w-40"
+                      onClick={() => void likedGamesQuery.fetchNextPage()}
+                      disabled={likedGamesQuery.isFetchingNextPage}
+                    >
+                      {likedGamesQuery.isFetchingNextPage
+                        ? '다시 불러오는 중...'
+                        : '다시 시도'}
+                    </AuthButton>
+                  </>
+                ) : likedGamesQuery.isFetchingNextPage ? (
+                  <p className="text-mypage-muted text-sm">
+                    찜 목록을 더 불러오는 중입니다...
+                  </p>
+                ) : hasFavoriteGamesNextPage ? (
+                  <p className="text-mypage-muted text-sm">
+                    아래로 스크롤하면 찜 목록을 더 볼 수 있어요.
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          ) : isFavoriteGamesError ? (
+            <div
+              role="status"
+              aria-live="polite"
+              className="border-mypage-divider bg-mypage-card flex min-h-56 flex-col items-center justify-center gap-4 rounded-[24px] border border-dashed px-6 py-10 text-center"
+            >
+              <p className="text-sm text-red-300">
+                찜 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+              </p>
+              <AuthButton
+                type="button"
+                variant="secondary"
+                className="w-full max-w-36"
+                onClick={() => void likedGamesQuery.refetch()}
+                disabled={
+                  likedGamesQuery.isFetching ||
+                  likedGamesQuery.isFetchingNextPage
+                }
+              >
+                {likedGamesQuery.isFetching ||
+                likedGamesQuery.isFetchingNextPage
+                  ? '다시 불러오는 중...'
+                  : '다시 시도'}
+              </AuthButton>
+            </div>
+          ) : (
+            <FavoriteGamesEmptyState />
+          )}
+        </div>
+      </section>
+
+      <ConfirmModal
+        open={Boolean(selectedFavoriteGame)}
+        title="찜한 게임을 삭제할까요?"
+        description={`'${selectedFavoriteGame?.title ?? ''}'을(를) 찜한 목록에서 삭제하시겠습니까?`}
+        confirmLabel="예"
+        cancelLabel="아니오"
+        isPending={unlikeLikedGameMutation.isPending}
+        onClose={() => setSelectedFavoriteGame(null)}
+        onConfirm={() => {
+          void handleFavoriteGameDeleteConfirm();
+        }}
+      />
+    </>
+  );
+}
+
+export default MyPageLikedGamesSection;

--- a/src/pages/mypage/components/MyPageProfileContainer.tsx
+++ b/src/pages/mypage/components/MyPageProfileContainer.tsx
@@ -1,0 +1,99 @@
+import type { FormEvent } from 'react';
+
+import MyPageProfileSection from '../../../components/mypage/MyPageProfileSection';
+import PasswordChangePanel, {
+  type PasswordChangeFieldName,
+  type PasswordChangeValues,
+} from '../../../components/mypage/PasswordChangePanel';
+
+type MyPageProfileContainerProps = {
+  nickname: string;
+  name: string;
+  email: string | null;
+  genderLabel: string;
+  profileImageUrl?: string | null;
+  isProfileLoading: boolean;
+  isProfileImageUploading: boolean;
+  isProfileUpdating: boolean;
+  isLoggingOut: boolean;
+  onLogout: () => void;
+  onNicknameSave: (nickname: string) => Promise<boolean>;
+  onProfileImageSelect: (file: File | null) => Promise<void>;
+  isPasswordPanelOpen: boolean;
+  onPasswordToggle: () => void;
+  passwordValues: PasswordChangeValues;
+  passwordErrors: Partial<Record<PasswordChangeFieldName, string>>;
+  passwordPanelMessage?: string;
+  passwordPanelMessageTone?: 'success' | 'error';
+  isPasswordChangePending: boolean;
+  onPasswordValueChange: (
+    fieldName: PasswordChangeFieldName,
+    value: string,
+  ) => void;
+  onPasswordBlur: (fieldName: PasswordChangeFieldName) => void;
+  onPasswordCancel: () => void;
+  onPasswordSubmit: (event: FormEvent<HTMLFormElement>) => void;
+};
+
+function MyPageProfileContainer({
+  nickname,
+  name,
+  email,
+  genderLabel,
+  profileImageUrl,
+  isProfileLoading,
+  isProfileImageUploading,
+  isProfileUpdating,
+  isLoggingOut,
+  onLogout,
+  onNicknameSave,
+  onProfileImageSelect,
+  isPasswordPanelOpen,
+  onPasswordToggle,
+  passwordValues,
+  passwordErrors,
+  passwordPanelMessage,
+  passwordPanelMessageTone = 'error',
+  isPasswordChangePending,
+  onPasswordValueChange,
+  onPasswordBlur,
+  onPasswordCancel,
+  onPasswordSubmit,
+}: MyPageProfileContainerProps) {
+  return (
+    <MyPageProfileSection
+      nickname={nickname}
+      name={name}
+      email={email}
+      genderLabel={genderLabel}
+      profileImageUrl={profileImageUrl}
+      isProfileLoading={isProfileLoading}
+      isProfileImageUploading={isProfileImageUploading}
+      isProfileUpdating={isProfileUpdating}
+      isLoggingOut={isLoggingOut}
+      isPasswordPanelOpen={isPasswordPanelOpen}
+      onPasswordToggle={onPasswordToggle}
+      onLogout={onLogout}
+      onNicknameSave={onNicknameSave}
+      onProfileImageSelect={(file) => {
+        void onProfileImageSelect(file);
+      }}
+    >
+      {isPasswordPanelOpen ? (
+        <PasswordChangePanel
+          values={passwordValues}
+          errors={passwordErrors}
+          message={passwordPanelMessage}
+          messageTone={passwordPanelMessageTone}
+          isPending={isPasswordChangePending}
+          onValueChange={onPasswordValueChange}
+          onFieldBlur={onPasswordBlur}
+          onCancel={onPasswordCancel}
+          onSubmit={onPasswordSubmit}
+        />
+      ) : null}
+    </MyPageProfileSection>
+  );
+}
+
+export default MyPageProfileContainer;

--- a/src/pages/mypage/hooks/useMyPageProfile.ts
+++ b/src/pages/mypage/hooks/useMyPageProfile.ts
@@ -1,0 +1,187 @@
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import {
+  extractAuthApiErrorMessage,
+  extractAuthApiFieldErrors,
+} from '../../../features/auth/api/auth';
+import { authKeys } from '../../../features/auth/api/queryKeys';
+import {
+  useConfirmProfileImageMutation,
+  useCurrentUserProfileQuery,
+  useProfileImagePresignedUrlMutation,
+  useUpdateUserInfoMutation,
+  useUploadFileToS3Mutation,
+} from '../../../features/auth/api/useAuthApi';
+import type { CurrentUserProfileResponse } from '../../../features/auth/types/auth';
+import { setAuthAccount } from '../../../utils/auth';
+import { useAuthStore } from '../../../store/useAuthStore';
+import type { MyPageToastPayload } from '../types';
+import { toGenderLabel } from '../utils';
+
+type UseMyPageProfileOptions = {
+  enabled: boolean;
+  onToast: (toast: MyPageToastPayload) => void;
+};
+
+function useMyPageProfile({ enabled, onToast }: UseMyPageProfileOptions) {
+  const queryClient = useQueryClient();
+  const profileQuery = useCurrentUserProfileQuery(enabled);
+  const updateUserInfoMutation = useUpdateUserInfoMutation();
+  const profileImagePresignedUrlMutation =
+    useProfileImagePresignedUrlMutation();
+  const uploadFileToS3Mutation = useUploadFileToS3Mutation();
+  const confirmProfileImageMutation = useConfirmProfileImageMutation();
+  const storedAccount = useAuthStore((state) => state.account);
+  const resolvedProfile = profileQuery.data ?? storedAccount;
+  const isProfileLoading = profileQuery.isLoading && !resolvedProfile;
+  const isProfileImageUploading =
+    profileImagePresignedUrlMutation.isPending ||
+    uploadFileToS3Mutation.isPending ||
+    confirmProfileImageMutation.isPending;
+
+  useEffect(() => {
+    if (profileQuery.data) {
+      setAuthAccount(profileQuery.data);
+    }
+  }, [profileQuery.data]);
+
+  const handleProfileImageSelect = async (file: File | null) => {
+    if (!file) {
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      onToast({
+        tone: 'error',
+        message: '이미지 파일만 업로드할 수 있습니다.',
+      });
+      return;
+    }
+
+    const previousProfile =
+      queryClient.getQueryData<CurrentUserProfileResponse>(authKeys.me()) ??
+      resolvedProfile ??
+      null;
+    let hasOptimisticProfileUpdate = false;
+
+    try {
+      const presignedResponse =
+        await profileImagePresignedUrlMutation.mutateAsync({
+          file_name: file.name,
+          content_type: file.type || 'application/octet-stream',
+        });
+
+      await uploadFileToS3Mutation.mutateAsync({
+        presigned_url: presignedResponse.presigned_url,
+        file,
+        content_type: file.type || 'application/octet-stream',
+      });
+
+      queryClient.setQueryData<CurrentUserProfileResponse>(
+        authKeys.me(),
+        (currentProfile) =>
+          currentProfile
+            ? {
+                ...currentProfile,
+                profile_img_url: presignedResponse.img_url,
+              }
+            : currentProfile,
+      );
+
+      if (previousProfile) {
+        setAuthAccount({
+          ...previousProfile,
+          profile_img_url: presignedResponse.img_url,
+        });
+      }
+
+      hasOptimisticProfileUpdate = true;
+
+      const confirmResponse = await confirmProfileImageMutation.mutateAsync({
+        profile_img_url: presignedResponse.img_url,
+      });
+      const confirmedProfileImageUrl =
+        confirmResponse.profile_img_url ?? presignedResponse.img_url;
+
+      queryClient.setQueryData<CurrentUserProfileResponse>(
+        authKeys.me(),
+        (currentProfile) =>
+          currentProfile
+            ? {
+                ...currentProfile,
+                profile_img_url: confirmedProfileImageUrl,
+              }
+            : currentProfile,
+      );
+
+      if (previousProfile) {
+        setAuthAccount({
+          ...previousProfile,
+          profile_img_url: confirmedProfileImageUrl,
+        });
+      }
+
+      void queryClient.invalidateQueries({ queryKey: authKeys.me() });
+      onToast({
+        tone: 'success',
+        message: '프로필이 변경되었습니다.',
+      });
+    } catch (error) {
+      if (hasOptimisticProfileUpdate && previousProfile) {
+        queryClient.setQueryData<CurrentUserProfileResponse>(
+          authKeys.me(),
+          previousProfile,
+        );
+        setAuthAccount(previousProfile);
+        void queryClient.invalidateQueries({ queryKey: authKeys.me() });
+      }
+
+      onToast({
+        tone: 'error',
+        message: extractAuthApiErrorMessage(error),
+      });
+    }
+  };
+
+  const handleNicknameSave = async (nextNickname: string) => {
+    try {
+      await updateUserInfoMutation.mutateAsync({
+        nickname: nextNickname,
+      });
+      onToast({
+        tone: 'success',
+        message: '프로필이 변경되었습니다.',
+      });
+
+      return true;
+    } catch (error) {
+      const fieldErrors = extractAuthApiFieldErrors(error);
+      const nicknameErrorMessage =
+        fieldErrors.nickname || extractAuthApiErrorMessage(error);
+
+      onToast({
+        tone: 'error',
+        message: nicknameErrorMessage,
+      });
+
+      return false;
+    }
+  };
+
+  return {
+    resolvedProfile,
+    profileName: resolvedProfile?.name || 'N/A',
+    profileEmail: resolvedProfile?.email || null,
+    profileGenderLabel: toGenderLabel(resolvedProfile?.gender),
+    profileImageUrl: resolvedProfile?.profile_img_url ?? null,
+    profileNickname: resolvedProfile?.nickname ?? '회원',
+    isProfileLoading,
+    isProfileImageUploading,
+    isProfileUpdating: updateUserInfoMutation.isPending,
+    handleProfileImageSelect,
+    handleNicknameSave,
+  };
+}
+
+export default useMyPageProfile;

--- a/src/pages/mypage/hooks/useMyPageSecurity.ts
+++ b/src/pages/mypage/hooks/useMyPageSecurity.ts
@@ -1,0 +1,322 @@
+import type { FormEvent } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+
+import { ROUTES } from '../../../constants/routes';
+import {
+  extractAuthApiErrorMessage,
+  extractAuthApiFieldErrors,
+} from '../../../features/auth/api/auth';
+import {
+  useChangePasswordMutation,
+  useDeleteAccountMutation,
+} from '../../../features/auth/api/useAuthApi';
+import { clearAuthTokens } from '../../../utils/auth';
+import type {
+  PasswordChangeFieldName,
+  PasswordChangeValues,
+} from '../../../components/mypage/PasswordChangePanel';
+import type { MyPageToastPayload } from '../types';
+
+type PasswordTouchedState = Record<PasswordChangeFieldName, boolean>;
+type PasswordFieldErrors = Partial<Record<PasswordChangeFieldName, string>>;
+type PasswordPanelMessage = {
+  tone: 'success' | 'error';
+  message: string;
+} | null;
+
+type UseMyPageSecurityOptions = {
+  onToast: (toast: MyPageToastPayload) => void;
+};
+
+const initialPasswordValues: PasswordChangeValues = {
+  currentPassword: '',
+  newPassword: '',
+  newPasswordConfirm: '',
+};
+
+const initialTouchedState: PasswordTouchedState = {
+  currentPassword: false,
+  newPassword: false,
+  newPasswordConfirm: false,
+};
+
+const getPasswordFieldErrors = (
+  values: PasswordChangeValues,
+  touchedState: PasswordTouchedState,
+) => {
+  const trimmedCurrentPassword = values.currentPassword.trim();
+  const trimmedNewPassword = values.newPassword.trim();
+  const trimmedNewPasswordConfirm = values.newPasswordConfirm.trim();
+
+  return {
+    currentPassword:
+      touchedState.currentPassword && !trimmedCurrentPassword
+        ? '현재 비밀번호를 입력해주세요.'
+        : '',
+    newPassword:
+      touchedState.newPassword && !trimmedNewPassword
+        ? '새 비밀번호를 입력해주세요.'
+        : touchedState.newPassword &&
+            trimmedNewPassword.length > 0 &&
+            trimmedNewPassword.length < 8
+          ? '비밀번호는 8자 이상이어야 합니다.'
+          : '',
+    newPasswordConfirm:
+      touchedState.newPasswordConfirm && !trimmedNewPasswordConfirm
+        ? '새 비밀번호를 한번 더 입력해주세요.'
+        : touchedState.newPasswordConfirm &&
+            trimmedNewPassword.length > 0 &&
+            trimmedNewPasswordConfirm.length > 0 &&
+            trimmedNewPassword !== trimmedNewPasswordConfirm
+          ? '비밀번호와 일치하지 않습니다.'
+          : '',
+  } satisfies Record<PasswordChangeFieldName, string>;
+};
+
+const mapPasswordApiFieldErrors = (
+  fieldErrors: Record<string, string>,
+): PasswordFieldErrors => ({
+  currentPassword: fieldErrors.old_password,
+  newPassword: fieldErrors.new_password,
+  newPasswordConfirm: fieldErrors.new_password_check,
+});
+
+function useMyPageSecurity({ onToast }: UseMyPageSecurityOptions) {
+  const navigate = useNavigate();
+  const changePasswordMutation = useChangePasswordMutation();
+  const deleteAccountMutation = useDeleteAccountMutation();
+  const [isPasswordPanelOpen, setIsPasswordPanelOpen] = useState(false);
+  const [passwordValues, setPasswordValues] = useState<PasswordChangeValues>(
+    initialPasswordValues,
+  );
+  const [touchedState, setTouchedState] =
+    useState<PasswordTouchedState>(initialTouchedState);
+  const [apiFieldErrors, setApiFieldErrors] = useState<PasswordFieldErrors>({});
+  const [passwordPanelMessage, setPasswordPanelMessage] =
+    useState<PasswordPanelMessage>(null);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [deletePassword, setDeletePassword] = useState('');
+  const [deletePasswordError, setDeletePasswordError] = useState('');
+  const localFieldErrors = useMemo(
+    () => getPasswordFieldErrors(passwordValues, touchedState),
+    [passwordValues, touchedState],
+  );
+
+  const resolvedPasswordErrors: Record<PasswordChangeFieldName, string> = {
+    currentPassword:
+      apiFieldErrors.currentPassword ?? localFieldErrors.currentPassword,
+    newPassword: apiFieldErrors.newPassword ?? localFieldErrors.newPassword,
+    newPasswordConfirm:
+      apiFieldErrors.newPasswordConfirm ?? localFieldErrors.newPasswordConfirm,
+  };
+
+  useEffect(() => {
+    if (!isPasswordPanelOpen || passwordPanelMessage?.tone !== 'success') {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setIsPasswordPanelOpen(false);
+      setPasswordValues(initialPasswordValues);
+      setTouchedState(initialTouchedState);
+      setApiFieldErrors({});
+      setPasswordPanelMessage(null);
+    }, 2000);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [isPasswordPanelOpen, passwordPanelMessage]);
+
+  const resetPasswordPanel = () => {
+    setPasswordValues(initialPasswordValues);
+    setTouchedState(initialTouchedState);
+    setApiFieldErrors({});
+    setPasswordPanelMessage(null);
+  };
+
+  const closePasswordPanel = () => {
+    setIsPasswordPanelOpen(false);
+    resetPasswordPanel();
+  };
+
+  const togglePasswordPanel = () => {
+    setIsPasswordPanelOpen((current) => {
+      if (current) {
+        resetPasswordPanel();
+      }
+
+      return !current;
+    });
+  };
+
+  const handlePasswordValueChange = (
+    fieldName: PasswordChangeFieldName,
+    value: string,
+  ) => {
+    setPasswordValues((previous) => ({
+      ...previous,
+      [fieldName]: value,
+    }));
+
+    setApiFieldErrors((previous) => {
+      if (!previous[fieldName]) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        [fieldName]: '',
+      };
+    });
+
+    setPasswordPanelMessage(null);
+  };
+
+  const handlePasswordBlur = (fieldName: PasswordChangeFieldName) => {
+    setTouchedState((previous) => ({
+      ...previous,
+      [fieldName]: true,
+    }));
+  };
+
+  const handlePasswordSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const nextTouchedState = {
+      currentPassword: true,
+      newPassword: true,
+      newPasswordConfirm: true,
+    } satisfies PasswordTouchedState;
+
+    setTouchedState(nextTouchedState);
+    setApiFieldErrors({});
+    setPasswordPanelMessage(null);
+
+    const nextFieldErrors = getPasswordFieldErrors(
+      passwordValues,
+      nextTouchedState,
+    );
+    const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
+
+    if (hasLocalError) {
+      return;
+    }
+
+    try {
+      const response = await changePasswordMutation.mutateAsync({
+        old_password: passwordValues.currentPassword.trim(),
+        new_password: passwordValues.newPassword.trim(),
+        new_password_check: passwordValues.newPasswordConfirm.trim(),
+      });
+
+      setPasswordValues(initialPasswordValues);
+      setTouchedState(initialTouchedState);
+      setApiFieldErrors({});
+      setPasswordPanelMessage({
+        tone: 'success',
+        message: response.detail,
+      });
+    } catch (error) {
+      const nextApiFieldErrors = mapPasswordApiFieldErrors(
+        extractAuthApiFieldErrors(error),
+      );
+
+      if (Object.values(nextApiFieldErrors).some(Boolean)) {
+        setApiFieldErrors(nextApiFieldErrors);
+        return;
+      }
+
+      setPasswordPanelMessage({
+        tone: 'error',
+        message: extractAuthApiErrorMessage(error),
+      });
+    }
+  };
+
+  const openDeleteModal = () => {
+    setDeletePassword('');
+    setDeletePasswordError('');
+    setIsDeleteModalOpen(true);
+  };
+
+  const closeDeleteModal = () => {
+    setIsDeleteModalOpen(false);
+    setDeletePassword('');
+    setDeletePasswordError('');
+  };
+
+  const handleDeletePasswordChange = (value: string) => {
+    setDeletePassword(value);
+
+    if (deletePasswordError) {
+      setDeletePasswordError('');
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    const trimmedPassword = deletePassword.trim();
+
+    if (!trimmedPassword) {
+      setDeletePasswordError('현재 비밀번호를 입력해주세요.');
+      return;
+    }
+
+    try {
+      await deleteAccountMutation.mutateAsync({
+        password: trimmedPassword,
+      });
+
+      clearAuthTokens();
+      navigate(`/${ROUTES.LOGIN}`, {
+        replace: true,
+        state: {
+          noticeMessage: '회원 탈퇴가 완료되었습니다.',
+        },
+      });
+    } catch (error) {
+      const fieldErrors = extractAuthApiFieldErrors(error);
+
+      if (fieldErrors.password) {
+        setDeletePasswordError(fieldErrors.password);
+        return;
+      }
+
+      const errorMessage = extractAuthApiErrorMessage(error);
+
+      if (errorMessage.includes('비밀번호')) {
+        setDeletePasswordError(errorMessage);
+        return;
+      }
+
+      onToast({
+        tone: 'error',
+        message: errorMessage,
+      });
+    }
+  };
+
+  return {
+    isPasswordPanelOpen,
+    togglePasswordPanel,
+    closePasswordPanel,
+    passwordValues,
+    resolvedPasswordErrors,
+    passwordPanelMessage,
+    handlePasswordValueChange,
+    handlePasswordBlur,
+    handlePasswordSubmit,
+    isChangePasswordPending: changePasswordMutation.isPending,
+    isDeleteModalOpen,
+    openDeleteModal,
+    closeDeleteModal,
+    deletePassword,
+    deletePasswordError,
+    handleDeletePasswordChange,
+    handleDeleteAccount,
+    isDeleteAccountPending: deleteAccountMutation.isPending,
+  };
+}
+
+export default useMyPageSecurity;

--- a/src/pages/mypage/types.ts
+++ b/src/pages/mypage/types.ts
@@ -1,0 +1,6 @@
+export type MyPageToast = {
+  tone: 'success' | 'error';
+  message: string;
+} | null;
+
+export type MyPageToastPayload = Exclude<MyPageToast, null>;

--- a/src/pages/mypage/utils.ts
+++ b/src/pages/mypage/utils.ts
@@ -1,0 +1,43 @@
+import type {
+  AuthGender,
+  LikedGameItemResponse,
+} from '../../features/auth/types/auth';
+import type { GameListItem } from '../../features/games/types';
+import type { FavoriteGamePreview } from '../../features/mypage/types';
+
+export const toGenderLabel = (gender?: AuthGender) => {
+  if (gender === 'M') {
+    return '남성';
+  }
+
+  if (gender === 'W') {
+    return '여성';
+  }
+
+  return 'N/A';
+};
+
+export const toFavoriteGamePreview = (
+  game: LikedGameItemResponse,
+): FavoriteGamePreview => {
+  const normalizedGenres = game.genres.filter((genre) => genre.trim());
+
+  return {
+    gameId: game.game_id,
+    title: game.game_title.trim() || 'N/A',
+    summary: normalizedGenres.length > 0 ? normalizedGenres.join(', ') : 'N/A',
+    thumbnailUrl: game.thumbnail_url,
+    genres: normalizedGenres,
+  };
+};
+
+export const toFavoriteGameListItem = (
+  game: FavoriteGamePreview,
+): GameListItem => ({
+  gameId: game.gameId,
+  name: game.title,
+  genres: game.genres.length > 0 ? game.genres : ['N/A'],
+  thumbnailUrl: game.thumbnailUrl,
+  rating: null,
+  isLiked: true,
+});

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -4,11 +4,12 @@ import { ChevronDown, ChevronRight, Heart, Sparkles, Star } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 
+import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import ActionButton from '../../components/common/ActionButton';
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
 import { authKeys } from '../../features/auth/api/queryKeys';
-import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
+import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import type { LikedGamesResponse } from '../../features/auth/types/auth';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
 import {
@@ -26,7 +27,6 @@ import type { MatchResultItem } from '../../features/matching/types';
 import { useSurveyResultsInfinite } from '../../features/survey/api/useSurveyApi';
 import { extractApiErrorMessage } from '../../features/survey/api/survey';
 import type { SurveyResultItem } from '../../features/survey/types/survey';
-import { isMockServiceWorkerEnabled } from '../../lib/env';
 
 const FALLBACK_BACKDROP_ITEMS = [
   {
@@ -270,9 +270,8 @@ function RecommendationListPage() {
   const isMatchSource = source === 'match';
   const isSurveySource =
     source === 'survey' || (!source && Boolean(legacySessionId));
-  const isMockMode = isMockServiceWorkerEnabled();
-  const { canAccessAuthenticatedRoute, isAuthReady } = useAuthGuardState();
-  const canAccessPage = isMockMode || canAccessAuthenticatedRoute;
+  const authGate = useAuthGate({ allowMockBypass: true });
+  const canAccessPage = authGate.accessStatus === 'authorized';
 
   const surveyResultsQuery = useSurveyResultsInfinite(
     !isMatchSource && isSurveySource && canAccessPage,
@@ -550,25 +549,16 @@ function RecommendationListPage() {
             </aside>
           </div>
 
-          {!isMockMode && !isAuthReady ? (
-            <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
-              <h2 className="text-2xl font-bold text-white">
-                인증 상태를 확인하는 중입니다.
-              </h2>
-              <p className="mt-4 text-base leading-7 break-keep text-white/60">
-                잠시만 기다려 주세요. 세션 확인 후 추천 결과를 불러옵니다.
-              </p>
-            </section>
+          {authGate.accessStatus === 'loading' ? (
+            <AuthGateStatusPanel
+              title="인증 상태를 확인하는 중입니다."
+              description="잠시만 기다려 주세요. 세션 확인 후 추천 결과를 불러옵니다."
+            />
           ) : !canAccessPage ? (
-            <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
-              <h2 className="text-2xl font-bold text-white">
-                로그인 후 추천 결과를 볼 수 있어요.
-              </h2>
-              <p className="mt-4 text-base leading-7 break-keep text-white/60">
-                실제 API 모드에서는 인증 토큰이 필요합니다. 개발 중에는 MSW를
-                켜두면 추천 결과 흐름을 확인할 수 있습니다.
-              </p>
-            </section>
+            <AuthGateStatusPanel
+              title="로그인 후 추천 결과를 볼 수 있어요."
+              description="실제 API 모드에서는 인증 토큰이 필요합니다. 개발 중에는 MSW를 켜두면 추천 결과 흐름을 확인할 수 있습니다."
+            />
           ) : !isMatchSource && !isSurveySource ? (
             <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
               <h2 className="text-2xl font-bold text-white">

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -1,23 +1,22 @@
 import { useEffect } from 'react';
 
+import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import Header from '../../components/common/Header';
-import useAuthGuardState from '../../features/auth/hooks/useAuthGuardState';
+import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import SurveyChatPanel from '../../features/survey/components/SurveyChatPanel';
 import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
-import { isMockServiceWorkerEnabled } from '../../lib/env';
 import { useAuthStore } from '../../store/useAuthStore';
 
 function SurveyPage() {
-  const { canAccessAuthenticatedRoute, isAuthReady } = useAuthGuardState();
-  const isMockMode = isMockServiceWorkerEnabled();
-  const canAccessSurvey = isMockMode || canAccessAuthenticatedRoute;
+  const authGate = useAuthGate({ allowMockBypass: true });
+  const canAccessSurvey = authGate.accessStatus === 'authorized';
   const account = useAuthStore((state) => state.account);
   const syncOwnerKey = useSurveyStore((state) => state.syncOwnerKey);
   const surveyOwnerKey = account?.login_id
     ? `survey-user:${account.login_id}`
-    : canAccessAuthenticatedRoute
+    : authGate.isAuthenticated
       ? 'survey-user:authenticated'
-      : isMockMode
+      : authGate.canBypassAuth
         ? 'survey-user:mock'
         : 'survey-user:guest';
 
@@ -31,28 +30,18 @@ function SurveyPage() {
       <Header fixed />
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-[100dvh] md:max-h-[100dvh] md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
-        {!isMockMode && !isAuthReady ? (
-          <section className="survey-panel max-w-2xl px-8 py-10">
-            <h2 className="text-2xl font-bold text-white">
-              인증 상태를 확인하는 중입니다.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-white/60">
-              잠시만 기다려 주세요. 세션 확인 후 설문 화면을 이어서
-              보여드릴게요.
-            </p>
-          </section>
+        {authGate.accessStatus === 'loading' ? (
+          <AuthGateStatusPanel
+            title="인증 상태를 확인하는 중입니다."
+            description="잠시만 기다려 주세요. 세션 확인 후 설문 화면을 이어서 보여드릴게요."
+          />
         ) : canAccessSurvey ? (
           <SurveyChatPanel />
         ) : (
-          <section className="survey-panel max-w-2xl px-8 py-10">
-            <h2 className="text-2xl font-bold text-white">
-              로그인 후 설문을 시작할 수 있어요.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-white/60">
-              로그인하면 취향을 바탕으로 질문을 이어가고, 설문이 끝난 뒤 바로
-              추천 결과까지 확인할 수 있어요.
-            </p>
-          </section>
+          <AuthGateStatusPanel
+            title="로그인 후 설문을 시작할 수 있어요."
+            description="로그인하면 취향을 바탕으로 질문을 이어가고, 설문이 끝난 뒤 바로 추천 결과까지 확인할 수 있어요."
+          />
         )}
       </main>
     </div>


### PR DESCRIPTION
## 관련 이슈

- closes #220

## 변경 내용

- useAuthGate/AuthWrapper 기반으로 인증 접근 제어를 공통화했습니다.
- Survey/Matching/Recommendation 페이지의 인증 상태 분기를 공통 패널(AuthGateStatusPanel)로 정리했습니다.
- 마이페이지를 메인 조합형 구조로 분리하고, 프로필/보안/찜 목록 로직을 섹션·훅 단위로 분리했습니다.
- 마이페이지 라우트를 React.lazy + Suspense로 코드 스플리팅 적용했습니다.
- 프로필 이미지 로드 실패 시 기본 아이콘으로 폴백되도록 보완했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
