### PR TITLE
[Feat] 매칭 좋아요 상태와 공통 좋아요 흐름 정리

### DIFF
--- a/docs/ai/api-contract.md
+++ b/docs/ai/api-contract.md
@@ -25,6 +25,7 @@
 - **회원 탈퇴**: `DELETE /api/v1/accounts/me` (request body에 `password` 포함)
 - **마이페이지 찜 목록 조회**: `GET /api/v1/accounts/me/game-like`
 - **마이페이지 찜 해제**: `DELETE /api/v1/accounts/me/game-like/{game_id}`
+- **게임 좋아요 등록/해제**: `POST/DELETE /api/v1/games/{game_id}/like`
 
 #### 비밀번호 변경 필드 계약
 
@@ -204,10 +205,16 @@ MSW mock은 실제 API 경로와 응답 구조를 최대한 동일하게 맞춥�
 - 상세 데이터 조회는 `getGameDetail(gameId)` 경계를 사용
 - 모달을 닫아도 추천 리스트 스크롤 위치와 현재 결과 상태는 유지
 
-### 8. Out of Scope / Follow-up Notes
+### 8. Matching Like State Rules
+
+- `GET /api/v1/match/candidates` 의 `is_liked` 는 정적 seed 값이 아니라 **현재 로그인 사용자의 찜 상태**를 기준으로 계산합니다.
+- 매칭 화면의 하트 클릭은 게임 공통 좋아요 API(`POST/DELETE /api/v1/games/{game_id}/like`)를 그대로 사용합니다.
+- 매칭 화면은 좋아요를 별도 로컬 상태로 복제하지 않고, 공통 좋아요 cache/source-of-truth 를 따릅니다.
+- 매칭 제출 시 mock liked 상태를 동기화할 때 `is_liked` 뿐 아니라 `like_count` 도 기존 좋아요 API와 같은 규칙으로 함께 맞춥니다.
+
+### 9. Out of Scope / Follow-up Notes
 
 - 추천 리스트 row의 찜 버튼 API 연결은 별도 작업 범위로 유지
-- 매칭 후보 조회 응답은 최신 명세서와 현재 프론트 구조 차이가 있어, 추후 매칭 adapter 정리 PR에서 별도 동기화 필요
 - 문서가 갱신되면 구현 코드는 이 문서를 우선 기준으로 맞추고, 명세 변경 시 adapter 계층을 먼저 수정합니다
 
 ## Customer Support Chatbot

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -234,8 +234,14 @@ export const syncMockLikedGamesForAuthorization = (
   );
 
   updates.forEach((update) => {
+    const hadLiked = likedGamesById.has(update.game_id);
+
     if (update.is_liked) {
       const existingLikedGame = likedGamesById.get(update.game_id);
+
+      if (!hadLiked) {
+        increaseLikeCount(update.game_id);
+      }
 
       likedGamesById.set(update.game_id, {
         game_id: update.game_id,
@@ -252,6 +258,10 @@ export const syncMockLikedGamesForAuthorization = (
       });
 
       return;
+    }
+
+    if (hadLiked) {
+      decreaseLikeCount(update.game_id);
     }
 
     likedGamesById.delete(update.game_id);

--- a/src/features/games/queryCache.ts
+++ b/src/features/games/queryCache.ts
@@ -2,6 +2,7 @@ import type { InfiniteData, QueryClient } from '@tanstack/react-query';
 
 import type { GameGenreFilter } from './genres';
 import type { GameDetail, GameListItem, SearchGamesResult } from './types';
+import type { MatchingCandidatesResponse } from '../matching/types';
 
 const gamesRootKey = ['games'] as const;
 const gamesTop100RootKey = [...gamesRootKey, 'top100'] as const;
@@ -120,5 +121,20 @@ export const syncGameLikeStateInQueryCache = (
   queryClient.setQueryData<InfiniteData<LikeableResultPage>>(
     ['match-results'],
     updateRecommendationPages,
+  );
+
+  queryClient.setQueriesData<MatchingCandidatesResponse>(
+    { queryKey: ['match-candidates'] },
+    (currentData) =>
+      currentData && Array.isArray(currentData.results)
+        ? {
+            ...currentData,
+            results: currentData.results.map((result) =>
+              result.game_id === update.gameId
+                ? { ...result, is_liked: update.isLiked }
+                : result,
+            ),
+          }
+        : currentData,
   );
 };

--- a/src/features/matching/mocks/data.ts
+++ b/src/features/matching/mocks/data.ts
@@ -6,7 +6,6 @@ type MatchingMockCandidateRecord = {
   thumbnail_url: string | null;
   trailer_url: string | null;
   rating: number | null;
-  is_liked: boolean;
 };
 
 const createCandidate = (
@@ -16,7 +15,6 @@ const createCandidate = (
   thumbnailUrl: string,
   trailerUrl: string,
   rating: number,
-  isLiked = false,
   description = `${title}는 ${genres.join(' · ')} 흐름을 대표하는 후보 게임입니다.`,
 ): MatchingMockCandidateRecord => ({
   game_id: gameId,
@@ -26,7 +24,6 @@ const createCandidate = (
   thumbnail_url: thumbnailUrl,
   trailer_url: trailerUrl,
   rating,
-  is_liked: isLiked,
 });
 
 export const matchingMockCandidatesByGenreId: Record<
@@ -57,7 +54,6 @@ export const matchingMockCandidatesByGenreId: Record<
       'https://cdn.cloudflare.steamstatic.com/steam/apps/1384160/header.jpg',
       'https://www.youtube.com/watch?v=3XH0D4xYjWk',
       4.6,
-      true,
     ),
     createCandidate(
       2138710,
@@ -92,7 +88,6 @@ export const matchingMockCandidatesByGenreId: Record<
       'https://cdn.cloudflare.steamstatic.com/steam/apps/367520/header.jpg',
       'https://www.youtube.com/watch?v=UAO2urG23S4',
       4.9,
-      true,
     ),
     createCandidate(
       105600,
@@ -135,7 +130,6 @@ export const matchingMockCandidatesByGenreId: Record<
       'https://cdn.cloudflare.steamstatic.com/steam/apps/1086940/header.jpg',
       'https://www.youtube.com/watch?v=1T22wNvoNiU',
       4.9,
-      true,
     ),
     createCandidate(
       1091500,
@@ -178,7 +172,6 @@ export const matchingMockCandidatesByGenreId: Record<
       'https://cdn.cloudflare.steamstatic.com/steam/apps/1172470/header.jpg',
       'https://www.youtube.com/watch?v=innmNewjkuk',
       4.3,
-      true,
     ),
     createCandidate(
       359550,
@@ -237,7 +230,6 @@ export const matchingMockCandidatesByGenreId: Record<
       'https://cdn.cloudflare.steamstatic.com/steam/apps/949230/header.jpg',
       'https://www.youtube.com/watch?v=WdD66WGBVHM',
       4.0,
-      true,
     ),
     createCandidate(
       294100,
@@ -288,7 +280,6 @@ export const matchingMockCandidatesByGenreId: Record<
       'https://cdn.cloudflare.steamstatic.com/steam/apps/2290180/header.jpg',
       'https://www.youtube.com/watch?v=Vt4anCwdg1A',
       4.1,
-      true,
     ),
   ],
   6: [
@@ -307,7 +298,6 @@ export const matchingMockCandidatesByGenreId: Record<
       'https://cdn.cloudflare.steamstatic.com/steam/apps/2379780/header.jpg',
       'https://www.youtube.com/watch?v=VUyP21iQ_-g',
       4.9,
-      true,
     ),
     createCandidate(
       590380,
@@ -350,7 +340,6 @@ export const matchingMockCandidatesByGenreId: Record<
       'https://cdn.cloudflare.steamstatic.com/steam/apps/960170/header.jpg',
       'https://www.youtube.com/watch?v=gF9gP6L2Y8w',
       4.7,
-      true,
     ),
     createCandidate(
       774171,

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -234,6 +234,9 @@ export const matchingHandlers = [
     }
 
     const candidates = matchingMockCandidatesByGenreId[genreId];
+    const currentLikedGameIds = getMockLikedGameIdsForAuthorization(
+      request.headers.get('Authorization'),
+    );
 
     if (!candidates) {
       return getErrorResponse(404, '해당 장르의 게임을 찾을 수 없습니다.');
@@ -251,7 +254,7 @@ export const matchingHandlers = [
         genres: candidate.genres,
         trailer_url: candidate.trailer_url,
         rating: candidate.rating,
-        is_liked: candidate.is_liked,
+        is_liked: currentLikedGameIds.has(candidate.game_id),
       })),
     });
   }),

--- a/src/features/matching/store/useMatchingStore.ts
+++ b/src/features/matching/store/useMatchingStore.ts
@@ -24,7 +24,6 @@ interface MatchingStoreState {
     candidates: MatchingCandidateItem[],
   ) => void;
   setRating: (gameId: number, rating: MatchingRatingValue) => void;
-  toggleLiked: (gameId: number) => void;
   goNext: () => void;
   goPrevious: () => void;
   resetFlow: () => void;
@@ -53,7 +52,6 @@ const createEvaluationMap = (
         ? previous
         : {
             rating: null,
-            isLiked: candidate.is_liked,
           };
 
       return [candidate.game_id, nextValue];
@@ -112,29 +110,11 @@ export const useMatchingStore = create<MatchingStoreState>((set) => ({
         [gameId]: {
           ...(state.evaluationsByGameId[gameId] ?? {
             rating: null,
-            isLiked: false,
           }),
           rating,
         },
       },
     })),
-  toggleLiked: (gameId) =>
-    set((state) => {
-      const currentValue = state.evaluationsByGameId[gameId] ?? {
-        rating: null,
-        isLiked: false,
-      };
-
-      return {
-        evaluationsByGameId: {
-          ...state.evaluationsByGameId,
-          [gameId]: {
-            ...currentValue,
-            isLiked: !currentValue.isLiked,
-          },
-        },
-      };
-    }),
   goNext: () =>
     set((state) => ({
       currentIndex:

--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -60,7 +60,6 @@ export type MatchingRatingValue = 1 | 2 | 3 | 4 | 5;
 
 export interface MatchingEvaluationValue {
   rating: MatchingRatingValue | null;
-  isLiked: boolean;
 }
 
 export type MatchingEvaluationsByGameId = Record<

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -1,6 +1,7 @@
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { ChevronLeft, ChevronRight, Heart } from 'lucide-react';
-import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   Link,
   Navigate,
@@ -15,6 +16,9 @@ import { ROUTES } from '../../constants/routes';
 import { authKeys } from '../../features/auth/api/queryKeys';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import type { LikedGamesResponse } from '../../features/auth/types/auth';
+import { likeGame, unlikeGame } from '../../features/games/gameApi';
+import { syncGameLikeStateInQueryCache } from '../../features/games/queryCache';
+import type { MatchingCandidateItem } from '../../features/matching/types';
 import {
   useMatchCandidatesQuery,
   useSubmitMatchResponsesMutation,
@@ -28,6 +32,11 @@ import {
 } from '../../features/matching/genres';
 import { useMatchingStore } from '../../features/matching/store/useMatchingStore';
 import { extractApiErrorMessage } from '../../features/survey/api/survey';
+
+const MATCHING_LIKE_LOGIN_REQUIRED_MESSAGE =
+  '로그인 후 좋아요를 사용할 수 있어요.';
+const MATCHING_LIKE_ERROR_MESSAGE =
+  '좋아요 상태를 변경하지 못했어요. 잠시 후 다시 시도해 주세요.';
 
 const formatMatchingCandidateRating = (rating: number | null) => {
   if (typeof rating !== 'number') {
@@ -45,6 +54,14 @@ const isLikedGamesResponse = (value: unknown): value is LikedGamesResponse => {
   }
 
   return Array.isArray((value as Partial<LikedGamesResponse>).results);
+};
+
+const getMatchingLikeErrorMessage = (error: unknown) => {
+  if (error instanceof AxiosError && error.response?.status === 401) {
+    return MATCHING_LIKE_LOGIN_REQUIRED_MESSAGE;
+  }
+
+  return MATCHING_LIKE_ERROR_MESSAGE;
 };
 
 function MatchingGenreDetailPage() {
@@ -67,22 +84,19 @@ function MatchingGenreDetailPage() {
     () => matchCandidatesQuery.data?.results ?? [],
     [matchCandidatesQuery.data?.results],
   );
-  const selectedGenreSlug = useMatchingStore(
-    (state) => state.selectedGenreSlug,
-  );
-  const selectedGenreId = useMatchingStore((state) => state.selectedGenreId);
-  const flowCandidates = useMatchingStore((state) => state.candidates);
   const currentIndex = useMatchingStore((state) => state.currentIndex);
   const evaluationsByGameId = useMatchingStore(
     (state) => state.evaluationsByGameId,
   );
   const restartFlow = useMatchingStore((state) => state.restartFlow);
   const setRating = useMatchingStore((state) => state.setRating);
-  const toggleLiked = useMatchingStore((state) => state.toggleLiked);
   const goNext = useMatchingStore((state) => state.goNext);
   const goPrevious = useMatchingStore((state) => state.goPrevious);
   const resetFlow = useMatchingStore((state) => state.resetFlow);
   const hasInitializedFlowRef = useRef(false);
+  const [likeFeedbackMessage, setLikeFeedbackMessage] = useState<string | null>(
+    null,
+  );
 
   useLayoutEffect(() => {
     resetFlow();
@@ -103,12 +117,7 @@ function MatchingGenreDetailPage() {
     resetSubmitMatchResponsesMutation();
   }, [genre, candidates, restartFlow, resetSubmitMatchResponsesMutation]);
 
-  const displayCandidates =
-    selectedGenreSlug === genre?.slug &&
-    selectedGenreId === genre?.genreId &&
-    flowCandidates.length > 0
-      ? flowCandidates
-      : candidates;
+  const displayCandidates = candidates;
   const totalSteps = displayCandidates.length;
   const totalGamesLabel = `${totalSteps}개의 게임`;
   const safeIndex =
@@ -117,7 +126,6 @@ function MatchingGenreDetailPage() {
   const currentEvaluation = currentCandidate
     ? (evaluationsByGameId[currentCandidate.game_id] ?? {
         rating: null,
-        isLiked: currentCandidate.is_liked,
       })
     : null;
   const isLastCard = totalSteps > 0 && safeIndex === totalSteps - 1;
@@ -131,6 +139,87 @@ function MatchingGenreDetailPage() {
   const submitErrorMessage = submitMatchResponsesMutation.error
     ? extractApiErrorMessage(submitMatchResponsesMutation.error)
     : null;
+  const updateLikedGamesCache = (
+    candidate: MatchingCandidateItem,
+    nextIsLiked: boolean,
+  ) => {
+    queryClient.setQueriesData<LikedGamesResponse>(
+      { queryKey: authKeys.likedGames() },
+      (current) => {
+        if (!isLikedGamesResponse(current)) {
+          return current;
+        }
+
+        const currentLikedGames = current as LikedGamesResponse;
+
+        if (nextIsLiked) {
+          const alreadyExists = currentLikedGames.results.some(
+            (likedGame) => likedGame.game_id === candidate.game_id,
+          );
+
+          if (alreadyExists) {
+            return current;
+          }
+
+          return {
+            ...currentLikedGames,
+            count: currentLikedGames.count + 1,
+            results: [
+              {
+                game_id: candidate.game_id,
+                game_title: candidate.title,
+                thumbnail_url: candidate.thumbnail_url,
+                genres: candidate.genres,
+                liked_at: new Date().toISOString(),
+              },
+              ...currentLikedGames.results,
+            ],
+          };
+        }
+
+        const nextResults = currentLikedGames.results.filter(
+          (likedGame) => likedGame.game_id !== candidate.game_id,
+        );
+
+        if (nextResults.length === currentLikedGames.results.length) {
+          return current;
+        }
+
+        return {
+          ...currentLikedGames,
+          count: Math.max(0, currentLikedGames.count - 1),
+          results: nextResults,
+        };
+      },
+    );
+  };
+  const likeMutation = useMutation({
+    mutationFn: ({
+      candidate,
+      nextIsLiked,
+    }: {
+      candidate: MatchingCandidateItem;
+      nextIsLiked: boolean;
+    }) =>
+      nextIsLiked ? likeGame(candidate.game_id) : unlikeGame(candidate.game_id),
+    onMutate: () => {
+      setLikeFeedbackMessage(null);
+    },
+    onSuccess: (response, variables) => {
+      updateLikedGamesCache(variables.candidate, response.isLiked);
+      syncGameLikeStateInQueryCache(queryClient, {
+        gameId: response.gameId,
+        isLiked: response.isLiked,
+        likeCount: response.likeCount,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: authKeys.likedGames(),
+      });
+    },
+    onError: (error) => {
+      setLikeFeedbackMessage(getMatchingLikeErrorMessage(error));
+    },
+  });
 
   if (authGate.accessStatus === 'unauthorized') {
     return (
@@ -145,63 +234,6 @@ function MatchingGenreDetailPage() {
     );
   }
 
-  const syncLikedGamesCache = () => {
-    queryClient.setQueriesData<LikedGamesResponse>(
-      { queryKey: authKeys.likedGames() },
-      (current) => {
-        if (!isLikedGamesResponse(current)) {
-          return current;
-        }
-
-        const currentLikedGames = current as LikedGamesResponse;
-        const likedAt = new Date().toISOString();
-        const nextLikedGamesById = new Map(
-          currentLikedGames.results.map((likedGame) => [
-            likedGame.game_id,
-            likedGame,
-          ]),
-        );
-
-        displayCandidates.forEach((candidate) => {
-          const evaluation = evaluationsByGameId[candidate.game_id];
-
-          if (!evaluation) {
-            return;
-          }
-
-          if (evaluation.isLiked) {
-            const existingLikedGame = nextLikedGamesById.get(candidate.game_id);
-
-            nextLikedGamesById.set(candidate.game_id, {
-              game_id: candidate.game_id,
-              game_title: candidate.title,
-              thumbnail_url: candidate.thumbnail_url,
-              genres: candidate.genres,
-              liked_at: existingLikedGame?.liked_at ?? likedAt,
-            });
-            return;
-          }
-
-          nextLikedGamesById.delete(candidate.game_id);
-        });
-
-        const nextResults = [...nextLikedGamesById.values()].sort(
-          (a, b) => Date.parse(b.liked_at) - Date.parse(a.liked_at),
-        );
-
-        return {
-          ...currentLikedGames,
-          count: nextResults.length,
-          results: nextResults,
-        };
-      },
-    );
-
-    void queryClient.invalidateQueries({
-      queryKey: authKeys.likedGames(),
-    });
-  };
-
   const handleSubmit = async () => {
     if (!allCandidatesRated || displayCandidates.length === 0) {
       return;
@@ -212,10 +244,9 @@ function MatchingGenreDetailPage() {
         match_result: displayCandidates.map((candidate) => ({
           game_id: candidate.game_id,
           rating: evaluationsByGameId[candidate.game_id]!.rating!,
-          is_liked: evaluationsByGameId[candidate.game_id]!.isLiked,
+          is_liked: candidate.is_liked,
         })),
       });
-      syncLikedGamesCache();
       navigate(`/${ROUTES.RECOMMENDATION_LIST}?source=match`);
     } catch {
       return;
@@ -363,15 +394,21 @@ function MatchingGenreDetailPage() {
                       </div>
                       <button
                         type="button"
-                        onClick={() => toggleLiked(currentCandidate.game_id)}
-                        aria-pressed={currentEvaluation.isLiked}
+                        onClick={() =>
+                          likeMutation.mutate({
+                            candidate: currentCandidate,
+                            nextIsLiked: !currentCandidate.is_liked,
+                          })
+                        }
+                        aria-pressed={currentCandidate.is_liked}
                         aria-label={
-                          currentEvaluation.isLiked
+                          currentCandidate.is_liked
                             ? '좋아요 해제'
                             : '좋아요 추가'
                         }
-                        className={`mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center self-start rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] ${
-                          currentEvaluation.isLiked
+                        disabled={likeMutation.isPending}
+                        className={`mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center self-start rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] disabled:cursor-not-allowed disabled:opacity-60 ${
+                          currentCandidate.is_liked
                             ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
                             : 'border-white/10 bg-white/3 text-white/54 hover:border-white/20 hover:text-white/80'
                         }`}
@@ -379,7 +416,7 @@ function MatchingGenreDetailPage() {
                         <Heart
                           size={20}
                           fill={
-                            currentEvaluation.isLiked ? 'currentColor' : 'none'
+                            currentCandidate.is_liked ? 'currentColor' : 'none'
                           }
                         />
                       </button>
@@ -430,6 +467,12 @@ function MatchingGenreDetailPage() {
                       </p>
                     ) : null}
 
+                    {likeFeedbackMessage ? (
+                      <p className="mt-2.5 text-sm leading-6 break-keep text-[#ffc2c2]">
+                        {likeFeedbackMessage}
+                      </p>
+                    ) : null}
+
                     {isLastCard ? (
                       <div className="mt-auto pt-5">
                         <div className="flex flex-wrap items-end justify-between gap-3">
@@ -448,7 +491,8 @@ function MatchingGenreDetailPage() {
                             onClick={() => void handleSubmit()}
                             disabled={
                               !allCandidatesRated ||
-                              submitMatchResponsesMutation.isPending
+                              submitMatchResponsesMutation.isPending ||
+                              likeMutation.isPending
                             }
                             className="inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212] disabled:cursor-not-allowed disabled:bg-[#5c1a1a] disabled:text-white/44"
                           >


### PR DESCRIPTION
## 관련 이슈

- closes #254 

## 변경 내용

- 외부 API 명세 기준에 맞춰 매칭 후보 응답의 `is_liked`가 현재 로그인 사용자의 찜 상태를 기준으로 계산되도록 수정
- 매칭 화면의 좋아요 상태를 로컬 store에서 따로 들고 있지 않도록 정리하고, 기존 게임 좋아요 API 및 공통 캐시 흐름을 재사용하도록 변경
- 매칭 화면에서 하트 클릭 시 즉시 메인 목록, 게임 상세, 추천 결과, 마이페이지 찜 목록과 같은 좋아요 상태가 보이도록 동기화
- 매칭 제출 시 auth mock liked 상태를 동기화할 때 `like_count`도 기존 좋아요 API 규칙과 동일하게 증가/감소하도록 수정
- 게임 좋아요 경로를 `/api/v1/games/{game_id}/like` 기준으로 프론트/MSW/내부 계약 문서가 일관되게 동작하도록 정리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 외부 xlsx 명세 기준으로 매칭 좋아요 상태 경계를 공통 좋아요 흐름에 맞추는 데 집중했습니다.
- repo 내부 계약 문서는 코드 변경에 맞춰 함께 동기화합니다.
