### PR TITLE
refactor(auth): 로그인·회원가입 폼 로직을 custom hook으로 분리

### DIFF
--- a/src/features/auth/hooks/useLoginForm.ts
+++ b/src/features/auth/hooks/useLoginForm.ts
@@ -1,0 +1,328 @@
+import type { FormEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
+import { api } from '../../../api/axios';
+import { ROUTES } from '../../../constants/routes';
+import { mockServiceWorkerEnabled } from '../../../lib/env';
+import { resolveLoginApiError } from '../api/auth';
+import { useLoginMutation } from '../api/useAuthApi';
+import { AUTH_SESSION_EXPIRED_NOTICE_MESSAGE } from '../constants/session';
+import type { LoginRequest } from '../types/auth';
+import { resolveAuthFeedbackVisibility } from '../utils/feedbackPriority';
+import { focusFieldByName } from '../utils/focusField';
+import { hydrateAuthSessionFromAccessToken } from '../utils/sessionManager';
+import { getSocialCallbackErrorMessage } from '../utils/socialAuth';
+
+type LoginFieldName = keyof LoginRequest;
+type LoginFieldErrors = Partial<Record<LoginFieldName, string>>;
+type LoginTouchedState = Record<LoginFieldName, boolean>;
+type LoginLocationState = {
+  noticeMessage?: string;
+  errorMessage?: string;
+};
+
+type DevMockLoginAccount = {
+  loginId: string;
+  password: string;
+  name: string;
+  nickname: string;
+  gender: string;
+  note: string;
+};
+
+type DevMockLoginAccountsResponse = {
+  accounts: DevMockLoginAccount[];
+};
+
+export const LOGIN_FORM_FIELD_IDS: Record<LoginFieldName, string> = {
+  login_id: 'login-id',
+  password: 'login-password',
+};
+
+const getLoginFieldErrors = (
+  values: LoginRequest,
+  touchedState: LoginTouchedState,
+) => {
+  const trimmedLoginId = values.login_id.trim();
+  const trimmedPassword = values.password.trim();
+
+  return {
+    login_id:
+      touchedState.login_id && !trimmedLoginId ? '아이디를 입력해주세요.' : '',
+    password:
+      touchedState.password && !trimmedPassword
+        ? '비밀번호를 입력해주세요.'
+        : '',
+  } satisfies Record<LoginFieldName, string>;
+};
+
+const resolveMockAccounts = (
+  accounts: DevMockLoginAccountsResponse['accounts'] | undefined,
+) => (Array.isArray(accounts) ? accounts : []);
+
+function useLoginForm() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const loginMutation = useLoginMutation();
+  const [mockAccounts, setMockAccounts] = useState<DevMockLoginAccount[]>([]);
+  const [isMockPanelOpen, setIsMockPanelOpen] = useState(false);
+  const mockPanelRef = useRef<HTMLDivElement | null>(null);
+
+  const [formValues, setFormValues] = useState<LoginRequest>({
+    login_id: '',
+    password: '',
+  });
+  const [touchedState, setTouchedState] = useState<LoginTouchedState>({
+    login_id: false,
+    password: false,
+  });
+  const [apiFieldErrors, setApiFieldErrors] = useState<LoginFieldErrors>({});
+  const locationState = location.state as LoginLocationState | null;
+  const locationSearchParams = new URLSearchParams(location.search);
+  const locationSearchErrorMessage =
+    getSocialCallbackErrorMessage(locationSearchParams);
+  const locationSearchNoticeMessage =
+    locationSearchParams.get('expired') === 'true'
+      ? AUTH_SESSION_EXPIRED_NOTICE_MESSAGE
+      : '';
+  const [formMessage, setFormMessage] = useState(
+    locationState?.errorMessage ?? locationSearchErrorMessage ?? '',
+  );
+  const [noticeMessage, setNoticeMessage] = useState(
+    locationState?.noticeMessage ?? locationSearchNoticeMessage,
+  );
+  const fieldErrors = getLoginFieldErrors(formValues, touchedState);
+  const resolvedFieldErrors: Record<LoginFieldName, string> = {
+    login_id: apiFieldErrors.login_id ?? fieldErrors.login_id,
+    password: apiFieldErrors.password ?? fieldErrors.password,
+  };
+  const feedbackVisibility = resolveAuthFeedbackVisibility({
+    fieldErrors: resolvedFieldErrors,
+    formMessage,
+  });
+  const showNoticeMessage =
+    !feedbackVisibility.hasFieldError &&
+    !feedbackVisibility.showFormMessage &&
+    Boolean(noticeMessage.trim());
+  const primaryMockAccount =
+    mockAccounts.find((account) => account.loginId === 'pgti-demo') ??
+    mockAccounts[0];
+  const visibleMockAccounts = primaryMockAccount ? [primaryMockAccount] : [];
+  const showMockAccounts =
+    mockServiceWorkerEnabled && visibleMockAccounts.length > 0;
+
+  useEffect(() => {
+    setFormMessage(
+      locationState?.errorMessage ?? locationSearchErrorMessage ?? '',
+    );
+  }, [locationState?.errorMessage, locationSearchErrorMessage]);
+
+  useEffect(() => {
+    setNoticeMessage(
+      locationState?.noticeMessage ?? locationSearchNoticeMessage,
+    );
+  }, [locationState?.noticeMessage, locationSearchNoticeMessage]);
+
+  useEffect(() => {
+    if (!mockServiceWorkerEnabled) {
+      return;
+    }
+
+    let isMounted = true;
+
+    void api
+      .get<DevMockLoginAccountsResponse>('/api/v1/accounts/dev-login-accounts')
+      .then(({ data }) => {
+        if (!isMounted) {
+          return;
+        }
+
+        setMockAccounts(resolveMockAccounts(data?.accounts));
+      })
+      .catch(async () => {
+        try {
+          const { mockLoginAccounts } = await import('../mocks/mockUsers');
+
+          if (!isMounted) {
+            return;
+          }
+
+          setMockAccounts(mockLoginAccounts);
+        } catch {
+          if (!isMounted) {
+            return;
+          }
+
+          setMockAccounts([]);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (showMockAccounts) {
+      return;
+    }
+
+    setIsMockPanelOpen(false);
+  }, [showMockAccounts]);
+
+  useEffect(() => {
+    if (!isMockPanelOpen) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsMockPanelOpen(false);
+      }
+    };
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (
+        mockPanelRef.current &&
+        !mockPanelRef.current.contains(event.target as Node) &&
+        !(event.target as HTMLElement)?.closest('.dev-login-fab')
+      ) {
+        setIsMockPanelOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    window.addEventListener('mousedown', handleOutsideClick);
+
+    return () => {
+      window.removeEventListener('keydown', handleEscape);
+      window.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [isMockPanelOpen]);
+
+  const clearApiFieldError = (fieldName: LoginFieldName) => {
+    setApiFieldErrors((previous) => {
+      if (!previous[fieldName]) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        [fieldName]: '',
+      };
+    });
+  };
+
+  const clearMessages = () => {
+    setFormMessage('');
+    setNoticeMessage('');
+  };
+
+  const handleChange = (fieldName: LoginFieldName, value: string) => {
+    setFormValues((previous) => ({
+      ...previous,
+      [fieldName]: value,
+    }));
+    clearApiFieldError(fieldName);
+    clearMessages();
+  };
+
+  const handleBlur = (fieldName: LoginFieldName) => {
+    setTouchedState((previous) => ({
+      ...previous,
+      [fieldName]: true,
+    }));
+  };
+
+  const handleApplyMockAccount = (account: DevMockLoginAccount) => {
+    setFormValues({
+      login_id: account.loginId,
+      password: account.password,
+    });
+    setTouchedState({
+      login_id: false,
+      password: false,
+    });
+    setApiFieldErrors({});
+    clearMessages();
+    setIsMockPanelOpen(false);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const nextTouchedState = {
+      login_id: true,
+      password: true,
+    } satisfies LoginTouchedState;
+
+    setTouchedState(nextTouchedState);
+    setApiFieldErrors({});
+    clearMessages();
+
+    const nextFieldErrors = getLoginFieldErrors(formValues, nextTouchedState);
+    const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
+
+    if (hasLocalError) {
+      const firstInvalidField: LoginFieldName | null = nextFieldErrors.login_id
+        ? 'login_id'
+        : nextFieldErrors.password
+          ? 'password'
+          : null;
+
+      focusFieldByName(firstInvalidField, LOGIN_FORM_FIELD_IDS);
+      return;
+    }
+
+    const payload: LoginRequest = {
+      login_id: formValues.login_id.trim(),
+      password: formValues.password.trim(),
+    };
+
+    let accessToken: string;
+
+    try {
+      const response = await loginMutation.mutateAsync(payload);
+      accessToken = response.access_token;
+    } catch (error) {
+      const resolvedError = resolveLoginApiError(error, payload);
+
+      setApiFieldErrors(resolvedError.fieldErrors);
+      setFormMessage(resolvedError.message);
+      focusFieldByName(resolvedError.focusField, LOGIN_FORM_FIELD_IDS);
+      return;
+    }
+
+    try {
+      await hydrateAuthSessionFromAccessToken(accessToken);
+      navigate(ROUTES.HOME);
+    } catch {
+      setFormMessage(
+        '로그인 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      );
+    }
+  };
+
+  return {
+    formValues,
+    resolvedFieldErrors,
+    formMessage,
+    noticeMessage,
+    showNoticeMessage,
+    showFormMessage: feedbackVisibility.showFormMessage,
+    isSubmitting: loginMutation.isPending,
+    visibleMockAccounts,
+    showMockAccounts,
+    isMockPanelOpen,
+    mockPanelRef,
+    handleChange,
+    handleBlur,
+    handleSubmit,
+    handleApplyMockAccount,
+    closeMockPanel: () => setIsMockPanelOpen(false),
+    toggleMockPanel: () => setIsMockPanelOpen((previous) => !previous),
+  };
+}
+
+export default useLoginForm;

--- a/src/features/auth/hooks/useSignupForm.ts
+++ b/src/features/auth/hooks/useSignupForm.ts
@@ -1,0 +1,509 @@
+import type { FormEvent } from 'react';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
+
+import { ROUTES } from '../../../constants/routes';
+import {
+  extractAuthApiErrorMessage,
+  extractAuthApiFieldErrors,
+} from '../api/auth';
+import {
+  useCheckIdDuplicateMutation,
+  useCheckNicknameDuplicateMutation,
+  useLoginMutation,
+  useSignupMutation,
+} from '../api/useAuthApi';
+import type { AuthGender, SignupRequest } from '../types/auth';
+import { resolveAuthFeedbackVisibility } from '../utils/feedbackPriority';
+import { focusFieldByName, getFirstErrorFieldName } from '../utils/focusField';
+import { hydrateAuthSessionFromAccessToken } from '../utils/sessionManager';
+
+type SignupFormValues = Omit<SignupRequest, 'gender'> & {
+  gender: AuthGender | '';
+};
+
+type SignupFieldName = keyof SignupFormValues;
+type SignupFieldErrors = Partial<Record<SignupFieldName, string>>;
+type SignupTouchedState = Record<SignupFieldName, boolean>;
+
+type DuplicateCheckState = {
+  verifiedValue: string | null;
+  message: string;
+  tone: 'success' | 'error' | null;
+};
+
+type DuplicateCheckToastState = {
+  message: string;
+  tone: 'success' | 'error';
+  anchor: 'login_id' | 'nickname';
+} | null;
+
+export const SIGNUP_FORM_GENDER_OPTIONS = [
+  { label: '남성', value: 'M' },
+  { label: '여성', value: 'W' },
+] as const;
+
+export const SIGNUP_FORM_FIELD_MAX_LENGTHS = {
+  name: 30,
+  login_id: 15,
+  nickname: 10,
+} as const;
+
+export const SIGNUP_FORM_GENDER_ID_PREFIX = 'signup-gender';
+
+export const SIGNUP_FORM_FIELD_IDS: Record<SignupFieldName, string> = {
+  name: 'signup-name',
+  login_id: 'signup-id',
+  nickname: 'signup-nickname',
+  password: 'signup-password',
+  password_check: 'signup-password-confirm',
+  gender: `${SIGNUP_FORM_GENDER_ID_PREFIX}-M`,
+};
+
+const NICKNAME_WHITESPACE_MESSAGE = '닉네임에는 띄어쓰기를 사용할 수 없습니다.';
+
+const initialDuplicateCheckState: DuplicateCheckState = {
+  verifiedValue: null,
+  message: '',
+  tone: null,
+};
+
+const SIGNUP_FIELD_ORDER = [
+  'name',
+  'login_id',
+  'nickname',
+  'password',
+  'password_check',
+  'gender',
+] as const satisfies readonly SignupFieldName[];
+
+const getSignupFieldErrors = (
+  values: SignupFormValues,
+  touchedState: SignupTouchedState,
+  loginIdVerified: boolean,
+  nicknameVerified: boolean,
+) => {
+  const trimmedName = values.name.trim();
+  const trimmedLoginId = values.login_id.trim();
+  const trimmedNickname = values.nickname.trim();
+  const trimmedPassword = values.password.trim();
+  const trimmedPasswordCheck = values.password_check.trim();
+
+  return {
+    name: touchedState.name && !trimmedName ? '이름을 입력해주세요.' : '',
+    login_id:
+      touchedState.login_id && !trimmedLoginId
+        ? '아이디를 입력해주세요.'
+        : touchedState.login_id && trimmedLoginId && !loginIdVerified
+          ? '아이디 중복확인을 해주세요.'
+          : '',
+    nickname:
+      touchedState.nickname && !trimmedNickname
+        ? '닉네임을 입력해주세요.'
+        : touchedState.nickname && trimmedNickname && !nicknameVerified
+          ? '닉네임 중복확인을 해주세요.'
+          : '',
+    password:
+      touchedState.password && !trimmedPassword
+        ? '비밀번호를 입력해주세요.'
+        : touchedState.password &&
+            trimmedPassword.length > 0 &&
+            trimmedPassword.length < 8
+          ? '비밀번호는 8자 이상이어야 합니다.'
+          : '',
+    password_check:
+      touchedState.password_check && !trimmedPasswordCheck
+        ? '비밀번호를 한번 더 입력해주세요.'
+        : touchedState.password_check &&
+            trimmedPassword.length > 0 &&
+            trimmedPasswordCheck.length > 0 &&
+            trimmedPassword !== trimmedPasswordCheck
+          ? '비밀번호와 일치하지 않습니다.'
+          : '',
+    gender: touchedState.gender && !values.gender ? '성별을 선택해주세요.' : '',
+  } satisfies Record<SignupFieldName, string>;
+};
+
+function useSignupForm() {
+  const navigate = useNavigate();
+  const signupMutation = useSignupMutation();
+  const loginMutation = useLoginMutation();
+  const checkIdDuplicateMutation = useCheckIdDuplicateMutation();
+  const checkNicknameDuplicateMutation = useCheckNicknameDuplicateMutation();
+  const [formValues, setFormValues] = useState<SignupFormValues>({
+    name: '',
+    login_id: '',
+    nickname: '',
+    password: '',
+    password_check: '',
+    gender: '',
+  });
+  const [touchedState, setTouchedState] = useState<SignupTouchedState>({
+    name: false,
+    login_id: false,
+    nickname: false,
+    password: false,
+    password_check: false,
+    gender: false,
+  });
+  const [apiFieldErrors, setApiFieldErrors] = useState<SignupFieldErrors>({});
+  const [formMessage, setFormMessage] = useState('');
+  const [nicknameWhitespaceMessage, setNicknameWhitespaceMessage] =
+    useState('');
+  const [loginIdCheckState, setLoginIdCheckState] =
+    useState<DuplicateCheckState>(initialDuplicateCheckState);
+  const [nicknameCheckState, setNicknameCheckState] =
+    useState<DuplicateCheckState>(initialDuplicateCheckState);
+  const [duplicateCheckToast, setDuplicateCheckToast] =
+    useState<DuplicateCheckToastState>(null);
+
+  const trimmedLoginId = formValues.login_id.trim();
+  const trimmedNickname = formValues.nickname.trim();
+  const trimmedPassword = formValues.password.trim();
+
+  const isLoginIdVerified =
+    loginIdCheckState.tone === 'success' &&
+    loginIdCheckState.verifiedValue === trimmedLoginId;
+  const isNicknameVerified =
+    nicknameCheckState.tone === 'success' &&
+    nicknameCheckState.verifiedValue === trimmedNickname;
+
+  const localFieldErrors = getSignupFieldErrors(
+    formValues,
+    touchedState,
+    isLoginIdVerified,
+    isNicknameVerified,
+  );
+
+  const resolvedFieldErrors: Record<SignupFieldName, string> = {
+    name: apiFieldErrors.name ?? localFieldErrors.name,
+    login_id:
+      apiFieldErrors.login_id ||
+      (loginIdCheckState.tone === 'error' ? loginIdCheckState.message : '') ||
+      localFieldErrors.login_id,
+    nickname:
+      apiFieldErrors.nickname ||
+      nicknameWhitespaceMessage ||
+      (nicknameCheckState.tone === 'error' ? nicknameCheckState.message : '') ||
+      localFieldErrors.nickname,
+    password: apiFieldErrors.password ?? localFieldErrors.password,
+    password_check:
+      apiFieldErrors.password_check ?? localFieldErrors.password_check,
+    gender: apiFieldErrors.gender ?? localFieldErrors.gender,
+  };
+  const feedbackVisibility = resolveAuthFeedbackVisibility({
+    fieldErrors: resolvedFieldErrors,
+    formMessage,
+    hasToast: Boolean(duplicateCheckToast),
+  });
+  const isSubmitting = signupMutation.isPending || loginMutation.isPending;
+  const loginIdHelperMessage =
+    !resolvedFieldErrors.login_id && loginIdCheckState.tone === 'success'
+      ? loginIdCheckState.message
+      : '';
+  const nicknameHelperMessage =
+    !resolvedFieldErrors.nickname && nicknameCheckState.tone === 'success'
+      ? nicknameCheckState.message
+      : '';
+  const loginIdToast =
+    feedbackVisibility.showToast && duplicateCheckToast?.anchor === 'login_id'
+      ? duplicateCheckToast
+      : null;
+  const nicknameToast =
+    feedbackVisibility.showToast && duplicateCheckToast?.anchor === 'nickname'
+      ? duplicateCheckToast
+      : null;
+
+  useEffect(() => {
+    if (!duplicateCheckToast) {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setDuplicateCheckToast(null);
+    }, 2200);
+
+    return () => window.clearTimeout(timeout);
+  }, [duplicateCheckToast]);
+
+  const clearApiFieldError = (fieldName: SignupFieldName) => {
+    setApiFieldErrors((previous) => {
+      if (!previous[fieldName]) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        [fieldName]: '',
+      };
+    });
+  };
+
+  const handleFieldChange = (fieldName: SignupFieldName, value: string) => {
+    let nextValue = value;
+    let nextNicknameHasWhitespace = false;
+
+    if (fieldName === 'name') {
+      nextValue = value.slice(0, SIGNUP_FORM_FIELD_MAX_LENGTHS.name);
+    }
+
+    if (fieldName === 'login_id') {
+      nextValue = value.slice(0, SIGNUP_FORM_FIELD_MAX_LENGTHS.login_id);
+    }
+
+    if (fieldName === 'nickname') {
+      nextNicknameHasWhitespace = /\s/.test(value);
+      nextValue = value
+        .replace(/\s+/g, '')
+        .slice(0, SIGNUP_FORM_FIELD_MAX_LENGTHS.nickname);
+      setNicknameWhitespaceMessage(
+        nextNicknameHasWhitespace ? NICKNAME_WHITESPACE_MESSAGE : '',
+      );
+    }
+
+    setFormValues((previous) => ({
+      ...previous,
+      [fieldName]: nextValue,
+    }));
+
+    clearApiFieldError(fieldName);
+    setFormMessage('');
+
+    if (fieldName === 'login_id') {
+      setLoginIdCheckState((previous) =>
+        previous.verifiedValue === nextValue.trim() &&
+        previous.tone === 'success'
+          ? previous
+          : initialDuplicateCheckState,
+      );
+    }
+
+    if (fieldName === 'nickname') {
+      setNicknameCheckState((previous) =>
+        previous.verifiedValue === nextValue.trim() &&
+        previous.tone === 'success' &&
+        !nextNicknameHasWhitespace
+          ? previous
+          : initialDuplicateCheckState,
+      );
+    }
+  };
+
+  const handleFieldBlur = (fieldName: SignupFieldName) => {
+    setTouchedState((previous) => ({
+      ...previous,
+      [fieldName]: true,
+    }));
+  };
+
+  const handleCheckLoginIdDuplicate = async () => {
+    setTouchedState((previous) => ({
+      ...previous,
+      login_id: true,
+    }));
+    setFormMessage('');
+
+    if (!trimmedLoginId) {
+      focusFieldByName('login_id', SIGNUP_FORM_FIELD_IDS);
+      return;
+    }
+
+    try {
+      const response = await checkIdDuplicateMutation.mutateAsync({
+        login_id: trimmedLoginId,
+      });
+
+      setLoginIdCheckState({
+        verifiedValue: trimmedLoginId,
+        message: response.detail,
+        tone: 'success',
+      });
+      setDuplicateCheckToast({
+        message: response.detail,
+        tone: 'success',
+        anchor: 'login_id',
+      });
+      clearApiFieldError('login_id');
+    } catch (error) {
+      const fieldErrors = extractAuthApiFieldErrors(error);
+      const message = fieldErrors.login_id ?? extractAuthApiErrorMessage(error);
+
+      setLoginIdCheckState({
+        verifiedValue: null,
+        message,
+        tone: 'error',
+      });
+      setDuplicateCheckToast({
+        message,
+        tone: 'error',
+        anchor: 'login_id',
+      });
+    }
+  };
+
+  const handleCheckNicknameDuplicate = async () => {
+    setTouchedState((previous) => ({
+      ...previous,
+      nickname: true,
+    }));
+    setFormMessage('');
+
+    if (!trimmedNickname) {
+      focusFieldByName('nickname', SIGNUP_FORM_FIELD_IDS);
+      return;
+    }
+
+    try {
+      const response = await checkNicknameDuplicateMutation.mutateAsync({
+        nickname: trimmedNickname,
+      });
+
+      setNicknameCheckState({
+        verifiedValue: trimmedNickname,
+        message: response.detail,
+        tone: 'success',
+      });
+      setDuplicateCheckToast({
+        message: response.detail,
+        tone: 'success',
+        anchor: 'nickname',
+      });
+      clearApiFieldError('nickname');
+    } catch (error) {
+      const fieldErrors = extractAuthApiFieldErrors(error);
+      const message = fieldErrors.nickname ?? extractAuthApiErrorMessage(error);
+
+      setNicknameCheckState({
+        verifiedValue: null,
+        message,
+        tone: 'error',
+      });
+      setDuplicateCheckToast({
+        message,
+        tone: 'error',
+        anchor: 'nickname',
+      });
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const nextTouchedState = {
+      name: true,
+      login_id: true,
+      nickname: true,
+      password: true,
+      password_check: true,
+      gender: true,
+    } satisfies SignupTouchedState;
+
+    setTouchedState(nextTouchedState);
+    setApiFieldErrors({});
+    setFormMessage('');
+
+    const nextFieldErrors = getSignupFieldErrors(
+      formValues,
+      nextTouchedState,
+      isLoginIdVerified,
+      isNicknameVerified,
+    );
+    const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
+
+    if (hasLocalError || !formValues.gender) {
+      const firstInvalidField = getFirstErrorFieldName(
+        nextFieldErrors,
+        SIGNUP_FIELD_ORDER,
+      );
+
+      focusFieldByName(firstInvalidField, SIGNUP_FORM_FIELD_IDS);
+      return;
+    }
+
+    const payload: SignupRequest = {
+      name: formValues.name.trim(),
+      login_id: trimmedLoginId,
+      nickname: trimmedNickname,
+      password: trimmedPassword,
+      password_check: formValues.password_check.trim(),
+      gender: formValues.gender,
+    };
+
+    try {
+      await signupMutation.mutateAsync(payload);
+    } catch (error) {
+      const nextApiFieldErrors = extractAuthApiFieldErrors(error);
+      const nextMessage = extractAuthApiErrorMessage(error);
+      let focusTargetField = getFirstErrorFieldName(
+        nextApiFieldErrors as Partial<Record<SignupFieldName, string>>,
+        SIGNUP_FIELD_ORDER,
+      );
+
+      if (Object.keys(nextApiFieldErrors).length > 0) {
+        setApiFieldErrors(nextApiFieldErrors);
+      } else if (nextMessage.includes('닉네임')) {
+        setApiFieldErrors((previous) => ({
+          ...previous,
+          nickname: nextMessage,
+        }));
+        focusTargetField = 'nickname';
+      } else if (
+        nextMessage.includes('아이디') ||
+        nextMessage.includes('회원가입')
+      ) {
+        setApiFieldErrors((previous) => ({
+          ...previous,
+          login_id: nextMessage,
+        }));
+        focusTargetField = 'login_id';
+      } else {
+        setFormMessage(nextMessage);
+      }
+
+      focusFieldByName(focusTargetField, SIGNUP_FORM_FIELD_IDS);
+      return;
+    }
+
+    try {
+      const loginResponse = await loginMutation.mutateAsync({
+        login_id: payload.login_id,
+        password: payload.password,
+      });
+
+      await hydrateAuthSessionFromAccessToken(loginResponse.access_token);
+      navigate(ROUTES.HOME);
+    } catch {
+      navigate(`/${ROUTES.LOGIN}`, {
+        replace: true,
+        state: {
+          noticeMessage:
+            '회원가입이 완료되었습니다. 로그인 후 서비스를 이용해 주세요.',
+        },
+      });
+    }
+  };
+
+  return {
+    formValues,
+    resolvedFieldErrors,
+    formMessage,
+    showFormMessage: feedbackVisibility.showFormMessage,
+    isSubmitting,
+    isCheckingLoginIdDuplicate: checkIdDuplicateMutation.isPending,
+    isCheckingNicknameDuplicate: checkNicknameDuplicateMutation.isPending,
+    isLoginIdVerified,
+    isNicknameVerified,
+    loginIdHelperMessage,
+    nicknameHelperMessage,
+    loginIdToast,
+    nicknameToast,
+    handleFieldChange,
+    handleFieldBlur,
+    handleCheckLoginIdDuplicate,
+    handleCheckNicknameDuplicate,
+    handleSubmit,
+    closeDuplicateCheckToast: () => setDuplicateCheckToast(null),
+  };
+}
+
+export default useSignupForm;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,315 +1,46 @@
-import type { FormEvent } from 'react';
-import { useEffect, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router';
 import { KeyRound, X } from 'lucide-react';
 
-import { api } from '../api/axios';
 import AuthButton from '../components/auth/AuthButton';
 import AuthDivider from '../components/auth/AuthDivider';
 import AuthFormMessage from '../components/auth/AuthFormMessage';
-import AuthLinkButton from '../components/auth/AuthLinkButton';
-import AuthLayout from '../components/layout/AuthLayout';
 import AuthInputField from '../components/auth/AuthInputField';
+import AuthLinkButton from '../components/auth/AuthLinkButton';
 import AuthSocialLoginGroup from '../components/auth/AuthSocialLoginGroup';
 import {
   AUTH_SHARED_FORM_CLASS_NAMES,
   AUTH_SHARED_LAYOUT_CLASS_NAMES,
 } from '../components/auth/authSharedStyles';
+import AuthLayout from '../components/layout/AuthLayout';
 import { ROUTES } from '../constants/routes';
-import { resolveLoginApiError } from '../features/auth/api/auth';
-import { AUTH_SESSION_EXPIRED_NOTICE_MESSAGE } from '../features/auth/constants/session';
-import { useLoginMutation } from '../features/auth/api/useAuthApi';
-import type { LoginRequest } from '../features/auth/types/auth';
-import { hydrateAuthSessionFromAccessToken } from '../features/auth/utils/sessionManager';
-import { resolveAuthFeedbackVisibility } from '../features/auth/utils/feedbackPriority';
-import { focusFieldByName } from '../features/auth/utils/focusField';
-import { getSocialCallbackErrorMessage } from '../features/auth/utils/socialAuth';
-import { mockServiceWorkerEnabled } from '../lib/env';
-
-type LoginFieldName = keyof LoginRequest;
-type LoginFieldErrors = Partial<Record<LoginFieldName, string>>;
-type LoginTouchedState = Record<LoginFieldName, boolean>;
-type LoginLocationState = {
-  noticeMessage?: string;
-  errorMessage?: string;
-};
-
-type DevMockLoginAccount = {
-  loginId: string;
-  password: string;
-  name: string;
-  nickname: string;
-  gender: string;
-  note: string;
-};
-
-type DevMockLoginAccountsResponse = {
-  accounts: DevMockLoginAccount[];
-};
+import useLoginForm, {
+  LOGIN_FORM_FIELD_IDS,
+} from '../features/auth/hooks/useLoginForm';
 
 const LOGIN_MOCK_FAB_CLASS_NAME =
   'support-chat-fab group fixed left-4 bottom-4 z-[95] flex h-14 w-14 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none sm:left-6 sm:bottom-6';
 const LOGIN_MOCK_PANEL_CLASS_NAME =
   'support-chat-panel fixed left-4 bottom-22 z-[90] flex w-[min(92vw,22rem)] origin-bottom-left flex-col overflow-hidden transition-all duration-300 ease-out sm:left-6 sm:bottom-24';
 
-const getLoginFieldErrors = (
-  values: LoginRequest,
-  touchedState: LoginTouchedState,
-) => {
-  const trimmedLoginId = values.login_id.trim();
-  const trimmedPassword = values.password.trim();
-
-  return {
-    login_id:
-      touchedState.login_id && !trimmedLoginId ? '아이디를 입력해주세요.' : '',
-    password:
-      touchedState.password && !trimmedPassword
-        ? '비밀번호를 입력해주세요.'
-        : '',
-  } satisfies Record<LoginFieldName, string>;
-};
-
-const LOGIN_FIELD_ELEMENT_IDS: Record<LoginFieldName, string> = {
-  login_id: 'login-id',
-  password: 'login-password',
-};
-
-const resolveMockAccounts = (
-  accounts: DevMockLoginAccountsResponse['accounts'] | undefined,
-) => (Array.isArray(accounts) ? accounts : []);
-
 function LoginPage() {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const loginMutation = useLoginMutation();
-  const [mockAccounts, setMockAccounts] = useState<DevMockLoginAccount[]>([]);
-  const [isMockPanelOpen, setIsMockPanelOpen] = useState(false);
-  const mockPanelRef = useRef<HTMLDivElement | null>(null);
-
-  const [formValues, setFormValues] = useState<LoginRequest>({
-    login_id: '',
-    password: '',
-  });
-  const [touchedState, setTouchedState] = useState<LoginTouchedState>({
-    login_id: false,
-    password: false,
-  });
-  const [apiFieldErrors, setApiFieldErrors] = useState<LoginFieldErrors>({});
-  const locationState = location.state as LoginLocationState | null;
-  const locationSearchParams = new URLSearchParams(location.search);
-  const locationSearchErrorMessage =
-    getSocialCallbackErrorMessage(locationSearchParams);
-  const locationSearchNoticeMessage =
-    locationSearchParams.get('expired') === 'true'
-      ? AUTH_SESSION_EXPIRED_NOTICE_MESSAGE
-      : '';
-  const [formMessage, setFormMessage] = useState(
-    locationState?.errorMessage ?? locationSearchErrorMessage ?? '',
-  );
-  const [noticeMessage, setNoticeMessage] = useState(
-    locationState?.noticeMessage ?? locationSearchNoticeMessage,
-  );
-  const fieldErrors = getLoginFieldErrors(formValues, touchedState);
-  const resolvedFieldErrors: Record<LoginFieldName, string> = {
-    login_id: apiFieldErrors.login_id ?? fieldErrors.login_id,
-    password: apiFieldErrors.password ?? fieldErrors.password,
-  };
-  const feedbackVisibility = resolveAuthFeedbackVisibility({
-    fieldErrors: resolvedFieldErrors,
+  const {
+    formValues,
+    resolvedFieldErrors,
     formMessage,
-  });
-  const showNoticeMessage =
-    !feedbackVisibility.hasFieldError &&
-    !feedbackVisibility.showFormMessage &&
-    Boolean(noticeMessage.trim());
-  const primaryMockAccount =
-    mockAccounts.find((account) => account.loginId === 'pgti-demo') ??
-    mockAccounts[0];
-  const visibleMockAccounts = primaryMockAccount ? [primaryMockAccount] : [];
-  const showMockAccounts =
-    mockServiceWorkerEnabled && visibleMockAccounts.length > 0;
-
-  useEffect(() => {
-    setFormMessage(
-      locationState?.errorMessage ?? locationSearchErrorMessage ?? '',
-    );
-  }, [locationState?.errorMessage, locationSearchErrorMessage]);
-
-  useEffect(() => {
-    setNoticeMessage(
-      locationState?.noticeMessage ?? locationSearchNoticeMessage,
-    );
-  }, [locationState?.noticeMessage, locationSearchNoticeMessage]);
-
-  useEffect(() => {
-    if (!mockServiceWorkerEnabled) {
-      return;
-    }
-
-    let isMounted = true;
-
-    void api
-      .get<DevMockLoginAccountsResponse>('/api/v1/accounts/dev-login-accounts')
-      .then(({ data }) => {
-        if (!isMounted) {
-          return;
-        }
-
-        setMockAccounts(resolveMockAccounts(data?.accounts));
-      })
-      .catch(async () => {
-        try {
-          const { mockLoginAccounts } =
-            await import('../features/auth/mocks/mockUsers');
-
-          if (!isMounted) {
-            return;
-          }
-
-          setMockAccounts(mockLoginAccounts);
-        } catch {
-          if (!isMounted) {
-            return;
-          }
-
-          setMockAccounts([]);
-        }
-      });
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    if (showMockAccounts) {
-      return;
-    }
-
-    setIsMockPanelOpen(false);
-  }, [showMockAccounts]);
-
-  useEffect(() => {
-    if (!isMockPanelOpen) {
-      return;
-    }
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsMockPanelOpen(false);
-      }
-    };
-
-    const handleOutsideClick = (event: MouseEvent) => {
-      if (
-        mockPanelRef.current &&
-        !mockPanelRef.current.contains(event.target as Node) &&
-        !(event.target as HTMLElement)?.closest('.dev-login-fab')
-      ) {
-        setIsMockPanelOpen(false);
-      }
-    };
-
-    window.addEventListener('keydown', handleEscape);
-    window.addEventListener('mousedown', handleOutsideClick);
-
-    return () => {
-      window.removeEventListener('keydown', handleEscape);
-      window.removeEventListener('mousedown', handleOutsideClick);
-    };
-  }, [isMockPanelOpen]);
-
-  const handleChange = (fieldName: LoginFieldName, value: string) => {
-    setFormValues((previous) => ({
-      ...previous,
-      [fieldName]: value,
-    }));
-
-    setApiFieldErrors((previous) => {
-      if (!previous[fieldName]) {
-        return previous;
-      }
-
-      return {
-        ...previous,
-        [fieldName]: '',
-      };
-    });
-
-    setFormMessage('');
-    setNoticeMessage('');
-  };
-
-  const handleApplyMockAccount = (account: DevMockLoginAccount) => {
-    setFormValues({
-      login_id: account.loginId,
-      password: account.password,
-    });
-    setTouchedState({
-      login_id: false,
-      password: false,
-    });
-    setApiFieldErrors({});
-    setFormMessage('');
-    setNoticeMessage('');
-    setIsMockPanelOpen(false);
-  };
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    const nextTouchedState = {
-      login_id: true,
-      password: true,
-    } satisfies LoginTouchedState;
-
-    setTouchedState(nextTouchedState);
-    setApiFieldErrors({});
-    setFormMessage('');
-    setNoticeMessage('');
-
-    const nextFieldErrors = getLoginFieldErrors(formValues, nextTouchedState);
-    const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
-
-    if (hasLocalError) {
-      const firstInvalidField: LoginFieldName | null = nextFieldErrors.login_id
-        ? 'login_id'
-        : nextFieldErrors.password
-          ? 'password'
-          : null;
-
-      focusFieldByName(firstInvalidField, LOGIN_FIELD_ELEMENT_IDS);
-      return;
-    }
-
-    const payload: LoginRequest = {
-      login_id: formValues.login_id.trim(),
-      password: formValues.password.trim(),
-    };
-
-    let accessToken: string;
-
-    try {
-      const response = await loginMutation.mutateAsync(payload);
-      accessToken = response.access_token;
-    } catch (error) {
-      const resolvedError = resolveLoginApiError(error, payload);
-
-      setApiFieldErrors(resolvedError.fieldErrors);
-      setFormMessage(resolvedError.message);
-      focusFieldByName(resolvedError.focusField, LOGIN_FIELD_ELEMENT_IDS);
-      return;
-    }
-
-    try {
-      await hydrateAuthSessionFromAccessToken(accessToken);
-      navigate(ROUTES.HOME);
-    } catch {
-      setFormMessage(
-        '로그인 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.',
-      );
-    }
-  };
+    noticeMessage,
+    showNoticeMessage,
+    showFormMessage,
+    isSubmitting,
+    visibleMockAccounts,
+    showMockAccounts,
+    isMockPanelOpen,
+    mockPanelRef,
+    handleChange,
+    handleBlur,
+    handleSubmit,
+    handleApplyMockAccount,
+    closeMockPanel,
+    toggleMockPanel,
+  } = useLoginForm();
 
   return (
     <>
@@ -331,7 +62,7 @@ function LoginPage() {
           onSubmit={handleSubmit}
         >
           <AuthInputField
-            id="login-id"
+            id={LOGIN_FORM_FIELD_IDS.login_id}
             name="login_id"
             label="아이디"
             type="text"
@@ -339,18 +70,13 @@ function LoginPage() {
             placeholder="ID"
             value={formValues.login_id}
             onChange={(event) => handleChange('login_id', event.target.value)}
-            onBlur={() =>
-              setTouchedState((previous) => ({
-                ...previous,
-                login_id: true,
-              }))
-            }
+            onBlur={() => handleBlur('login_id')}
             errorMessage={resolvedFieldErrors.login_id}
-            disabled={loginMutation.isPending}
+            disabled={isSubmitting}
           />
 
           <AuthInputField
-            id="login-password"
+            id={LOGIN_FORM_FIELD_IDS.password}
             name="password"
             label="비밀번호"
             type="password"
@@ -358,14 +84,9 @@ function LoginPage() {
             placeholder="PASSWORD"
             value={formValues.password}
             onChange={(event) => handleChange('password', event.target.value)}
-            onBlur={() =>
-              setTouchedState((previous) => ({
-                ...previous,
-                password: true,
-              }))
-            }
+            onBlur={() => handleBlur('password')}
             errorMessage={resolvedFieldErrors.password}
-            disabled={loginMutation.isPending}
+            disabled={isSubmitting}
           />
 
           {showNoticeMessage ? (
@@ -377,7 +98,7 @@ function LoginPage() {
             </AuthFormMessage>
           ) : null}
 
-          {feedbackVisibility.showFormMessage ? (
+          {showFormMessage ? (
             <AuthFormMessage
               className={AUTH_SHARED_FORM_CLASS_NAMES.feedbackMessage}
             >
@@ -388,9 +109,9 @@ function LoginPage() {
           <AuthButton
             type="submit"
             className={AUTH_SHARED_FORM_CLASS_NAMES.submitButton}
-            disabled={loginMutation.isPending}
+            disabled={isSubmitting}
           >
-            {loginMutation.isPending ? '로그인 중...' : '로그인'}
+            {isSubmitting ? '로그인 중...' : '로그인'}
           </AuthButton>
         </form>
 
@@ -431,7 +152,7 @@ function LoginPage() {
               </div>
               <button
                 type="button"
-                onClick={() => setIsMockPanelOpen(false)}
+                onClick={closeMockPanel}
                 className="support-chat-icon-btn"
                 aria-label="개발용 로그인 계정 패널 닫기"
               >
@@ -486,7 +207,7 @@ function LoginPage() {
 
           <button
             type="button"
-            onClick={() => setIsMockPanelOpen((previous) => !previous)}
+            onClick={toggleMockPanel}
             className={`${LOGIN_MOCK_FAB_CLASS_NAME} dev-login-fab`}
             aria-label={
               isMockPanelOpen

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,7 +1,3 @@
-import type { FormEvent } from 'react';
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
-
 import AuthButton from '../components/auth/AuthButton';
 import AuthFormMessage from '../components/auth/AuthFormMessage';
 import AuthInputActionButton from '../components/auth/AuthInputActionButton';
@@ -13,462 +9,35 @@ import {
 } from '../components/auth/authSharedStyles';
 import AuthLayout from '../components/layout/AuthLayout';
 import ToastMessage from '../components/mypage/ToastMessage';
-import { ROUTES } from '../constants/routes';
-import {
-  extractAuthApiErrorMessage,
-  extractAuthApiFieldErrors,
-} from '../features/auth/api/auth';
-import {
-  useCheckIdDuplicateMutation,
-  useCheckNicknameDuplicateMutation,
-  useLoginMutation,
-  useSignupMutation,
-} from '../features/auth/api/useAuthApi';
-import type { AuthGender, SignupRequest } from '../features/auth/types/auth';
-import { hydrateAuthSessionFromAccessToken } from '../features/auth/utils/sessionManager';
-import { resolveAuthFeedbackVisibility } from '../features/auth/utils/feedbackPriority';
-import {
-  focusFieldByName,
-  getFirstErrorFieldName,
-} from '../features/auth/utils/focusField';
-
-type SignupFormValues = Omit<SignupRequest, 'gender'> & {
-  gender: AuthGender | '';
-};
-
-type SignupFieldName = keyof SignupFormValues;
-type SignupFieldErrors = Partial<Record<SignupFieldName, string>>;
-type SignupTouchedState = Record<SignupFieldName, boolean>;
-
-type DuplicateCheckState = {
-  verifiedValue: string | null;
-  message: string;
-  tone: 'success' | 'error' | null;
-};
-
-type DuplicateCheckToastState = {
-  message: string;
-  tone: 'success' | 'error';
-  anchor: 'login_id' | 'nickname';
-} | null;
-
-const signupGenderOptions = [
-  { label: '남성', value: 'M' },
-  { label: '여성', value: 'W' },
-] as const;
-
-const NAME_MAX_LENGTH = 30;
-const LOGIN_ID_MAX_LENGTH = 15;
-const NICKNAME_MAX_LENGTH = 10;
-const NICKNAME_WHITESPACE_MESSAGE = '닉네임에는 띄어쓰기를 사용할 수 없습니다.';
-
-const initialDuplicateCheckState: DuplicateCheckState = {
-  verifiedValue: null,
-  message: '',
-  tone: null,
-};
-
-const SIGNUP_FIELD_ORDER = [
-  'name',
-  'login_id',
-  'nickname',
-  'password',
-  'password_check',
-  'gender',
-] as const satisfies readonly SignupFieldName[];
-
-const SIGNUP_FIELD_ELEMENT_IDS: Record<SignupFieldName, string> = {
-  name: 'signup-name',
-  login_id: 'signup-id',
-  nickname: 'signup-nickname',
-  password: 'signup-password',
-  password_check: 'signup-password-confirm',
-  gender: 'signup-gender-M',
-};
-
-const getSignupFieldErrors = (
-  values: SignupFormValues,
-  touchedState: SignupTouchedState,
-  loginIdVerified: boolean,
-  nicknameVerified: boolean,
-) => {
-  const trimmedName = values.name.trim();
-  const trimmedLoginId = values.login_id.trim();
-  const trimmedNickname = values.nickname.trim();
-  const trimmedPassword = values.password.trim();
-  const trimmedPasswordCheck = values.password_check.trim();
-
-  return {
-    name: touchedState.name && !trimmedName ? '이름을 입력해주세요.' : '',
-    login_id:
-      touchedState.login_id && !trimmedLoginId
-        ? '아이디를 입력해주세요.'
-        : touchedState.login_id && trimmedLoginId && !loginIdVerified
-          ? '아이디 중복확인을 해주세요.'
-          : '',
-    nickname:
-      touchedState.nickname && !trimmedNickname
-        ? '닉네임을 입력해주세요.'
-        : touchedState.nickname && trimmedNickname && !nicknameVerified
-          ? '닉네임 중복확인을 해주세요.'
-          : '',
-    password:
-      touchedState.password && !trimmedPassword
-        ? '비밀번호를 입력해주세요.'
-        : touchedState.password &&
-            trimmedPassword.length > 0 &&
-            trimmedPassword.length < 8
-          ? '비밀번호는 8자 이상이어야 합니다.'
-          : '',
-    password_check:
-      touchedState.password_check && !trimmedPasswordCheck
-        ? '비밀번호를 한번 더 입력해주세요.'
-        : touchedState.password_check &&
-            trimmedPassword.length > 0 &&
-            trimmedPasswordCheck.length > 0 &&
-            trimmedPassword !== trimmedPasswordCheck
-          ? '비밀번호와 일치하지 않습니다.'
-          : '',
-    gender: touchedState.gender && !values.gender ? '성별을 선택해주세요.' : '',
-  } satisfies Record<SignupFieldName, string>;
-};
+import useSignupForm, {
+  SIGNUP_FORM_FIELD_IDS,
+  SIGNUP_FORM_FIELD_MAX_LENGTHS,
+  SIGNUP_FORM_GENDER_ID_PREFIX,
+  SIGNUP_FORM_GENDER_OPTIONS,
+} from '../features/auth/hooks/useSignupForm';
 
 function SignupPage() {
-  const navigate = useNavigate();
-  const signupMutation = useSignupMutation();
-  const loginMutation = useLoginMutation();
-  const checkIdDuplicateMutation = useCheckIdDuplicateMutation();
-  const checkNicknameDuplicateMutation = useCheckNicknameDuplicateMutation();
-  const [formValues, setFormValues] = useState<SignupFormValues>({
-    name: '',
-    login_id: '',
-    nickname: '',
-    password: '',
-    password_check: '',
-    gender: '',
-  });
-  const [touchedState, setTouchedState] = useState<SignupTouchedState>({
-    name: false,
-    login_id: false,
-    nickname: false,
-    password: false,
-    password_check: false,
-    gender: false,
-  });
-  const [apiFieldErrors, setApiFieldErrors] = useState<SignupFieldErrors>({});
-  const [formMessage, setFormMessage] = useState('');
-  const [nicknameWhitespaceMessage, setNicknameWhitespaceMessage] =
-    useState('');
-  const [loginIdCheckState, setLoginIdCheckState] =
-    useState<DuplicateCheckState>(initialDuplicateCheckState);
-  const [nicknameCheckState, setNicknameCheckState] =
-    useState<DuplicateCheckState>(initialDuplicateCheckState);
-  const [duplicateCheckToast, setDuplicateCheckToast] =
-    useState<DuplicateCheckToastState>(null);
-
-  const trimmedLoginId = formValues.login_id.trim();
-  const trimmedNickname = formValues.nickname.trim();
-  const trimmedPassword = formValues.password.trim();
-
-  const isLoginIdVerified =
-    loginIdCheckState.tone === 'success' &&
-    loginIdCheckState.verifiedValue === trimmedLoginId;
-  const isNicknameVerified =
-    nicknameCheckState.tone === 'success' &&
-    nicknameCheckState.verifiedValue === trimmedNickname;
-
-  const localFieldErrors = getSignupFieldErrors(
+  const {
     formValues,
-    touchedState,
+    resolvedFieldErrors,
+    formMessage,
+    showFormMessage,
+    isSubmitting,
+    isCheckingLoginIdDuplicate,
+    isCheckingNicknameDuplicate,
     isLoginIdVerified,
     isNicknameVerified,
-  );
-
-  const resolvedFieldErrors: Record<SignupFieldName, string> = {
-    name: apiFieldErrors.name ?? localFieldErrors.name,
-    login_id:
-      apiFieldErrors.login_id ||
-      (loginIdCheckState.tone === 'error' ? loginIdCheckState.message : '') ||
-      localFieldErrors.login_id,
-    nickname:
-      apiFieldErrors.nickname ||
-      nicknameWhitespaceMessage ||
-      (nicknameCheckState.tone === 'error' ? nicknameCheckState.message : '') ||
-      localFieldErrors.nickname,
-    password: apiFieldErrors.password ?? localFieldErrors.password,
-    password_check:
-      apiFieldErrors.password_check ?? localFieldErrors.password_check,
-    gender: apiFieldErrors.gender ?? localFieldErrors.gender,
-  };
-  const feedbackVisibility = resolveAuthFeedbackVisibility({
-    fieldErrors: resolvedFieldErrors,
-    formMessage,
-    hasToast: Boolean(duplicateCheckToast),
-  });
-
-  const isSubmitting = signupMutation.isPending || loginMutation.isPending;
-
-  useEffect(() => {
-    if (!duplicateCheckToast) {
-      return undefined;
-    }
-
-    const timeout = window.setTimeout(() => {
-      setDuplicateCheckToast(null);
-    }, 2200);
-
-    return () => window.clearTimeout(timeout);
-  }, [duplicateCheckToast]);
-
-  const clearApiFieldError = (fieldName: SignupFieldName) => {
-    setApiFieldErrors((previous) => {
-      if (!previous[fieldName]) {
-        return previous;
-      }
-
-      return {
-        ...previous,
-        [fieldName]: '',
-      };
-    });
-  };
-
-  const handleFieldChange = (fieldName: SignupFieldName, value: string) => {
-    let nextValue = value;
-    let nextNicknameHasWhitespace = false;
-
-    if (fieldName === 'name') {
-      nextValue = value.slice(0, NAME_MAX_LENGTH);
-    }
-
-    if (fieldName === 'login_id') {
-      nextValue = value.slice(0, LOGIN_ID_MAX_LENGTH);
-    }
-
-    if (fieldName === 'nickname') {
-      nextNicknameHasWhitespace = /\s/.test(value);
-
-      nextValue = value.replace(/\s+/g, '').slice(0, NICKNAME_MAX_LENGTH);
-      setNicknameWhitespaceMessage(
-        nextNicknameHasWhitespace ? NICKNAME_WHITESPACE_MESSAGE : '',
-      );
-    }
-
-    setFormValues((previous) => ({
-      ...previous,
-      [fieldName]: nextValue,
-    }));
-
-    clearApiFieldError(fieldName);
-    setFormMessage('');
-
-    if (fieldName === 'login_id') {
-      setLoginIdCheckState((previous) =>
-        previous.verifiedValue === nextValue.trim() &&
-        previous.tone === 'success'
-          ? previous
-          : initialDuplicateCheckState,
-      );
-    }
-
-    if (fieldName === 'nickname') {
-      setNicknameCheckState((previous) =>
-        previous.verifiedValue === nextValue.trim() &&
-        previous.tone === 'success' &&
-        !nextNicknameHasWhitespace
-          ? previous
-          : initialDuplicateCheckState,
-      );
-    }
-  };
-
-  const handleCheckLoginIdDuplicate = async () => {
-    setTouchedState((previous) => ({
-      ...previous,
-      login_id: true,
-    }));
-    setFormMessage('');
-
-    if (!trimmedLoginId) {
-      focusFieldByName('login_id', SIGNUP_FIELD_ELEMENT_IDS);
-      return;
-    }
-
-    try {
-      const response = await checkIdDuplicateMutation.mutateAsync({
-        login_id: trimmedLoginId,
-      });
-
-      setLoginIdCheckState({
-        verifiedValue: trimmedLoginId,
-        message: response.detail,
-        tone: 'success',
-      });
-      setDuplicateCheckToast({
-        message: response.detail,
-        tone: 'success',
-        anchor: 'login_id',
-      });
-      clearApiFieldError('login_id');
-    } catch (error) {
-      const fieldErrors = extractAuthApiFieldErrors(error);
-      const message = fieldErrors.login_id ?? extractAuthApiErrorMessage(error);
-
-      setLoginIdCheckState({
-        verifiedValue: null,
-        message,
-        tone: 'error',
-      });
-      setDuplicateCheckToast({
-        message,
-        tone: 'error',
-        anchor: 'login_id',
-      });
-    }
-  };
-
-  const handleCheckNicknameDuplicate = async () => {
-    setTouchedState((previous) => ({
-      ...previous,
-      nickname: true,
-    }));
-    setFormMessage('');
-
-    if (!trimmedNickname) {
-      focusFieldByName('nickname', SIGNUP_FIELD_ELEMENT_IDS);
-      return;
-    }
-
-    try {
-      const response = await checkNicknameDuplicateMutation.mutateAsync({
-        nickname: trimmedNickname,
-      });
-
-      setNicknameCheckState({
-        verifiedValue: trimmedNickname,
-        message: response.detail,
-        tone: 'success',
-      });
-      setDuplicateCheckToast({
-        message: response.detail,
-        tone: 'success',
-        anchor: 'nickname',
-      });
-      clearApiFieldError('nickname');
-    } catch (error) {
-      const fieldErrors = extractAuthApiFieldErrors(error);
-      const message = fieldErrors.nickname ?? extractAuthApiErrorMessage(error);
-
-      setNicknameCheckState({
-        verifiedValue: null,
-        message,
-        tone: 'error',
-      });
-      setDuplicateCheckToast({
-        message,
-        tone: 'error',
-        anchor: 'nickname',
-      });
-    }
-  };
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    const nextTouchedState = {
-      name: true,
-      login_id: true,
-      nickname: true,
-      password: true,
-      password_check: true,
-      gender: true,
-    } satisfies SignupTouchedState;
-
-    setTouchedState(nextTouchedState);
-    setApiFieldErrors({});
-    setFormMessage('');
-
-    const nextFieldErrors = getSignupFieldErrors(
-      formValues,
-      nextTouchedState,
-      isLoginIdVerified,
-      isNicknameVerified,
-    );
-    const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
-
-    if (hasLocalError || !formValues.gender) {
-      const firstInvalidField = getFirstErrorFieldName(
-        nextFieldErrors,
-        SIGNUP_FIELD_ORDER,
-      );
-
-      focusFieldByName(firstInvalidField, SIGNUP_FIELD_ELEMENT_IDS);
-      return;
-    }
-
-    const payload: SignupRequest = {
-      name: formValues.name.trim(),
-      login_id: trimmedLoginId,
-      nickname: trimmedNickname,
-      password: trimmedPassword,
-      password_check: formValues.password_check.trim(),
-      gender: formValues.gender,
-    };
-
-    try {
-      await signupMutation.mutateAsync(payload);
-    } catch (error) {
-      const nextApiFieldErrors = extractAuthApiFieldErrors(error);
-      const nextMessage = extractAuthApiErrorMessage(error);
-      let focusTargetField = getFirstErrorFieldName(
-        nextApiFieldErrors as Partial<Record<SignupFieldName, string>>,
-        SIGNUP_FIELD_ORDER,
-      );
-
-      if (Object.keys(nextApiFieldErrors).length > 0) {
-        setApiFieldErrors(nextApiFieldErrors);
-      } else if (nextMessage.includes('닉네임')) {
-        setApiFieldErrors((previous) => ({
-          ...previous,
-          nickname: nextMessage,
-        }));
-        focusTargetField = 'nickname';
-      } else if (
-        nextMessage.includes('아이디') ||
-        nextMessage.includes('회원가입')
-      ) {
-        setApiFieldErrors((previous) => ({
-          ...previous,
-          login_id: nextMessage,
-        }));
-        focusTargetField = 'login_id';
-      } else {
-        setFormMessage(nextMessage);
-      }
-
-      focusFieldByName(focusTargetField, SIGNUP_FIELD_ELEMENT_IDS);
-
-      return;
-    }
-
-    try {
-      const loginResponse = await loginMutation.mutateAsync({
-        login_id: payload.login_id,
-        password: payload.password,
-      });
-
-      await hydrateAuthSessionFromAccessToken(loginResponse.access_token);
-      navigate(ROUTES.HOME);
-    } catch {
-      navigate(`/${ROUTES.LOGIN}`, {
-        replace: true,
-        state: {
-          noticeMessage:
-            '회원가입이 완료되었습니다. 로그인 후 서비스를 이용해 주세요.',
-        },
-      });
-    }
-  };
+    loginIdHelperMessage,
+    nicknameHelperMessage,
+    loginIdToast,
+    nicknameToast,
+    handleFieldChange,
+    handleFieldBlur,
+    handleCheckLoginIdDuplicate,
+    handleCheckNicknameDuplicate,
+    handleSubmit,
+    closeDuplicateCheckToast,
+  } = useSignupForm();
 
   return (
     <AuthLayout
@@ -492,64 +61,45 @@ function SignupPage() {
         </div>
 
         <AuthInputField
-          id="signup-name"
+          id={SIGNUP_FORM_FIELD_IDS.name}
           name="name"
           label="이름"
           type="text"
           autoComplete="name"
           placeholder="이름을 입력하세요"
-          maxLength={NAME_MAX_LENGTH}
+          maxLength={SIGNUP_FORM_FIELD_MAX_LENGTHS.name}
           value={formValues.name}
           onChange={(event) => handleFieldChange('name', event.target.value)}
-          onBlur={() =>
-            setTouchedState((previous) => ({
-              ...previous,
-              name: true,
-            }))
-          }
+          onBlur={() => handleFieldBlur('name')}
           errorMessage={resolvedFieldErrors.name}
           disabled={isSubmitting}
         />
 
         <AuthInputField
-          id="signup-id"
+          id={SIGNUP_FORM_FIELD_IDS.login_id}
           name="login_id"
           label="아이디"
           type="text"
           autoComplete="username"
           placeholder="아이디를 입력하세요"
-          maxLength={LOGIN_ID_MAX_LENGTH}
+          maxLength={SIGNUP_FORM_FIELD_MAX_LENGTHS.login_id}
           value={formValues.login_id}
           onChange={(event) =>
             handleFieldChange('login_id', event.target.value)
           }
-          onBlur={() =>
-            setTouchedState((previous) => ({
-              ...previous,
-              login_id: true,
-            }))
-          }
+          onBlur={() => handleFieldBlur('login_id')}
           errorMessage={resolvedFieldErrors.login_id}
-          helperMessage={
-            !resolvedFieldErrors.login_id &&
-            loginIdCheckState.tone === 'success'
-              ? loginIdCheckState.message
-              : ''
-          }
-          helperMessageTone={
-            loginIdCheckState.tone === 'success' ? 'success' : 'muted'
-          }
+          helperMessage={loginIdHelperMessage}
+          helperMessageTone="success"
           disabled={isSubmitting}
           action={
             <AuthInputActionButton
               onClick={handleCheckLoginIdDuplicate}
               disabled={
-                checkIdDuplicateMutation.isPending ||
-                isSubmitting ||
-                isLoginIdVerified
+                isCheckingLoginIdDuplicate || isSubmitting || isLoginIdVerified
               }
             >
-              {checkIdDuplicateMutation.isPending
+              {isCheckingLoginIdDuplicate
                 ? '확인 중...'
                 : isLoginIdVerified
                   ? '확인완료'
@@ -557,12 +107,11 @@ function SignupPage() {
             </AuthInputActionButton>
           }
           toast={
-            feedbackVisibility.showToast &&
-            duplicateCheckToast?.anchor === 'login_id' ? (
+            loginIdToast ? (
               <ToastMessage
-                message={duplicateCheckToast.message}
-                tone={duplicateCheckToast.tone}
-                onClose={() => setDuplicateCheckToast(null)}
+                message={loginIdToast.message}
+                tone={loginIdToast.tone}
+                onClose={closeDuplicateCheckToast}
                 variant="absoluteCenter"
               />
             ) : null
@@ -570,42 +119,32 @@ function SignupPage() {
         />
 
         <AuthInputField
-          id="signup-nickname"
+          id={SIGNUP_FORM_FIELD_IDS.nickname}
           name="nickname"
           label="닉네임"
           type="text"
           autoComplete="nickname"
           placeholder="닉네임을 입력하세요"
-          maxLength={NICKNAME_MAX_LENGTH}
+          maxLength={SIGNUP_FORM_FIELD_MAX_LENGTHS.nickname}
           value={formValues.nickname}
           onChange={(event) =>
             handleFieldChange('nickname', event.target.value)
           }
-          onBlur={() =>
-            setTouchedState((previous) => ({
-              ...previous,
-              nickname: true,
-            }))
-          }
+          onBlur={() => handleFieldBlur('nickname')}
           errorMessage={resolvedFieldErrors.nickname}
-          helperMessage={
-            !resolvedFieldErrors.nickname &&
-            nicknameCheckState.tone === 'success'
-              ? nicknameCheckState.message
-              : ''
-          }
+          helperMessage={nicknameHelperMessage}
           helperMessageTone="success"
           disabled={isSubmitting}
           action={
             <AuthInputActionButton
               onClick={handleCheckNicknameDuplicate}
               disabled={
-                checkNicknameDuplicateMutation.isPending ||
+                isCheckingNicknameDuplicate ||
                 isSubmitting ||
                 isNicknameVerified
               }
             >
-              {checkNicknameDuplicateMutation.isPending
+              {isCheckingNicknameDuplicate
                 ? '확인 중...'
                 : isNicknameVerified
                   ? '확인완료'
@@ -613,12 +152,11 @@ function SignupPage() {
             </AuthInputActionButton>
           }
           toast={
-            feedbackVisibility.showToast &&
-            duplicateCheckToast?.anchor === 'nickname' ? (
+            nicknameToast ? (
               <ToastMessage
-                message={duplicateCheckToast.message}
-                tone={duplicateCheckToast.tone}
-                onClose={() => setDuplicateCheckToast(null)}
+                message={nicknameToast.message}
+                tone={nicknameToast.tone}
+                onClose={closeDuplicateCheckToast}
                 variant="absoluteCenter"
               />
             ) : null
@@ -626,7 +164,7 @@ function SignupPage() {
         />
 
         <AuthInputField
-          id="signup-password"
+          id={SIGNUP_FORM_FIELD_IDS.password}
           name="password"
           label="비밀번호"
           type="password"
@@ -636,18 +174,13 @@ function SignupPage() {
           onChange={(event) =>
             handleFieldChange('password', event.target.value)
           }
-          onBlur={() =>
-            setTouchedState((previous) => ({
-              ...previous,
-              password: true,
-            }))
-          }
+          onBlur={() => handleFieldBlur('password')}
           errorMessage={resolvedFieldErrors.password}
           disabled={isSubmitting}
         />
 
         <AuthInputField
-          id="signup-password-confirm"
+          id={SIGNUP_FORM_FIELD_IDS.password_check}
           name="password_check"
           label="비밀번호 확인"
           type="password"
@@ -657,12 +190,7 @@ function SignupPage() {
           onChange={(event) =>
             handleFieldChange('password_check', event.target.value)
           }
-          onBlur={() =>
-            setTouchedState((previous) => ({
-              ...previous,
-              password_check: true,
-            }))
-          }
+          onBlur={() => handleFieldBlur('password_check')}
           errorMessage={resolvedFieldErrors.password_check}
           disabled={isSubmitting}
         />
@@ -670,17 +198,15 @@ function SignupPage() {
         <AuthRadioGroup
           label="성별"
           name="gender"
-          idPrefix="signup-gender"
+          idPrefix={SIGNUP_FORM_GENDER_ID_PREFIX}
           value={formValues.gender}
-          options={signupGenderOptions}
-          onChange={(event) =>
-            handleFieldChange('gender', event.target.value as AuthGender)
-          }
+          options={SIGNUP_FORM_GENDER_OPTIONS}
+          onChange={(event) => handleFieldChange('gender', event.target.value)}
           errorMessage={resolvedFieldErrors.gender}
           disabled={isSubmitting}
         />
 
-        {feedbackVisibility.showFormMessage ? (
+        {showFormMessage ? (
           <AuthFormMessage
             className={AUTH_SHARED_FORM_CLASS_NAMES.feedbackMessage}
           >


### PR DESCRIPTION
## 관련 이슈

- closes #234

## 변경 내용

- 로그인 페이지의 폼 상태, API 에러 처리, 포커스 제어, 개발용 mock 계정 패널 상태를 `useLoginForm`으로 분리했습니다.
- 회원가입 페이지의 폼 상태, 필드 검증, 중복 확인, toast 메시지, 제출 후 자동 로그인 흐름을 `useSignupForm`으로 분리했습니다.
- `LoginPage.tsx`, `SignupPage.tsx`에서 비즈니스 로직을 걷어내고 레이아웃과 입력 섹션 렌더링 중심으로 정리했습니다.
- 필드 id, 입력 길이 제한, 성별 옵션처럼 함께 바뀌는 값을 훅 모듈에서 함께 관리하도록 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- API 경로, 요청/응답 스펙 변경은 없고 폼 내부 로직 구조만 분리한 리팩터링입니다.
