### PR TITLE
refactor(mypage): 마이페이지 기능 단위 분리 및 고객센터 챗봇 책임 분리

### DIFF
--- a/src/features/support-chat/data/faqs.ts
+++ b/src/features/support-chat/data/faqs.ts
@@ -2,6 +2,7 @@ import type {
   SupportChatQuickAction,
   SupportChatRouteContext,
 } from '../types/supportChat';
+import { ROUTE_PATHS } from '@/constants/routes';
 
 type SupportFaqEntry = {
   id: string;
@@ -84,6 +85,6 @@ export const buildSupportChatFallbackMessage = (
   `${routeContext.pageLabel} 화면과 관련된 문의를 도와드릴 수 있어요.\n현재 챗봇은 고객센터 FAQ 기반으로 동작하고 있습니다. 아래 예시 질문을 눌러주시거나, 문의 내용을 조금 더 구체적으로 적어주시면 비슷한 도움말을 안내해 드릴게요.`;
 
 export const createDefaultRouteContext = (): SupportChatRouteContext => ({
-  pathname: '/',
+  pathname: ROUTE_PATHS.HOME,
   pageLabel: '현재',
 });

--- a/src/features/support-chat/hooks/useSupportChat.ts
+++ b/src/features/support-chat/hooks/useSupportChat.ts
@@ -1,29 +1,12 @@
-import {
-  type MutableRefObject,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router';
 
 import type { SupportChatPanelProps } from '@/components/support-chat/SupportChatPanel';
-import {
-  extractSupportChatErrorMessage,
-  streamChatbotResponse,
-} from '@/features/support-chat/api/chatbot';
-import { useSendChatbotMessageMutation } from '@/features/support-chat/api/useSupportChatApi';
 import { SUPPORT_CHAT_QUICK_ACTIONS } from '@/features/support-chat/data/faqs';
 import { useSupportChatStore } from '@/features/support-chat/store/useSupportChatStore';
+import useSupportChatConversation from './useSupportChatConversation';
+import useSupportChatPanelState from './useSupportChatPanelState';
 import { getSupportChatRouteContext } from '../utils/routeContext';
-
-const AUTO_SCROLL_NEAR_BOTTOM_THRESHOLD_PX = 72;
-const SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE =
-  '메시지는 공백일 수 없고 2자 이상이어야 합니다.';
-
-const isRecoverableSessionError = (message: string) =>
-  message.includes('session_id') || message.includes('유효하지 않은');
 
 type UseSupportChatResult = {
   panelProps: SupportChatPanelProps;
@@ -35,12 +18,7 @@ type UseSupportChatResult = {
 
 export const useSupportChat = (): UseSupportChatResult => {
   const location = useLocation();
-  const [inputValue, setInputValue] = useState('');
   const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
-  const panelRef = useRef<HTMLDivElement | null>(null);
-  const viewportRef = useRef<HTMLDivElement | null>(null);
-  const streamAbortRef = useRef<AbortController | null>(null);
-  const lastHandledMessageCursorRef = useRef<string | null>(null);
 
   const routeContext = useMemo(
     () => getSupportChatRouteContext(location.pathname),
@@ -73,81 +51,6 @@ export const useSupportChat = (): UseSupportChatResult => {
     removeMessage,
   } = useSupportChatStore();
 
-  const messageUpdateCursor = useMemo(() => {
-    const latestMessage = messages.at(-1);
-
-    return `${messages.length}:${latestMessage?.id ?? 'none'}:${latestMessage?.content.length ?? 0}:${isSubmitting ? 1 : 0}:${showQuickActions ? 1 : 0}`;
-  }, [isSubmitting, messages, showQuickActions]);
-
-  const sendMessageMutation = useSendChatbotMessageMutation();
-
-  const abortStreamingResponse = useCallback(
-    (resetSubmitting = false) => {
-      if (streamAbortRef.current) {
-        streamAbortRef.current.abort();
-        streamAbortRef.current = null;
-      }
-
-      if (resetSubmitting) {
-        setSubmitting(false);
-      }
-    },
-    [setSubmitting],
-  );
-
-  const isNearBottom = useCallback((viewport: HTMLDivElement) => {
-    const distanceFromBottom =
-      viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop;
-
-    return distanceFromBottom <= AUTO_SCROLL_NEAR_BOTTOM_THRESHOLD_PX;
-  }, []);
-
-  const scrollViewportToBottom = useCallback(
-    (behavior: ScrollBehavior) => {
-      const viewport = viewportRef.current;
-
-      if (!viewport) {
-        return;
-      }
-
-      viewport.scrollTo({
-        top: viewport.scrollHeight,
-        behavior,
-      });
-      setPinnedToBottom(true);
-      setHasUnreadMessages(false);
-    },
-    [setPinnedToBottom],
-  );
-
-  const appendAssistantErrorMessage = useCallback(
-    (message: string) => {
-      const trimmedMessage = message.trim();
-
-      if (!trimmedMessage) {
-        return;
-      }
-
-      hideQuickActions();
-      appendAssistantMessage(trimmedMessage);
-    },
-    [appendAssistantMessage, hideQuickActions],
-  );
-
-  const handleClosePanel = useCallback(() => {
-    abortStreamingResponse(true);
-    closePanel();
-  }, [abortStreamingResponse, closePanel]);
-
-  const handleTogglePanel = useCallback(() => {
-    if (isOpen) {
-      handleClosePanel();
-      return;
-    }
-
-    togglePanel();
-  }, [handleClosePanel, isOpen, togglePanel]);
-
   useEffect(() => {
     if (!hasBootstrapped) {
       bootstrapConversation(routeContext);
@@ -157,261 +60,58 @@ export const useSupportChat = (): UseSupportChatResult => {
     setRouteContext(routeContext);
   }, [bootstrapConversation, hasBootstrapped, routeContext, setRouteContext]);
 
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        handleClosePanel();
-      }
-    };
-
-    const handleOutsideClick = (event: MouseEvent) => {
-      if (
-        panelRef.current &&
-        !panelRef.current.contains(event.target as Node) &&
-        !(event.target as HTMLElement)?.closest('.support-chat-fab')
-      ) {
-        handleClosePanel();
-      }
-    };
-
-    window.addEventListener('keydown', handleEscape);
-    window.addEventListener('mousedown', handleOutsideClick);
-
-    return () => {
-      window.removeEventListener('keydown', handleEscape);
-      window.removeEventListener('mousedown', handleOutsideClick);
-    };
-  }, [handleClosePanel, isOpen]);
-
-  useEffect(
-    () => () => {
-      abortStreamingResponse(true);
-    },
-    [abortStreamingResponse],
-  );
-
-  useEffect(() => {
-    if (!isOpen) {
-      if (streamAbortRef.current) {
-        abortStreamingResponse(true);
-      }
-
-      setHasUnreadMessages(false);
-      setPinnedToBottom(true);
-      return;
-    }
-
-    const frameId = window.requestAnimationFrame(() => {
-      scrollViewportToBottom('auto');
-    });
-
-    return () => {
-      window.cancelAnimationFrame(frameId);
-    };
-  }, [
+  const {
+    inputValue,
+    setInputValue,
+    handleSubmit,
+    handleQuickActionSelect,
+    handleReset,
     abortStreamingResponse,
-    isOpen,
-    scrollViewportToBottom,
-    setPinnedToBottom,
-  ]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const viewport = viewportRef.current;
-
-    if (!viewport) {
-      return;
-    }
-
-    const handleViewportScroll = () => {
-      const nearBottom = isNearBottom(viewport);
-      setPinnedToBottom(nearBottom);
-
-      if (nearBottom) {
-        setHasUnreadMessages(false);
-      }
-    };
-
-    handleViewportScroll();
-    viewport.addEventListener('scroll', handleViewportScroll, {
-      passive: true,
-    });
-
-    return () => {
-      viewport.removeEventListener('scroll', handleViewportScroll);
-    };
-  }, [isNearBottom, isOpen, setPinnedToBottom]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      lastHandledMessageCursorRef.current = messageUpdateCursor;
-      return;
-    }
-
-    const hasNewIncomingUpdate =
-      lastHandledMessageCursorRef.current !== messageUpdateCursor;
-    lastHandledMessageCursorRef.current = messageUpdateCursor;
-
-    if (!hasNewIncomingUpdate) {
-      return;
-    }
-
-    if (isPinnedToBottom) {
-      const frameId = window.requestAnimationFrame(() => {
-        scrollViewportToBottom('auto');
-      });
-
-      return () => {
-        window.cancelAnimationFrame(frameId);
-      };
-    }
-
-    setHasUnreadMessages(true);
-  }, [isOpen, isPinnedToBottom, messageUpdateCursor, scrollViewportToBottom]);
-
-  const handleReset = useCallback(() => {
-    abortStreamingResponse(true);
-    setInputValue('');
-    setHasUnreadMessages(false);
-    setPinnedToBottom(true);
-    resetConversation(routeContext);
-  }, [
-    abortStreamingResponse,
-    resetConversation,
+  } = useSupportChatConversation({
     routeContext,
+    sessionId,
+    isSubmitting,
+    appendUserMessage,
+    appendAssistantMessage,
+    beginAssistantMessage,
+    appendAssistantChunk,
+    finalizeAssistantMessage,
+    removeMessage,
+    hideQuickActions,
+    resetConversation,
+    setSessionId,
+    setSubmitting,
     setPinnedToBottom,
-  ]);
+    setHasUnreadMessages,
+  });
 
-  const submitMessage = useCallback(
-    async (message: string) => {
-      const trimmedMessage = message.trim();
-
-      if (trimmedMessage.length < 2) {
-        appendAssistantErrorMessage(SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE);
-        return;
-      }
-
-      if (isSubmitting) {
-        return;
-      }
-
-      const assistantPlaceholderMessageId = crypto.randomUUID();
-
-      hideQuickActions();
-      appendUserMessage(trimmedMessage);
-      beginAssistantMessage(assistantPlaceholderMessageId);
-      setSubmitting(true);
-
-      try {
-        let response;
-
-        try {
-          response = await sendMessageMutation.mutateAsync({
-            message: trimmedMessage,
-            session_id: sessionId ?? undefined,
-          });
-        } catch (requestError) {
-          const errorMessage = extractSupportChatErrorMessage(requestError);
-
-          if (sessionId && isRecoverableSessionError(errorMessage)) {
-            setSessionId(null);
-            response = await sendMessageMutation.mutateAsync({
-              message: trimmedMessage,
-            });
-          } else {
-            throw requestError;
-          }
-        }
-
-        setSessionId(response.session_id);
-
-        const abortController = new AbortController();
-        streamAbortRef.current = abortController;
-
-        await streamChatbotResponse({
-          sessionId: response.session_id,
-          signal: abortController.signal,
-          onEvent: (event) => {
-            if (event.type === 'chunk') {
-              appendAssistantChunk(
-                assistantPlaceholderMessageId,
-                event.content,
-              );
-            }
-
-            if (event.type === 'complete') {
-              finalizeAssistantMessage(assistantPlaceholderMessageId);
-              setSubmitting(false);
-            }
-          },
-        });
-      } catch (requestError) {
-        removeMessage(assistantPlaceholderMessageId);
-        const errorMessage = extractSupportChatErrorMessage(requestError);
-
-        if (errorMessage) {
-          appendAssistantErrorMessage(errorMessage);
-        }
-
-        setSubmitting(false);
-      } finally {
-        streamAbortRef.current = null;
-      }
-    },
-    [
-      appendAssistantChunk,
-      appendAssistantErrorMessage,
-      appendUserMessage,
-      beginAssistantMessage,
-      finalizeAssistantMessage,
-      hideQuickActions,
-      isSubmitting,
-      removeMessage,
-      sendMessageMutation,
-      sessionId,
-      setSessionId,
-      setSubmitting,
-    ],
-  );
-
-  const handleSubmit = useCallback(async () => {
-    if (!inputValue.trim()) {
-      appendAssistantErrorMessage(SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE);
-      return;
-    }
-
-    const nextValue = inputValue;
-    setInputValue('');
-    await submitMessage(nextValue);
-  }, [appendAssistantErrorMessage, inputValue, submitMessage]);
-
-  const handleQuickActionSelect = useCallback(
-    async (label: string) => {
-      await submitMessage(label);
-    },
-    [submitMessage],
-  );
-
-  const showJumpToLatestButton =
-    isOpen && hasUnreadMessages && !isPinnedToBottom;
-  const liveStatusMessage = showJumpToLatestButton
-    ? '새 메시지가 도착했습니다. 새 메시지 확인 버튼을 누르면 최신 메시지로 이동합니다.'
-    : isSubmitting
-      ? '챗봇이 응답을 작성 중입니다.'
-      : null;
+  const {
+    panelRef,
+    viewportRef,
+    handleClosePanel,
+    handleTogglePanel,
+    showJumpToLatestButton,
+    liveStatusMessage,
+    scrollViewportToBottom,
+  } = useSupportChatPanelState({
+    isOpen,
+    isSubmitting,
+    isPinnedToBottom,
+    showQuickActions,
+    messages,
+    closePanel,
+    togglePanel,
+    setPinnedToBottom,
+    hasUnreadMessages,
+    setHasUnreadMessages,
+    abortStreamingResponse,
+  });
 
   return {
     panelProps: {
       isOpen,
-      panelRef: panelRef as MutableRefObject<HTMLDivElement | null>,
-      viewportRef: viewportRef as MutableRefObject<HTMLDivElement | null>,
+      panelRef,
+      viewportRef,
       routeContext,
       messages,
       quickActions: showQuickActions
@@ -429,7 +129,7 @@ export const useSupportChat = (): UseSupportChatResult => {
         scrollViewportToBottom('smooth');
       },
       onQuickActionSelect: handleQuickActionSelect,
-      onInputChange: setInputValue,
+      onInputChange: (value) => setInputValue(value),
       onSubmit: handleSubmit,
     },
     launcherProps: {

--- a/src/features/support-chat/hooks/useSupportChatConversation.ts
+++ b/src/features/support-chat/hooks/useSupportChatConversation.ts
@@ -1,0 +1,223 @@
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  extractSupportChatErrorMessage,
+  streamChatbotResponse,
+} from '@/features/support-chat/api/chatbot';
+import { useSendChatbotMessageMutation } from '@/features/support-chat/api/useSupportChatApi';
+import type { SupportChatRouteContext } from '@/features/support-chat/types/supportChat';
+
+const SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE =
+  '메시지는 공백일 수 없고 2자 이상이어야 합니다.';
+
+const isRecoverableSessionError = (message: string) =>
+  message.includes('session_id') || message.includes('유효하지 않은');
+
+type UseSupportChatConversationParams = {
+  routeContext: SupportChatRouteContext;
+  sessionId: number | null;
+  isSubmitting: boolean;
+  appendUserMessage: (content: string) => void;
+  appendAssistantMessage: (content: string) => void;
+  beginAssistantMessage: (messageId: string) => void;
+  appendAssistantChunk: (messageId: string, chunk: string) => void;
+  finalizeAssistantMessage: (messageId: string) => void;
+  removeMessage: (messageId: string) => void;
+  hideQuickActions: () => void;
+  resetConversation: (routeContext?: SupportChatRouteContext) => void;
+  setSessionId: (sessionId: number | null) => void;
+  setSubmitting: (isSubmitting: boolean) => void;
+  setPinnedToBottom: (isPinnedToBottom: boolean) => void;
+  setHasUnreadMessages: Dispatch<SetStateAction<boolean>>;
+};
+
+function useSupportChatConversation({
+  routeContext,
+  sessionId,
+  isSubmitting,
+  appendUserMessage,
+  appendAssistantMessage,
+  beginAssistantMessage,
+  appendAssistantChunk,
+  finalizeAssistantMessage,
+  removeMessage,
+  hideQuickActions,
+  resetConversation,
+  setSessionId,
+  setSubmitting,
+  setPinnedToBottom,
+  setHasUnreadMessages,
+}: UseSupportChatConversationParams) {
+  const [inputValue, setInputValue] = useState('');
+  const streamAbortRef = useRef<AbortController | null>(null);
+  const sendMessageMutation = useSendChatbotMessageMutation();
+
+  const abortStreamingResponse = useCallback(
+    (resetSubmitting = false) => {
+      if (streamAbortRef.current) {
+        streamAbortRef.current.abort();
+        streamAbortRef.current = null;
+      }
+
+      if (resetSubmitting) {
+        setSubmitting(false);
+      }
+    },
+    [setSubmitting],
+  );
+
+  const appendAssistantErrorMessage = useCallback(
+    (message: string) => {
+      const trimmedMessage = message.trim();
+
+      if (!trimmedMessage) {
+        return;
+      }
+
+      hideQuickActions();
+      appendAssistantMessage(trimmedMessage);
+    },
+    [appendAssistantMessage, hideQuickActions],
+  );
+
+  const submitMessage = useCallback(
+    async (message: string) => {
+      const trimmedMessage = message.trim();
+
+      if (trimmedMessage.length < 2) {
+        appendAssistantErrorMessage(SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE);
+        return;
+      }
+
+      if (isSubmitting) {
+        return;
+      }
+
+      const assistantPlaceholderMessageId = crypto.randomUUID();
+
+      hideQuickActions();
+      appendUserMessage(trimmedMessage);
+      beginAssistantMessage(assistantPlaceholderMessageId);
+      setSubmitting(true);
+
+      try {
+        let response;
+
+        try {
+          response = await sendMessageMutation.mutateAsync({
+            message: trimmedMessage,
+            session_id: sessionId ?? undefined,
+          });
+        } catch (requestError) {
+          const errorMessage = extractSupportChatErrorMessage(requestError);
+
+          if (sessionId && isRecoverableSessionError(errorMessage)) {
+            setSessionId(null);
+            response = await sendMessageMutation.mutateAsync({
+              message: trimmedMessage,
+            });
+          } else {
+            throw requestError;
+          }
+        }
+
+        setSessionId(response.session_id);
+
+        const abortController = new AbortController();
+        streamAbortRef.current = abortController;
+
+        await streamChatbotResponse({
+          sessionId: response.session_id,
+          signal: abortController.signal,
+          onEvent: (event) => {
+            if (event.type === 'chunk') {
+              appendAssistantChunk(
+                assistantPlaceholderMessageId,
+                event.content,
+              );
+            }
+
+            if (event.type === 'complete') {
+              finalizeAssistantMessage(assistantPlaceholderMessageId);
+              setSubmitting(false);
+            }
+          },
+        });
+      } catch (requestError) {
+        removeMessage(assistantPlaceholderMessageId);
+        const errorMessage = extractSupportChatErrorMessage(requestError);
+
+        if (errorMessage) {
+          appendAssistantErrorMessage(errorMessage);
+        }
+
+        setSubmitting(false);
+      } finally {
+        streamAbortRef.current = null;
+      }
+    },
+    [
+      appendAssistantChunk,
+      appendAssistantErrorMessage,
+      appendUserMessage,
+      beginAssistantMessage,
+      finalizeAssistantMessage,
+      hideQuickActions,
+      isSubmitting,
+      removeMessage,
+      sendMessageMutation,
+      sessionId,
+      setSessionId,
+      setSubmitting,
+    ],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!inputValue.trim()) {
+      appendAssistantErrorMessage(SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE);
+      return;
+    }
+
+    const nextValue = inputValue;
+    setInputValue('');
+    await submitMessage(nextValue);
+  }, [appendAssistantErrorMessage, inputValue, submitMessage]);
+
+  const handleQuickActionSelect = useCallback(
+    async (label: string) => {
+      await submitMessage(label);
+    },
+    [submitMessage],
+  );
+
+  const handleReset = useCallback(() => {
+    abortStreamingResponse(true);
+    setInputValue('');
+    setHasUnreadMessages(false);
+    setPinnedToBottom(true);
+    resetConversation(routeContext);
+  }, [
+    abortStreamingResponse,
+    resetConversation,
+    routeContext,
+    setHasUnreadMessages,
+    setPinnedToBottom,
+  ]);
+
+  return {
+    inputValue,
+    setInputValue,
+    handleSubmit,
+    handleQuickActionSelect,
+    handleReset,
+    abortStreamingResponse,
+  };
+}
+
+export default useSupportChatConversation;

--- a/src/features/support-chat/hooks/useSupportChatPanelState.ts
+++ b/src/features/support-chat/hooks/useSupportChatPanelState.ts
@@ -1,0 +1,234 @@
+import {
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
+
+const AUTO_SCROLL_NEAR_BOTTOM_THRESHOLD_PX = 72;
+
+type UseSupportChatPanelStateParams = {
+  isOpen: boolean;
+  isSubmitting: boolean;
+  isPinnedToBottom: boolean;
+  showQuickActions: boolean;
+  messages: Array<{
+    id: string;
+    content: string;
+  }>;
+  closePanel: () => void;
+  togglePanel: () => void;
+  setPinnedToBottom: (isPinnedToBottom: boolean) => void;
+  hasUnreadMessages: boolean;
+  setHasUnreadMessages: Dispatch<SetStateAction<boolean>>;
+  abortStreamingResponse: (resetSubmitting?: boolean) => void;
+};
+
+function useSupportChatPanelState({
+  isOpen,
+  isSubmitting,
+  isPinnedToBottom,
+  showQuickActions,
+  messages,
+  closePanel,
+  togglePanel,
+  setPinnedToBottom,
+  hasUnreadMessages,
+  setHasUnreadMessages,
+  abortStreamingResponse,
+}: UseSupportChatPanelStateParams) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const lastHandledMessageCursorRef = useRef<string | null>(null);
+
+  const messageUpdateCursor = useMemo(() => {
+    const latestMessage = messages.at(-1);
+
+    return `${messages.length}:${latestMessage?.id ?? 'none'}:${latestMessage?.content.length ?? 0}:${isSubmitting ? 1 : 0}:${showQuickActions ? 1 : 0}`;
+  }, [isSubmitting, messages, showQuickActions]);
+
+  const isNearBottom = useCallback((viewport: HTMLDivElement) => {
+    const distanceFromBottom =
+      viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop;
+
+    return distanceFromBottom <= AUTO_SCROLL_NEAR_BOTTOM_THRESHOLD_PX;
+  }, []);
+
+  const scrollViewportToBottom = useCallback(
+    (behavior: ScrollBehavior) => {
+      const viewport = viewportRef.current;
+
+      if (!viewport) {
+        return;
+      }
+
+      viewport.scrollTo({
+        top: viewport.scrollHeight,
+        behavior,
+      });
+      setPinnedToBottom(true);
+      setHasUnreadMessages(false);
+    },
+    [setHasUnreadMessages, setPinnedToBottom],
+  );
+
+  const handleClosePanel = useCallback(() => {
+    abortStreamingResponse(true);
+    closePanel();
+  }, [abortStreamingResponse, closePanel]);
+
+  const handleTogglePanel = useCallback(() => {
+    if (isOpen) {
+      handleClosePanel();
+      return;
+    }
+
+    togglePanel();
+  }, [handleClosePanel, isOpen, togglePanel]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleClosePanel();
+      }
+    };
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(event.target as Node) &&
+        !(event.target as HTMLElement)?.closest('.support-chat-fab')
+      ) {
+        handleClosePanel();
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    window.addEventListener('mousedown', handleOutsideClick);
+
+    return () => {
+      window.removeEventListener('keydown', handleEscape);
+      window.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [handleClosePanel, isOpen]);
+
+  useEffect(
+    () => () => {
+      abortStreamingResponse(true);
+    },
+    [abortStreamingResponse],
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      abortStreamingResponse(true);
+      setHasUnreadMessages(false);
+      setPinnedToBottom(true);
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      scrollViewportToBottom('auto');
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [
+    abortStreamingResponse,
+    isOpen,
+    scrollViewportToBottom,
+    setHasUnreadMessages,
+    setPinnedToBottom,
+  ]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const viewport = viewportRef.current;
+
+    if (!viewport) {
+      return;
+    }
+
+    const handleViewportScroll = () => {
+      const nearBottom = isNearBottom(viewport);
+      setPinnedToBottom(nearBottom);
+
+      if (nearBottom) {
+        setHasUnreadMessages(false);
+      }
+    };
+
+    handleViewportScroll();
+    viewport.addEventListener('scroll', handleViewportScroll, {
+      passive: true,
+    });
+
+    return () => {
+      viewport.removeEventListener('scroll', handleViewportScroll);
+    };
+  }, [isNearBottom, isOpen, setHasUnreadMessages, setPinnedToBottom]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      lastHandledMessageCursorRef.current = messageUpdateCursor;
+      return;
+    }
+
+    const hasNewIncomingUpdate =
+      lastHandledMessageCursorRef.current !== messageUpdateCursor;
+    lastHandledMessageCursorRef.current = messageUpdateCursor;
+
+    if (!hasNewIncomingUpdate) {
+      return;
+    }
+
+    if (isPinnedToBottom) {
+      const frameId = window.requestAnimationFrame(() => {
+        scrollViewportToBottom('auto');
+      });
+
+      return () => {
+        window.cancelAnimationFrame(frameId);
+      };
+    }
+
+    setHasUnreadMessages(true);
+  }, [
+    isOpen,
+    isPinnedToBottom,
+    messageUpdateCursor,
+    scrollViewportToBottom,
+    setHasUnreadMessages,
+  ]);
+
+  const showJumpToLatestButton =
+    isOpen && hasUnreadMessages && !isPinnedToBottom;
+  const liveStatusMessage = showJumpToLatestButton
+    ? '새 메시지가 도착했습니다. 새 메시지 확인 버튼을 누르면 최신 메시지로 이동합니다.'
+    : isSubmitting
+      ? '챗봇이 응답을 작성 중입니다.'
+      : null;
+
+  return {
+    panelRef: panelRef as MutableRefObject<HTMLDivElement | null>,
+    viewportRef: viewportRef as MutableRefObject<HTMLDivElement | null>,
+    handleClosePanel,
+    handleTogglePanel,
+    showJumpToLatestButton,
+    liveStatusMessage,
+    scrollViewportToBottom,
+  };
+}
+
+export default useSupportChatPanelState;

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -4,7 +4,7 @@ import { Navigate } from 'react-router';
 import AuthWrapper from '../../components/auth/AuthWrapper';
 import LazyHeader from '../../components/common/LazyHeader';
 import ToastMessage from '../../components/mypage/ToastMessage';
-import { ROUTES } from '../../constants/routes';
+import { ROUTE_PATHS } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
@@ -12,8 +12,9 @@ import type { GameListItem } from '../../features/games/types';
 import MyPageAccountDangerZone from './components/MyPageAccountDangerZone';
 import MyPageLikedGamesSection from './components/MyPageLikedGamesSection';
 import MyPageProfileContainer from './components/MyPageProfileContainer';
+import useMyPageDeleteAccount from './hooks/useMyPageDeleteAccount';
+import useMyPagePasswordChange from './hooks/useMyPagePasswordChange';
 import useMyPageProfile from './hooks/useMyPageProfile';
-import useMyPageSecurity from './hooks/useMyPageSecurity';
 import type { MyPageToast } from './types';
 
 const loadingFallback = (
@@ -29,7 +30,7 @@ const loadingFallback = (
 
 const unauthorizedFallback = (
   <Navigate
-    to={`/${ROUTES.LOGIN}`}
+    to={ROUTE_PATHS.LOGIN}
     replace
     state={{ noticeMessage: '로그인 후 마이페이지를 이용할 수 있습니다.' }}
   />
@@ -45,7 +46,8 @@ function MyPage() {
     enabled: authGate.canAccessAuthenticatedRoute,
     onToast: setToast,
   });
-  const myPageSecurity = useMyPageSecurity({
+  const myPagePasswordChange = useMyPagePasswordChange();
+  const myPageDeleteAccount = useMyPageDeleteAccount({
     onToast: setToast,
   });
 
@@ -75,19 +77,25 @@ function MyPage() {
             }}
             onNicknameSave={myPageProfile.handleNicknameSave}
             onProfileImageSelect={myPageProfile.handleProfileImageSelect}
-            isPasswordPanelOpen={myPageSecurity.isPasswordPanelOpen}
-            onPasswordToggle={myPageSecurity.togglePasswordPanel}
-            passwordValues={myPageSecurity.passwordValues}
-            passwordErrors={myPageSecurity.resolvedPasswordErrors}
-            passwordPanelMessage={myPageSecurity.passwordPanelMessage?.message}
-            passwordPanelMessageTone={
-              myPageSecurity.passwordPanelMessage?.tone ?? 'error'
+            isPasswordPanelOpen={myPagePasswordChange.isPasswordPanelOpen}
+            onPasswordToggle={myPagePasswordChange.togglePasswordPanel}
+            passwordValues={myPagePasswordChange.passwordValues}
+            passwordErrors={myPagePasswordChange.resolvedPasswordErrors}
+            passwordPanelMessage={
+              myPagePasswordChange.passwordPanelMessage?.message
             }
-            isPasswordChangePending={myPageSecurity.isChangePasswordPending}
-            onPasswordValueChange={myPageSecurity.handlePasswordValueChange}
-            onPasswordBlur={myPageSecurity.handlePasswordBlur}
-            onPasswordCancel={myPageSecurity.closePasswordPanel}
-            onPasswordSubmit={myPageSecurity.handlePasswordSubmit}
+            passwordPanelMessageTone={
+              myPagePasswordChange.passwordPanelMessage?.tone ?? 'error'
+            }
+            isPasswordChangePending={
+              myPagePasswordChange.isChangePasswordPending
+            }
+            onPasswordValueChange={
+              myPagePasswordChange.handlePasswordValueChange
+            }
+            onPasswordBlur={myPagePasswordChange.handlePasswordBlur}
+            onPasswordCancel={myPagePasswordChange.closePasswordPanel}
+            onPasswordSubmit={myPagePasswordChange.handlePasswordSubmit}
           />
 
           <MyPageLikedGamesSection
@@ -97,14 +105,16 @@ function MyPage() {
           />
 
           <MyPageAccountDangerZone
-            isDeleteModalOpen={myPageSecurity.isDeleteModalOpen}
-            deletePassword={myPageSecurity.deletePassword}
-            deletePasswordError={myPageSecurity.deletePasswordError}
-            isDeletePending={myPageSecurity.isDeleteAccountPending}
-            onOpenDeleteModal={myPageSecurity.openDeleteModal}
-            onCloseDeleteModal={myPageSecurity.closeDeleteModal}
-            onDeletePasswordChange={myPageSecurity.handleDeletePasswordChange}
-            onConfirmDeleteAccount={myPageSecurity.handleDeleteAccount}
+            isDeleteModalOpen={myPageDeleteAccount.isDeleteModalOpen}
+            deletePassword={myPageDeleteAccount.deletePassword}
+            deletePasswordError={myPageDeleteAccount.deletePasswordError}
+            isDeletePending={myPageDeleteAccount.isDeleteAccountPending}
+            onOpenDeleteModal={myPageDeleteAccount.openDeleteModal}
+            onCloseDeleteModal={myPageDeleteAccount.closeDeleteModal}
+            onDeletePasswordChange={
+              myPageDeleteAccount.handleDeletePasswordChange
+            }
+            onConfirmDeleteAccount={myPageDeleteAccount.handleDeleteAccount}
           />
         </main>
 

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -1,22 +1,13 @@
 import { Heart } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
 
 import AuthButton from '../../../components/auth/AuthButton';
 import ConfirmModal from '../../../components/mypage/ConfirmModal';
 import FavoriteGameCard from '../../../components/mypage/FavoriteGameCard';
 import FavoriteGameCardSkeleton from '../../../components/mypage/FavoriteGameCardSkeleton';
 import FavoriteGamesEmptyState from '../../../components/mypage/FavoriteGamesEmptyState';
-import { extractAuthApiErrorMessage } from '../../../features/auth/api/auth';
-import {
-  DEFAULT_LIKED_GAMES_PAGE_SIZE,
-  useLikedGamesInfiniteQuery,
-  useUnlikeLikedGameMutation,
-} from '../../../features/auth/api/useAuthApi';
 import type { GameListItem } from '../../../features/games/types';
-import type { FavoriteGamePreview } from '../../../features/mypage/types';
-import type { LikedGameItemResponse } from '../../../features/auth/types/auth';
+import useMyPageLikedGames from '../hooks/useMyPageLikedGames';
 import type { MyPageToastPayload } from '../types';
-import { toFavoriteGameListItem, toFavoriteGamePreview } from '../utils';
 
 type MyPageLikedGamesSectionProps = {
   enabled: boolean;
@@ -29,108 +20,29 @@ function MyPageLikedGamesSection({
   onOpenGameDetail,
   onToast,
 }: MyPageLikedGamesSectionProps) {
-  const likedGamesQuery = useLikedGamesInfiniteQuery(
-    enabled,
-    DEFAULT_LIKED_GAMES_PAGE_SIZE,
-  );
-  const unlikeLikedGameMutation = useUnlikeLikedGameMutation();
-  const [selectedFavoriteGame, setSelectedFavoriteGame] =
-    useState<FavoriteGamePreview | null>(null);
-  const favoriteGamesScrollRef = useRef<HTMLDivElement | null>(null);
-  const favoriteGamesLoadMoreRef = useRef<HTMLDivElement | null>(null);
-  const likedGameResults = useMemo(() => {
-    const pages = likedGamesQuery.data?.pages ?? [];
-
-    return pages.flatMap((page) => page.results);
-  }, [likedGamesQuery.data]);
-  const favoriteGames = useMemo(() => {
-    const deduplicatedGames = new Map<number, LikedGameItemResponse>();
-
-    likedGameResults.forEach((game) => {
-      deduplicatedGames.set(game.game_id, game);
-    });
-
-    return [...deduplicatedGames.values()].map(toFavoriteGamePreview);
-  }, [likedGameResults]);
-  const hasFavoriteGamesNextPage = Boolean(likedGamesQuery.hasNextPage);
-  const isFavoriteGamesFetchNextPageError =
-    likedGamesQuery.isFetchNextPageError;
-  const isFavoriteGamesFetchingNextPage = likedGamesQuery.isFetchingNextPage;
-  const fetchNextFavoriteGamesPage = likedGamesQuery.fetchNextPage;
-  const favoriteCount =
-    likedGamesQuery.data?.pages?.[0]?.count ?? favoriteGames.length;
-  const isFavoriteGamesLoading =
-    likedGamesQuery.isLoading && !favoriteGames.length;
-  const isFavoriteGamesError = likedGamesQuery.isError && !favoriteGames.length;
-
-  useEffect(() => {
-    if (isFavoriteGamesFetchNextPageError || !hasFavoriteGamesNextPage) {
-      return undefined;
-    }
-
-    const rootElement = favoriteGamesScrollRef.current;
-    const targetElement = favoriteGamesLoadMoreRef.current;
-
-    if (!rootElement || !targetElement) {
-      return undefined;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const [entry] = entries;
-
-        if (!entry?.isIntersecting || isFavoriteGamesFetchingNextPage) {
-          return;
-        }
-
-        void fetchNextFavoriteGamesPage();
-      },
-      {
-        root: rootElement,
-        rootMargin: '0px 0px 160px 0px',
-        threshold: 0.1,
-      },
-    );
-
-    observer.observe(targetElement);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [
-    favoriteGames.length,
-    fetchNextFavoriteGamesPage,
+  const {
+    favoriteGamesScrollRef,
+    favoriteGamesLoadMoreRef,
+    favoriteGames,
+    favoriteCount,
+    isFavoriteGamesLoading,
+    isFavoriteGamesError,
     hasFavoriteGamesNextPage,
-    isFavoriteGamesFetchNextPageError,
     isFavoriteGamesFetchingNextPage,
-  ]);
-
-  const handleFavoriteGameCardClick = (game: FavoriteGamePreview) => {
-    onOpenGameDetail(toFavoriteGameListItem(game));
-  };
-
-  const handleFavoriteGameDeleteConfirm = async () => {
-    if (!selectedFavoriteGame) {
-      return;
-    }
-
-    try {
-      const response = await unlikeLikedGameMutation.mutateAsync(
-        selectedFavoriteGame.gameId,
-      );
-
-      setSelectedFavoriteGame(null);
-      onToast({
-        tone: 'success',
-        message: response.detail || '찜한 게임이 목록에서 삭제되었습니다.',
-      });
-    } catch (error) {
-      onToast({
-        tone: 'error',
-        message: extractAuthApiErrorMessage(error),
-      });
-    }
-  };
+    isFavoriteGamesFetchNextPageError,
+    isFetchingFavoriteGames,
+    selectedFavoriteGame,
+    isUnlikePending,
+    setSelectedFavoriteGame,
+    handleFavoriteGameCardClick,
+    handleFavoriteGameDeleteConfirm,
+    refetchFavoriteGames,
+    fetchNextFavoriteGamesPage,
+  } = useMyPageLikedGames({
+    enabled,
+    onOpenGameDetail,
+    onToast,
+  });
 
   return (
     <>
@@ -180,7 +92,7 @@ function MyPageLikedGamesSection({
                   aria-hidden="true"
                   className="h-0.5 w-full"
                 />
-                {likedGamesQuery.isFetchNextPageError ? (
+                {isFavoriteGamesFetchNextPageError ? (
                   <>
                     <p className="text-sm text-red-300">
                       추가 찜 목록을 불러오지 못했습니다.
@@ -189,15 +101,15 @@ function MyPageLikedGamesSection({
                       type="button"
                       variant="secondary"
                       className="w-full max-w-40"
-                      onClick={() => void likedGamesQuery.fetchNextPage()}
-                      disabled={likedGamesQuery.isFetchingNextPage}
+                      onClick={() => void fetchNextFavoriteGamesPage()}
+                      disabled={isFavoriteGamesFetchingNextPage}
                     >
-                      {likedGamesQuery.isFetchingNextPage
+                      {isFavoriteGamesFetchingNextPage
                         ? '다시 불러오는 중...'
                         : '다시 시도'}
                     </AuthButton>
                   </>
-                ) : likedGamesQuery.isFetchingNextPage ? (
+                ) : isFavoriteGamesFetchingNextPage ? (
                   <p className="text-mypage-muted text-sm">
                     찜 목록을 더 불러오는 중입니다...
                   </p>
@@ -221,16 +133,10 @@ function MyPageLikedGamesSection({
                 type="button"
                 variant="secondary"
                 className="w-full max-w-36"
-                onClick={() => void likedGamesQuery.refetch()}
-                disabled={
-                  likedGamesQuery.isFetching ||
-                  likedGamesQuery.isFetchingNextPage
-                }
+                onClick={() => void refetchFavoriteGames()}
+                disabled={isFetchingFavoriteGames}
               >
-                {likedGamesQuery.isFetching ||
-                likedGamesQuery.isFetchingNextPage
-                  ? '다시 불러오는 중...'
-                  : '다시 시도'}
+                {isFetchingFavoriteGames ? '다시 불러오는 중...' : '다시 시도'}
               </AuthButton>
             </div>
           ) : (
@@ -245,7 +151,7 @@ function MyPageLikedGamesSection({
         description={`'${selectedFavoriteGame?.title ?? ''}'을(를) 찜한 목록에서 삭제하시겠습니까?`}
         confirmLabel="예"
         cancelLabel="아니오"
-        isPending={unlikeLikedGameMutation.isPending}
+        isPending={isUnlikePending}
         onClose={() => setSelectedFavoriteGame(null)}
         onConfirm={() => {
           void handleFavoriteGameDeleteConfirm();

--- a/src/pages/mypage/hooks/useMyPageDeleteAccount.ts
+++ b/src/pages/mypage/hooks/useMyPageDeleteAccount.ts
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+
+import { ROUTE_PATHS } from '../../../constants/routes';
+import {
+  extractAuthApiErrorMessage,
+  extractAuthApiFieldErrors,
+} from '../../../features/auth/api/auth';
+import { useDeleteAccountMutation } from '../../../features/auth/api/useAuthApi';
+import { clearAuthSession } from '../../../features/auth/utils/sessionManager';
+import type { MyPageToastPayload } from '../types';
+
+type UseMyPageDeleteAccountOptions = {
+  onToast: (toast: MyPageToastPayload) => void;
+};
+
+function useMyPageDeleteAccount({ onToast }: UseMyPageDeleteAccountOptions) {
+  const navigate = useNavigate();
+  const deleteAccountMutation = useDeleteAccountMutation();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [deletePassword, setDeletePassword] = useState('');
+  const [deletePasswordError, setDeletePasswordError] = useState('');
+
+  const openDeleteModal = () => {
+    setDeletePassword('');
+    setDeletePasswordError('');
+    setIsDeleteModalOpen(true);
+  };
+
+  const closeDeleteModal = () => {
+    setIsDeleteModalOpen(false);
+    setDeletePassword('');
+    setDeletePasswordError('');
+  };
+
+  const handleDeletePasswordChange = (value: string) => {
+    setDeletePassword(value);
+
+    if (deletePasswordError) {
+      setDeletePasswordError('');
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    const trimmedPassword = deletePassword.trim();
+
+    if (!trimmedPassword) {
+      setDeletePasswordError('현재 비밀번호를 입력해주세요.');
+      return;
+    }
+
+    try {
+      await deleteAccountMutation.mutateAsync({
+        password: trimmedPassword,
+      });
+
+      clearAuthSession();
+      navigate(ROUTE_PATHS.LOGIN, {
+        replace: true,
+        state: {
+          noticeMessage: '회원 탈퇴가 완료되었습니다.',
+        },
+      });
+    } catch (error) {
+      const fieldErrors = extractAuthApiFieldErrors(error);
+
+      if (fieldErrors.password) {
+        setDeletePasswordError(fieldErrors.password);
+        return;
+      }
+
+      const errorMessage = extractAuthApiErrorMessage(error);
+
+      if (errorMessage.includes('비밀번호')) {
+        setDeletePasswordError(errorMessage);
+        return;
+      }
+
+      onToast({
+        tone: 'error',
+        message: errorMessage,
+      });
+    }
+  };
+
+  return {
+    isDeleteModalOpen,
+    openDeleteModal,
+    closeDeleteModal,
+    deletePassword,
+    deletePasswordError,
+    handleDeletePasswordChange,
+    handleDeleteAccount,
+    isDeleteAccountPending: deleteAccountMutation.isPending,
+  };
+}
+
+export default useMyPageDeleteAccount;

--- a/src/pages/mypage/hooks/useMyPageLikedGames.ts
+++ b/src/pages/mypage/hooks/useMyPageLikedGames.ts
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { extractAuthApiErrorMessage } from '../../../features/auth/api/auth';
+import {
+  DEFAULT_LIKED_GAMES_PAGE_SIZE,
+  useLikedGamesInfiniteQuery,
+  useUnlikeLikedGameMutation,
+} from '../../../features/auth/api/useAuthApi';
+import type { GameListItem } from '../../../features/games/types';
+import type { FavoriteGamePreview } from '../../../features/mypage/types';
+import type { LikedGameItemResponse } from '../../../features/auth/types/auth';
+import type { MyPageToastPayload } from '../types';
+import { toFavoriteGameListItem, toFavoriteGamePreview } from '../utils';
+
+type UseMyPageLikedGamesOptions = {
+  enabled: boolean;
+  onOpenGameDetail: (game: GameListItem) => void;
+  onToast: (toast: MyPageToastPayload) => void;
+};
+
+function useMyPageLikedGames({
+  enabled,
+  onOpenGameDetail,
+  onToast,
+}: UseMyPageLikedGamesOptions) {
+  const likedGamesQuery = useLikedGamesInfiniteQuery(
+    enabled,
+    DEFAULT_LIKED_GAMES_PAGE_SIZE,
+  );
+  const unlikeLikedGameMutation = useUnlikeLikedGameMutation();
+  const [selectedFavoriteGame, setSelectedFavoriteGame] =
+    useState<FavoriteGamePreview | null>(null);
+  const favoriteGamesScrollRef = useRef<HTMLDivElement | null>(null);
+  const favoriteGamesLoadMoreRef = useRef<HTMLDivElement | null>(null);
+  const likedGameResults = useMemo(() => {
+    const pages = likedGamesQuery.data?.pages ?? [];
+
+    return pages.flatMap((page) => page.results);
+  }, [likedGamesQuery.data]);
+  const favoriteGames = useMemo(() => {
+    const deduplicatedGames = new Map<number, LikedGameItemResponse>();
+
+    likedGameResults.forEach((game) => {
+      deduplicatedGames.set(game.game_id, game);
+    });
+
+    return [...deduplicatedGames.values()].map(toFavoriteGamePreview);
+  }, [likedGameResults]);
+  const hasFavoriteGamesNextPage = Boolean(likedGamesQuery.hasNextPage);
+  const isFavoriteGamesFetchNextPageError =
+    likedGamesQuery.isFetchNextPageError;
+  const isFavoriteGamesFetchingNextPage = likedGamesQuery.isFetchingNextPage;
+  const fetchNextFavoriteGamesPage = likedGamesQuery.fetchNextPage;
+  const refetchFavoriteGames = likedGamesQuery.refetch;
+  const favoriteCount =
+    likedGamesQuery.data?.pages?.[0]?.count ?? favoriteGames.length;
+  const isFavoriteGamesLoading =
+    likedGamesQuery.isLoading && !favoriteGames.length;
+  const isFavoriteGamesError = likedGamesQuery.isError && !favoriteGames.length;
+
+  useEffect(() => {
+    if (isFavoriteGamesFetchNextPageError || !hasFavoriteGamesNextPage) {
+      return undefined;
+    }
+
+    const rootElement = favoriteGamesScrollRef.current;
+    const targetElement = favoriteGamesLoadMoreRef.current;
+
+    if (!rootElement || !targetElement) {
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+
+        if (!entry?.isIntersecting || isFavoriteGamesFetchingNextPage) {
+          return;
+        }
+
+        void fetchNextFavoriteGamesPage();
+      },
+      {
+        root: rootElement,
+        rootMargin: '0px 0px 160px 0px',
+        threshold: 0.1,
+      },
+    );
+
+    observer.observe(targetElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    hasFavoriteGamesNextPage,
+    isFavoriteGamesFetchNextPageError,
+    isFavoriteGamesFetchingNextPage,
+    fetchNextFavoriteGamesPage,
+  ]);
+
+  const handleFavoriteGameCardClick = (game: FavoriteGamePreview) => {
+    onOpenGameDetail(toFavoriteGameListItem(game));
+  };
+
+  const handleFavoriteGameDeleteConfirm = async () => {
+    if (!selectedFavoriteGame) {
+      return;
+    }
+
+    try {
+      const response = await unlikeLikedGameMutation.mutateAsync(
+        selectedFavoriteGame.gameId,
+      );
+
+      setSelectedFavoriteGame(null);
+      onToast({
+        tone: 'success',
+        message: response.detail || '찜한 게임이 목록에서 삭제되었습니다.',
+      });
+    } catch (error) {
+      onToast({
+        tone: 'error',
+        message: extractAuthApiErrorMessage(error),
+      });
+    }
+  };
+
+  return {
+    favoriteGamesScrollRef,
+    favoriteGamesLoadMoreRef,
+    favoriteGames,
+    favoriteCount,
+    isFavoriteGamesLoading,
+    isFavoriteGamesError,
+    hasFavoriteGamesNextPage,
+    isFavoriteGamesFetchingNextPage,
+    isFavoriteGamesFetchNextPageError,
+    isFetchingFavoriteGames:
+      likedGamesQuery.isFetching || likedGamesQuery.isFetchingNextPage,
+    selectedFavoriteGame,
+    isUnlikePending: unlikeLikedGameMutation.isPending,
+    setSelectedFavoriteGame,
+    handleFavoriteGameCardClick,
+    handleFavoriteGameDeleteConfirm,
+    refetchFavoriteGames,
+    fetchNextFavoriteGamesPage,
+  };
+}
+
+export default useMyPageLikedGames;

--- a/src/pages/mypage/hooks/useMyPagePasswordChange.ts
+++ b/src/pages/mypage/hooks/useMyPagePasswordChange.ts
@@ -1,33 +1,23 @@
 import type { FormEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
 
-import { ROUTES } from '../../../constants/routes';
 import {
   extractAuthApiErrorMessage,
   extractAuthApiFieldErrors,
 } from '../../../features/auth/api/auth';
-import {
-  useChangePasswordMutation,
-  useDeleteAccountMutation,
-} from '../../../features/auth/api/useAuthApi';
-import { clearAuthSession } from '../../../features/auth/utils/sessionManager';
+import { useChangePasswordMutation } from '../../../features/auth/api/useAuthApi';
 import type {
   PasswordChangeFieldName,
   PasswordChangeValues,
 } from '../../../components/mypage/PasswordChangePanel';
-import type { MyPageToastPayload } from '../types';
 
 type PasswordTouchedState = Record<PasswordChangeFieldName, boolean>;
 type PasswordFieldErrors = Partial<Record<PasswordChangeFieldName, string>>;
+
 type PasswordPanelMessage = {
   tone: 'success' | 'error';
   message: string;
 } | null;
-
-type UseMyPageSecurityOptions = {
-  onToast: (toast: MyPageToastPayload) => void;
-};
 
 const initialPasswordValues: PasswordChangeValues = {
   currentPassword: '',
@@ -82,10 +72,8 @@ const mapPasswordApiFieldErrors = (
   newPasswordConfirm: fieldErrors.new_password_check,
 });
 
-function useMyPageSecurity({ onToast }: UseMyPageSecurityOptions) {
-  const navigate = useNavigate();
+function useMyPagePasswordChange() {
   const changePasswordMutation = useChangePasswordMutation();
-  const deleteAccountMutation = useDeleteAccountMutation();
   const [isPasswordPanelOpen, setIsPasswordPanelOpen] = useState(false);
   const [passwordValues, setPasswordValues] = useState<PasswordChangeValues>(
     initialPasswordValues,
@@ -95,9 +83,6 @@ function useMyPageSecurity({ onToast }: UseMyPageSecurityOptions) {
   const [apiFieldErrors, setApiFieldErrors] = useState<PasswordFieldErrors>({});
   const [passwordPanelMessage, setPasswordPanelMessage] =
     useState<PasswordPanelMessage>(null);
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [deletePassword, setDeletePassword] = useState('');
-  const [deletePasswordError, setDeletePasswordError] = useState('');
   const localFieldErrors = useMemo(
     () => getPasswordFieldErrors(passwordValues, touchedState),
     [passwordValues, touchedState],
@@ -235,68 +220,6 @@ function useMyPageSecurity({ onToast }: UseMyPageSecurityOptions) {
     }
   };
 
-  const openDeleteModal = () => {
-    setDeletePassword('');
-    setDeletePasswordError('');
-    setIsDeleteModalOpen(true);
-  };
-
-  const closeDeleteModal = () => {
-    setIsDeleteModalOpen(false);
-    setDeletePassword('');
-    setDeletePasswordError('');
-  };
-
-  const handleDeletePasswordChange = (value: string) => {
-    setDeletePassword(value);
-
-    if (deletePasswordError) {
-      setDeletePasswordError('');
-    }
-  };
-
-  const handleDeleteAccount = async () => {
-    const trimmedPassword = deletePassword.trim();
-
-    if (!trimmedPassword) {
-      setDeletePasswordError('현재 비밀번호를 입력해주세요.');
-      return;
-    }
-
-    try {
-      await deleteAccountMutation.mutateAsync({
-        password: trimmedPassword,
-      });
-
-      clearAuthSession();
-      navigate(`/${ROUTES.LOGIN}`, {
-        replace: true,
-        state: {
-          noticeMessage: '회원 탈퇴가 완료되었습니다.',
-        },
-      });
-    } catch (error) {
-      const fieldErrors = extractAuthApiFieldErrors(error);
-
-      if (fieldErrors.password) {
-        setDeletePasswordError(fieldErrors.password);
-        return;
-      }
-
-      const errorMessage = extractAuthApiErrorMessage(error);
-
-      if (errorMessage.includes('비밀번호')) {
-        setDeletePasswordError(errorMessage);
-        return;
-      }
-
-      onToast({
-        tone: 'error',
-        message: errorMessage,
-      });
-    }
-  };
-
   return {
     isPasswordPanelOpen,
     togglePasswordPanel,
@@ -308,15 +231,7 @@ function useMyPageSecurity({ onToast }: UseMyPageSecurityOptions) {
     handlePasswordBlur,
     handlePasswordSubmit,
     isChangePasswordPending: changePasswordMutation.isPending,
-    isDeleteModalOpen,
-    openDeleteModal,
-    closeDeleteModal,
-    deletePassword,
-    deletePasswordError,
-    handleDeletePasswordChange,
-    handleDeleteAccount,
-    isDeleteAccountPending: deleteAccountMutation.isPending,
   };
 }
 
-export default useMyPageSecurity;
+export default useMyPagePasswordChange;


### PR DESCRIPTION
## 관련 이슈

- closes #237 

## 변경 내용

- 로그인 페이지 리팩토링: 폼 상태, API 에러 처리, 포커스 제어, 개발용 mock 계정 패널 상태를 useLoginForm으로 분리했습니다.
- 회원가입 페이지 리팩토링: 폼 상태, 필드 검증, 중복 확인, toast 메시지, 제출 후 자동 로그인 흐름을 useSignupForm으로 분리했습니다.
- 컴포넌트 경량화: LoginPage.tsx, SignupPage.tsx에서 비즈니스 로직을 걷어내고 레이아웃과 입력 섹션 렌더링 중심으로 정리했습니다.
- 모듈 응집도 향상: 필드 id, 입력 길이 제한, 성별 옵션처럼 로직과 밀접하게 연관된 상수값들을 훅 모듈 내에서 함께 관리하도록 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- API 경로, 요청/응답 스펙 변경은 없고 폼 내부 로직 구조만 분리한 리팩터링입니다.
