### PR TITLE
refactor(auth): 회원 정보 수정(PATCH) 응답 타입 변경 및 부분 캐시 업데이트 (#251)

### DIFF
--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -26,6 +26,7 @@ import type {
   SignupRequest,
   SignupResponse,
   UpdateUserInfoRequest,
+  UpdateUserInfoResponse,
   UploadFileToS3Request,
 } from '../types/auth';
 
@@ -219,7 +220,7 @@ export const getCurrentUserProfile = async () => {
 };
 
 export const updateUserInfo = async (payload: UpdateUserInfoRequest) => {
-  const response = await api.patch<CurrentUserProfileResponse>(
+  const response = await api.patch<UpdateUserInfoResponse>(
     `${AUTH_BASE_PATH}/me`,
     payload,
   );

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -24,14 +24,17 @@ import {
 import { authKeys } from './queryKeys';
 import type {
   ConfirmProfileImageRequest,
+  CurrentUserProfileResponse,
   LikedGamesResponse,
   LikedGamesRequest,
   ProfileImagePresignedUrlRequest,
+  UpdateUserInfoResponse,
   UpdateUserInfoRequest,
   UploadFileToS3Request,
 } from '../types/auth';
 import { syncGameLikeStateInQueryCache } from '../../games/queryCache';
 import { syncAuthAccount } from '../utils/sessionManager';
+import { useAuthStore } from '../../../store/useAuthStore';
 
 export const DEFAULT_LIKED_GAMES_PAGE_SIZE = 20;
 
@@ -183,10 +186,42 @@ export const useUpdateUserInfoMutation = () => {
     mutationKey: authKeys.updateUserInfo(),
     mutationFn: (payload: UpdateUserInfoRequest) => updateUserInfo(payload),
     onSuccess: (data) => {
-      queryClient.setQueryData(authKeys.me(), data);
-      syncAuthAccount(data);
+      const cachedProfile =
+        queryClient.getQueryData<CurrentUserProfileResponse>(authKeys.me()) ??
+        useAuthStore.getState().account;
+
+      if (!cachedProfile) {
+        void queryClient.invalidateQueries({ queryKey: authKeys.me() });
+        return;
+      }
+
+      const nextProfile: CurrentUserProfileResponse = {
+        ...cachedProfile,
+        ...mergeUpdatedUserInfo(cachedProfile, data),
+      };
+
+      queryClient.setQueryData(authKeys.me(), nextProfile);
+      syncAuthAccount(nextProfile);
     },
   });
+};
+
+const mergeUpdatedUserInfo = (
+  currentProfile: CurrentUserProfileResponse,
+  response: UpdateUserInfoResponse,
+): Partial<CurrentUserProfileResponse> => {
+  const nextProfile: Partial<CurrentUserProfileResponse> = {};
+
+  if (typeof response.nickname === 'string') {
+    nextProfile.nickname = response.nickname;
+  }
+
+  if (response.profile_img_url !== undefined) {
+    nextProfile.profile_img_url =
+      response.profile_img_url ?? currentProfile.profile_img_url ?? null;
+  }
+
+  return nextProfile;
 };
 
 export const useCheckIdDuplicateMutation = () =>

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -25,6 +25,7 @@ import type {
   SocialAuthProvider,
   SignupRequest,
   UpdateUserInfoRequest,
+  UpdateUserInfoResponse,
 } from '../types/auth';
 import { createMockUserMap, type MockUserRecord } from './mockUsers';
 
@@ -622,14 +623,19 @@ const accountHandlers = [
 
     await delay(180);
 
-    return HttpResponse.json({
-      login_id: user.loginId,
-      name: user.name,
-      nickname: user.nickname,
-      gender: user.gender,
-      email: user.email,
-      profile_img_url: user.profileImageUrl,
-    } satisfies CurrentUserProfileResponse);
+    const responseBody: UpdateUserInfoResponse = {
+      detail: '회원 정보가 수정되었습니다.',
+    };
+
+    if (hasNickname) {
+      responseBody.nickname = user.nickname;
+    }
+
+    if (hasProfileImage) {
+      responseBody.profile_img_url = user.profileImageUrl;
+    }
+
+    return HttpResponse.json(responseBody);
   }),
 
   http.post(

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -70,6 +70,12 @@ export interface UpdateUserInfoRequest {
   profile_img_url?: string;
 }
 
+export interface UpdateUserInfoResponse {
+  nickname?: CurrentUserProfileResponse['nickname'];
+  profile_img_url?: CurrentUserProfileResponse['profile_img_url'];
+  detail: string;
+}
+
 export interface ProfileImagePresignedUrlRequest {
   file_name: string;
   content_type: string;


### PR DESCRIPTION
## 관련 이슈

- closes #251 

## 변경 내용

- PATCH /api/v1/accounts/me 응답 타입을 전체 프로필이 아닌 부분 응답(nickname, profile_img_url, detail) 기준으로 수정했습니다.
- 회원 정보 수정 API의 성공 응답 타입으로 UpdateUserInfoResponse를 추가했습니다.
- useUpdateUserInfoMutation에서 authKeys.me() 캐시를 응답값으로 통째로 덮어쓰지 않고, 기존 프로필 캐시와 부분 응답을 병합하도록 변경했습니다.
- me 캐시가 비어 있는 경우에는 invalidateQueries로 전체 프로필을 다시 조회하도록 예외 처리했습니다.
- 병합된 프로필 데이터를 syncAuthAccount에도 반영해 store와 화면 데이터가 어긋나지 않도록 정리했습니다.
- MSW의 PATCH /api/v1/accounts/me 핸들러도 실서버와 동일하게 수정된 필드만 반환하도록 동기화했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 요구사항 정의서 REQ-MEM-012와 API 명세서를 확인한 뒤 반영했습니다.
- PATCH /api/v1/accounts/me는 전체 프로필이 아니라 수정된 필드만 반환하는 것으로 처리했습니다.
- 현재 updateUserInfo를 사용하는 마이페이지 닉네임/프로필 수정 흐름은 병합된 me 캐시를 참조하므로, 전체 프로필이 필요한 화면이 깨지지 않도록 유지했습니다.
