### PR TITLE
[Fix] 게임 상세 모달 — 5분 경과 후 캐시 만료로 콘텐츠 미표시 버그 수정

### DIFF
--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -170,7 +170,14 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
           <X aria-hidden="true" className="h-5 w-5" />
         </button>
 
-        {detailQuery.isError ? (
+        {detailQuery.isPending ? (
+          <div className="flex min-h-96 flex-col items-center justify-center px-6 py-16 text-center">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
+            <p className="mt-4 text-sm text-white/50">
+              게임 정보를 불러오는 중입니다.
+            </p>
+          </div>
+        ) : detailQuery.isError ? (
           <div className="flex min-h-96 flex-col items-center justify-center px-6 py-16 text-center sm:px-10">
             <h2
               id="game-detail-modal-title"

--- a/src/features/games/hooks/useGameDetailModal.ts
+++ b/src/features/games/hooks/useGameDetailModal.ts
@@ -122,8 +122,9 @@ export const useGameDetailModal = (game: GameListItem) => {
 
       return mergeGameDetail(previousDetail, incomingDetail);
     },
-    staleTime: 0,
-    refetchOnMount: 'always',
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    refetchOnMount: true,
     refetchOnWindowFocus: false,
     retry: false,
   });


### PR DESCRIPTION
## 관련 이슈

Closes #245

## 변경 사항 요약

- `useGameDetailModal.ts`: `staleTime: 0` → `5분`, `gcTime: 30분` 추가, `refetchOnMount: 'always'` → `true`
- `GameDetailModal.tsx`: `isPending` 로딩 분기(스피너 + 안내 텍스트) 추가

## 버그 원인

`staleTime: 0`으로 설정되어 있어 모달을 닫은 뒤 React Query 기본 `gcTime`(5분)이 경과하면 캐시가 GC됩니다. 이후 재오픈 시 캐시가 없어 `isPending: true` 상태가 되고, 전용 로딩 UI가 없어 모달 콘텐츠가 빈 화면처럼 보이는 문제가 있었습니다.

## 수정 후 동작

| 재오픈 시점 | 동작 |
|------------|------|
| 5분 이내 | 캐시 fresh → 즉시 콘텐츠 표시, 불필요한 refetch 없음 |
| 5분~30분 | 캐시 stale이지만 존재 → 기존 데이터 표시 + 백그라운드 refetch |
| 30분 초과 | 캐시 GC → 스피너 표시 후 정상 로딩 |

## 테스트 방법

- [x] 게임 상세 모달 열기 → 콘텐츠 정상 표시 확인
- [x] 모달 닫기 → 5분 이내 재오픈 → 즉시 콘텐츠 표시 (Network 탭에서 API 재호출 없음 확인)
- [x] DevTools에서 React Query 캐시를 수동 삭제 후 재오픈 → 스피너 표시 후 데이터 로딩 확인

