### PR TITLE
[Refactor] Tailwind CSS IntelliSense canonical class 일괄 수정

### DIFF
--- a/src/components/common/ActionButton.tsx
+++ b/src/components/common/ActionButton.tsx
@@ -18,7 +18,7 @@ const variantClassNames: Record<ActionButtonVariant, string> = {
     'bg-login-field border-login-field text-login-label rounded-xl border text-sm/5 font-medium hover:-translate-y-0.5 hover:border-white/20 hover:text-white focus-visible:ring-white/15',
   ghost:
     'border-login-outline rounded-full border bg-transparent text-lg/7 font-semibold text-white hover:-translate-y-0.5 hover:border-white/25 hover:bg-white/5 focus-visible:ring-white/15',
-  icon: 'h-9 w-9 rounded-full border border-white/10 bg-white/[0.02] text-white/60 hover:border-white/20 hover:bg-white/[0.04] hover:text-white/90 focus-visible:ring-white/20',
+  icon: 'h-9 w-9 rounded-full border border-white/10 bg-white/2 text-white/60 hover:border-white/20 hover:bg-white/4 hover:text-white/90 focus-visible:ring-white/20',
 };
 
 function ActionButton({

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -33,7 +33,7 @@ const Header = ({ fixed = true }: HeaderProps) => {
   const profilePlaceholder = (
     <div
       aria-hidden="true"
-      className="h-10 w-10 rounded-full border-2 border-white/8 bg-white/[0.04]"
+      className="h-10 w-10 rounded-full border-2 border-white/8 bg-white/4"
     />
   );
   const guestActionsPlaceholder = (

--- a/src/components/common/StatusMessage.tsx
+++ b/src/components/common/StatusMessage.tsx
@@ -26,7 +26,7 @@ const toneClassNames: Record<
   surface: {
     error: 'border-red-500/20 bg-red-500/10 text-red-300',
     success: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-300',
-    muted: 'border-white/12 bg-white/[0.03] text-white/70',
+    muted: 'border-white/12 bg-white/3 text-white/70',
   },
   inline: {
     error: 'text-red-400',

--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -54,14 +54,14 @@ function AuthLayout({
 
         {withPanel ? (
           <section
-            className={`auth-layout-panel w-full max-w-[520px] rounded-[28px] border px-4 py-5 backdrop-blur-sm sm:rounded-3xl sm:px-8 sm:py-8 ${panelClassName}`}
+            className={`auth-layout-panel w-full max-w-130 rounded-[28px] border px-4 py-5 backdrop-blur-sm sm:rounded-3xl sm:px-8 sm:py-8 ${panelClassName}`}
           >
-            <div className={`mx-auto w-full max-w-[440px] ${contentClassName}`}>
+            <div className={`mx-auto w-full max-w-110 ${contentClassName}`}>
               {content}
             </div>
           </section>
         ) : (
-          <section className={`w-full max-w-[440px] ${contentClassName}`}>
+          <section className={`w-full max-w-110 ${contentClassName}`}>
             {content}
           </section>
         )}

--- a/src/components/mypage/ConfirmModal.tsx
+++ b/src/components/mypage/ConfirmModal.tsx
@@ -28,7 +28,7 @@ function ConfirmModal({
   }
 
   return (
-    <div className="fixed inset-0 z-[80] flex items-center justify-center px-4">
+    <div className="fixed inset-0 z-80 flex items-center justify-center px-4">
       <button
         type="button"
         aria-label="모달 닫기"

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -16,7 +16,7 @@ function FavoriteGameCard({
 }: FavoriteGameCardProps) {
   return (
     <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover flex h-full flex-col overflow-hidden rounded-[22px] border transition duration-200">
-      <div className="bg-mypage-soft relative aspect-[3/4] overflow-hidden">
+      <div className="bg-mypage-soft relative aspect-3/4 overflow-hidden">
         <button
           type="button"
           onClick={() => onClick?.(game)}
@@ -34,7 +34,7 @@ function FavoriteGameCard({
               이미지 준비 중
             </div>
           )}
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/70 via-black/18 to-transparent" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-linear-to-t from-black/70 via-black/18 to-transparent" />
         </button>
         <div className="absolute top-3 right-3">
           <ActionButton
@@ -42,7 +42,7 @@ function FavoriteGameCard({
             variant="icon"
             aria-label={`${game.title} 찜 해제`}
             onClick={() => onFavoriteClick?.(game)}
-            className="hover:!border-login-primary hover:!bg-login-primary-hover !border-login-primary !bg-login-primary !text-white shadow-[0_10px_24px_rgba(0,0,0,0.38)] hover:!text-white focus-visible:ring-red-300/45"
+            className="hover:border-login-primary! hover:bg-login-primary-hover! border-login-primary! bg-login-primary! text-white! shadow-[0_10px_24px_rgba(0,0,0,0.38)] hover:text-white! focus-visible:ring-red-300/45"
           >
             <X size={15} strokeWidth={2.25} />
           </ActionButton>

--- a/src/components/mypage/FavoriteGameCardSkeleton.tsx
+++ b/src/components/mypage/FavoriteGameCardSkeleton.tsx
@@ -16,7 +16,7 @@ function FavoriteGameCardSkeleton({
           key={index}
           className="border-mypage-card bg-mypage-card overflow-hidden rounded-[22px] border"
         >
-          <div className="aspect-[3/4] animate-pulse bg-white/8" />
+          <div className="aspect-3/4 animate-pulse bg-white/8" />
           <div className="space-y-2 px-4 py-4">
             <div className="h-5 w-3/4 animate-pulse rounded-full bg-white/10" />
             <div className="h-4 w-full animate-pulse rounded-full bg-white/8" />

--- a/src/components/mypage/FavoriteGamesEmptyState.tsx
+++ b/src/components/mypage/FavoriteGamesEmptyState.tsx
@@ -2,7 +2,7 @@ import { HeartOff } from 'lucide-react';
 
 function FavoriteGamesEmptyState() {
   return (
-    <div className="border-mypage-divider bg-mypage-card flex min-h-64 flex-col items-center justify-center rounded-[24px] border border-dashed px-6 py-10 text-center">
+    <div className="border-mypage-divider bg-mypage-card flex min-h-64 flex-col items-center justify-center rounded-3xl border border-dashed px-6 py-10 text-center">
       <span className="bg-mypage-soft mb-5 inline-flex h-14 w-14 items-center justify-center rounded-full text-white/80">
         <HeartOff size={24} />
       </span>

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -205,7 +205,7 @@ function MyPageProfileSection({
                   </button>
                   <button
                     type="button"
-                    className="bg-login-primary rounded-full px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-[#dd0d14] disabled:cursor-not-allowed disabled:opacity-50"
+                    className="bg-login-primary hover:bg-login-primary-hover rounded-full px-3 py-1.5 text-xs font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
                     onClick={() => {
                       void handleNicknameSave();
                     }}

--- a/src/components/mypage/PasswordChangePanel.tsx
+++ b/src/components/mypage/PasswordChangePanel.tsx
@@ -36,7 +36,7 @@ function PasswordChangePanel({
   onSubmit,
 }: PasswordChangePanelProps) {
   return (
-    <section className="bg-mypage-card border-mypage-panel mt-6 w-full rounded-[24px] border px-4 py-5 text-left sm:px-5 sm:py-6">
+    <section className="bg-mypage-card border-mypage-panel mt-6 w-full rounded-3xl border px-4 py-5 text-left sm:px-5 sm:py-6">
       <div className="mb-5">
         <h2 className="text-xl font-semibold text-white">비밀번호 변경</h2>
         <p className="text-mypage-muted mt-2 text-sm/6">

--- a/src/components/mypage/ToastMessage.tsx
+++ b/src/components/mypage/ToastMessage.tsx
@@ -39,7 +39,7 @@ function ToastMessage({
 
   return (
     <div
-      className={`bg-mypage-panel border-mypage-panel shadow-mypage-float z-[70] flex w-fit max-w-[min(92vw,360px)] items-start gap-3 rounded-2xl border px-4 py-3 backdrop-blur-xl ${positioningClass} ${className}`}
+      className={`bg-mypage-panel border-mypage-panel shadow-mypage-float z-70 flex w-fit max-w-[min(92vw,360px)] items-start gap-3 rounded-2xl border px-4 py-3 backdrop-blur-xl ${positioningClass} ${className}`}
     >
       <span
         className={`mt-0.5 shrink-0 ${
@@ -48,7 +48,7 @@ function ToastMessage({
       >
         <Icon size={18} />
       </span>
-      <p className="min-w-0 text-sm/6 font-medium break-words text-white">
+      <p className="min-w-0 text-sm/6 font-medium wrap-break-word text-white">
         {message}
       </p>
       <button

--- a/src/components/support-chat/SupportChatLauncherButton.tsx
+++ b/src/components/support-chat/SupportChatLauncherButton.tsx
@@ -14,7 +14,7 @@ function SupportChatLauncherButton({
       type="button"
       onClick={onClick}
       aria-label={isOpen ? '고객센터 챗봇 닫기' : '고객센터 챗봇 열기'}
-      className="support-chat-fab group fixed right-4 bottom-4 z-[95] flex h-16 w-16 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none motion-reduce:transition-none motion-reduce:hover:translate-y-0 sm:right-6 sm:bottom-6"
+      className="support-chat-fab group fixed right-4 bottom-4 z-95 flex h-16 w-16 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none motion-reduce:transition-none motion-reduce:hover:translate-y-0 sm:right-6 sm:bottom-6"
     >
       <span className="support-chat-fab-glow" />
       <Bot

--- a/src/components/support-chat/SupportChatMessageBubble.tsx
+++ b/src/components/support-chat/SupportChatMessageBubble.tsx
@@ -48,7 +48,7 @@ function SupportChatMessageBubble({ message }: SupportChatMessageBubbleProps) {
         ) : null}
 
         <div
-          className={`min-w-0 rounded-[24px] px-4 py-3.5 ${meta.bodyClassName}`}
+          className={`min-w-0 rounded-3xl px-4 py-3.5 ${meta.bodyClassName}`}
         >
           {isTyping ? (
             <SupportChatTypingIndicator />

--- a/src/components/support-chat/SupportChatPanel.tsx
+++ b/src/components/support-chat/SupportChatPanel.tsx
@@ -54,7 +54,7 @@ function SupportChatPanel({
   return (
     <div
       ref={panelRef}
-      className={`support-chat-panel fixed right-4 bottom-24 z-[90] flex h-[min(78vh,46rem)] w-[min(94vw,27rem)] origin-bottom-right flex-col overflow-hidden transition-all duration-300 ease-out motion-reduce:transition-none sm:right-6 sm:bottom-26 ${
+      className={`support-chat-panel fixed right-4 bottom-24 z-90 flex h-[min(78vh,46rem)] w-[min(94vw,27rem)] origin-bottom-right flex-col overflow-hidden transition-all duration-300 ease-out motion-reduce:transition-none sm:right-6 sm:bottom-26 ${
         isOpen
           ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
           : 'pointer-events-none translate-y-4 scale-95 opacity-0'
@@ -93,11 +93,11 @@ function SupportChatPanel({
       </div>
 
       {showJumpToLatestButton ? (
-        <div className="pointer-events-none absolute right-4 bottom-[5.75rem] z-20 flex justify-end">
+        <div className="pointer-events-none absolute right-4 bottom-23 z-20 flex justify-end">
           <button
             type="button"
             onClick={onJumpToLatest}
-            className="pointer-events-auto inline-flex items-center rounded-full border border-[#cf4a44]/75 bg-[#2a0f0f]/95 px-3.5 py-2 text-xs font-semibold text-white shadow-[0_16px_30px_rgba(0,0,0,0.35)] transition hover:border-[#e05f58] hover:bg-[#371413] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#df3b33] motion-reduce:transition-none"
+            className="focus-visible:outline-support-chat-accent pointer-events-auto inline-flex items-center rounded-full border border-[#cf4a44]/75 bg-[#2a0f0f]/95 px-3.5 py-2 text-xs font-semibold text-white shadow-[0_16px_30px_rgba(0,0,0,0.35)] transition hover:border-[#e05f58] hover:bg-[#371413] focus-visible:outline-2 focus-visible:outline-offset-2 motion-reduce:transition-none"
           >
             새 메시지 확인
           </button>

--- a/src/features/matching/components/MatchingGuideCards.tsx
+++ b/src/features/matching/components/MatchingGuideCards.tsx
@@ -26,7 +26,7 @@ function MatchingGuideCards() {
       {guideCards.map(({ title, description, icon: Icon }) => (
         <article
           key={title}
-          className="rounded-[22px] border border-white/8 bg-white/[0.025] px-4 py-4 shadow-[0_18px_34px_rgba(0,0,0,0.16)]"
+          className="rounded-[22px] border border-white/8 bg-white/2.5 px-4 py-4 shadow-[0_18px_34px_rgba(0,0,0,0.16)]"
         >
           <div className="flex h-10 w-10 items-center justify-center rounded-full border border-[#9c1b1b]/35 bg-[#150909] text-[#e34141]">
             <Icon size={18} />

--- a/src/features/matching/components/MatchingMediaPanel.tsx
+++ b/src/features/matching/components/MatchingMediaPanel.tsx
@@ -88,7 +88,7 @@ function MatchingMediaPanel({
           <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
             이 카드에서 볼 포인트
           </p>
-          <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1.5 text-xs font-medium text-white/52">
+          <span className="rounded-full border border-white/10 bg-white/3 px-3 py-1.5 text-xs font-medium text-white/52">
             {stepLabel}
           </span>
         </div>
@@ -98,7 +98,7 @@ function MatchingMediaPanel({
         </p>
 
         <div className="mt-3.5 grid gap-2.5 sm:grid-cols-3">
-          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3">
+          <div className="rounded-[18px] border border-white/8 bg-white/3 px-3.5 py-3">
             <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
               평균 평점
             </p>
@@ -106,7 +106,7 @@ function MatchingMediaPanel({
               {formatMatchingCandidateRating(candidate.rating)}
             </p>
           </div>
-          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3">
+          <div className="rounded-[18px] border border-white/8 bg-white/3 px-3.5 py-3">
             <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
               미디어
             </p>
@@ -114,7 +114,7 @@ function MatchingMediaPanel({
               {candidate.trailer_url ? '유튜브 트레일러' : '이미지 미리보기'}
             </p>
           </div>
-          <div className="rounded-[18px] border border-white/8 bg-white/[0.03] px-3.5 py-3">
+          <div className="rounded-[18px] border border-white/8 bg-white/3 px-3.5 py-3">
             <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
               장르 감각
             </p>

--- a/src/features/matching/components/MatchingRatingStars.tsx
+++ b/src/features/matching/components/MatchingRatingStars.tsx
@@ -25,7 +25,7 @@ function MatchingRatingStars({ value, onRate }: MatchingRatingStarsProps) {
             className={`flex h-9.5 w-9.5 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
               isActive
                 ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
-                : 'border-white/10 bg-white/[0.03] text-white/34 hover:border-white/18 hover:text-white/72'
+                : 'border-white/10 bg-white/3 text-white/34 hover:border-white/18 hover:text-white/72'
             }`}
           >
             <Star

--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -492,9 +492,9 @@ function SurveyChatPanel() {
   const guardrailLauncher =
     shouldShowGuardrailPanel && typeof document !== 'undefined'
       ? createPortal(
-          <div className="pointer-events-none fixed bottom-6 left-2 z-[95] hidden lg:block">
+          <div className="pointer-events-none fixed bottom-6 left-2 z-95 hidden lg:block">
             {isGuardrailPanelOpen ? (
-              <aside className="pointer-events-auto mb-3 ml-3 w-[300px] rounded-[26px] border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,20,0.84),rgba(8,8,9,0.94))] px-4 py-4 shadow-[0_18px_40px_rgba(0,0,0,0.26)] backdrop-blur-xl">
+              <aside className="pointer-events-auto mb-3 ml-3 w-75 rounded-[26px] border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,20,0.84),rgba(8,8,9,0.94))] px-4 py-4 shadow-[0_18px_40px_rgba(0,0,0,0.26)] backdrop-blur-xl">
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <p className="text-[11px] font-semibold tracking-[0.18em] text-[#ff8a8a] uppercase">
@@ -505,13 +505,13 @@ function SurveyChatPanel() {
                     </h3>
                   </div>
                   <div className="flex items-start gap-2">
-                    <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-[11px] font-medium text-white/64">
+                    <span className="rounded-full border border-white/10 bg-white/4 px-2.5 py-1 text-[11px] font-medium text-white/64">
                       {guardrailStatusLabel}
                     </span>
                     <button
                       type="button"
                       onClick={() => setIsGuardrailPanelOpen(false)}
-                      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/10 bg-white/[0.03] text-white/58 transition hover:bg-white/[0.06] hover:text-white"
+                      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/10 bg-white/3 text-white/58 transition hover:bg-white/6 hover:text-white"
                       aria-label="개발용 가드레일 패널 닫기"
                     >
                       <X size={14} />
@@ -525,15 +525,15 @@ function SurveyChatPanel() {
                   비게임 질문 3회 누적 시 5분 제한을 적용합니다.
                 </p>
 
-                <div className="mt-3 rounded-[18px] border border-white/8 bg-white/[0.03] px-3 py-3">
+                <div className="mt-3 rounded-[18px] border border-white/8 bg-white/3 px-3 py-3">
                   <p className="text-[11px] font-semibold tracking-[0.18em] text-white/42 uppercase">
                     허용 키워드
                   </p>
-                  <div className="mt-2 flex max-h-[132px] flex-wrap gap-1.5 overflow-y-auto pr-1">
+                  <div className="mt-2 flex max-h-33 flex-wrap gap-1.5 overflow-y-auto pr-1">
                     {GAME_RELATED_KEYWORDS.map((keyword) => (
                       <span
                         key={keyword}
-                        className="rounded-full border border-white/8 bg-white/[0.04] px-2.5 py-1 text-[11px] font-medium text-white/72"
+                        className="rounded-full border border-white/8 bg-white/4 px-2.5 py-1 text-[11px] font-medium text-white/72"
                       >
                         {keyword}
                       </span>
@@ -574,7 +574,7 @@ function SurveyChatPanel() {
               type="button"
               onClick={handleReset}
               disabled={isSubmitting}
-              className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/3 px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <RotateCcw size={16} />
               설문 초기화
@@ -587,11 +587,11 @@ function SurveyChatPanel() {
         <div className="survey-panel flex h-full min-h-0 flex-col overflow-hidden border-white/6 bg-[linear-gradient(180deg,rgba(12,12,14,0.86),rgba(7,7,8,0.94))]">
           <div
             ref={viewportRef}
-            className="survey-message-scroll max-h-none flex-1 space-y-4 px-4 py-4 sm:px-5 sm:py-[1.125rem] md:px-6"
+            className="survey-message-scroll max-h-none flex-1 space-y-4 px-4 py-4 sm:px-5 sm:py-4.5 md:px-6"
           >
             {!messages.length && isSubmitting ? (
               <div className="flex w-full justify-start">
-                <div className="rounded-3xl border border-white/8 bg-white/[0.04] px-4 py-3.5 text-sm text-white/60">
+                <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-3.5 text-sm text-white/60">
                   AI가 첫 질문을 준비하고 있습니다...
                 </div>
               </div>
@@ -631,7 +631,7 @@ function SurveyChatPanel() {
             {recommendationReady ? (
               <div className="flex w-full justify-center pt-2">
                 {isRecommendationButtonDisabled ? (
-                  <div className="max-w-[520px] rounded-[26px] border border-white/8 bg-white/[0.025] px-5 py-4 text-center text-sm leading-6 break-keep text-white/58">
+                  <div className="max-w-130 rounded-[26px] border border-white/8 bg-white/2.5 px-5 py-4 text-center text-sm leading-6 break-keep text-white/58">
                     추천 결과는 준비되었지만 현재 설문 제한 상태에서는 바로
                     이동할 수 없어요. 설문 초기화 후 다시 진행해 주세요.
                   </div>
@@ -639,7 +639,7 @@ function SurveyChatPanel() {
                   <button
                     type="button"
                     onClick={handleMoveToRecommendation}
-                    className="inline-flex items-center gap-2 rounded-full bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(150,0,0,0.32)] transition hover:translate-y-[-1px] hover:brightness-105"
+                    className="inline-flex items-center gap-2 rounded-full bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(150,0,0,0.32)] transition hover:-translate-y-px hover:brightness-105"
                   >
                     추천 결과 바로 보기
                     <ChevronRight size={16} />
@@ -651,7 +651,7 @@ function SurveyChatPanel() {
 
           <div className="border-t border-white/8 px-4 py-3.5 sm:px-5 sm:py-4 md:px-6">
             <form ref={formRef} onSubmit={handleSubmit}>
-              <label className="relative block h-[60px] overflow-hidden rounded-full border border-white/10 bg-[#0e0e10] transition focus-within:border-[#b42525] focus-within:bg-[#121214]">
+              <label className="relative block h-15 overflow-hidden rounded-full border border-white/10 bg-[#0e0e10] transition focus-within:border-[#b42525] focus-within:bg-[#121214]">
                 <textarea
                   ref={textareaRef}
                   rows={1}
@@ -659,12 +659,12 @@ function SurveyChatPanel() {
                   onChange={(event) => setInputValue(event.target.value)}
                   onKeyDown={handleTextareaKeyDown}
                   placeholder={inputPlaceholder}
-                  className="h-full min-h-full w-full resize-none overflow-hidden bg-transparent py-[17px] pr-[5.8rem] pl-4 text-[15px] leading-6 text-white outline-none placeholder:text-white/26 sm:pl-5"
+                  className="h-full min-h-full w-full resize-none overflow-hidden bg-transparent py-4.25 pr-[5.8rem] pl-4 text-[15px] leading-6 text-white outline-none placeholder:text-white/26 sm:pl-5"
                   disabled={isTextareaDisabled}
                 />
                 {isChatTemporarilyBlocked ? (
                   <div className="absolute inset-y-0 right-0 flex items-center pr-2">
-                    <div className="inline-flex h-[46px] min-w-[62px] items-center justify-center rounded-full border border-[#6f2525] bg-[#170b0b] px-2.5 text-sm font-semibold text-[#ffb4b4]">
+                    <div className="inline-flex h-11.5 min-w-15.5 items-center justify-center rounded-full border border-[#6f2525] bg-[#170b0b] px-2.5 text-sm font-semibold text-[#ffb4b4]">
                       {formatRemainingBlockTime(remainingBlockTimeMs)}
                     </div>
                   </div>
@@ -680,7 +680,7 @@ function SurveyChatPanel() {
                             ? '응답 생성 중'
                             : '메시지 보내기'
                       }
-                      className="inline-flex h-[46px] w-[46px] items-center justify-center rounded-full bg-[linear-gradient(135deg,#ff3535,#9f1212)] text-white shadow-[0_14px_30px_rgba(139,0,0,0.28)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
+                      className="inline-flex h-11.5 w-11.5 items-center justify-center rounded-full bg-[linear-gradient(135deg,#ff3535,#9f1212)] text-white shadow-[0_14px_30px_rgba(139,0,0,0.28)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
                     >
                       <SendHorizontal size={16} />
                     </button>

--- a/src/features/survey/components/SurveyMessageBubble.tsx
+++ b/src/features/survey/components/SurveyMessageBubble.tsx
@@ -15,8 +15,8 @@ const roleMeta = {
     contentClassName: 'flex-row',
     textClassName: 'text-left',
     bubbleClassName:
-      'bg-white/[0.04] text-white border border-white/8 rounded-[24px] rounded-tl-md shadow-[0_18px_40px_rgba(0,0,0,0.28)]',
-    iconClassName: 'bg-white/[0.05] text-[#ff4d4d]',
+      'bg-white/4 text-white border border-white/8 rounded-[24px] rounded-tl-md shadow-[0_18px_40px_rgba(0,0,0,0.28)]',
+    iconClassName: 'bg-white/5 text-[#ff4d4d]',
   },
   user: {
     icon: UserRound,

--- a/src/features/survey/components/SurveyProgress.tsx
+++ b/src/features/survey/components/SurveyProgress.tsx
@@ -12,7 +12,7 @@ function SurveyProgress({ progress, compact = false }: SurveyProgressProps) {
 
   if (compact) {
     return (
-      <section className="min-w-[172px] rounded-[22px] border border-white/10 bg-white/[0.03] px-3.5 py-3 shadow-[0_14px_30px_rgba(0,0,0,0.16)] backdrop-blur-md">
+      <section className="min-w-43 rounded-[22px] border border-white/10 bg-white/3 px-3.5 py-3 shadow-[0_14px_30px_rgba(0,0,0,0.16)] backdrop-blur-md">
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-2 text-[11px] font-semibold tracking-[0.18em] text-white/42 uppercase">
             <Activity size={14} className="text-[#ff5b5b]" />
@@ -37,7 +37,7 @@ function SurveyProgress({ progress, compact = false }: SurveyProgressProps) {
     <section className="survey-panel p-3.5">
       <div className="mb-2 flex items-center justify-between gap-3">
         <div className="flex items-center gap-2.5">
-          <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-white/[0.05] text-[#ff4d4d]">
+          <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-white/5 text-[#ff4d4d]">
             <Activity size={16} />
           </div>
           <div className="space-y-0.5">

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -227,9 +227,9 @@ function MatchingGenreDetailPage() {
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.12),transparent_24%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
       <LazyHeader fixed />
 
-      <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1120px] px-4 pt-[5.25rem] pb-8 sm:px-6 sm:pt-[5.6rem] sm:pb-10 md:px-8 md:pt-[5.9rem] md:pb-12">
+      <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-21 pb-8 sm:px-6 sm:pt-[5.6rem] sm:pb-10 md:px-8 md:pt-[5.9rem] md:pb-12">
         {!genre || !isValidGenreSlug ? (
-          <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 sm:px-8 sm:py-12">
+          <section className="survey-panel mx-auto max-w-190 px-6 py-10 sm:px-8 sm:py-12">
             <p className="text-sm font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
               Matching
             </p>
@@ -242,7 +242,7 @@ function MatchingGenreDetailPage() {
             </p>
             <Link
               to={`/${ROUTES.MATCHING_LIST}`}
-              className="mt-7 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
+              className="mt-7 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
             >
               <ChevronLeft size={16} />
               장르 선택으로 돌아가기
@@ -253,21 +253,21 @@ function MatchingGenreDetailPage() {
             title="인증 상태를 확인하는 중입니다."
             description="잠시만 기다려 주세요. 세션 확인 후 매칭 화면을 불러옵니다."
             align="center"
-            className="mx-auto max-w-[760px] sm:py-12"
+            className="mx-auto max-w-190 sm:py-12"
           />
         ) : !canAccessPage ? (
           <AuthGateStatusPanel
             title="로그인 후 매칭을 진행할 수 있어요."
             description="로그인하면 장르를 고르고 트레일러를 보며 별점을 남긴 뒤, 취향에 맞는 추천 결과까지 바로 이어서 확인할 수 있어요."
-            className="mx-auto max-w-[760px] sm:py-12"
+            className="mx-auto max-w-190 sm:py-12"
             align="center"
           />
         ) : matchCandidatesQuery.isLoading ? (
-          <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 text-center text-white/68 sm:px-8 sm:py-12">
+          <section className="survey-panel mx-auto max-w-190 px-6 py-10 text-center text-white/68 sm:px-8 sm:py-12">
             매칭 후보 게임을 불러오는 중입니다...
           </section>
         ) : matchCandidatesQuery.error ? (
-          <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 sm:px-8 sm:py-12">
+          <section className="survey-panel mx-auto max-w-190 px-6 py-10 sm:px-8 sm:py-12">
             <p className="text-sm font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
               Matching
             </p>
@@ -281,13 +281,13 @@ function MatchingGenreDetailPage() {
               <button
                 type="button"
                 onClick={() => void matchCandidatesQuery.refetch()}
-                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
               >
                 다시 시도
               </button>
               <Link
                 to={`/${ROUTES.MATCHING_LIST}`}
-                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
               >
                 <ChevronLeft size={16} />
                 장르 선택으로 돌아가기
@@ -295,7 +295,7 @@ function MatchingGenreDetailPage() {
             </div>
           </section>
         ) : candidates.length === 0 ? (
-          <section className="survey-panel mx-auto max-w-[760px] px-6 py-10 sm:px-8 sm:py-12">
+          <section className="survey-panel mx-auto max-w-190 px-6 py-10 sm:px-8 sm:py-12">
             <h1 className="text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl">
               이 장르에 준비된 후보 게임이 아직 없어요.
             </h1>
@@ -304,7 +304,7 @@ function MatchingGenreDetailPage() {
             </p>
             <Link
               to={`/${ROUTES.MATCHING_LIST}`}
-              className="mt-7 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
+              className="mt-7 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
             >
               <ChevronLeft size={16} />
               다른 장르 보기
@@ -315,14 +315,14 @@ function MatchingGenreDetailPage() {
             <div className="pointer-events-none absolute top-[4.85rem] left-1/2 z-20 w-screen -translate-x-1/2 pr-[clamp(1rem,5vw,20rem)] pl-[clamp(0.35rem,3vw,20rem)] sm:top-[5.15rem] md:top-[5.35rem]">
               <Link
                 to={`/${ROUTES.MATCHING_LIST}`}
-                className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
+                className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-4 py-2 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
               >
                 <ChevronLeft size={16} />
                 다른 장르 보기
               </Link>
             </div>
 
-            <section className="mx-auto max-w-[960px]">
+            <section className="mx-auto max-w-240">
               <div className="text-center">
                 <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
                   {safeIndex + 1} / {totalSteps} 단계
@@ -373,7 +373,7 @@ function MatchingGenreDetailPage() {
                         className={`mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center self-start rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
                           currentEvaluation.isLiked
                             ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
-                            : 'border-white/10 bg-white/[0.03] text-white/54 hover:border-white/20 hover:text-white/80'
+                            : 'border-white/10 bg-white/3 text-white/54 hover:border-white/20 hover:text-white/80'
                         }`}
                       >
                         <Heart
@@ -386,10 +386,10 @@ function MatchingGenreDetailPage() {
                     </div>
 
                     <div className="mt-2.5 flex flex-wrap items-center gap-1.5 text-xs text-white/46">
-                      <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
+                      <span className="rounded-full border border-white/8 bg-white/3 px-3 py-1.5">
                         장르 {currentCandidate.genres.join(' · ')}
                       </span>
-                      <span className="rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5">
+                      <span className="rounded-full border border-white/8 bg-white/3 px-3 py-1.5">
                         평균 평점{' '}
                         {formatMatchingCandidateRating(currentCandidate.rating)}
                       </span>
@@ -412,7 +412,7 @@ function MatchingGenreDetailPage() {
                       </div>
                     </div>
 
-                    <div className="mt-5 rounded-[20px] border border-white/8 bg-white/[0.03] px-4 py-3.5">
+                    <div className="mt-5 rounded-[20px] border border-white/8 bg-white/3 px-4 py-3.5">
                       <p className="text-sm leading-7 break-keep text-white/64">
                         {isLastCard
                           ? currentEvaluation.rating === null
@@ -437,7 +437,7 @@ function MatchingGenreDetailPage() {
                             type="button"
                             onClick={goPrevious}
                             disabled={!canGoPrevious}
-                            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/[0.02] disabled:text-white/28"
+                            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/2 disabled:text-white/28"
                           >
                             <ChevronLeft size={16} />
                             이전
@@ -467,7 +467,7 @@ function MatchingGenreDetailPage() {
                           type="button"
                           onClick={goPrevious}
                           disabled={!canGoPrevious}
-                          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/[0.02] disabled:text-white/28"
+                          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/2 disabled:text-white/28"
                         >
                           <ChevronLeft size={16} />
                           이전

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -53,23 +53,23 @@ function MatchingListPage() {
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.18),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
       <LazyHeader fixed />
 
-      <main className="relative z-10 mx-auto min-h-screen w-full max-w-[1120px] px-4 pt-[5.5rem] pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-[6.25rem] md:pb-14">
+      <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-22 pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-25 md:pb-14">
         {authGate.accessStatus === 'loading' ? (
           <AuthGateStatusPanel
             title="인증 상태를 확인하는 중입니다."
             description="잠시만 기다려 주세요. 세션 확인 후 장르별 매칭 화면을 보여드릴게요."
             align="center"
-            className="mx-auto max-w-[760px] sm:py-12"
+            className="mx-auto max-w-190 sm:py-12"
           />
         ) : !canAccessPage ? (
           <AuthGateStatusPanel
             title="로그인 후 매칭을 시작할 수 있어요."
             description="로그인하면 장르를 고르고 트레일러를 보며 별점을 남긴 뒤, 취향에 맞는 추천 결과까지 바로 이어서 확인할 수 있어요."
             align="center"
-            className="mx-auto max-w-[760px] sm:py-12"
+            className="mx-auto max-w-190 sm:py-12"
           />
         ) : (
-          <section className="mx-auto max-w-[960px]">
+          <section className="mx-auto max-w-240">
             <div className="mb-7 text-center sm:mb-8">
               <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
                 Matching
@@ -88,7 +88,7 @@ function MatchingListPage() {
                 <Link
                   key={genre.slug}
                   to={`/${ROUTES.MATCHING_LIST}/${genre.slug}`}
-                  className="group overflow-hidden rounded-[24px] border border-white/8 bg-[#0c0c0d] p-2.5 shadow-[0_18px_36px_rgba(0,0,0,0.26)] transition hover:border-[#a31c1c]/65 hover:bg-[#111112]"
+                  className="group overflow-hidden rounded-3xl border border-white/8 bg-[#0c0c0d] p-2.5 shadow-[0_18px_36px_rgba(0,0,0,0.26)] transition hover:border-[#a31c1c]/65 hover:bg-[#111112]"
                 >
                   <div className="relative overflow-hidden rounded-[18px]">
                     <img

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -19,12 +19,12 @@ function SurveyBackdrop() {
         {SURVEY_BACKDROP_ITEMS.map((game, index) => (
           <div
             key={`${game.gameId}-${index}`}
-            className="overflow-hidden rounded-[28px] border border-white/6 bg-white/[0.03] blur-[14px]"
+            className="overflow-hidden rounded-[28px] border border-white/6 bg-white/3 blur-[14px]"
           >
             <img
               src={game.thumbnailUrl ?? ''}
               alt={game.name}
-              className="h-full min-h-[180px] w-full scale-110 object-cover"
+              className="h-full min-h-45 w-full scale-110 object-cover"
             />
           </div>
         ))}
@@ -71,13 +71,13 @@ function SurveyPage() {
       <div className="app-aurora pointer-events-none absolute inset-0 opacity-90" />
       <LazyHeader fixed />
 
-      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-[100dvh] md:max-h-[100dvh] md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
+      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
         {authGate.accessStatus === 'loading' ? (
           <AuthGateStatusPanel
             title="인증 상태를 확인하는 중입니다."
             description="잠시만 기다려 주세요. 세션 확인 후 설문 화면을 이어서 보여드릴게요."
             align="center"
-            className="mx-auto max-w-[760px] sm:py-12"
+            className="mx-auto max-w-190 sm:py-12"
           />
         ) : canAccessSurvey ? (
           <SurveyChatPanel />
@@ -86,7 +86,7 @@ function SurveyPage() {
             title="로그인 후 설문을 시작할 수 있어요."
             description="로그인하면 취향을 바탕으로 질문을 이어가고, 설문이 끝난 뒤 바로 추천 결과까지 확인할 수 있어요."
             align="center"
-            className="mx-auto max-w-[760px] sm:py-12"
+            className="mx-auto max-w-190 sm:py-12"
           />
         )}
       </main>


### PR DESCRIPTION
## 관련 이슈

- closes #243

## 변경 내용

- arbitrary spacing/z-index/border-radius → Tailwind scale 값으로 변환
  (`max-w-[520px]`→`max-w-130`, `z-[80]`→`z-80`, `rounded-[24px]`→`rounded-3xl` 등)
- opacity bracket 문법 제거
  (`bg-white/[0.03]`→`bg-white/3`, `bg-white/[2.5]`→`bg-white/2.5` 등)
- Tailwind v4 문법 적용
  - gradient: `bg-gradient-to-t` → `bg-linear-to-t`
  - word-break: `break-words` → `wrap-break-word`
  - dvh 단위: `h-[100dvh]` → `h-dvh`, `max-h-[100dvh]` → `max-h-dvh`
  - important: `!class` / `hover:!class` → `class!` / `hover:class!`
- hex 색상 → 테마 변수 치환
  (`hover:bg-[#dd0d14]`→`hover:bg-login-primary-hover`, `outline-[#df3b33]`→`outline-support-chat-accent`)

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.

## 스크린샷

UI 변경 없음 — 동일한 스타일을 Tailwind v4 표준 표기로만 변환한 리팩토링입니다.

## 참고사항

- 수정 파일 23개, 변경 사항 76건 / 시각적 차이 없음
- `!important` 문법은 Tailwind v4부터 접두사(`!class`) 대신 접미사(`class!`) 방식 사용
- `bg-white/[0.0x]` 형태는 Tailwind v4에서 arbitrary 소수점(0~1 스케일)으로 해석되어 의도치 않은 불투명도가 적용될 수 있어 퍼센트 표기(`bg-white/x`)로 통일