### PR TITLE
[Feat] 추천 리스트 헤더 정리 및 스크롤 UX 개선

### DIFF
--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { ChevronDown, ChevronRight, Heart, Sparkles, Star } from 'lucide-react';
+import { ChevronDown, ChevronRight, Heart, Star } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 
@@ -263,7 +263,9 @@ function RecommendationListPage() {
     null,
   );
   const recommendationScrollRef = useRef<HTMLDivElement | null>(null);
-  const loadMoreAnchorOffsetRef = useRef<number | null>(null);
+  const loadMoreScrollTopRef = useRef<number | null>(null);
+  const detailListScrollTopRef = useRef<number | null>(null);
+  const detailWindowScrollYRef = useRef<number>(0);
   const queryClient = useQueryClient();
   const source = searchParams.get('source');
   const legacySessionId = searchParams.get('session_id');
@@ -314,33 +316,57 @@ function RecommendationListPage() {
     );
 
   useEffect(() => {
-    if (loadMoreAnchorOffsetRef.current === null) {
+    if (loadMoreScrollTopRef.current === null) {
       return;
     }
 
     const scrollContainer = recommendationScrollRef.current;
 
     if (!scrollContainer) {
-      loadMoreAnchorOffsetRef.current = null;
+      loadMoreScrollTopRef.current = null;
       return;
     }
 
-    const nextScrollTop =
-      scrollContainer.scrollHeight - loadMoreAnchorOffsetRef.current;
-    scrollContainer.scrollTop = Math.max(0, nextScrollTop);
-    loadMoreAnchorOffsetRef.current = null;
+    scrollContainer.scrollTop = loadMoreScrollTopRef.current;
+    loadMoreScrollTopRef.current = null;
   }, [recommendationItems.length]);
 
   const handleOpenDetail = (item: RecommendationDisplayItem) => {
+    detailListScrollTopRef.current =
+      recommendationScrollRef.current?.scrollTop ?? null;
+    detailWindowScrollYRef.current =
+      typeof window !== 'undefined' ? window.scrollY : 0;
     setSelectedGame(toGameListItem(item));
+  };
+
+  const handleCloseDetail = () => {
+    setSelectedGame(null);
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      window.scrollTo({
+        top: detailWindowScrollYRef.current,
+        behavior: 'auto',
+      });
+
+      if (
+        recommendationScrollRef.current &&
+        detailListScrollTopRef.current !== null
+      ) {
+        recommendationScrollRef.current.scrollTop =
+          detailListScrollTopRef.current;
+      }
+    });
   };
 
   const handleLoadMore = () => {
     const scrollContainer = recommendationScrollRef.current;
 
     if (scrollContainer) {
-      loadMoreAnchorOffsetRef.current =
-        scrollContainer.scrollHeight - scrollContainer.scrollTop;
+      loadMoreScrollTopRef.current = scrollContainer.scrollTop;
     }
 
     void fetchNextPage();
@@ -510,17 +536,13 @@ function RecommendationListPage() {
         <section className="mx-auto w-full max-w-245">
           <div className="mb-8 grid gap-4 lg:grid-cols-[minmax(0,1fr)_240px] lg:items-end">
             <div>
-              <div className="inline-flex w-fit items-center gap-2 rounded-full border border-white/8 bg-white/3 px-4 py-1.5 text-[11px] font-semibold tracking-[0.22em] text-white/45 uppercase backdrop-blur-md">
-                <Sparkles size={13} />
-                AI Curated
-              </div>
-              <h1 className="mt-5 text-3xl font-semibold tracking-[-0.04em] text-white sm:text-4xl md:text-[52px]">
+              <h1 className="text-3xl font-semibold tracking-[-0.04em] text-white sm:text-4xl md:text-[52px]">
                 게임 추천 리스트
               </h1>
               <p className="mt-4 max-w-155 text-sm leading-7 break-keep text-white/58 sm:text-base">
                 {isMatchSource
-                  ? '장르별 매칭에서 남긴 별점과 좋아요를 바탕으로 정리된 추천 결과예요. 마음에 드는 게임은 좋아요로 표시해 두고 마이페이지에서도 다시 확인할 수 있어요.'
-                  : '설문에서 드러난 취향을 바탕으로, 지금 바로 플레이하고 싶어질 만한 게임들을 차분하게 정리해뒀어요.'}
+                  ? '장르별 매칭에서 남긴 선호도 평가를 바탕으로 정리된 추천 결과예요.'
+                  : '설문에서 드러난 취향을 바탕으로, 플레이 스타일에 맞는 게임들을 한눈에 살펴볼 수 있게 정리했어요.'}
               </p>
               <div className="mt-5 flex flex-wrap gap-2.5">
                 {recommendationHighlights.map((highlight) => (
@@ -535,9 +557,6 @@ function RecommendationListPage() {
             </div>
 
             <aside className="rounded-[26px] border border-white/8 bg-[linear-gradient(180deg,rgba(18,18,20,0.88),rgba(9,9,10,0.92))] p-5 shadow-[0_18px_40px_rgba(0,0,0,0.24)] backdrop-blur-xl">
-              <p className="text-[11px] font-medium tracking-[0.22em] text-white/34 uppercase">
-                Summary
-              </p>
               <p className="mt-5 text-[34px] font-semibold tracking-[-0.04em] text-white">
                 {cappedTotalCount > 0 ? cappedTotalCount : '...'}
               </p>
@@ -595,10 +614,7 @@ function RecommendationListPage() {
               <div className="px-4 py-5 sm:px-6 lg:px-7 lg:py-6">
                 <div className="flex flex-col gap-3 border-b border-white/8 pb-5 sm:flex-row sm:items-end sm:justify-between">
                   <div>
-                    <p className="text-[11px] font-medium tracking-[0.22em] text-white/34 uppercase">
-                      Refined For You
-                    </p>
-                    <p className="mt-3 text-sm leading-6 break-keep text-white/56">
+                    <p className="text-sm leading-6 break-keep text-white/56">
                       {isMatchSource
                         ? '장르별 매칭에서 수집한 선호도 평가를 바탕으로 정리된 결과예요.'
                         : '마음에 드는 게임을 비교해보고, 더보기로 결과를 이어서 확인해보세요.'}
@@ -682,7 +698,7 @@ function RecommendationListPage() {
         <GameDetailModal
           key={selectedGame.gameId}
           game={selectedGame}
-          onClose={() => setSelectedGame(null)}
+          onClose={handleCloseDetail}
         />
       ) : null}
     </div>


### PR DESCRIPTION
## 관련 이슈

- closes #224 

## 변경 내용

- 추천 리스트 상단의 `AI Curated` 배지를 제거
- 리스트 섹션 내부의 `Refined For You` 라벨을 제거
- 추천 리스트 설명 문구를 실제 동작에 맞게 더 자연스럽게 정리
  - 매칭 결과 설명에서 좋아요 연동을 직접 언급하던 문구 제거
  - 설문 결과 설명 문구도 더 자연스럽게 다듬음
- `더보기` 클릭 후 리스트가 하단으로 과하게 밀리지 않도록, 사용자가 보고 있던 스크롤 위치를 그대로 유지하도록 수정
- 게임 상세 모달을 열기 전 리스트/페이지 스크롤 위치를 저장하고, 모달을 닫으면 원래 보던 위치로 복원되도록 보강

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷


https://github.com/user-attachments/assets/e28294ee-1210-4660-be4f-1f724ef1592c



## 참고사항

- 이번 PR은 추천 리스트 헤더 카피 정리와 스크롤 사용성 개선에 집중했습니다.
- 더보기 후에는 사용자가 보던 지점에서 자연스럽게 이어서 스크롤할 수 있도록 동작을 조정했습니다.
