### PR TITLE
fix(auth): 쿠키 도메인 진단과 세션 복구 흐름 보강

### DIFF
--- a/src/features/auth/api/auth.diagnostics.ts
+++ b/src/features/auth/api/auth.diagnostics.ts
@@ -30,6 +30,25 @@ const resolveOrigin = (target: string) => {
 };
 
 const isHttpsOrigin = (origin: string) => origin.startsWith('https://');
+const getHostname = (target: string) => {
+  if (!target) {
+    return '';
+  }
+
+  try {
+    return new URL(target, getFrontendOrigin()).hostname;
+  } catch {
+    return '';
+  }
+};
+
+const isSecureBrowserContext = () => {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+
+  return window.isSecureContext;
+};
 
 type AuthRequestDiagnostics = {
   label: 'login' | 'logout' | 'refresh';
@@ -49,20 +68,32 @@ export const logCredentialedAuthRequestDiagnostics = ({
   const frontendOrigin = getFrontendOrigin();
   const configuredBackendOrigin = resolveOrigin(configuredApiBaseUrl);
   const requestOrigin = resolveOrigin(requestUrl);
+  const frontendHostname = getHostname(frontendOrigin);
+  const configuredBackendHostname = getHostname(configuredBackendOrigin);
+  const requestHostname = getHostname(requestOrigin);
   const isCrossOrigin = Boolean(
     requestOrigin && frontendOrigin && requestOrigin !== frontendOrigin,
   );
+  const hostnamesDiffer = Boolean(
+    frontendHostname && requestHostname && frontendHostname !== requestHostname,
+  );
+  const secureContext = isSecureBrowserContext();
 
   console.info(`[auth-diagnostics] ${label} request`, {
     frontendOrigin,
+    frontendHostname,
     configuredBackendOrigin,
+    configuredBackendHostname,
     canonicalFrontendOrigin: CANONICAL_FRONTEND_ORIGIN,
     canonicalBackendOrigin: CANONICAL_BACKEND_ORIGIN,
     requestOrigin,
+    requestHostname,
     isCrossOrigin,
+    hostnamesDiffer,
     withCredentials,
     frontendUsesHttps: isHttpsOrigin(frontendOrigin),
     requestTargetUsesHttps: isHttpsOrigin(requestOrigin),
+    isSecureContext: secureContext,
   });
 
   if (
@@ -95,6 +126,18 @@ export const logCredentialedAuthRequestDiagnostics = ({
   if (isCrossOrigin && !withCredentials) {
     console.warn(
       '[auth-diagnostics] cross-origin auth request is missing withCredentials=true',
+    );
+  }
+
+  if (hostnamesDiffer) {
+    console.warn(
+      `[auth-diagnostics] frontend hostname (${frontendHostname}) and API hostname (${requestHostname}) differ. Browser third-party cookie blocking may prevent refresh_token storage/transmission.`,
+    );
+  }
+
+  if (!secureContext) {
+    console.warn(
+      '[auth-diagnostics] window.isSecureContext is false. Secure cookies may be rejected by the browser in this environment.',
     );
   }
 };

--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { type AxiosRequestConfig } from 'axios';
 
 import { api } from '@/api/axios';
 import { apiBaseUrl } from '@/lib/env';
@@ -38,13 +38,21 @@ const loginRequestUrl = `${authApiUrl}/login`;
 const logoutRequestUrl = `${authApiUrl}/logout`;
 const refreshRequestUrl = `${authApiUrl}/token/refresh`;
 
-const createCredentialedAuthRequestConfig = () => ({
-  withCredentials: true,
-  timeout: AUTH_REFRESH_TIMEOUT_MS,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
+const createCredentialedAuthRequestConfig = <T = unknown>(
+  config: AxiosRequestConfig<T> = {},
+): AxiosRequestConfig<T> => {
+  const { headers, ...restConfig } = config;
+
+  return {
+    ...restConfig,
+    withCredentials: true,
+    timeout: AUTH_REFRESH_TIMEOUT_MS,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(headers ?? {}),
+    },
+  };
+};
 
 export const requestLogin = async (payload: LoginRequest) => {
   const requestConfig = createCredentialedAuthRequestConfig();
@@ -52,7 +60,7 @@ export const requestLogin = async (payload: LoginRequest) => {
   logCredentialedAuthRequestDiagnostics({
     label: 'login',
     requestUrl: loginRequestUrl,
-    withCredentials: requestConfig.withCredentials,
+    withCredentials: true,
   });
 
   const response = await api.post<LoginResponse>(
@@ -70,7 +78,7 @@ export const requestLogout = async () => {
   logCredentialedAuthRequestDiagnostics({
     label: 'logout',
     requestUrl: logoutRequestUrl,
-    withCredentials: requestConfig.withCredentials,
+    withCredentials: true,
   });
 
   const response = await api.post<LogoutResponse>(
@@ -90,7 +98,7 @@ export const requestRefreshAccessToken = async (
   logCredentialedAuthRequestDiagnostics({
     label: 'refresh',
     requestUrl: refreshRequestUrl,
-    withCredentials: requestConfig.withCredentials,
+    withCredentials: true,
   });
 
   const response = await axios.post<RefreshAccessTokenResponse>(
@@ -105,6 +113,7 @@ export const requestRefreshAccessToken = async (
 export const getCurrentUserProfile = async () => {
   const response = await api.get<CurrentUserProfileResponse>(
     `${AUTH_BASE_PATH}/me`,
+    createCredentialedAuthRequestConfig(),
   );
 
   return response.data;
@@ -114,6 +123,7 @@ export const updateUserInfo = async (payload: UpdateUserInfoRequest) => {
   const response = await api.patch<UpdateUserInfoResponse>(
     `${AUTH_BASE_PATH}/me`,
     payload,
+    createCredentialedAuthRequestConfig(),
   );
 
   return response.data;
@@ -122,9 +132,9 @@ export const updateUserInfo = async (payload: UpdateUserInfoRequest) => {
 export const getLikedGames = async (payload: LikedGamesRequest = {}) => {
   const response = await api.get<LikedGamesResponse>(
     `${AUTH_BASE_PATH}/me/game-like`,
-    {
+    createCredentialedAuthRequestConfig({
       params: payload,
-    },
+    }),
   );
 
   return response.data;
@@ -133,6 +143,7 @@ export const getLikedGames = async (payload: LikedGamesRequest = {}) => {
 export const unlikeLikedGame = async (gameId: number) => {
   const response = await api.delete<DeleteLikedGameResponse>(
     `${AUTH_BASE_PATH}/me/game-like/${gameId}`,
+    createCredentialedAuthRequestConfig(),
   );
 
   return response.data;
@@ -144,6 +155,7 @@ export const getProfileImagePresignedUrl = async (
   const response = await api.post<ProfileImagePresignedUrlResponse>(
     `${AUTH_BASE_PATH}/me/profile-image/presigned-url`,
     payload,
+    createCredentialedAuthRequestConfig(),
   );
 
   return response.data;
@@ -171,6 +183,7 @@ export const confirmProfileImage = async (
   const response = await api.patch<ConfirmProfileImageResponse>(
     `${AUTH_BASE_PATH}/me/profile-image`,
     payload,
+    createCredentialedAuthRequestConfig(),
   );
 
   return response.data;
@@ -180,21 +193,26 @@ export const changePassword = async (payload: ChangePasswordRequest) => {
   const response = await api.post<ChangePasswordResponse>(
     `${AUTH_BASE_PATH}/me/change-password`,
     payload,
+    createCredentialedAuthRequestConfig(),
   );
 
   return response.data;
 };
 
 export const deleteAccount = async (payload: DeleteAccountRequest) => {
-  await api.delete(`${AUTH_BASE_PATH}/me`, {
-    data: payload,
-  });
+  await api.delete(
+    `${AUTH_BASE_PATH}/me`,
+    createCredentialedAuthRequestConfig({
+      data: payload,
+    }),
+  );
 };
 
 export const signup = async (payload: SignupRequest) => {
   const response = await api.post<SignupResponse>(
     `${AUTH_BASE_PATH}/signup`,
     payload,
+    createCredentialedAuthRequestConfig(),
   );
 
   return response.data;
@@ -204,6 +222,7 @@ export const checkIdDuplicate = async (payload: CheckIdDuplicateRequest) => {
   const response = await api.post<DuplicateCheckResponse>(
     `${AUTH_BASE_PATH}/check-id`,
     payload,
+    createCredentialedAuthRequestConfig(),
   );
 
   return response.data;
@@ -215,6 +234,7 @@ export const checkNicknameDuplicate = async (
   const response = await api.post<DuplicateCheckResponse>(
     `${AUTH_BASE_PATH}/check-nickname`,
     payload,
+    createCredentialedAuthRequestConfig(),
   );
 
   return response.data;

--- a/src/features/auth/constants/session.ts
+++ b/src/features/auth/constants/session.ts
@@ -2,6 +2,8 @@ export const AUTH_SESSION_EXPIRED_EVENT = 'auth:session-expired';
 
 export const AUTH_SESSION_EXPIRED_NOTICE_MESSAGE =
   '로그인 세션이 만료되었습니다. 다시 로그인해 주세요.';
+export const AUTH_SESSION_RESTORE_FAILED_NOTICE_MESSAGE =
+  '로그인 상태를 유지할 수 없습니다. 다시 로그인해 주세요.';
 
 export type AuthSessionExpiredDetail = {
   noticeMessage?: string;

--- a/src/features/auth/utils/sessionManager.ts
+++ b/src/features/auth/utils/sessionManager.ts
@@ -1,6 +1,7 @@
 import { useAuthStore } from '../../../store/useAuthStore';
 import {
   AUTH_SESSION_EXPIRED_NOTICE_MESSAGE,
+  AUTH_SESSION_RESTORE_FAILED_NOTICE_MESSAGE,
   createAuthSessionExpiredEvent,
   type AuthSessionExpiredDetail,
 } from '../constants/session';
@@ -37,6 +38,16 @@ export const clearAuthSession = () => {
   setAuthBootstrapReady();
 };
 
+const hasSessionRestoreHint = () => {
+  const store = useAuthStore.getState();
+
+  return Boolean(
+    store.isAuthenticated ||
+    store.account ||
+    store.profilePreviewImageUrl?.trim().length,
+  );
+};
+
 export const hydrateAuthSessionFromAccessToken = async (
   accessToken: string,
 ) => {
@@ -68,7 +79,17 @@ export const restoreAuthSession = async () => {
     const accessToken = await refreshStoredAccessToken();
     return await hydrateAuthSessionFromAccessToken(accessToken);
   } catch (error) {
+    const shouldNotifySessionRestoreFailure = hasSessionRestoreHint();
+
     clearAuthSession();
+
+    if (shouldNotifySessionRestoreFailure) {
+      notifyAuthSessionExpired({
+        noticeMessage: AUTH_SESSION_RESTORE_FAILED_NOTICE_MESSAGE,
+        source: 'refresh',
+      });
+    }
+
     throw error;
   }
 };


### PR DESCRIPTION
## 관련 이슈

- closes #259 

## 변경 내용

- 인증 transport 전반에 명시적 withCredentials: true 설정을 공통 config로 강제해, login, logout, token/refresh를 포함한 인증 관련 요청이 동일한 credential 정책을 따르도록 정리했습니다.
- POST /api/v1/accounts/token/refresh 요청 경로를 포함해 refresh 흐름이 cross-origin 환경에서도 쿠키 전송을 시도할 수 있도록 axios 설정을 재점검했습니다.
- auth.diagnostics.ts에 DEV 전용 도메인 정책 진단을 보강했습니다.
- 현재 접속 hostname과 API hostname이 다를 때 third-party cookie 차단 위험 경고를 출력하도록 추가했습니다.
- window.isSecureContext가 false인 경우 Secure 쿠키 저장/전송이 거부될 수 있음을 사전에 경고하도록 추가했습니다.
- refresh 요청 시작/성공/실패, access token store 동기화 여부를 DEV 로그에서 함께 추적할 수 있도록 유지·보강했습니다.
- sessionManager.ts에서 refresh 성공 후 access token을 메모리 store에 즉시 반영하는 기존 흐름이 유지되는지 재검토했고, 해당 로직은 그대로 유지했습니다.
- 세션 복구 실패 시 이전 로그인 흔적이 남아 있던 경우에는 재로그인 안내가 자연스럽게 이어지도록 세션 만료/복구 실패 처리 흐름을 보완했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-A PI 명세서 기준으로 로그인은 access_token body + refresh_token cookie, refresh는 표에 body 예시가 있으나 현재 프론트/실서버 기준 canonical 흐름은 HttpOnly 쿠키 기반으로 유지했습니다.
- 백엔드에는 refresh_token 쿠키의 Domain 속성을 비우거나 host-only cookie로 발급하고, Access-Control-Allow-Origin: https://oz-union-16-fe.vercel.app, Access-Control-Allow-Credentials: true를 맞춰 달라고 요청한 상태입니다.
- 브라우저 런타임 코드에서는 실제 Set-Cookie 응답 헤더와 Cookie 요청 헤더 원문을 읽을 수 없으므로, 배포 검증은 DevTools와 DEV diagnostics 로그를 함께 사용하는 전제로 정리했습니다.
