### PR TITLE
refactor(chat): 고객센터 챗봇 휘발성 정책과 훅 책임 분리 정리

### DIFF
--- a/src/features/support-chat/hooks/useSupportChat.ts
+++ b/src/features/support-chat/hooks/useSupportChat.ts
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useLocation } from 'react-router';
 
 import type { SupportChatPanelProps } from '@/components/support-chat/SupportChatPanel';
 import { SUPPORT_CHAT_QUICK_ACTIONS } from '@/features/support-chat/data/faqs';
 import { useSupportChatStore } from '@/features/support-chat/store/useSupportChatStore';
 import useSupportChatConversation from './useSupportChatConversation';
-import useSupportChatPanelState from './useSupportChatPanelState';
+import useSupportChatPanel from './useSupportChatPanel';
 import { getSupportChatRouteContext } from '../utils/routeContext';
 
 type UseSupportChatResult = {
@@ -18,74 +18,39 @@ type UseSupportChatResult = {
 
 export const useSupportChat = (): UseSupportChatResult => {
   const location = useLocation();
-  const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
+  const previousPathnameRef = useRef<string | null>(null);
 
   const routeContext = useMemo(
     () => getSupportChatRouteContext(location.pathname),
     [location.pathname],
   );
 
+  const { hasBootstrapped, bootstrapConversation, setRouteContext } =
+    useSupportChatStore();
+
   const {
-    sessionId,
     messages,
     quickActions,
     showQuickActions,
-    hasBootstrapped,
-    isPinnedToBottom,
-    isOpen,
     isSubmitting,
-    bootstrapConversation,
-    resetConversation,
-    closePanel,
-    togglePanel,
-    setRouteContext,
-    setSessionId,
-    setPinnedToBottom,
-    setSubmitting,
-    hideQuickActions,
-    appendUserMessage,
-    appendAssistantMessage,
-    beginAssistantMessage,
-    appendAssistantChunk,
-    finalizeAssistantMessage,
-    removeMessage,
-  } = useSupportChatStore();
-
-  useEffect(() => {
-    if (!hasBootstrapped) {
-      bootstrapConversation(routeContext);
-      return;
-    }
-
-    setRouteContext(routeContext);
-  }, [bootstrapConversation, hasBootstrapped, routeContext, setRouteContext]);
-
-  const {
     inputValue,
     setInputValue,
     handleSubmit,
     handleQuickActionSelect,
-    handleReset,
-    abortStreamingResponse,
-  } = useSupportChatConversation({
-    routeContext,
-    sessionId,
-    isSubmitting,
-    appendUserMessage,
-    appendAssistantMessage,
-    beginAssistantMessage,
-    appendAssistantChunk,
-    finalizeAssistantMessage,
-    removeMessage,
-    hideQuickActions,
-    resetConversation,
-    setSessionId,
-    setSubmitting,
-    setPinnedToBottom,
-    setHasUnreadMessages,
-  });
+    resetConversationState,
+  } = useSupportChatConversation({ routeContext });
+
+  const handleCloseConversation = useCallback(() => {
+    resetConversationState({
+      routeContext,
+      keepPanelOpen: false,
+      preserveBootstrap: false,
+    });
+  }, [resetConversationState, routeContext]);
 
   const {
+    isOpen,
+    isPinnedToBottom,
     panelRef,
     viewportRef,
     handleClosePanel,
@@ -93,19 +58,57 @@ export const useSupportChat = (): UseSupportChatResult => {
     showJumpToLatestButton,
     liveStatusMessage,
     scrollViewportToBottom,
-  } = useSupportChatPanelState({
-    isOpen,
-    isSubmitting,
-    isPinnedToBottom,
-    showQuickActions,
-    messages,
-    closePanel,
-    togglePanel,
-    setPinnedToBottom,
-    hasUnreadMessages,
-    setHasUnreadMessages,
-    abortStreamingResponse,
+    resetPanelUiState,
+  } = useSupportChatPanel({
+    onRequestClose: handleCloseConversation,
   });
+
+  const handleResetConversation = useCallback(() => {
+    resetPanelUiState();
+    resetConversationState({
+      routeContext,
+      keepPanelOpen: true,
+      preserveBootstrap: true,
+    });
+  }, [resetConversationState, resetPanelUiState, routeContext]);
+
+  useEffect(() => {
+    if (!hasBootstrapped) {
+      bootstrapConversation(routeContext);
+      previousPathnameRef.current = routeContext.pathname;
+      return;
+    }
+
+    if (
+      previousPathnameRef.current &&
+      previousPathnameRef.current !== routeContext.pathname
+    ) {
+      previousPathnameRef.current = routeContext.pathname;
+      const frameId = window.requestAnimationFrame(() => {
+        resetPanelUiState();
+        resetConversationState({
+          routeContext,
+          keepPanelOpen: isOpen,
+          preserveBootstrap: true,
+        });
+      });
+
+      return () => {
+        window.cancelAnimationFrame(frameId);
+      };
+    }
+
+    setRouteContext(routeContext);
+    previousPathnameRef.current = routeContext.pathname;
+  }, [
+    bootstrapConversation,
+    hasBootstrapped,
+    isOpen,
+    resetConversationState,
+    resetPanelUiState,
+    routeContext,
+    setRouteContext,
+  ]);
 
   return {
     panelProps: {
@@ -123,13 +126,13 @@ export const useSupportChat = (): UseSupportChatResult => {
       showJumpToLatestButton,
       liveStatusMessage,
       inputValue,
-      onReset: handleReset,
+      onReset: handleResetConversation,
       onClose: handleClosePanel,
       onJumpToLatest: () => {
         scrollViewportToBottom('smooth');
       },
       onQuickActionSelect: handleQuickActionSelect,
-      onInputChange: (value) => setInputValue(value),
+      onInputChange: setInputValue,
       onSubmit: handleSubmit,
     },
     launcherProps: {

--- a/src/features/support-chat/hooks/useSupportChatConversation.ts
+++ b/src/features/support-chat/hooks/useSupportChatConversation.ts
@@ -1,16 +1,11 @@
-import {
-  type Dispatch,
-  type SetStateAction,
-  useCallback,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import {
   extractSupportChatErrorMessage,
   streamChatbotResponse,
 } from '@/features/support-chat/api/chatbot';
 import { useSendChatbotMessageMutation } from '@/features/support-chat/api/useSupportChatApi';
+import { useSupportChatStore } from '@/features/support-chat/store/useSupportChatStore';
 import type { SupportChatRouteContext } from '@/features/support-chat/types/supportChat';
 
 const SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE =
@@ -19,47 +14,48 @@ const SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE =
 const isRecoverableSessionError = (message: string) =>
   message.includes('session_id') || message.includes('유효하지 않은');
 
+export type SupportChatConversationResetOptions = {
+  routeContext?: SupportChatRouteContext;
+  keepPanelOpen?: boolean;
+  preserveBootstrap?: boolean;
+  abortInFlightRequest?: boolean;
+};
+
 type UseSupportChatConversationParams = {
   routeContext: SupportChatRouteContext;
-  sessionId: number | null;
-  isSubmitting: boolean;
-  appendUserMessage: (content: string) => void;
-  appendAssistantMessage: (content: string) => void;
-  beginAssistantMessage: (messageId: string) => void;
-  appendAssistantChunk: (messageId: string, chunk: string) => void;
-  finalizeAssistantMessage: (messageId: string) => void;
-  removeMessage: (messageId: string) => void;
-  hideQuickActions: () => void;
-  resetConversation: (routeContext?: SupportChatRouteContext) => void;
-  setSessionId: (sessionId: number | null) => void;
-  setSubmitting: (isSubmitting: boolean) => void;
-  setPinnedToBottom: (isPinnedToBottom: boolean) => void;
-  setHasUnreadMessages: Dispatch<SetStateAction<boolean>>;
 };
 
 function useSupportChatConversation({
   routeContext,
-  sessionId,
-  isSubmitting,
-  appendUserMessage,
-  appendAssistantMessage,
-  beginAssistantMessage,
-  appendAssistantChunk,
-  finalizeAssistantMessage,
-  removeMessage,
-  hideQuickActions,
-  resetConversation,
-  setSessionId,
-  setSubmitting,
-  setPinnedToBottom,
-  setHasUnreadMessages,
 }: UseSupportChatConversationParams) {
   const [inputValue, setInputValue] = useState('');
   const streamAbortRef = useRef<AbortController | null>(null);
+  const requestGenerationRef = useRef(0);
   const sendMessageMutation = useSendChatbotMessageMutation();
+
+  const {
+    sessionId,
+    messages,
+    quickActions,
+    showQuickActions,
+    isSubmitting,
+    appendUserMessage,
+    appendAssistantMessage,
+    beginAssistantMessage,
+    appendAssistantChunk,
+    finalizeAssistantMessage,
+    removeMessage,
+    hideQuickActions,
+    resetConversation,
+    setSessionId,
+    setSubmitting,
+    setPinnedToBottom,
+  } = useSupportChatStore();
 
   const abortStreamingResponse = useCallback(
     (resetSubmitting = false) => {
+      requestGenerationRef.current += 1;
+
       if (streamAbortRef.current) {
         streamAbortRef.current.abort();
         streamAbortRef.current = null;
@@ -70,6 +66,32 @@ function useSupportChatConversation({
       }
     },
     [setSubmitting],
+  );
+
+  const resetConversationState = useCallback(
+    ({
+      routeContext: nextRouteContext = routeContext,
+      keepPanelOpen = true,
+      preserveBootstrap = true,
+      abortInFlightRequest = true,
+    }: SupportChatConversationResetOptions = {}) => {
+      if (abortInFlightRequest) {
+        abortStreamingResponse(true);
+      }
+
+      setInputValue('');
+      setPinnedToBottom(true);
+      resetConversation(nextRouteContext, {
+        isOpen: keepPanelOpen,
+        hasBootstrapped: preserveBootstrap,
+      });
+    },
+    [
+      abortStreamingResponse,
+      resetConversation,
+      routeContext,
+      setPinnedToBottom,
+    ],
   );
 
   const appendAssistantErrorMessage = useCallback(
@@ -100,6 +122,7 @@ function useSupportChatConversation({
       }
 
       const assistantPlaceholderMessageId = crypto.randomUUID();
+      const requestGeneration = requestGenerationRef.current;
 
       hideQuickActions();
       appendUserMessage(trimmedMessage);
@@ -117,6 +140,10 @@ function useSupportChatConversation({
         } catch (requestError) {
           const errorMessage = extractSupportChatErrorMessage(requestError);
 
+          if (requestGeneration !== requestGenerationRef.current) {
+            return;
+          }
+
           if (sessionId && isRecoverableSessionError(errorMessage)) {
             setSessionId(null);
             response = await sendMessageMutation.mutateAsync({
@@ -125,6 +152,10 @@ function useSupportChatConversation({
           } else {
             throw requestError;
           }
+        }
+
+        if (requestGeneration !== requestGenerationRef.current) {
+          return;
         }
 
         setSessionId(response.session_id);
@@ -136,6 +167,10 @@ function useSupportChatConversation({
           sessionId: response.session_id,
           signal: abortController.signal,
           onEvent: (event) => {
+            if (requestGeneration !== requestGenerationRef.current) {
+              return;
+            }
+
             if (event.type === 'chunk') {
               appendAssistantChunk(
                 assistantPlaceholderMessageId,
@@ -150,6 +185,10 @@ function useSupportChatConversation({
           },
         });
       } catch (requestError) {
+        if (requestGeneration !== requestGenerationRef.current) {
+          return;
+        }
+
         removeMessage(assistantPlaceholderMessageId);
         const errorMessage = extractSupportChatErrorMessage(requestError);
 
@@ -159,7 +198,9 @@ function useSupportChatConversation({
 
         setSubmitting(false);
       } finally {
-        streamAbortRef.current = null;
+        if (requestGeneration === requestGenerationRef.current) {
+          streamAbortRef.current = null;
+        }
       }
     },
     [
@@ -196,26 +237,16 @@ function useSupportChatConversation({
     [submitMessage],
   );
 
-  const handleReset = useCallback(() => {
-    abortStreamingResponse(true);
-    setInputValue('');
-    setHasUnreadMessages(false);
-    setPinnedToBottom(true);
-    resetConversation(routeContext);
-  }, [
-    abortStreamingResponse,
-    resetConversation,
-    routeContext,
-    setHasUnreadMessages,
-    setPinnedToBottom,
-  ]);
-
   return {
+    messages,
+    quickActions,
+    showQuickActions,
+    isSubmitting,
     inputValue,
     setInputValue,
     handleSubmit,
     handleQuickActionSelect,
-    handleReset,
+    resetConversationState,
     abortStreamingResponse,
   };
 }

--- a/src/features/support-chat/hooks/useSupportChatPanel.ts
+++ b/src/features/support-chat/hooks/useSupportChatPanel.ts
@@ -1,54 +1,49 @@
-import {
-  type Dispatch,
-  type MutableRefObject,
-  type SetStateAction,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useSupportChatStore } from '@/features/support-chat/store/useSupportChatStore';
+import type { SupportChatMessage } from '@/features/support-chat/types/supportChat';
 
 const AUTO_SCROLL_NEAR_BOTTOM_THRESHOLD_PX = 72;
 
-type UseSupportChatPanelStateParams = {
-  isOpen: boolean;
-  isSubmitting: boolean;
-  isPinnedToBottom: boolean;
-  showQuickActions: boolean;
-  messages: Array<{
-    id: string;
-    content: string;
-  }>;
-  closePanel: () => void;
-  togglePanel: () => void;
-  setPinnedToBottom: (isPinnedToBottom: boolean) => void;
-  hasUnreadMessages: boolean;
-  setHasUnreadMessages: Dispatch<SetStateAction<boolean>>;
-  abortStreamingResponse: (resetSubmitting?: boolean) => void;
+type UseSupportChatPanelParams = {
+  onRequestClose: () => void;
 };
 
-function useSupportChatPanelState({
-  isOpen,
-  isSubmitting,
-  isPinnedToBottom,
-  showQuickActions,
-  messages,
-  closePanel,
-  togglePanel,
-  setPinnedToBottom,
-  hasUnreadMessages,
-  setHasUnreadMessages,
-  abortStreamingResponse,
-}: UseSupportChatPanelStateParams) {
+const toMessageUpdateCursor = (
+  messages: SupportChatMessage[],
+  isSubmitting: boolean,
+  showQuickActions: boolean,
+) => {
+  const latestMessage = messages.at(-1);
+
+  return `${messages.length}:${latestMessage?.id ?? 'none'}:${latestMessage?.content.length ?? 0}:${isSubmitting ? 1 : 0}:${showQuickActions ? 1 : 0}`;
+};
+
+function useSupportChatPanel({ onRequestClose }: UseSupportChatPanelParams) {
+  const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const lastHandledMessageCursorRef = useRef<string | null>(null);
 
-  const messageUpdateCursor = useMemo(() => {
-    const latestMessage = messages.at(-1);
+  const {
+    messages,
+    showQuickActions,
+    isOpen,
+    isSubmitting,
+    isPinnedToBottom,
+    togglePanel,
+    setPinnedToBottom,
+  } = useSupportChatStore();
 
-    return `${messages.length}:${latestMessage?.id ?? 'none'}:${latestMessage?.content.length ?? 0}:${isSubmitting ? 1 : 0}:${showQuickActions ? 1 : 0}`;
-  }, [isSubmitting, messages, showQuickActions]);
+  const messageUpdateCursor = useMemo(
+    () => toMessageUpdateCursor(messages, isSubmitting, showQuickActions),
+    [isSubmitting, messages, showQuickActions],
+  );
+
+  const resetPanelUiState = useCallback(() => {
+    setHasUnreadMessages(false);
+    setPinnedToBottom(true);
+  }, [setPinnedToBottom]);
 
   const isNearBottom = useCallback((viewport: HTMLDivElement) => {
     const distanceFromBottom =
@@ -69,16 +64,15 @@ function useSupportChatPanelState({
         top: viewport.scrollHeight,
         behavior,
       });
-      setPinnedToBottom(true);
-      setHasUnreadMessages(false);
+      resetPanelUiState();
     },
-    [setHasUnreadMessages, setPinnedToBottom],
+    [resetPanelUiState],
   );
 
   const handleClosePanel = useCallback(() => {
-    abortStreamingResponse(true);
-    closePanel();
-  }, [abortStreamingResponse, closePanel]);
+    resetPanelUiState();
+    onRequestClose();
+  }, [onRequestClose, resetPanelUiState]);
 
   const handleTogglePanel = useCallback(() => {
     if (isOpen) {
@@ -119,18 +113,8 @@ function useSupportChatPanelState({
     };
   }, [handleClosePanel, isOpen]);
 
-  useEffect(
-    () => () => {
-      abortStreamingResponse(true);
-    },
-    [abortStreamingResponse],
-  );
-
   useEffect(() => {
     if (!isOpen) {
-      abortStreamingResponse(true);
-      setHasUnreadMessages(false);
-      setPinnedToBottom(true);
       return;
     }
 
@@ -141,13 +125,15 @@ function useSupportChatPanelState({
     return () => {
       window.cancelAnimationFrame(frameId);
     };
-  }, [
-    abortStreamingResponse,
-    isOpen,
-    scrollViewportToBottom,
-    setHasUnreadMessages,
-    setPinnedToBottom,
-  ]);
+  }, [isOpen, scrollViewportToBottom]);
+
+  useEffect(() => {
+    if (isOpen) {
+      return;
+    }
+
+    lastHandledMessageCursorRef.current = messageUpdateCursor;
+  }, [isOpen, messageUpdateCursor]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -177,7 +163,7 @@ function useSupportChatPanelState({
     return () => {
       viewport.removeEventListener('scroll', handleViewportScroll);
     };
-  }, [isNearBottom, isOpen, setHasUnreadMessages, setPinnedToBottom]);
+  }, [isNearBottom, isOpen, setPinnedToBottom]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -203,14 +189,14 @@ function useSupportChatPanelState({
       };
     }
 
-    setHasUnreadMessages(true);
-  }, [
-    isOpen,
-    isPinnedToBottom,
-    messageUpdateCursor,
-    scrollViewportToBottom,
-    setHasUnreadMessages,
-  ]);
+    const frameId = window.requestAnimationFrame(() => {
+      setHasUnreadMessages(true);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [isOpen, isPinnedToBottom, messageUpdateCursor, scrollViewportToBottom]);
 
   const showJumpToLatestButton =
     isOpen && hasUnreadMessages && !isPinnedToBottom;
@@ -221,14 +207,17 @@ function useSupportChatPanelState({
       : null;
 
   return {
-    panelRef: panelRef as MutableRefObject<HTMLDivElement | null>,
-    viewportRef: viewportRef as MutableRefObject<HTMLDivElement | null>,
+    isOpen,
+    isPinnedToBottom,
+    panelRef,
+    viewportRef,
     handleClosePanel,
     handleTogglePanel,
     showJumpToLatestButton,
     liveStatusMessage,
     scrollViewportToBottom,
+    resetPanelUiState,
   };
 }
 
-export default useSupportChatPanelState;
+export default useSupportChatPanel;

--- a/src/features/support-chat/store/useSupportChatStore.ts
+++ b/src/features/support-chat/store/useSupportChatStore.ts
@@ -22,9 +22,15 @@ type SupportChatStoreState = {
   isSubmitting: boolean;
   routeContext: SupportChatRouteContext;
   bootstrapConversation: (routeContext?: SupportChatRouteContext) => void;
-  resetConversation: (routeContext?: SupportChatRouteContext) => void;
+  resetConversation: (
+    routeContext?: SupportChatRouteContext,
+    options?: {
+      isOpen?: boolean;
+      hasBootstrapped?: boolean;
+    },
+  ) => void;
   openPanel: () => void;
-  closePanel: () => void;
+  closeAndResetConversation: (routeContext?: SupportChatRouteContext) => void;
   togglePanel: () => void;
   setRouteContext: (routeContext: SupportChatRouteContext) => void;
   setSessionId: (sessionId: number | null) => void;
@@ -97,15 +103,19 @@ export const useSupportChatStore = create<SupportChatStoreState>()(
         routeContext,
       });
     },
-    resetConversation: (routeContext = get().routeContext) =>
+    resetConversation: (routeContext = get().routeContext, options = {}) =>
       set({
         ...initialState,
-        hasBootstrapped: true,
-        isOpen: true,
+        hasBootstrapped: options.hasBootstrapped ?? true,
+        isOpen: options.isOpen ?? true,
         routeContext,
       }),
     openPanel: () => set({ isOpen: true }),
-    closePanel: () => set({ isOpen: false }),
+    closeAndResetConversation: (routeContext = get().routeContext) =>
+      set({
+        ...initialState,
+        routeContext,
+      }),
     togglePanel: () => set((state) => ({ isOpen: !state.isOpen })),
     setRouteContext: (routeContext) => set({ routeContext }),
     setSessionId: (sessionId) => set({ sessionId }),


### PR DESCRIPTION
## 관련 이슈

- closes #249

## 변경 내용

- 고객센터 챗봇 대화가 요구사항 정의서 REQ-CHAT-001에 맞게 현재 화면 한정 임시 상태로만 유지되도록 정리했습니다.
- 챗봇 종료 버튼, 패널 바깥 클릭, Esc 입력 시 닫기 + 대화 초기화가 함께 실행되도록 통합했습니다.
- route 변경 시 기존 routeContext만 갱신하던 흐름을 수정해, 대화 세션과 메시지 내역이 즉시 초기화되도록 변경했습니다.
- 닫기 또는 화면 이탈 직전에 진행 중이던 요청/스트리밍 결과가 뒤늦게 상태를 덮어쓰지 않도록 generation guard를 추가했습니다.
- useSupportChatConversation이 입력 상태, 메시지 제출, 세션 복구, SSE 스트리밍, 대화 reset 등 비즈니스/통신 로직을 전담하도록 재구성했습니다.
- useSupportChatPanel이 패널 열림/닫기, unread 상태, 자동 스크롤, 바깥 클릭, Esc 처리 등 UI/인터랙션을 전담하도록 분리했습니다.
- useSupportChat은 두 훅을 조합해 SupportChatWidget에 필요한 인터페이스만 전달하는 브릿지 역할로 경량화했습니다.
- 기존 useSupportChatPanelState는 역할이 새 패널 훅으로 흡수되어 useSupportChatPanel로 정리했습니다.


## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷


https://github.com/user-attachments/assets/c81b05aa-d40a-4d7d-a207-ba7eadf15055

## 참고사항

- 요구사항 정의서 확인 결과 REQ-CHAT-001~003의 핵심은 현재 화면 한정 임시 유지, 닫기/route 변경/새로고침/탭 종료 시 초기화, 저장소 비사용, SSE 스트리밍 유지였습니다.
- API 명세서 확인 결과 고객센터 챗봇은 기존대로 POST /api/v1/chatbot/messages, GET /api/v1/chatbot/stream?session_id=를 사용하며, 이번 작업에서 API 스펙 변경은 없습니다.
