### PR TITLE
refactor(auth): 인증 API 모듈 분리 및 소비 지점 의존성 정리

### DIFF
--- a/src/features/auth/api/auth.error.handler.ts
+++ b/src/features/auth/api/auth.error.handler.ts
@@ -1,0 +1,248 @@
+import { AxiosError } from 'axios';
+
+import type { ErrorResponseBody, LoginRequest } from '../types/auth';
+
+const DEFAULT_API_ERROR_MESSAGE =
+  '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+
+type LoginFieldName = keyof LoginRequest;
+
+export type LoginErrorStatusCode = 400 | 401 | 403;
+
+export type LoginErrorPolicy = {
+  fallbackMessage: string;
+  defaultFocusField: LoginFieldName | null;
+  hideFormMessageWhenFieldError: boolean;
+  preferApiMessage: boolean;
+};
+
+export type ResolveLoginApiErrorResult = {
+  statusCode: LoginErrorStatusCode | null;
+  fieldErrors: Partial<Record<LoginFieldName, string>>;
+  message: string;
+  focusField: LoginFieldName | null;
+};
+
+export const LOGIN_ERROR_POLICIES: Record<
+  LoginErrorStatusCode,
+  LoginErrorPolicy
+> = {
+  400: {
+    fallbackMessage: '아이디 또는 비밀번호를 입력해주세요.',
+    defaultFocusField: null,
+    hideFormMessageWhenFieldError: true,
+    preferApiMessage: false,
+  },
+  401: {
+    fallbackMessage: '아이디 또는 비밀번호가 올바르지 않습니다.',
+    defaultFocusField: 'password',
+    hideFormMessageWhenFieldError: false,
+    preferApiMessage: true,
+  },
+  403: {
+    fallbackMessage:
+      '접근 권한이 없거나 이용이 제한된 계정입니다. 고객센터에 문의하세요.',
+    defaultFocusField: null,
+    hideFormMessageWhenFieldError: false,
+    preferApiMessage: true,
+  },
+};
+
+const extractFieldErrorMessage = (
+  value?: string | Record<string, string[]>,
+) => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value && typeof value === 'object') {
+    const [firstMessageGroup] = Object.values(value);
+
+    if (typeof firstMessageGroup === 'string') {
+      return firstMessageGroup;
+    }
+
+    if (Array.isArray(firstMessageGroup) && firstMessageGroup[0]) {
+      return firstMessageGroup[0];
+    }
+  }
+
+  return null;
+};
+
+const extractFieldErrors = (
+  value?: string | Record<string, string[]>,
+): Record<string, string> => {
+  if (!value || typeof value === 'string') {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([fieldName, messages]) => {
+        if (typeof messages === 'string') {
+          return [fieldName, messages];
+        }
+
+        if (Array.isArray(messages) && messages[0]) {
+          return [fieldName, messages[0]];
+        }
+
+        return null;
+      })
+      .filter((entry): entry is [string, string] => Boolean(entry)),
+  );
+};
+
+export const extractAuthApiFieldErrors = (error: unknown) => {
+  if (!(error instanceof AxiosError)) {
+    return {};
+  }
+
+  const data = error.response?.data as ErrorResponseBody | undefined;
+
+  return {
+    ...extractFieldErrors(data?.detail),
+    ...extractFieldErrors(data?.error_detail),
+  };
+};
+
+export const extractAuthApiErrorMessage = (error: unknown) => {
+  if (!(error instanceof AxiosError)) {
+    return '요청을 처리하는 중 알 수 없는 오류가 발생했습니다.';
+  }
+
+  const data = error.response?.data as ErrorResponseBody | undefined;
+
+  const detailMessage = extractFieldErrorMessage(data?.detail);
+
+  if (detailMessage) {
+    return detailMessage;
+  }
+
+  const errorDetailMessage = extractFieldErrorMessage(data?.error_detail);
+
+  if (errorDetailMessage) {
+    return errorDetailMessage;
+  }
+
+  return DEFAULT_API_ERROR_MESSAGE;
+};
+
+const getFirstLoginErrorField = (
+  fieldErrors: Partial<Record<LoginFieldName, string>>,
+  payload?: Partial<LoginRequest>,
+) => {
+  if (fieldErrors.login_id) {
+    return 'login_id';
+  }
+
+  if (fieldErrors.password) {
+    return 'password';
+  }
+
+  if (payload) {
+    const loginId = payload.login_id?.trim() ?? '';
+    const password = payload.password?.trim() ?? '';
+
+    if (!loginId) {
+      return 'login_id';
+    }
+
+    if (!password) {
+      return 'password';
+    }
+  }
+
+  return null;
+};
+
+const resolveLoginMessageByPolicy = ({
+  policy,
+  fieldErrors,
+  apiMessage,
+}: {
+  policy: LoginErrorPolicy;
+  fieldErrors: Partial<Record<LoginFieldName, string>>;
+  apiMessage: string;
+}) => {
+  if (
+    policy.hideFormMessageWhenFieldError &&
+    getFirstLoginErrorField(fieldErrors)
+  ) {
+    return '';
+  }
+
+  if (policy.preferApiMessage && apiMessage !== DEFAULT_API_ERROR_MESSAGE) {
+    return apiMessage;
+  }
+
+  return policy.fallbackMessage;
+};
+
+export const resolveLoginApiError = (
+  error: unknown,
+  payload?: Partial<LoginRequest>,
+): ResolveLoginApiErrorResult => {
+  const apiFieldErrors = extractAuthApiFieldErrors(error);
+  const fieldErrors = {
+    login_id: apiFieldErrors.login_id,
+    password: apiFieldErrors.password,
+  } satisfies Partial<Record<LoginFieldName, string>>;
+  const focusField = getFirstLoginErrorField(fieldErrors, payload);
+
+  if (!(error instanceof AxiosError)) {
+    return {
+      statusCode: null,
+      fieldErrors,
+      message: extractAuthApiErrorMessage(error),
+      focusField,
+    };
+  }
+
+  const statusCode = error.response?.status ?? null;
+  const apiMessage = extractAuthApiErrorMessage(error);
+
+  if (statusCode === 400 || statusCode === 401 || statusCode === 403) {
+    const policy = LOGIN_ERROR_POLICIES[statusCode];
+
+    return {
+      statusCode,
+      fieldErrors,
+      message: resolveLoginMessageByPolicy({
+        policy,
+        fieldErrors,
+        apiMessage,
+      }),
+      focusField: focusField ?? policy.defaultFocusField,
+    };
+  }
+
+  return {
+    statusCode: null,
+    fieldErrors,
+    message: extractAuthApiErrorMessage(error),
+    focusField,
+  };
+};
+
+export const extractSuspendedAccountInfo = (error: unknown) => {
+  if (!(error instanceof AxiosError) || error.response?.status !== 403) {
+    return null;
+  }
+
+  const data = error.response.data as ErrorResponseBody | undefined;
+  const errorMessage =
+    extractFieldErrorMessage(data?.error_detail) ||
+    extractFieldErrorMessage(data?.detail);
+
+  if (errorMessage !== '정지된 계정입니다.') {
+    return null;
+  }
+
+  return {
+    message: errorMessage,
+    suspendedAt:
+      typeof data?.suspended_at === 'string' ? data.suspended_at : null,
+  };
+};

--- a/src/features/auth/api/auth.session.helper.ts
+++ b/src/features/auth/api/auth.session.helper.ts
@@ -1,0 +1,95 @@
+import { mockServiceWorkerEnabled } from '@/lib/env';
+import type { LoginResponse, RefreshAccessTokenResponse } from '../types/auth';
+
+const MOCK_REFRESH_TOKEN_STORAGE_KEY = 'mock-refresh-token';
+
+type AuthTokenResponse = Pick<LoginResponse, 'access_token' | 'refresh_token'> &
+  Partial<Pick<RefreshAccessTokenResponse, 'refresh_token'>>;
+
+const readMockRefreshToken = () => {
+  if (!mockServiceWorkerEnabled || typeof window === 'undefined') {
+    return '';
+  }
+
+  return window.sessionStorage.getItem(MOCK_REFRESH_TOKEN_STORAGE_KEY) ?? '';
+};
+
+const persistMockRefreshToken = (refreshToken: string | null | undefined) => {
+  if (!mockServiceWorkerEnabled || typeof window === 'undefined') {
+    return;
+  }
+
+  const normalizedRefreshToken = refreshToken?.trim() ?? '';
+
+  if (!normalizedRefreshToken) {
+    window.sessionStorage.removeItem(MOCK_REFRESH_TOKEN_STORAGE_KEY);
+    return;
+  }
+
+  window.sessionStorage.setItem(
+    MOCK_REFRESH_TOKEN_STORAGE_KEY,
+    normalizedRefreshToken,
+  );
+};
+
+const deriveMockRefreshTokenFromAccessToken = (accessToken: string) => {
+  const normalizedAccessToken = accessToken.trim();
+  const mockAccessTokenPrefix = 'mock-access-token-';
+
+  if (!normalizedAccessToken.startsWith(mockAccessTokenPrefix)) {
+    return null;
+  }
+
+  const loginId = normalizedAccessToken.slice(mockAccessTokenPrefix.length);
+
+  if (!loginId) {
+    return null;
+  }
+
+  return `mock-refresh-token-${loginId}`;
+};
+
+export const hasMockRefreshToken = () => Boolean(readMockRefreshToken().trim());
+
+export const clearMockRefreshToken = () => {
+  persistMockRefreshToken(null);
+};
+
+export const createRefreshTokenFallbackRequestBody = () => {
+  if (!mockServiceWorkerEnabled) {
+    return {};
+  }
+
+  const refreshToken = readMockRefreshToken().trim();
+
+  return refreshToken ? { refresh_token: refreshToken } : {};
+};
+
+export const normalizeAuthTokenResponse = <T extends AuthTokenResponse>(
+  response: T,
+  sourceLabel: '로그인' | '토큰 갱신',
+) => {
+  const normalizedAccessToken = response.access_token?.trim() ?? '';
+
+  if (!normalizedAccessToken) {
+    throw new Error(`${sourceLabel} 응답에 access_token이 없습니다.`);
+  }
+
+  return {
+    ...response,
+    access_token: normalizedAccessToken,
+  };
+};
+
+export const syncMockRefreshTokenFromResponse = (
+  response: AuthTokenResponse,
+) => {
+  if (!mockServiceWorkerEnabled) {
+    return;
+  }
+
+  persistMockRefreshToken(
+    response.refresh_token ??
+      deriveMockRefreshTokenFromAccessToken(response.access_token),
+  );
+};

--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -1,0 +1,186 @@
+import axios from 'axios';
+
+import { api } from '@/api/axios';
+import { apiBaseUrl } from '@/lib/env';
+import { AUTH_BASE_PATH } from '../constants/auth';
+import type {
+  CheckIdDuplicateRequest,
+  CheckNicknameDuplicateRequest,
+  ChangePasswordRequest,
+  ChangePasswordResponse,
+  ConfirmProfileImageRequest,
+  ConfirmProfileImageResponse,
+  CurrentUserProfileResponse,
+  DeleteAccountRequest,
+  DeleteLikedGameResponse,
+  DuplicateCheckResponse,
+  LikedGamesRequest,
+  LikedGamesResponse,
+  LoginRequest,
+  LoginResponse,
+  LogoutResponse,
+  ProfileImagePresignedUrlRequest,
+  ProfileImagePresignedUrlResponse,
+  RefreshAccessTokenResponse,
+  SignupRequest,
+  SignupResponse,
+  UpdateUserInfoRequest,
+  UpdateUserInfoResponse,
+  UploadFileToS3Request,
+} from '../types/auth';
+
+const AUTH_REFRESH_TIMEOUT_MS = 7000;
+
+const normalizeApiBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
+const authApiUrl = `${normalizeApiBaseUrl(apiBaseUrl)}${AUTH_BASE_PATH}`;
+
+export const requestLogin = async (payload: LoginRequest) => {
+  const response = await api.post<LoginResponse>(
+    `${AUTH_BASE_PATH}/login`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const requestLogout = async () => {
+  const response = await api.post<LogoutResponse>(`${AUTH_BASE_PATH}/logout`);
+
+  return response.data;
+};
+
+export const requestRefreshAccessToken = async (
+  payload: { refresh_token?: string } = {},
+) => {
+  const response = await axios.post<RefreshAccessTokenResponse>(
+    `${authApiUrl}/token/refresh`,
+    payload,
+    {
+      withCredentials: true,
+      timeout: AUTH_REFRESH_TIMEOUT_MS,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+
+  return response.data;
+};
+
+export const getCurrentUserProfile = async () => {
+  const response = await api.get<CurrentUserProfileResponse>(
+    `${AUTH_BASE_PATH}/me`,
+  );
+
+  return response.data;
+};
+
+export const updateUserInfo = async (payload: UpdateUserInfoRequest) => {
+  const response = await api.patch<UpdateUserInfoResponse>(
+    `${AUTH_BASE_PATH}/me`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const getLikedGames = async (payload: LikedGamesRequest = {}) => {
+  const response = await api.get<LikedGamesResponse>(
+    `${AUTH_BASE_PATH}/me/game-like`,
+    {
+      params: payload,
+    },
+  );
+
+  return response.data;
+};
+
+export const unlikeLikedGame = async (gameId: number) => {
+  const response = await api.delete<DeleteLikedGameResponse>(
+    `${AUTH_BASE_PATH}/me/game-like/${gameId}`,
+  );
+
+  return response.data;
+};
+
+export const getProfileImagePresignedUrl = async (
+  payload: ProfileImagePresignedUrlRequest,
+) => {
+  const response = await api.post<ProfileImagePresignedUrlResponse>(
+    `${AUTH_BASE_PATH}/me/profile-image/presigned-url`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const uploadFileToS3 = async ({
+  presigned_url,
+  file,
+  content_type,
+}: UploadFileToS3Request) => {
+  const resolvedContentType =
+    content_type || file.type || 'application/octet-stream';
+
+  await axios.put(presigned_url, file, {
+    headers: {
+      'Content-Type': resolvedContentType,
+    },
+    withCredentials: false,
+  });
+};
+
+export const confirmProfileImage = async (
+  payload: ConfirmProfileImageRequest,
+) => {
+  const response = await api.patch<ConfirmProfileImageResponse>(
+    `${AUTH_BASE_PATH}/me/profile-image`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const changePassword = async (payload: ChangePasswordRequest) => {
+  const response = await api.post<ChangePasswordResponse>(
+    `${AUTH_BASE_PATH}/me/change-password`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const deleteAccount = async (payload: DeleteAccountRequest) => {
+  await api.delete(`${AUTH_BASE_PATH}/me`, {
+    data: payload,
+  });
+};
+
+export const signup = async (payload: SignupRequest) => {
+  const response = await api.post<SignupResponse>(
+    `${AUTH_BASE_PATH}/signup`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const checkIdDuplicate = async (payload: CheckIdDuplicateRequest) => {
+  const response = await api.post<DuplicateCheckResponse>(
+    `${AUTH_BASE_PATH}/check-id`,
+    payload,
+  );
+
+  return response.data;
+};
+
+export const checkNicknameDuplicate = async (
+  payload: CheckNicknameDuplicateRequest,
+) => {
+  const response = await api.post<DuplicateCheckResponse>(
+    `${AUTH_BASE_PATH}/check-nickname`,
+    payload,
+  );
+
+  return response.data;
+};

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,530 +1,76 @@
-import axios, { AxiosError } from 'axios';
+import type { LoginRequest } from '../types/auth';
+import {
+  clearMockRefreshToken,
+  createRefreshTokenFallbackRequestBody,
+  normalizeAuthTokenResponse,
+  syncMockRefreshTokenFromResponse,
+} from './auth.session.helper';
+import {
+  requestLogin,
+  requestLogout,
+  requestRefreshAccessToken,
+} from './auth.transport';
 
-import { api } from '@/api/axios';
-import { apiBaseUrl, mockServiceWorkerEnabled } from '@/lib/env';
-import { AUTH_BASE_PATH } from '../constants/auth';
-import type {
-  CheckIdDuplicateRequest,
-  CheckNicknameDuplicateRequest,
-  ChangePasswordRequest,
-  ChangePasswordResponse,
-  ConfirmProfileImageRequest,
-  ConfirmProfileImageResponse,
-  CurrentUserProfileResponse,
-  DeleteAccountRequest,
-  DeleteLikedGameResponse,
-  DuplicateCheckResponse,
-  ErrorResponseBody,
-  LikedGamesRequest,
-  LikedGamesResponse,
-  LoginRequest,
-  LoginResponse,
-  LogoutResponse,
-  ProfileImagePresignedUrlRequest,
-  ProfileImagePresignedUrlResponse,
-  RefreshAccessTokenResponse,
-  SignupRequest,
-  SignupResponse,
-  UpdateUserInfoRequest,
-  UpdateUserInfoResponse,
-  UploadFileToS3Request,
-} from '../types/auth';
-
-const normalizeApiBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
-const authApiUrl = `${normalizeApiBaseUrl(apiBaseUrl)}${AUTH_BASE_PATH}`;
-const AUTH_REFRESH_TIMEOUT_MS = 7000;
-const DEFAULT_API_ERROR_MESSAGE =
-  '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
-const MOCK_REFRESH_TOKEN_STORAGE_KEY = 'mock-refresh-token';
-
-type LoginFieldName = keyof LoginRequest;
-
-const readMockRefreshToken = () => {
-  if (!mockServiceWorkerEnabled || typeof window === 'undefined') {
-    return '';
-  }
-
-  return window.sessionStorage.getItem(MOCK_REFRESH_TOKEN_STORAGE_KEY) ?? '';
-};
-
-export const hasMockRefreshToken = () => Boolean(readMockRefreshToken().trim());
-
-const persistMockRefreshToken = (refreshToken: string | null | undefined) => {
-  if (!mockServiceWorkerEnabled || typeof window === 'undefined') {
-    return;
-  }
-
-  const normalizedRefreshToken = refreshToken?.trim() ?? '';
-
-  if (!normalizedRefreshToken) {
-    window.sessionStorage.removeItem(MOCK_REFRESH_TOKEN_STORAGE_KEY);
-    return;
-  }
-
-  window.sessionStorage.setItem(
-    MOCK_REFRESH_TOKEN_STORAGE_KEY,
-    normalizedRefreshToken,
-  );
-};
-
-const deriveMockRefreshTokenFromAccessToken = (accessToken: string) => {
-  const normalizedAccessToken = accessToken.trim();
-  const mockAccessTokenPrefix = 'mock-access-token-';
-
-  if (!normalizedAccessToken.startsWith(mockAccessTokenPrefix)) {
-    return null;
-  }
-
-  const loginId = normalizedAccessToken.slice(mockAccessTokenPrefix.length);
-
-  if (!loginId) {
-    return null;
-  }
-
-  return `mock-refresh-token-${loginId}`;
-};
-
-export type LoginErrorStatusCode = 400 | 401 | 403;
-
-export type LoginErrorPolicy = {
-  fallbackMessage: string;
-  defaultFocusField: LoginFieldName | null;
-  hideFormMessageWhenFieldError: boolean;
-  preferApiMessage: boolean;
-};
-
-export type ResolveLoginApiErrorResult = {
-  statusCode: LoginErrorStatusCode | null;
-  fieldErrors: Partial<Record<LoginFieldName, string>>;
-  message: string;
-  focusField: LoginFieldName | null;
-};
-
-export const LOGIN_ERROR_POLICIES: Record<
+export {
+  checkIdDuplicate,
+  checkNicknameDuplicate,
+  changePassword,
+  confirmProfileImage,
+  deleteAccount,
+  getCurrentUserProfile,
+  getLikedGames,
+  getProfileImagePresignedUrl,
+  signup,
+  unlikeLikedGame,
+  updateUserInfo,
+  uploadFileToS3,
+} from './auth.transport';
+export {
+  extractAuthApiErrorMessage,
+  extractAuthApiFieldErrors,
+  extractSuspendedAccountInfo,
+  LOGIN_ERROR_POLICIES,
+  resolveLoginApiError,
+} from './auth.error.handler';
+export type {
+  LoginErrorPolicy,
   LoginErrorStatusCode,
-  LoginErrorPolicy
-> = {
-  400: {
-    fallbackMessage: '아이디 또는 비밀번호를 입력해주세요.',
-    defaultFocusField: null,
-    hideFormMessageWhenFieldError: true,
-    preferApiMessage: false,
-  },
-  401: {
-    fallbackMessage: '아이디 또는 비밀번호가 올바르지 않습니다.',
-    defaultFocusField: 'password',
-    hideFormMessageWhenFieldError: false,
-    preferApiMessage: true,
-  },
-  403: {
-    fallbackMessage:
-      '접근 권한이 없거나 이용이 제한된 계정입니다. 고객센터에 문의하세요.',
-    defaultFocusField: null,
-    hideFormMessageWhenFieldError: false,
-    preferApiMessage: true,
-  },
-};
+  ResolveLoginApiErrorResult,
+} from './auth.error.handler';
+export { hasMockRefreshToken } from './auth.session.helper';
 
 export const login = async (payload: LoginRequest) => {
-  const response = await api.post<LoginResponse>(
-    `${AUTH_BASE_PATH}/login`,
-    payload,
-  );
-  const normalizedAccessToken = response.data.access_token?.trim() ?? '';
+  const response = await requestLogin(payload);
+  const normalizedResponse = normalizeAuthTokenResponse(response, '로그인');
 
-  if (!normalizedAccessToken) {
-    throw new Error('로그인 응답에 access_token이 없습니다.');
-  }
+  syncMockRefreshTokenFromResponse(normalizedResponse);
 
-  if (mockServiceWorkerEnabled) {
-    persistMockRefreshToken(
-      response.data.refresh_token ??
-        deriveMockRefreshTokenFromAccessToken(normalizedAccessToken),
-    );
-  }
-
-  return {
-    ...response.data,
-    access_token: normalizedAccessToken,
-  };
+  return normalizedResponse;
 };
 
 export const logout = async () => {
   try {
-    const response = await api.post<LogoutResponse>(`${AUTH_BASE_PATH}/logout`);
-    return response.data;
+    return await requestLogout();
   } finally {
-    if (mockServiceWorkerEnabled) {
-      persistMockRefreshToken(null);
-    }
+    clearMockRefreshToken();
   }
 };
 
 export const refreshAccessToken = async () => {
-  const requestBody = (() => {
-    if (!mockServiceWorkerEnabled) {
-      return {};
-    }
-
-    const refreshToken = readMockRefreshToken().trim();
-
-    return refreshToken ? { refresh_token: refreshToken } : {};
-  })();
-
-  // 실서버 기준으로 refresh token은 HttpOnly 쿠키 기반으로 관리합니다.
-  // 단, DEV+MSW에서는 새로고침 복구 안정화를 위해 sessionStorage refresh_token을 body fallback으로 함께 전송합니다.
   try {
-    const response = await axios.post<RefreshAccessTokenResponse>(
-      `${authApiUrl}/token/refresh`,
-      requestBody,
-      {
-        withCredentials: true,
-        timeout: AUTH_REFRESH_TIMEOUT_MS,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
+    const response = await requestRefreshAccessToken(
+      createRefreshTokenFallbackRequestBody(),
     );
-    const normalizedAccessToken = response.data.access_token?.trim() ?? '';
+    const normalizedResponse = normalizeAuthTokenResponse(
+      response,
+      '토큰 갱신',
+    );
 
-    if (!normalizedAccessToken) {
-      throw new Error('토큰 갱신 응답에 access_token이 없습니다.');
-    }
+    syncMockRefreshTokenFromResponse(normalizedResponse);
 
-    if (mockServiceWorkerEnabled) {
-      persistMockRefreshToken(
-        response.data.refresh_token ??
-          deriveMockRefreshTokenFromAccessToken(normalizedAccessToken),
-      );
-    }
-
-    return {
-      ...response.data,
-      access_token: normalizedAccessToken,
-    };
+    return normalizedResponse;
   } catch (error) {
-    if (mockServiceWorkerEnabled) {
-      persistMockRefreshToken(null);
-    }
-
+    clearMockRefreshToken();
     throw error;
   }
-};
-
-export const getCurrentUserProfile = async () => {
-  const response = await api.get<CurrentUserProfileResponse>(
-    `${AUTH_BASE_PATH}/me`,
-  );
-
-  return response.data;
-};
-
-export const updateUserInfo = async (payload: UpdateUserInfoRequest) => {
-  const response = await api.patch<UpdateUserInfoResponse>(
-    `${AUTH_BASE_PATH}/me`,
-    payload,
-  );
-
-  return response.data;
-};
-
-export const getLikedGames = async (payload: LikedGamesRequest = {}) => {
-  const response = await api.get<LikedGamesResponse>(
-    `${AUTH_BASE_PATH}/me/game-like`,
-    {
-      params: payload,
-    },
-  );
-
-  return response.data;
-};
-
-export const unlikeLikedGame = async (gameId: number) => {
-  const response = await api.delete<DeleteLikedGameResponse>(
-    `${AUTH_BASE_PATH}/me/game-like/${gameId}`,
-  );
-
-  return response.data;
-};
-
-export const getProfileImagePresignedUrl = async (
-  payload: ProfileImagePresignedUrlRequest,
-) => {
-  // Presigned URL 발급 경로는 백엔드 정책 고정 시 해당 엔드포인트로 유지합니다.
-  const response = await api.post<ProfileImagePresignedUrlResponse>(
-    `${AUTH_BASE_PATH}/me/profile-image/presigned-url`,
-    payload,
-  );
-
-  return response.data;
-};
-
-export const uploadFileToS3 = async ({
-  presigned_url,
-  file,
-  content_type,
-}: UploadFileToS3Request) => {
-  const resolvedContentType =
-    content_type || file.type || 'application/octet-stream';
-
-  await axios.put(presigned_url, file, {
-    headers: {
-      'Content-Type': resolvedContentType,
-    },
-    withCredentials: false,
-  });
-};
-
-export const confirmProfileImage = async (
-  payload: ConfirmProfileImageRequest,
-) => {
-  const response = await api.patch<ConfirmProfileImageResponse>(
-    `${AUTH_BASE_PATH}/me/profile-image`,
-    payload,
-  );
-
-  return response.data;
-};
-
-export const changePassword = async (payload: ChangePasswordRequest) => {
-  const response = await api.post<ChangePasswordResponse>(
-    `${AUTH_BASE_PATH}/me/change-password`,
-    payload,
-  );
-
-  return response.data;
-};
-
-export const deleteAccount = async (payload: DeleteAccountRequest) => {
-  await api.delete(`${AUTH_BASE_PATH}/me`, {
-    data: payload,
-  });
-};
-
-export const signup = async (payload: SignupRequest) => {
-  const response = await api.post<SignupResponse>(
-    `${AUTH_BASE_PATH}/signup`,
-    payload,
-  );
-
-  return response.data;
-};
-
-export const checkIdDuplicate = async (payload: CheckIdDuplicateRequest) => {
-  const response = await api.post<DuplicateCheckResponse>(
-    `${AUTH_BASE_PATH}/check-id`,
-    payload,
-  );
-
-  return response.data;
-};
-
-export const checkNicknameDuplicate = async (
-  payload: CheckNicknameDuplicateRequest,
-) => {
-  const response = await api.post<DuplicateCheckResponse>(
-    `${AUTH_BASE_PATH}/check-nickname`,
-    payload,
-  );
-
-  return response.data;
-};
-
-const extractFieldErrorMessage = (
-  value?: string | Record<string, string[]>,
-) => {
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (value && typeof value === 'object') {
-    const [firstMessageGroup] = Object.values(value);
-
-    if (typeof firstMessageGroup === 'string') {
-      return firstMessageGroup;
-    }
-
-    if (Array.isArray(firstMessageGroup) && firstMessageGroup[0]) {
-      return firstMessageGroup[0];
-    }
-  }
-
-  return null;
-};
-
-const extractFieldErrors = (
-  value?: string | Record<string, string[]>,
-): Record<string, string> => {
-  if (!value || typeof value === 'string') {
-    return {};
-  }
-
-  return Object.fromEntries(
-    Object.entries(value)
-      .map(([fieldName, messages]) => {
-        if (typeof messages === 'string') {
-          return [fieldName, messages];
-        }
-
-        if (Array.isArray(messages) && messages[0]) {
-          return [fieldName, messages[0]];
-        }
-
-        return null;
-      })
-      .filter((entry): entry is [string, string] => Boolean(entry)),
-  );
-};
-
-export const extractAuthApiFieldErrors = (error: unknown) => {
-  if (!(error instanceof AxiosError)) {
-    return {};
-  }
-
-  const data = error.response?.data as ErrorResponseBody | undefined;
-
-  return {
-    ...extractFieldErrors(data?.detail),
-    ...extractFieldErrors(data?.error_detail),
-  };
-};
-
-export const extractAuthApiErrorMessage = (error: unknown) => {
-  if (!(error instanceof AxiosError)) {
-    return '요청을 처리하는 중 알 수 없는 오류가 발생했습니다.';
-  }
-
-  const data = error.response?.data as ErrorResponseBody | undefined;
-
-  const detailMessage = extractFieldErrorMessage(data?.detail);
-
-  if (detailMessage) {
-    return detailMessage;
-  }
-
-  const errorDetailMessage = extractFieldErrorMessage(data?.error_detail);
-
-  if (errorDetailMessage) {
-    return errorDetailMessage;
-  }
-
-  return DEFAULT_API_ERROR_MESSAGE;
-};
-
-const getFirstLoginErrorField = (
-  fieldErrors: Partial<Record<LoginFieldName, string>>,
-  payload?: Partial<LoginRequest>,
-) => {
-  if (fieldErrors.login_id) {
-    return 'login_id';
-  }
-
-  if (fieldErrors.password) {
-    return 'password';
-  }
-
-  if (payload) {
-    const loginId = payload.login_id?.trim() ?? '';
-    const password = payload.password?.trim() ?? '';
-
-    if (!loginId) {
-      return 'login_id';
-    }
-
-    if (!password) {
-      return 'password';
-    }
-  }
-
-  return null;
-};
-
-const resolveLoginMessageByPolicy = ({
-  policy,
-  fieldErrors,
-  apiMessage,
-}: {
-  policy: LoginErrorPolicy;
-  fieldErrors: Partial<Record<LoginFieldName, string>>;
-  apiMessage: string;
-}) => {
-  if (
-    policy.hideFormMessageWhenFieldError &&
-    getFirstLoginErrorField(fieldErrors)
-  ) {
-    return '';
-  }
-
-  if (policy.preferApiMessage && apiMessage !== DEFAULT_API_ERROR_MESSAGE) {
-    return apiMessage;
-  }
-
-  return policy.fallbackMessage;
-};
-
-export const resolveLoginApiError = (
-  error: unknown,
-  payload?: Partial<LoginRequest>,
-): ResolveLoginApiErrorResult => {
-  const apiFieldErrors = extractAuthApiFieldErrors(error);
-  const fieldErrors = {
-    login_id: apiFieldErrors.login_id,
-    password: apiFieldErrors.password,
-  } satisfies Partial<Record<LoginFieldName, string>>;
-  const focusField = getFirstLoginErrorField(fieldErrors, payload);
-
-  if (!(error instanceof AxiosError)) {
-    return {
-      statusCode: null,
-      fieldErrors,
-      message: extractAuthApiErrorMessage(error),
-      focusField,
-    };
-  }
-
-  const statusCode = error.response?.status ?? null;
-  const apiMessage = extractAuthApiErrorMessage(error);
-
-  if (statusCode === 400 || statusCode === 401 || statusCode === 403) {
-    const policy = LOGIN_ERROR_POLICIES[statusCode];
-
-    return {
-      statusCode,
-      fieldErrors,
-      message: resolveLoginMessageByPolicy({
-        policy,
-        fieldErrors,
-        apiMessage,
-      }),
-      focusField: focusField ?? policy.defaultFocusField,
-    };
-  }
-
-  return {
-    statusCode: null,
-    fieldErrors,
-    message: extractAuthApiErrorMessage(error),
-    focusField,
-  };
-};
-
-export const extractSuspendedAccountInfo = (error: unknown) => {
-  if (!(error instanceof AxiosError) || error.response?.status !== 403) {
-    return null;
-  }
-
-  const data = error.response.data as ErrorResponseBody | undefined;
-  const errorMessage =
-    extractFieldErrorMessage(data?.error_detail) ||
-    extractFieldErrorMessage(data?.detail);
-
-  if (errorMessage !== '정지된 계정입니다.') {
-    return null;
-  }
-
-  return {
-    message: errorMessage,
-    suspendedAt:
-      typeof data?.suspended_at === 'string' ? data.suspended_at : null,
-  };
 };

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -7,7 +7,7 @@ import {
   clearLegacyAuthStorage,
   useAuthStore,
 } from '../../../store/useAuthStore';
-import { hasMockRefreshToken } from '../api/auth';
+import { hasMockRefreshToken } from '../api/auth.session.helper';
 import {
   restoreAuthSession,
   setAuthBootstrapLoading,

--- a/src/features/auth/hooks/useLoginForm.ts
+++ b/src/features/auth/hooks/useLoginForm.ts
@@ -5,7 +5,7 @@ import { useLocation, useNavigate } from 'react-router';
 import { api } from '../../../api/axios';
 import { ROUTES } from '../../../constants/routes';
 import { mockServiceWorkerEnabled } from '../../../lib/env';
-import { resolveLoginApiError } from '../api/auth';
+import { resolveLoginApiError } from '../api/auth.error.handler';
 import { useLoginMutation } from '../api/useAuthApi';
 import { AUTH_SESSION_EXPIRED_NOTICE_MESSAGE } from '../constants/session';
 import type { LoginRequest } from '../types/auth';

--- a/src/features/auth/hooks/useSignupForm.ts
+++ b/src/features/auth/hooks/useSignupForm.ts
@@ -6,7 +6,7 @@ import { ROUTES } from '../../../constants/routes';
 import {
   extractAuthApiErrorMessage,
   extractAuthApiFieldErrors,
-} from '../api/auth';
+} from '../api/auth.error.handler';
 import {
   useCheckIdDuplicateMutation,
   useCheckNicknameDuplicateMutation,

--- a/src/pages/mypage/hooks/useMyPageProfile.ts
+++ b/src/pages/mypage/hooks/useMyPageProfile.ts
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import {
   extractAuthApiErrorMessage,
   extractAuthApiFieldErrors,
-} from '../../../features/auth/api/auth';
+} from '../../../features/auth/api/auth.error.handler';
 import { authKeys } from '../../../features/auth/api/queryKeys';
 import {
   useConfirmProfileImageMutation,


### PR DESCRIPTION
## 관련 이슈

- closes #253

## 변경 내용

- src/features/auth/api/auth.ts에 밀집되어 있던 인증 관련 로직을 성격에 따라 분리했습니다.
- auth.transport.ts를 추가해 로그인, 로그아웃, 토큰 갱신, 회원 정보 조회/수정, 중복 확인, S3 업로드 등 순수 서버 통신 로직을 분리했습니다.
- auth.session.helper.ts를 추가해 DEV/MSW 전용 mock refresh token 저장/복원, fallback request body 생성, access token 정규화, mock refresh token 파생 로직을 분리했습니다.
- auth.error.handler.ts를 추가해 공통 에러 파싱, 로그인 에러 정책, 정지 계정 판별 로직을 분리했습니다.
- auth.ts는 외부에서 사용하는 퍼사드로 축소하고, 로그인/리프레시/로그아웃 흐름만 조합하는 역할로 정리했습니다.
- useAuthBootstrap, useLoginForm, useSignupForm, useMyPageProfile가 새 모듈 경계를 직접 참조하도록 소비 지점 import를 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- API 엔드포인트와 요청/응답 스펙은 변경하지 않았고, 프론트 내부 모듈 구조만 재정리했습니다.
- 기존 로그인, 토큰 갱신, 로그아웃 흐름은 유지되도록 transport/helper/handler 조합 구조로 옮겼습니다.
