### PR TITLE
[Feat] 설문 페이지 채팅 중심 UI로 개편

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -8,12 +8,15 @@ import {
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router';
 import {
+  BadgeInfo,
   ChevronRight,
   RotateCcw,
   SendHorizontal,
   TriangleAlert,
+  X,
 } from 'lucide-react';
 
 import { ROUTES } from '../../../constants/routes';
@@ -93,6 +96,7 @@ function SurveyChatPanel() {
   const lastMessageCountRef = useRef(0);
   const [inputValue, setInputValue] = useState('');
   const [currentTime, setCurrentTime] = useState(() => Date.now());
+  const [isGuardrailPanelOpen, setIsGuardrailPanelOpen] = useState(false);
 
   const {
     sessionId,
@@ -152,6 +156,12 @@ function SurveyChatPanel() {
     isChatTemporarilyBlocked ||
     hasExpiredChatBlock ||
     hasReachedNonGameChatLimit;
+  const shouldShowGuardrailPanel = import.meta.env.DEV;
+  const guardrailStatusLabel = isChatTemporarilyBlocked
+    ? `${formatRemainingBlockTime(remainingBlockTimeMs)} 남음`
+    : hasExpiredChatBlock
+      ? '제한 종료'
+      : `${nonGameStrikeCount}/${NON_GAME_CHAT_MAX_STRIKES} 누적`;
   const inputPlaceholder = useMemo(() => {
     if (isChatTemporarilyBlocked) {
       return '반복된 이상행동으로 인해 5분간 채팅이 정지됩니다.';
@@ -162,7 +172,7 @@ function SurveyChatPanel() {
     }
 
     if (recommendationReady) {
-      return "추천 결과가 준비되었어요. 우측 상단의 '추천 결과 보기' 버튼을 눌러 다음 단계로 이동해 주세요.";
+      return '추천 결과가 준비되었어요. 아래 버튼으로 다음 단계로 이동해 주세요.';
     }
 
     return '취향과 관련된 게임 이야기를 입력해 주세요.';
@@ -479,67 +489,105 @@ function SurveyChatPanel() {
     }
   };
 
+  const guardrailLauncher =
+    shouldShowGuardrailPanel && typeof document !== 'undefined'
+      ? createPortal(
+          <div className="pointer-events-none fixed bottom-6 left-2 z-[95] hidden lg:block">
+            {isGuardrailPanelOpen ? (
+              <aside className="pointer-events-auto mb-3 ml-3 w-[300px] rounded-[26px] border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,20,0.84),rgba(8,8,9,0.94))] px-4 py-4 shadow-[0_18px_40px_rgba(0,0,0,0.26)] backdrop-blur-xl">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-[11px] font-semibold tracking-[0.18em] text-[#ff8a8a] uppercase">
+                      Dev Guardrail
+                    </p>
+                    <h3 className="mt-1 text-sm font-semibold text-white">
+                      설문 키워드 휴리스틱
+                    </h3>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-[11px] font-medium text-white/64">
+                      {guardrailStatusLabel}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setIsGuardrailPanelOpen(false)}
+                      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/10 bg-white/[0.03] text-white/58 transition hover:bg-white/[0.06] hover:text-white"
+                      aria-label="개발용 가드레일 패널 닫기"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                </div>
+
+                <p className="mt-3 text-xs leading-5 break-keep text-white/54">
+                  개발 환경에서만 보이는 설명 패널입니다. 현재 설문은 키워드
+                  `includes()` 휴리스틱으로 게임 관련 질문 여부를 판정하고,
+                  비게임 질문 3회 누적 시 5분 제한을 적용합니다.
+                </p>
+
+                <div className="mt-3 rounded-[18px] border border-white/8 bg-white/[0.03] px-3 py-3">
+                  <p className="text-[11px] font-semibold tracking-[0.18em] text-white/42 uppercase">
+                    허용 키워드
+                  </p>
+                  <div className="mt-2 flex max-h-[132px] flex-wrap gap-1.5 overflow-y-auto pr-1">
+                    {GAME_RELATED_KEYWORDS.map((keyword) => (
+                      <span
+                        key={keyword}
+                        className="rounded-full border border-white/8 bg-white/[0.04] px-2.5 py-1 text-[11px] font-medium text-white/72"
+                      >
+                        {keyword}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </aside>
+            ) : null}
+
+            <button
+              type="button"
+              onClick={() => setIsGuardrailPanelOpen((current) => !current)}
+              className="pointer-events-auto flex h-16 w-16 items-center justify-center rounded-full border border-white/10 bg-[linear-gradient(135deg,rgba(255,53,53,0.94),rgba(130,11,11,0.96))] text-white shadow-[0_18px_40px_rgba(130,0,0,0.28)] transition hover:-translate-y-0.5 hover:brightness-105 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+              aria-label="개발용 설문 키워드 가이드 열기"
+            >
+              <BadgeInfo size={24} />
+            </button>
+          </div>,
+          document.body,
+        )
+      : null;
+
   return (
-    <section className="survey-panel flex min-h-0 flex-1 flex-col overflow-hidden">
+    <section className="survey-panel relative flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="border-b border-white/8 px-4 py-2.5 sm:px-5 md:px-6">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="min-w-0">
-            <h2 className="text-[22px] font-bold text-white sm:text-2xl md:text-[28px]">
-              설문 조사
+        <div className="grid gap-2.5 sm:grid-cols-[1fr_auto_1fr] sm:items-center">
+          <div className="hidden sm:block" />
+
+          <div className="min-w-0 text-center">
+            <h2 className="text-[24px] font-bold tracking-[-0.03em] text-white sm:text-[28px] md:text-[31px]">
+              게임 선호도 설문조사
             </h2>
-            <p className="mt-1 text-sm leading-6 break-keep text-white/58 md:text-[15px]">
-              대화형 AI 설문으로 플레이 스타일을 빠르게 파악하고, 이어지는 추천
-              리스트까지 자연스럽게 연결합니다.
-            </p>
           </div>
 
-          <div className="flex flex-wrap items-center gap-2.5">
+          <div className="flex flex-wrap items-center justify-end gap-2.5">
+            <SurveyProgress progress={progress} compact />
             <button
               type="button"
               onClick={handleReset}
               disabled={isSubmitting}
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-2.5 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-60"
             >
               <RotateCcw size={16} />
               설문 초기화
-            </button>
-
-            <button
-              type="button"
-              onClick={handleMoveToRecommendation}
-              disabled={isRecommendationButtonDisabled}
-              className="inline-flex items-center gap-2 rounded-xl bg-[linear-gradient(135deg,#ee2525,#9b1010)] px-4 py-2.5 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(150,0,0,0.32)] transition hover:translate-y-[-1px] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
-            >
-              추천 결과 보기
-              <ChevronRight size={16} />
             </button>
           </div>
         </div>
       </div>
 
-      <div className="survey-grid min-h-0 flex-1 gap-2.5 px-3 py-3 sm:px-4 sm:py-4 md:gap-3 md:px-5 md:py-4">
-        <div className="min-h-0 space-y-2.5">
-          <SurveyProgress progress={progress} />
-
-          <section className="survey-panel px-4 py-3.5 sm:px-5 md:py-3.5">
-            <h3 className="text-[12px] font-semibold tracking-[0.16em] text-white/42 uppercase">
-              안내사항
-            </h3>
-            <div className="mt-2 space-y-2 text-sm leading-[1.35rem] text-white/56">
-              <p>게임 취향, 플레이 스타일, 선호 장르 중심으로 답변해 주세요.</p>
-              <p>구체적으로 적을수록 설문 흐름이 더 빠르게 정리될 수 있어요.</p>
-              <p>
-                게임과 관련없는 질문을 3회 이상 반복할 시 5분 동안 설문 기능을
-                사용할 수 없습니다.
-              </p>
-            </div>
-          </section>
-        </div>
-
-        <div className="survey-panel flex min-h-0 flex-col">
+      <div className="min-h-0 flex-1 px-3 py-2.5 sm:px-4 sm:py-3 md:px-5 md:py-3">
+        <div className="survey-panel flex h-full min-h-0 flex-col overflow-hidden border-white/6 bg-[linear-gradient(180deg,rgba(12,12,14,0.86),rgba(7,7,8,0.94))]">
           <div
             ref={viewportRef}
-            className="survey-message-scroll flex-1 space-y-3.5 px-4 py-4 sm:px-5 sm:py-4 md:px-6"
+            className="survey-message-scroll max-h-none flex-1 space-y-4 px-4 py-4 sm:px-5 sm:py-[1.125rem] md:px-6"
           >
             {!messages.length && isSubmitting ? (
               <div className="flex w-full justify-start">
@@ -579,11 +627,31 @@ function SurveyChatPanel() {
                 </div>
               </div>
             ) : null}
+
+            {recommendationReady ? (
+              <div className="flex w-full justify-center pt-2">
+                {isRecommendationButtonDisabled ? (
+                  <div className="max-w-[520px] rounded-[26px] border border-white/8 bg-white/[0.025] px-5 py-4 text-center text-sm leading-6 break-keep text-white/58">
+                    추천 결과는 준비되었지만 현재 설문 제한 상태에서는 바로
+                    이동할 수 없어요. 설문 초기화 후 다시 진행해 주세요.
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleMoveToRecommendation}
+                    className="inline-flex items-center gap-2 rounded-full bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(150,0,0,0.32)] transition hover:translate-y-[-1px] hover:brightness-105"
+                  >
+                    추천 결과 바로 보기
+                    <ChevronRight size={16} />
+                  </button>
+                )}
+              </div>
+            ) : null}
           </div>
 
-          <div className="border-t border-white/8 px-4 py-3 sm:px-5 sm:py-3.5 md:px-6">
+          <div className="border-t border-white/8 px-4 py-3.5 sm:px-5 sm:py-4 md:px-6">
             <form ref={formRef} onSubmit={handleSubmit}>
-              <label className="relative block h-[58px] overflow-hidden rounded-full border border-white/10 bg-[#0e0e10] transition focus-within:border-[#b42525] focus-within:bg-[#121214]">
+              <label className="relative block h-[60px] overflow-hidden rounded-full border border-white/10 bg-[#0e0e10] transition focus-within:border-[#b42525] focus-within:bg-[#121214]">
                 <textarea
                   ref={textareaRef}
                   rows={1}
@@ -591,7 +659,7 @@ function SurveyChatPanel() {
                   onChange={(event) => setInputValue(event.target.value)}
                   onKeyDown={handleTextareaKeyDown}
                   placeholder={inputPlaceholder}
-                  className="h-full min-h-full w-full resize-none overflow-hidden bg-transparent py-4 pr-[5.9rem] pl-4 text-[15px] leading-6 text-white outline-none placeholder:text-white/26 sm:pl-5"
+                  className="h-full min-h-full w-full resize-none overflow-hidden bg-transparent py-[17px] pr-[5.8rem] pl-4 text-[15px] leading-6 text-white outline-none placeholder:text-white/26 sm:pl-5"
                   disabled={isTextareaDisabled}
                 />
                 {isChatTemporarilyBlocked ? (
@@ -623,6 +691,8 @@ function SurveyChatPanel() {
           </div>
         </div>
       </div>
+
+      {guardrailLauncher}
     </section>
   );
 }

--- a/src/features/survey/components/SurveyMessageBubble.tsx
+++ b/src/features/survey/components/SurveyMessageBubble.tsx
@@ -1,5 +1,7 @@
 import { Bot, UserRound } from 'lucide-react';
 
+import defaultProfileImage from '../../../assets/프로필 이미지.png';
+import { useAuthStore } from '../../../store/useAuthStore';
 import type { SurveyMessage } from '../types/survey';
 
 interface SurveyMessageBubbleProps {
@@ -8,7 +10,6 @@ interface SurveyMessageBubbleProps {
 
 const roleMeta = {
   assistant: {
-    label: 'AI 질문',
     icon: Bot,
     wrapperClassName: 'justify-start',
     contentClassName: 'flex-row',
@@ -18,7 +19,6 @@ const roleMeta = {
     iconClassName: 'bg-white/[0.05] text-[#ff4d4d]',
   },
   user: {
-    label: '내 답변',
     icon: UserRound,
     wrapperClassName: 'justify-end',
     contentClassName: 'flex-row-reverse',
@@ -32,24 +32,56 @@ const roleMeta = {
 function SurveyMessageBubble({ message }: SurveyMessageBubbleProps) {
   const meta = roleMeta[message.role];
   const Icon = meta.icon;
+  const account = useAuthStore((state) => state.account);
+  const isAuthenticatedUser = useAuthStore((state) => state.isAuthenticated);
+  const userAvatarUrl = account?.profile_img_url?.trim() || defaultProfileImage;
+  const normalizedContent = message.content.trim();
+  const isCompactMessage =
+    !normalizedContent.includes('\n') && normalizedContent.length <= 36;
+  const bubbleSpacingClassName = isCompactMessage ? 'gap-2.5' : 'gap-[0.7rem]';
+  const avatarSizeClassName = isCompactMessage
+    ? 'h-9 w-9'
+    : 'h-[38px] w-[38px]';
+  const bubblePaddingClassName = isCompactMessage
+    ? 'px-4 py-3'
+    : 'px-4 py-3.5 md:px-[1.125rem]';
+  const bubbleTextClassName = isCompactMessage
+    ? 'text-[15px] leading-6'
+    : 'text-[15px] leading-[1.6rem]';
 
   return (
     <div className={`flex w-full ${meta.wrapperClassName}`}>
       <div
-        className={`flex max-w-[92%] items-start gap-3 md:max-w-[74%] ${meta.contentClassName}`}
+        className={`flex max-w-[92%] items-start ${bubbleSpacingClassName} md:max-w-[78%] ${meta.contentClassName}`}
       >
         <div
-          className={`mt-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl ${meta.iconClassName}`}
+          className={`mt-1 flex shrink-0 items-center justify-center rounded-2xl ${avatarSizeClassName} ${meta.iconClassName}`}
         >
-          <Icon size={18} />
+          {message.role === 'user' ? (
+            <img
+              src={userAvatarUrl}
+              alt={
+                isAuthenticatedUser
+                  ? '회원 프로필 이미지'
+                  : '비회원 프로필 이미지'
+              }
+              className="h-full w-full rounded-2xl object-cover"
+              onError={(event) => {
+                if (event.currentTarget.src !== defaultProfileImage) {
+                  event.currentTarget.src = defaultProfileImage;
+                }
+              }}
+            />
+          ) : (
+            <Icon size={18} />
+          )}
         </div>
         <div
-          className={`px-4 py-4 md:px-5 ${meta.bubbleClassName} ${meta.textClassName}`}
+          className={`${bubblePaddingClassName} ${meta.bubbleClassName} ${meta.textClassName}`}
         >
-          <p className="mb-2 text-xs font-semibold tracking-[0.24em] text-white/45 uppercase">
-            {meta.label}
-          </p>
-          <p className="text-[15px] leading-7 whitespace-pre-line text-white/92">
+          <p
+            className={`whitespace-pre-line text-white/92 ${bubbleTextClassName}`}
+          >
             {message.content}
           </p>
         </div>

--- a/src/features/survey/components/SurveyProgress.tsx
+++ b/src/features/survey/components/SurveyProgress.tsx
@@ -4,10 +4,34 @@ import type { SurveyProgress as SurveyProgressType } from '../types/survey';
 
 interface SurveyProgressProps {
   progress: SurveyProgressType;
+  compact?: boolean;
 }
 
-function SurveyProgress({ progress }: SurveyProgressProps) {
+function SurveyProgress({ progress, compact = false }: SurveyProgressProps) {
   const percentage = Math.max(0, Math.min(progress.completion_rate * 100, 100));
+
+  if (compact) {
+    return (
+      <section className="min-w-[172px] rounded-[22px] border border-white/10 bg-white/[0.03] px-3.5 py-3 shadow-[0_14px_30px_rgba(0,0,0,0.16)] backdrop-blur-md">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-[11px] font-semibold tracking-[0.18em] text-white/42 uppercase">
+            <Activity size={14} className="text-[#ff5b5b]" />
+            진행률
+          </div>
+          <p className="text-sm font-semibold text-[#ff7a7a]">
+            {Math.round(percentage)}%
+          </p>
+        </div>
+
+        <div className="mt-2.5 h-1.5 overflow-hidden rounded-full bg-white/8">
+          <div
+            className="h-full rounded-full bg-[linear-gradient(90deg,#ff3434,#ff7f50)] transition-[width] duration-500"
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="survey-panel p-3.5">

--- a/src/features/survey/store/useSurveyStore.ts
+++ b/src/features/survey/store/useSurveyStore.ts
@@ -50,8 +50,26 @@ const createMessage = (
   createdAt: new Date().toISOString(),
 });
 
+const SURVEY_INTRO_MESSAGE =
+  '설문을 시작하기 전에 안내드릴게요.\n게임 취향, 플레이 스타일, 선호 장르 중심으로 답변해 주세요.\n구체적으로 적을수록 설문 흐름이 더 빠르게 정리될 수 있어요.\n게임과 관련 없는 질문을 3회 이상 반복하면 5분 동안 설문 기능을 사용할 수 없어요.';
+
 const COMPLETION_GUIDE_MESSAGE =
-  "추천 결과가 준비되었어요. 우측 상단의 '추천 결과 보기' 버튼을 눌러 바로 확인해 보세요.";
+  "추천 결과가 준비되었어요. 아래의 '추천 결과 바로 보기' 버튼을 눌러 확인해 보세요.";
+
+const getInitialMessages = (payload: SurveySessionStartResponse) => {
+  if (payload.assistant_message) {
+    return [
+      createMessage('assistant', SURVEY_INTRO_MESSAGE),
+      createMessage('assistant', payload.assistant_message),
+    ];
+  }
+
+  if (payload.recommendation_ready) {
+    return [createMessage('assistant', COMPLETION_GUIDE_MESSAGE)];
+  }
+
+  return [];
+};
 
 const createInitialState = (ownerKey: string | null = null) => ({
   ownerKey,
@@ -109,11 +127,7 @@ export const useSurveyStore = create<SurveyStoreState>()(
           lastSubmittedMessage: null,
           nonGameStrikeCount: 0,
           chatBlockedUntil: null,
-          messages: payload.assistant_message
-            ? [createMessage('assistant', payload.assistant_message)]
-            : payload.recommendation_ready
-              ? [createMessage('assistant', COMPLETION_GUIDE_MESSAGE)]
-              : [],
+          messages: getInitialMessages(payload),
           ownerKey: state.ownerKey,
         })),
       beginSession: (payload) =>
@@ -125,23 +139,26 @@ export const useSurveyStore = create<SurveyStoreState>()(
           isSubmitting: false,
           error: null,
           recommendationReady: payload.recommendation_ready,
-          messages: payload.assistant_message
-            ? state.messages.at(-1)?.role === 'assistant' &&
-              state.messages.at(-1)?.content === payload.assistant_message
-              ? state.messages
-              : [
-                  ...state.messages,
-                  createMessage('assistant', payload.assistant_message),
-                ]
-            : payload.recommendation_ready
-              ? state.messages.at(-1)?.role === 'assistant' &&
-                state.messages.at(-1)?.content === COMPLETION_GUIDE_MESSAGE
-                ? state.messages
-                : [
-                    ...state.messages,
-                    createMessage('assistant', COMPLETION_GUIDE_MESSAGE),
-                  ]
-              : state.messages,
+          messages:
+            state.messages.length === 0
+              ? getInitialMessages(payload)
+              : payload.assistant_message
+                ? state.messages.at(-1)?.role === 'assistant' &&
+                  state.messages.at(-1)?.content === payload.assistant_message
+                  ? state.messages
+                  : [
+                      ...state.messages,
+                      createMessage('assistant', payload.assistant_message),
+                    ]
+                : payload.recommendation_ready
+                  ? state.messages.at(-1)?.role === 'assistant' &&
+                    state.messages.at(-1)?.content === COMPLETION_GUIDE_MESSAGE
+                    ? state.messages
+                    : [
+                        ...state.messages,
+                        createMessage('assistant', COMPLETION_GUIDE_MESSAGE),
+                      ]
+                  : state.messages,
         })),
       applyChatResponse: (payload) =>
         set((state) => ({

--- a/src/index.css
+++ b/src/index.css
@@ -223,7 +223,6 @@
 
   .survey-message-scroll {
     min-height: 0;
-    max-height: min(64vh, 700px);
     overflow-y: auto;
     scrollbar-width: thin;
     scrollbar-color: rgba(255, 255, 255, 0.18) transparent;

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -5,7 +5,32 @@ import Header from '../../components/common/Header';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import SurveyChatPanel from '../../features/survey/components/SurveyChatPanel';
 import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
+import { mockTopGames } from '../../features/games/mockGames';
 import { useAuthStore } from '../../store/useAuthStore';
+
+const SURVEY_BACKDROP_ITEMS = [...mockTopGames, ...mockTopGames].slice(0, 14);
+
+function SurveyBackdrop() {
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      <div className="grid h-full grid-cols-3 gap-3 p-4 opacity-[0.22] saturate-0 sm:grid-cols-4 sm:gap-4 sm:p-6 lg:grid-cols-5 lg:gap-5 lg:p-8">
+        {SURVEY_BACKDROP_ITEMS.map((game, index) => (
+          <div
+            key={`${game.gameId}-${index}`}
+            className="overflow-hidden rounded-[28px] border border-white/6 bg-white/[0.03] blur-[14px]"
+          >
+            <img
+              src={game.thumbnailUrl ?? ''}
+              alt={game.name}
+              className="h-full min-h-[180px] w-full scale-110 object-cover"
+            />
+          </div>
+        ))}
+      </div>
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(170,25,25,0.16),transparent_24%),linear-gradient(180deg,rgba(5,5,5,0.46),rgba(5,5,5,0.92))]" />
+    </div>
+  );
+}
 
 function SurveyPage() {
   const authGate = useAuthGate({ allowMockBypass: true });
@@ -26,6 +51,7 @@ function SurveyPage() {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+      <SurveyBackdrop />
       <div className="app-aurora pointer-events-none absolute inset-0 opacity-90" />
       <Header fixed />
 


### PR DESCRIPTION
## 관련 이슈

- closes #222 

## 변경 내용

- 설문 페이지를 좌측 정보 패널 중심 구조에서 채팅 중심 단일 레이아웃으로 개편
- 설문 페이지 배경에 블러 처리된 게임 비주얼을 적용해 분위기를 보강
- 상단 헤더를 한 줄 구조로 정리하고 `게임 선호도 설문조사` 제목, 진행률, 설문 초기화를 재배치
- 설문 설명 문구를 고정 헤더에서 제거하고, 설문 시작 시 챗봇의 첫 안내 메시지로 자연스럽게 노출되도록 수정
- 기존 안내사항 패널을 제거하고, 실제 AI 질문 전에 고정 안내 메시지가 먼저 보이도록 정리
- 추천 결과 이동 CTA를 상단 영역이 아니라 채팅 흐름 안에서 노출되도록 변경
- `AI 질문`, `내 답변` 라벨을 제거하고 말풍선 중심 UI로 정리
- 사용자 말풍선 프로필 이미지를 로그인 프로필 이미지와 동일하게 맞춤
- 짧은 메시지와 긴 메시지 모두 말풍선 밀도를 조정해 더 자연스럽게 보이도록 개선
- 진행률 컴포넌트에 compact 변형을 추가하고 설문 헤더에 맞는 크기로 적용
- 개발 환경에서만 보이는 설문 키워드 가드레일 패널을 좌하단 플로팅 런처 형태로 추가
  - 클릭 시 현재 휴리스틱 상태와 허용 키워드 목록 확인 가능

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷


https://github.com/user-attachments/assets/e052a899-3733-4ba3-925d-b661044320e6



## 참고사항

- 이번 PR은 설문 페이지의 채팅 중심 UX 개편에 집중했습니다.
- 로그인 강제 가드 통일, 추천 리스트 헤더 정리, 매칭 접근 제어는 후속 PR 범위로 분리했습니다.
- 개발용 가드레일 런처는 `import.meta.env.DEV` 기준으로만 보이며, 배포 빌드에서는 노출되지 않습니다.
