### PR TITLE
[Feat] 설문·매칭 접근 흐름 및 인증 부트스트랩 정리

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -46,6 +46,8 @@ const Header = ({ fixed = true }: HeaderProps) => {
     account?.profile_img_url ??
     profileHydrationQuery.data?.profile_img_url ??
     profilePreviewImageUrl;
+  const shouldShowDeferredGuestPreview =
+    shouldDeferGuestActions && Boolean(resolvedProfileImageUrl);
 
   useEffect(() => {
     if (profileHydrationQuery.data) {
@@ -72,7 +74,7 @@ const Header = ({ fixed = true }: HeaderProps) => {
 
         <div className="flex items-center gap-2 sm:gap-3">
           {!isLoggedIn ? (
-            shouldHideGuestActions ? null : shouldDeferGuestActions ? (
+            shouldHideGuestActions ? null : shouldShowDeferredGuestPreview ? (
               resolvedProfileImageUrl ? (
                 <div
                   aria-hidden="true"
@@ -84,9 +86,7 @@ const Header = ({ fixed = true }: HeaderProps) => {
                     className="h-full w-full object-cover"
                   />
                 </div>
-              ) : (
-                <div className="h-9 w-44" aria-hidden="true" />
-              )
+              ) : null
             ) : (
               <>
                 <Link

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -46,6 +46,8 @@ const readMockRefreshToken = () => {
   return window.sessionStorage.getItem(MOCK_REFRESH_TOKEN_STORAGE_KEY) ?? '';
 };
 
+export const hasMockRefreshToken = () => Boolean(readMockRefreshToken().trim());
+
 const persistMockRefreshToken = (refreshToken: string | null | undefined) => {
   if (!mockServiceWorkerEnabled || typeof window === 'undefined') {
     return;

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -2,11 +2,16 @@ import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router';
 
 import { ROUTES } from '../../../constants/routes';
+import { isMockServiceWorkerEnabled } from '../../../lib/env';
 import {
   clearLegacyAuthStorage,
   useAuthStore,
 } from '../../../store/useAuthStore';
-import { getCurrentUserProfile, refreshAccessToken } from '../api/auth';
+import {
+  getCurrentUserProfile,
+  hasMockRefreshToken,
+  refreshAccessToken,
+} from '../api/auth';
 
 const AUTH_BOOTSTRAP_SKIP_PATHS = new Set([
   `/${ROUTES.AUTH_CALLBACK}`,
@@ -62,6 +67,11 @@ function useAuthBootstrap() {
     }
 
     if (AUTH_BOOTSTRAP_SKIP_PATHS.has(location.pathname)) {
+      store.setAuthBootstrapStatus('ready');
+      return;
+    }
+
+    if (isMockServiceWorkerEnabled() && !hasMockRefreshToken()) {
       store.setAuthBootstrapStatus('ready');
       return;
     }

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -1,7 +1,13 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight, Heart } from 'lucide-react';
 import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
-import { Link, useNavigate, useParams } from 'react-router';
+import {
+  Link,
+  Navigate,
+  useLocation,
+  useNavigate,
+  useParams,
+} from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import Header from '../../components/common/Header';
@@ -43,9 +49,10 @@ const isLikedGamesResponse = (value: unknown): value is LikedGamesResponse => {
 
 function MatchingGenreDetailPage() {
   const { genreSlug } = useParams();
+  const location = useLocation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const authGate = useAuthGate({ allowMockBypass: true });
+  const authGate = useAuthGate();
   const canAccessPage = authGate.accessStatus === 'authorized';
   const isValidGenreSlug = genreSlug ? isMatchingGenreSlug(genreSlug) : false;
   const genre = genreSlug ? getMatchingGenreBySlug(genreSlug) : undefined;
@@ -124,6 +131,19 @@ function MatchingGenreDetailPage() {
   const submitErrorMessage = submitMatchResponsesMutation.error
     ? extractApiErrorMessage(submitMatchResponsesMutation.error)
     : null;
+
+  if (authGate.accessStatus === 'unauthorized') {
+    return (
+      <Navigate
+        to={`/${ROUTES.LOGIN}`}
+        replace
+        state={{
+          noticeMessage: '로그인 후 매칭을 진행할 수 있어요.',
+          redirectTo: `${location.pathname}${location.search}`,
+        }}
+      />
+    );
+  }
 
   const syncLikedGamesCache = () => {
     queryClient.setQueriesData<LikedGamesResponse>(
@@ -238,8 +258,9 @@ function MatchingGenreDetailPage() {
         ) : !canAccessPage ? (
           <AuthGateStatusPanel
             title="로그인 후 매칭을 진행할 수 있어요."
-            description="실제 API 모드에서는 인증 토큰이 필요합니다. 개발 환경에서 MSW를 켜두면 로그인 없이도 매칭 흐름을 확인할 수 있어요."
+            description="로그인하면 장르를 고르고 트레일러를 보며 별점을 남긴 뒤, 취향에 맞는 추천 결과까지 바로 이어서 확인할 수 있어요."
             className="mx-auto max-w-[760px] sm:py-12"
+            align="center"
           />
         ) : matchCandidatesQuery.isLoading ? (
           <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 text-center text-white/68 sm:px-8 sm:py-12">
@@ -312,7 +333,7 @@ function MatchingGenreDetailPage() {
                 <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
                   트레일러와 분위기를 보며 {totalGamesLabel}에 별점을
                   남겨보세요. 좋아요는 마음에 든 게임을 표시해 두고
-                  마이페이지에서도 다시 확인할 수 있게 함께 저장돼요.
+                  마이페이지에서 다시 확인할 수 있게 함께 저장돼요.
                 </p>
               </div>
 
@@ -411,11 +432,6 @@ function MatchingGenreDetailPage() {
 
                     {isLastCard ? (
                       <div className="mt-auto pt-5">
-                        <p className="mx-auto mb-2.5 w-full max-w-[420px] text-center text-sm leading-6 break-keep text-white/42">
-                          {totalSteps}개 게임의 선호도 평가가 모두 준비되면
-                          제출할 수 있어요.
-                        </p>
-
                         <div className="flex flex-wrap items-end justify-between gap-3">
                           <button
                             type="button"

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -1,7 +1,8 @@
 import { ChevronRight } from 'lucide-react';
 import { useLayoutEffect, useMemo } from 'react';
-import { Link } from 'react-router';
+import { Link, Navigate, useLocation } from 'react-router';
 
+import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import Header from '../../components/common/Header';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
@@ -10,8 +11,10 @@ import { MATCHING_GENRES } from '../../features/matching/genres';
 import { useMatchingStore } from '../../features/matching/store/useMatchingStore';
 
 function MatchingListPage() {
-  const authGate = useAuthGate({ allowMockBypass: true });
-  const canFetchGenreImages = authGate.accessStatus === 'authorized';
+  const location = useLocation();
+  const authGate = useAuthGate();
+  const canAccessPage = authGate.accessStatus === 'authorized';
+  const canFetchGenreImages = canAccessPage;
   const resetFlow = useMatchingStore((state) => state.resetFlow);
   const genreImageQueries = useMatchingGenreImageQueries(
     MATCHING_GENRES.map((genre) => genre.genreId),
@@ -32,61 +35,92 @@ function MatchingListPage() {
     resetFlow();
   }, [resetFlow]);
 
+  if (authGate.accessStatus === 'unauthorized') {
+    return (
+      <Navigate
+        to={`/${ROUTES.LOGIN}`}
+        replace
+        state={{
+          noticeMessage: '로그인 후 매칭을 시작할 수 있어요.',
+          redirectTo: `${location.pathname}${location.search}`,
+        }}
+      />
+    );
+  }
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.18),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
       <Header fixed />
 
       <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1120px] px-4 pt-[5.5rem] pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-[6.25rem] md:pb-14">
-        <section className="mx-auto max-w-[960px]">
-          <div className="mb-7 text-center sm:mb-8">
-            <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
-              Matching
-            </p>
-            <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[42px]">
-              장르별 게임 매칭
-            </h1>
-            <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
-              좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에 맞는
-              게임을 빠르게 추천해드려요.
-            </p>
-          </div>
+        {authGate.accessStatus === 'loading' ? (
+          <AuthGateStatusPanel
+            title="인증 상태를 확인하는 중입니다."
+            description="잠시만 기다려 주세요. 세션 확인 후 장르별 매칭 화면을 보여드릴게요."
+            align="center"
+            className="mx-auto max-w-[760px] sm:py-12"
+          />
+        ) : !canAccessPage ? (
+          <AuthGateStatusPanel
+            title="로그인 후 매칭을 시작할 수 있어요."
+            description="로그인하면 장르를 고르고 트레일러를 보며 별점을 남긴 뒤, 취향에 맞는 추천 결과까지 바로 이어서 확인할 수 있어요."
+            align="center"
+            className="mx-auto max-w-[760px] sm:py-12"
+          />
+        ) : (
+          <section className="mx-auto max-w-[960px]">
+            <div className="mb-7 text-center sm:mb-8">
+              <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
+                Matching
+              </p>
+              <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[42px]">
+                장르별 게임 매칭
+              </h1>
+              <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
+                좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에
+                맞는 게임을 빠르게 추천해드려요.
+              </p>
+            </div>
 
-          <div className="grid gap-4 md:grid-cols-2">
-            {MATCHING_GENRES.map((genre) => (
-              <Link
-                key={genre.slug}
-                to={`/${ROUTES.MATCHING_LIST}/${genre.slug}`}
-                className="group overflow-hidden rounded-[24px] border border-white/8 bg-[#0c0c0d] p-2.5 shadow-[0_18px_36px_rgba(0,0,0,0.26)] transition hover:border-[#a31c1c]/65 hover:bg-[#111112]"
-              >
-                <div className="relative overflow-hidden rounded-[18px]">
-                  <img
-                    src={genreImageMap.get(genre.genreId) ?? genre.thumbnailUrl}
-                    alt={genre.title}
-                    className="aspect-[16/8.4] w-full object-cover transition duration-300 group-hover:scale-[1.025] group-hover:brightness-110"
-                  />
-                  <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,6,8,0.18),rgba(6,6,8,0.72))]" />
-                  <p className="absolute top-3.5 left-3.5 text-[10px] font-medium tracking-[0.2em] text-white/76 uppercase">
-                    {genre.subtitle}
-                  </p>
-                  <div className="absolute right-3.5 bottom-3.5 left-3.5 flex items-end justify-between gap-3">
-                    <div>
-                      <h2 className="text-[22px] font-semibold tracking-[-0.02em] text-white">
-                        {genre.title}
-                      </h2>
-                      <p className="mt-1.5 max-w-[24ch] text-[13px] leading-5 break-keep text-white/72">
-                        {genre.description}
-                      </p>
+            <div className="grid gap-4 md:grid-cols-2">
+              {MATCHING_GENRES.map((genre) => (
+                <Link
+                  key={genre.slug}
+                  to={`/${ROUTES.MATCHING_LIST}/${genre.slug}`}
+                  className="group overflow-hidden rounded-[24px] border border-white/8 bg-[#0c0c0d] p-2.5 shadow-[0_18px_36px_rgba(0,0,0,0.26)] transition hover:border-[#a31c1c]/65 hover:bg-[#111112]"
+                >
+                  <div className="relative overflow-hidden rounded-[18px]">
+                    <img
+                      src={
+                        genreImageMap.get(genre.genreId) ?? genre.thumbnailUrl
+                      }
+                      alt={genre.title}
+                      className="aspect-[16/8.4] w-full object-cover transition duration-300 group-hover:scale-[1.025] group-hover:brightness-110"
+                    />
+                    <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,6,8,0.18),rgba(6,6,8,0.72))]" />
+                    <p className="absolute top-3.5 left-3.5 text-[10px] font-medium tracking-[0.2em] text-white/76 uppercase">
+                      {genre.subtitle}
+                    </p>
+                    <div className="absolute right-3.5 bottom-3.5 left-3.5 flex items-end justify-between gap-3">
+                      <div>
+                        <h2 className="text-[22px] font-semibold tracking-[-0.02em] text-white">
+                          {genre.title}
+                        </h2>
+                        <p className="mt-1.5 max-w-[24ch] text-[13px] leading-5 break-keep text-white/72">
+                          {genre.description}
+                        </p>
+                      </div>
+                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-white/10 bg-black/28 text-white/78 transition group-hover:border-[#b02525]/60 group-hover:text-white">
+                        <ChevronRight size={17} />
+                      </span>
                     </div>
-                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-white/10 bg-black/28 text-white/78 transition group-hover:border-[#b02525]/60 group-hover:text-white">
-                      <ChevronRight size={17} />
-                    </span>
                   </div>
-                </div>
-              </Link>
-            ))}
-          </div>
-        </section>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
       </main>
     </div>
   );

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
+import { Navigate, useLocation } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import Header from '../../components/common/Header';
+import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import SurveyChatPanel from '../../features/survey/components/SurveyChatPanel';
 import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
@@ -33,7 +35,8 @@ function SurveyBackdrop() {
 }
 
 function SurveyPage() {
-  const authGate = useAuthGate({ allowMockBypass: true });
+  const location = useLocation();
+  const authGate = useAuthGate();
   const canAccessSurvey = authGate.accessStatus === 'authorized';
   const account = useAuthStore((state) => state.account);
   const syncOwnerKey = useSurveyStore((state) => state.syncOwnerKey);
@@ -49,6 +52,19 @@ function SurveyPage() {
     syncOwnerKey(surveyOwnerKey);
   }, [surveyOwnerKey, syncOwnerKey]);
 
+  if (authGate.accessStatus === 'unauthorized') {
+    return (
+      <Navigate
+        to={`/${ROUTES.LOGIN}`}
+        replace
+        state={{
+          noticeMessage: '로그인 후 설문을 시작할 수 있어요.',
+          redirectTo: `${location.pathname}${location.search}`,
+        }}
+      />
+    );
+  }
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <SurveyBackdrop />
@@ -60,6 +76,8 @@ function SurveyPage() {
           <AuthGateStatusPanel
             title="인증 상태를 확인하는 중입니다."
             description="잠시만 기다려 주세요. 세션 확인 후 설문 화면을 이어서 보여드릴게요."
+            align="center"
+            className="mx-auto max-w-[760px] sm:py-12"
           />
         ) : canAccessSurvey ? (
           <SurveyChatPanel />
@@ -67,6 +85,8 @@ function SurveyPage() {
           <AuthGateStatusPanel
             title="로그인 후 설문을 시작할 수 있어요."
             description="로그인하면 취향을 바탕으로 질문을 이어가고, 설문이 끝난 뒤 바로 추천 결과까지 확인할 수 있어요."
+            align="center"
+            className="mx-auto max-w-[760px] sm:py-12"
           />
         )}
       </main>


### PR DESCRIPTION
## 관련 이슈

- closes #227 

## 변경 내용

- 설문 페이지와 매칭 페이지의 접근 흐름을 로그인 기준으로 통일했습니다.
- 비로그인 상태에서 설문/매칭 진입 시 중간 안내 화면에 머무르지 않고 로그인 페이지로 바로 이동하도록 수정했습니다.
- DEV + MSW 환경에서 mock refresh token이 없을 때 불필요한 silent refresh를 시도하지 않도록 인증 부트스트랩 흐름을 보정했습니다.
- 그 결과 비로그인 개발 환경에서 `인증 상태를 확인하는 중입니다` 화면에 계속 머무르지 않고 바로 로그인 페이지로 이동하도록 개선했습니다.
- 로그인 헤더가 비어 보이던 분기를 수정해 bootstrap 중에도 잘못된 빈 영역이 보이지 않도록 정리했습니다.
- 매칭 상세 페이지의 제출 안내 문구를 실제 흐름에 맞게 간단히 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 설문/매칭 접근 제어와 인증 부트스트랩 흐름 정리에 집중했습니다.
- 로그인 페이지로 이동할 때 원래 보려던 경로 정보를 함께 넘길 수 있는 구조로 정리해두었습니다.
