### PR TITLE
fix(auth): 새로고침 세션 복구 및 헤더 프로필 깜빡임 보정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -19,8 +19,14 @@ const HIDDEN_GUEST_ACTION_PATHS = new Set([
 
 const Header = ({ fixed = true }: HeaderProps) => {
   const location = useLocation();
+  const authBootstrapStatus = useAuthStore(
+    (state) => state.authBootstrapStatus,
+  );
   const isLoggedIn = useAuthStore((state) => Boolean(state.accessToken));
   const account = useAuthStore((state) => state.account);
+  const profilePreviewImageUrl = useAuthStore(
+    (state) => state.profilePreviewImageUrl,
+  );
   const setAccount = useAuthStore((state) => state.setAccount);
   const profileHydrationQuery = useCurrentUserProfileQuery(
     isLoggedIn && !account,
@@ -28,8 +34,18 @@ const Header = ({ fixed = true }: HeaderProps) => {
   const shouldHideGuestActions = HIDDEN_GUEST_ACTION_PATHS.has(
     location.pathname,
   );
+  const shouldDeferGuestActions =
+    !isLoggedIn && !shouldHideGuestActions && authBootstrapStatus !== 'ready';
+  const shouldDeferProfileMenu =
+    isLoggedIn &&
+    !account &&
+    (authBootstrapStatus !== 'ready' ||
+      profileHydrationQuery.isLoading ||
+      profileHydrationQuery.isFetching);
   const resolvedProfileImageUrl =
-    account?.profile_img_url ?? profileHydrationQuery.data?.profile_img_url;
+    account?.profile_img_url ??
+    profileHydrationQuery.data?.profile_img_url ??
+    profilePreviewImageUrl;
 
   useEffect(() => {
     if (profileHydrationQuery.data) {
@@ -56,7 +72,22 @@ const Header = ({ fixed = true }: HeaderProps) => {
 
         <div className="flex items-center gap-2 sm:gap-3">
           {!isLoggedIn ? (
-            shouldHideGuestActions ? null : (
+            shouldHideGuestActions ? null : shouldDeferGuestActions ? (
+              resolvedProfileImageUrl ? (
+                <div
+                  aria-hidden="true"
+                  className="h-10 w-10 overflow-hidden rounded-full border-2 border-white/8"
+                >
+                  <img
+                    src={resolvedProfileImageUrl}
+                    alt=""
+                    className="h-full w-full object-cover"
+                  />
+                </div>
+              ) : (
+                <div className="h-9 w-44" aria-hidden="true" />
+              )
+            ) : (
               <>
                 <Link
                   to={`/${ROUTES.LOGIN}`}
@@ -75,6 +106,24 @@ const Header = ({ fixed = true }: HeaderProps) => {
                   </span>
                 </Link>
               </>
+            )
+          ) : shouldDeferProfileMenu ? (
+            resolvedProfileImageUrl ? (
+              <div
+                aria-hidden="true"
+                className="h-10 w-10 overflow-hidden rounded-full border-2 border-white/8"
+              >
+                <img
+                  src={resolvedProfileImageUrl}
+                  alt=""
+                  className="h-full w-full object-cover"
+                />
+              </div>
+            ) : (
+              <div
+                aria-hidden="true"
+                className="h-10 w-10 rounded-full border-2 border-white/8 bg-white/[0.04]"
+              />
             )
           ) : (
             <HeaderProfileMenu profileImageUrl={resolvedProfileImageUrl} />

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from 'axios';
 
 import { api } from '@/api/axios';
-import { apiBaseUrl } from '@/lib/env';
+import { apiBaseUrl, mockServiceWorkerEnabled } from '@/lib/env';
 import { AUTH_BASE_PATH } from '../constants/auth';
 import type {
   CheckIdDuplicateRequest,
@@ -34,8 +34,52 @@ const authApiUrl = `${normalizeApiBaseUrl(apiBaseUrl)}${AUTH_BASE_PATH}`;
 const AUTH_REFRESH_TIMEOUT_MS = 7000;
 const DEFAULT_API_ERROR_MESSAGE =
   '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+const MOCK_REFRESH_TOKEN_STORAGE_KEY = 'mock-refresh-token';
 
 type LoginFieldName = keyof LoginRequest;
+
+const readMockRefreshToken = () => {
+  if (!mockServiceWorkerEnabled || typeof window === 'undefined') {
+    return '';
+  }
+
+  return window.sessionStorage.getItem(MOCK_REFRESH_TOKEN_STORAGE_KEY) ?? '';
+};
+
+const persistMockRefreshToken = (refreshToken: string | null | undefined) => {
+  if (!mockServiceWorkerEnabled || typeof window === 'undefined') {
+    return;
+  }
+
+  const normalizedRefreshToken = refreshToken?.trim() ?? '';
+
+  if (!normalizedRefreshToken) {
+    window.sessionStorage.removeItem(MOCK_REFRESH_TOKEN_STORAGE_KEY);
+    return;
+  }
+
+  window.sessionStorage.setItem(
+    MOCK_REFRESH_TOKEN_STORAGE_KEY,
+    normalizedRefreshToken,
+  );
+};
+
+const deriveMockRefreshTokenFromAccessToken = (accessToken: string) => {
+  const normalizedAccessToken = accessToken.trim();
+  const mockAccessTokenPrefix = 'mock-access-token-';
+
+  if (!normalizedAccessToken.startsWith(mockAccessTokenPrefix)) {
+    return null;
+  }
+
+  const loginId = normalizedAccessToken.slice(mockAccessTokenPrefix.length);
+
+  if (!loginId) {
+    return null;
+  }
+
+  return `mock-refresh-token-${loginId}`;
+};
 
 export type LoginErrorStatusCode = 400 | 401 | 403;
 
@@ -83,32 +127,85 @@ export const login = async (payload: LoginRequest) => {
     `${AUTH_BASE_PATH}/login`,
     payload,
   );
+  const normalizedAccessToken = response.data.access_token?.trim() ?? '';
 
-  return response.data;
+  if (!normalizedAccessToken) {
+    throw new Error('로그인 응답에 access_token이 없습니다.');
+  }
+
+  if (mockServiceWorkerEnabled) {
+    persistMockRefreshToken(
+      response.data.refresh_token ??
+        deriveMockRefreshTokenFromAccessToken(normalizedAccessToken),
+    );
+  }
+
+  return {
+    ...response.data,
+    access_token: normalizedAccessToken,
+  };
 };
 
 export const logout = async () => {
-  const response = await api.post<LogoutResponse>(`${AUTH_BASE_PATH}/logout`);
-
-  return response.data;
+  try {
+    const response = await api.post<LogoutResponse>(`${AUTH_BASE_PATH}/logout`);
+    return response.data;
+  } finally {
+    if (mockServiceWorkerEnabled) {
+      persistMockRefreshToken(null);
+    }
+  }
 };
 
 export const refreshAccessToken = async () => {
-  // 실서버 기준으로 refresh token은 HttpOnly 쿠키 기반으로 관리합니다.
-  // API 명세의 body 예시는 추후 문서 동기화 대상으로 두고, 현재는 빈 body 요청으로 고정합니다.
-  const response = await axios.post<RefreshAccessTokenResponse>(
-    `${authApiUrl}/token/refresh`,
-    {},
-    {
-      withCredentials: true,
-      timeout: AUTH_REFRESH_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    },
-  );
+  const requestBody = (() => {
+    if (!mockServiceWorkerEnabled) {
+      return {};
+    }
 
-  return response.data;
+    const refreshToken = readMockRefreshToken().trim();
+
+    return refreshToken ? { refresh_token: refreshToken } : {};
+  })();
+
+  // 실서버 기준으로 refresh token은 HttpOnly 쿠키 기반으로 관리합니다.
+  // 단, DEV+MSW에서는 새로고침 복구 안정화를 위해 sessionStorage refresh_token을 body fallback으로 함께 전송합니다.
+  try {
+    const response = await axios.post<RefreshAccessTokenResponse>(
+      `${authApiUrl}/token/refresh`,
+      requestBody,
+      {
+        withCredentials: true,
+        timeout: AUTH_REFRESH_TIMEOUT_MS,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    const normalizedAccessToken = response.data.access_token?.trim() ?? '';
+
+    if (!normalizedAccessToken) {
+      throw new Error('토큰 갱신 응답에 access_token이 없습니다.');
+    }
+
+    if (mockServiceWorkerEnabled) {
+      persistMockRefreshToken(
+        response.data.refresh_token ??
+          deriveMockRefreshTokenFromAccessToken(normalizedAccessToken),
+      );
+    }
+
+    return {
+      ...response.data,
+      access_token: normalizedAccessToken,
+    };
+  } catch (error) {
+    if (mockServiceWorkerEnabled) {
+      persistMockRefreshToken(null);
+    }
+
+    throw error;
+  }
 };
 
 export const getCurrentUserProfile = async () => {

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -13,6 +13,29 @@ const AUTH_BOOTSTRAP_SKIP_PATHS = new Set([
   `/${ROUTES.LEGACY_AUTH_CALLBACK}`,
 ]);
 
+let authBootstrapPromise: Promise<void> | null = null;
+
+const runAuthBootstrap = async () => {
+  const { access_token: accessToken } = await refreshAccessToken();
+  useAuthStore.getState().setAccessToken(accessToken);
+  const profile = await getCurrentUserProfile();
+  useAuthStore.getState().setAccount(profile);
+};
+
+const ensureAuthBootstrap = () => {
+  if (!authBootstrapPromise) {
+    authBootstrapPromise = runAuthBootstrap()
+      .catch(() => {
+        useAuthStore.getState().clearAuth();
+      })
+      .finally(() => {
+        authBootstrapPromise = null;
+      });
+  }
+
+  return authBootstrapPromise;
+};
+
 function useAuthBootstrap() {
   const location = useLocation();
   const authBootstrapStatus = useAuthStore(
@@ -46,36 +69,11 @@ function useAuthBootstrap() {
     let isMounted = true;
     store.setAuthBootstrapStatus('loading');
 
-    const bootstrapAuth = async () => {
-      try {
-        const { access_token: accessToken } = await refreshAccessToken();
-
-        if (!isMounted) {
-          return;
-        }
-
-        useAuthStore.getState().setAccessToken(accessToken);
-        const profile = await getCurrentUserProfile();
-
-        if (!isMounted) {
-          return;
-        }
-
-        useAuthStore.getState().setAccount(profile);
-      } catch {
-        if (!isMounted) {
-          return;
-        }
-
-        useAuthStore.getState().clearAuth();
-      } finally {
-        if (isMounted) {
-          useAuthStore.getState().setAuthBootstrapStatus('ready');
-        }
+    void ensureAuthBootstrap().finally(() => {
+      if (isMounted) {
+        useAuthStore.getState().setAuthBootstrapStatus('ready');
       }
-    };
-
-    void bootstrapAuth();
+    });
 
     return () => {
       isMounted = false;

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -34,6 +34,18 @@ const validGenders: AuthGender[] = ['M', 'W'];
 
 const createAccessToken = (loginId: string) => `mock-access-token-${loginId}`;
 const createRefreshToken = (loginId: string) => `mock-refresh-token-${loginId}`;
+const parseLoginIdFromRefreshToken = (refreshToken: string) => {
+  const normalizedRefreshToken = refreshToken.trim();
+  const refreshTokenPrefix = 'mock-refresh-token-';
+
+  if (!normalizedRefreshToken.startsWith(refreshTokenPrefix)) {
+    return null;
+  }
+
+  const loginId = normalizedRefreshToken.slice(refreshTokenPrefix.length);
+
+  return loginId || null;
+};
 const MOCK_S3_HOST = 'https://mock-s3.oz-union-16.com';
 let refreshSessionLoginId: string | null = null;
 let pendingSocialLoginId: string | null = null;
@@ -351,8 +363,17 @@ const loginHandlers = [
     });
   }),
 
-  http.post(`${AUTH_BASE_PATH}/token/refresh`, async () => {
-    const loginId = pendingSocialLoginId ?? refreshSessionLoginId;
+  http.post(`${AUTH_BASE_PATH}/token/refresh`, async ({ request }) => {
+    const body = (await request.json().catch(() => null)) as {
+      refresh_token?: string;
+    } | null;
+    const requestRefreshToken =
+      typeof body?.refresh_token === 'string' ? body.refresh_token.trim() : '';
+    const loginIdFromRefreshToken = requestRefreshToken
+      ? parseLoginIdFromRefreshToken(requestRefreshToken)
+      : null;
+    const loginId =
+      pendingSocialLoginId ?? loginIdFromRefreshToken ?? refreshSessionLoginId;
 
     if (!loginId) {
       return HttpResponse.json(

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -13,6 +13,7 @@ export interface LoginResponse {
 
 export interface RefreshAccessTokenResponse {
   access_token: string;
+  refresh_token?: string | null;
 }
 
 export interface LogoutResponse {

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -10,9 +10,38 @@ import type { CurrentUserProfileResponse } from '../features/auth/types/auth';
 
 export type AuthBootstrapStatus = 'idle' | 'loading' | 'ready';
 
+const AUTH_PROFILE_PREVIEW_STORAGE_KEY = 'auth-profile-preview-image-url';
+
+const readPersistedProfilePreviewImageUrl = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.sessionStorage.getItem(AUTH_PROFILE_PREVIEW_STORAGE_KEY);
+};
+
+const persistProfilePreviewImageUrl = (profileImageUrl?: string | null) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const normalizedProfileImageUrl = profileImageUrl?.trim() ?? '';
+
+  if (!normalizedProfileImageUrl) {
+    window.sessionStorage.removeItem(AUTH_PROFILE_PREVIEW_STORAGE_KEY);
+    return;
+  }
+
+  window.sessionStorage.setItem(
+    AUTH_PROFILE_PREVIEW_STORAGE_KEY,
+    normalizedProfileImageUrl,
+  );
+};
+
 interface AuthState {
   accessToken: string | null;
   account: CurrentUserProfileResponse | null;
+  profilePreviewImageUrl: string | null;
   isAuthenticated: boolean;
   authBootstrapStatus: AuthBootstrapStatus;
   setAccessToken: (token: string) => void;
@@ -25,6 +54,7 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set) => ({
   accessToken: null,
   account: null,
+  profilePreviewImageUrl: readPersistedProfilePreviewImageUrl(),
   isAuthenticated: false,
   authBootstrapStatus: 'idle',
 
@@ -35,20 +65,31 @@ export const useAuthStore = create<AuthState>((set) => ({
       authBootstrapStatus: 'ready',
     }),
 
-  setAccount: (account) => set({ account }),
+  setAccount: (account) => {
+    persistProfilePreviewImageUrl(account?.profile_img_url);
+    set({
+      account,
+      profilePreviewImageUrl: account?.profile_img_url?.trim() ?? null,
+    });
+  },
 
-  setAuth: (token, account) =>
+  setAuth: (token, account) => {
+    persistProfilePreviewImageUrl(account?.profile_img_url);
     set({
       accessToken: token,
       account: account,
+      profilePreviewImageUrl: account?.profile_img_url?.trim() ?? null,
       isAuthenticated: true,
       authBootstrapStatus: 'ready',
-    }),
+    });
+  },
 
   clearAuth: () => {
+    persistProfilePreviewImageUrl(null);
     set({
       accessToken: null,
       account: null,
+      profilePreviewImageUrl: null,
       isAuthenticated: false,
     });
   },
@@ -82,3 +123,5 @@ export const clearLegacyAuthStorage = () => {
 // 하위 호환성을 위한 export (점진적 교체용)
 export const clearAuthTokens = () => useAuthStore.getState().clearAuth();
 export const clearAuthPersistedStorage = clearLegacyAuthStorage;
+export const getPersistedProfilePreviewImageUrl =
+  readPersistedProfilePreviewImageUrl;


### PR DESCRIPTION
## 관련 이슈

- closes #225

## 변경 내용

- 로그인 후 새로고침 시 세션이 유지되도록 인증 부트스트랩 흐름을 보강했습니다.
- refresh 요청을 single-flight로 묶어 개발 환경에서도 중복 호출로 세션이 풀리지 않도록 정리했습니다.
- DEV+MSW 환경에서 refresh_token body fallback을 지원하도록 로그인/토큰 갱신 로직과 MSW 핸들러를 함께 수정했습니다.
- 헤더가 인증 복구 중일 때 로그인/회원가입 버튼이 찰나에 노출되지 않도록 렌더링 기준을 조정했습니다.
- 헤더 프로필 이미지가 기본 이미지로 잠깐 바뀌었다가 원래 이미지로 돌아오는 현상을 막기 위해, 프로필 이미지 미리보기 URL을 세션 단위로 보존하도록 보완했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

https://github.com/user-attachments/assets/cb1cefad-e2cd-4408-b6f5-bebb2f7564b1


## 참고사항

- 토큰 자체는 기존처럼 메모리 전용으로 유지하고, 헤더 깜빡임 제거를 위해 프로필 이미지 URL만 세션 단위 미리보기 값으로 보존했습니다.
- DEV+MSW에서는 새로고침 복구를 위해 refresh_token body fallback을 사용하고, 실서버는 기존 쿠키 기반 흐름을 유지합니다.
