### PR TITLE
[Feat] 설문 완료 후 재진입 흐름 및 추천 페이지 연동 정리

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -87,16 +87,23 @@ const formatRemainingBlockTime = (remainingMs: number) => {
   return `${String(minutes).padStart(1, '0')}:${String(seconds).padStart(2, '0')}`;
 };
 
-function SurveyChatPanel() {
+type SurveyChatPanelProps = {
+  isHistoryView?: boolean;
+};
+
+function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
   const navigate = useNavigate();
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const formRef = useRef<HTMLFormElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const shouldRestoreFocusRef = useRef(false);
   const lastMessageCountRef = useRef(0);
+  const hasResolvedEntryCompletionStateRef = useRef(false);
   const [inputValue, setInputValue] = useState('');
   const [currentTime, setCurrentTime] = useState(() => Date.now());
   const [isGuardrailPanelOpen, setIsGuardrailPanelOpen] = useState(false);
+  const [enteredWithCompletedSurvey, setEnteredWithCompletedSurvey] =
+    useState(false);
 
   const {
     sessionId,
@@ -163,6 +170,10 @@ function SurveyChatPanel() {
       ? '제한 종료'
       : `${nonGameStrikeCount}/${NON_GAME_CHAT_MAX_STRIKES} 누적`;
   const inputPlaceholder = useMemo(() => {
+    if (isHistoryView && recommendationReady) {
+      return '완료된 설문 기록을 다시 보고 있어요.';
+    }
+
     if (isChatTemporarilyBlocked) {
       return '반복된 이상행동으로 인해 5분간 채팅이 정지됩니다.';
     }
@@ -176,7 +187,34 @@ function SurveyChatPanel() {
     }
 
     return '취향과 관련된 게임 이야기를 입력해 주세요.';
-  }, [hasExpiredChatBlock, isChatTemporarilyBlocked, recommendationReady]);
+  }, [
+    hasExpiredChatBlock,
+    isChatTemporarilyBlocked,
+    isHistoryView,
+    recommendationReady,
+  ]);
+  const recommendationButtonLabel =
+    isHistoryView || enteredWithCompletedSurvey
+      ? '추천 결과로 돌아가기'
+      : '추천 결과 바로 보기';
+
+  useEffect(() => {
+    if (hasResolvedEntryCompletionStateRef.current) {
+      return;
+    }
+
+    if (
+      !hasBootstrapped &&
+      !sessionId &&
+      messages.length === 0 &&
+      !recommendationReady
+    ) {
+      return;
+    }
+
+    hasResolvedEntryCompletionStateRef.current = true;
+    setEnteredWithCompletedSurvey(recommendationReady && messages.length > 0);
+  }, [hasBootstrapped, messages.length, recommendationReady, sessionId]);
 
   useEffect(() => {
     if (!isChatTemporarilyBlocked) {
@@ -641,7 +679,7 @@ function SurveyChatPanel() {
                     onClick={handleMoveToRecommendation}
                     className="inline-flex items-center gap-2 rounded-full bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(150,0,0,0.32)] transition hover:-translate-y-px hover:brightness-105"
                   >
-                    추천 결과 바로 보기
+                    {recommendationButtonLabel}
                     <ChevronRight size={16} />
                   </button>
                 )}

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -1,8 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { ChevronDown, ChevronRight, Heart, Star } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronRight,
+  Heart,
+  RotateCcw,
+  Star,
+} from 'lucide-react';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { Link, useSearchParams } from 'react-router';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import ActionButton from '../../components/common/ActionButton';
@@ -27,8 +33,10 @@ import type {
   MatchResultItem,
   MatchResultResponse,
 } from '../../features/matching/types';
+import { useResetSurveyMutation } from '../../features/survey/api/useSurveyApi';
 import { useSurveyResultsInfinite } from '../../features/survey/api/useSurveyApi';
 import { extractApiErrorMessage } from '../../features/survey/api/survey';
+import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
 import type {
   SurveyResultItem,
   SurveyResultResponse,
@@ -261,6 +269,7 @@ function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
 }
 
 function RecommendationListPage() {
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [selectedGame, setSelectedGame] = useState<GameListItem | null>(null);
   const [pendingLikeGameId, setPendingLikeGameId] = useState<number | null>(
@@ -276,6 +285,17 @@ function RecommendationListPage() {
   const detailListScrollTopRef = useRef<number | null>(null);
   const detailWindowScrollYRef = useRef<number>(0);
   const queryClient = useQueryClient();
+  const surveySessionId = useSurveyStore((state) => state.sessionId);
+  const surveyRecommendationReady = useSurveyStore(
+    (state) => state.recommendationReady,
+  );
+  const hydrateInitialSession = useSurveyStore(
+    (state) => state.hydrateInitialSession,
+  );
+  const clearModerationState = useSurveyStore(
+    (state) => state.clearModerationState,
+  );
+  const resetSurveyState = useSurveyStore((state) => state.resetSurveyState);
   const source = searchParams.get('source');
   const legacySessionId = searchParams.get('session_id');
   const isMatchSource = source === 'match';
@@ -290,6 +310,7 @@ function RecommendationListPage() {
   const matchResultsQuery = useMatchResultsInfinite(
     isMatchSource && canAccessPage,
   );
+  const resetSurveyMutation = useResetSurveyMutation();
   const activeQuery = isMatchSource ? matchResultsQuery : surveyResultsQuery;
   const { error, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
     activeQuery;
@@ -311,6 +332,8 @@ function RecommendationListPage() {
       errorMessage?.includes('매칭 추천 결과를 찾을 수 없습니다') ||
       recommendationItems.length === 0,
     );
+  const shouldShowSurveyActions =
+    isSurveySource && canAccessPage && surveyRecommendationReady;
 
   useLayoutEffect(() => {
     if (!canAccessPage) {
@@ -435,6 +458,40 @@ function RecommendationListPage() {
       typeof window !== 'undefined' ? window.scrollY : null;
 
     void fetchNextPage();
+  };
+
+  const handleViewPreviousSurvey = () => {
+    navigate(`/${ROUTES.SURVEY}?mode=history`);
+  };
+
+  const handleResetSurvey = async () => {
+    if (resetSurveyMutation.isPending) {
+      return;
+    }
+
+    setLikeFeedbackMessage(null);
+
+    if (!surveySessionId) {
+      clearModerationState();
+      resetSurveyState();
+      queryClient.removeQueries({ queryKey: ['survey-results'] });
+      navigate(`/${ROUTES.SURVEY}`);
+      return;
+    }
+
+    try {
+      const response = await resetSurveyMutation.mutateAsync({
+        session_id: surveySessionId,
+      });
+
+      setSelectedGame(null);
+      clearModerationState();
+      hydrateInitialSession(response);
+      queryClient.removeQueries({ queryKey: ['survey-results'] });
+      navigate(`/${ROUTES.SURVEY}`);
+    } catch (requestError) {
+      setLikeFeedbackMessage(extractApiErrorMessage(requestError));
+    }
   };
 
   useEffect(() => {
@@ -600,18 +657,45 @@ function RecommendationListPage() {
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-300 flex-col px-3 pt-24 pb-10 sm:px-4 sm:pt-28 sm:pb-12 md:px-8 md:pt-32 md:pb-16">
         <section className="mx-auto w-full max-w-245">
           <div className="mb-8">
-            <h1 className="text-3xl font-semibold tracking-[-0.04em] text-white sm:text-4xl md:text-[52px]">
-              게임 추천 리스트
-            </h1>
-            <div className="mt-5 flex flex-wrap gap-2.5">
-              {recommendationHighlights.map((highlight) => (
-                <span
-                  key={highlight}
-                  className="inline-flex items-center rounded-full border border-white/8 bg-white/3 px-3 py-1.5 text-xs font-medium text-white/68 backdrop-blur-sm"
-                >
-                  {highlight}
-                </span>
-              ))}
+            <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div>
+                <h1 className="text-3xl font-semibold tracking-[-0.04em] text-white sm:text-4xl md:text-[52px]">
+                  게임 추천 리스트
+                </h1>
+                <div className="mt-5 flex flex-wrap gap-2.5">
+                  {recommendationHighlights.map((highlight) => (
+                    <span
+                      key={highlight}
+                      className="inline-flex items-center rounded-full border border-white/8 bg-white/3 px-3 py-1.5 text-xs font-medium text-white/68 backdrop-blur-sm"
+                    >
+                      {highlight}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {shouldShowSurveyActions ? (
+                <div className="flex flex-wrap items-center gap-2.5 md:justify-end">
+                  <button
+                    type="button"
+                    onClick={handleViewPreviousSurvey}
+                    className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/3 px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/6"
+                  >
+                    이전 설문 보기
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleResetSurvey()}
+                    disabled={resetSurveyMutation.isPending}
+                    className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/3 px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <RotateCcw size={16} />
+                    {resetSurveyMutation.isPending
+                      ? '설문 초기화 중...'
+                      : '설문 초기화'}
+                  </button>
+                </div>
+              ) : null}
             </div>
           </div>
 

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { Navigate, useLocation } from 'react-router';
+import { useEffect, useState } from 'react';
+import { Navigate, useLocation, useSearchParams } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import LazyHeader from '../../components/common/LazyHeader';
@@ -36,10 +36,19 @@ function SurveyBackdrop() {
 
 function SurveyPage() {
   const location = useLocation();
+  const [searchParams] = useSearchParams();
   const authGate = useAuthGate();
   const canAccessSurvey = authGate.accessStatus === 'authorized';
   const account = useAuthStore((state) => state.account);
   const syncOwnerKey = useSurveyStore((state) => state.syncOwnerKey);
+  const messages = useSurveyStore((state) => state.messages);
+  const recommendationReady = useSurveyStore(
+    (state) => state.recommendationReady,
+  );
+  const isHistoryMode = searchParams.get('mode') === 'history';
+  const [enteredWithCompletedSurvey] = useState(
+    () => recommendationReady && messages.length > 0,
+  );
   const surveyOwnerKey = account?.login_id
     ? `survey-user:${account.login_id}`
     : authGate.isAuthenticated
@@ -51,6 +60,12 @@ function SurveyPage() {
   useEffect(() => {
     syncOwnerKey(surveyOwnerKey);
   }, [surveyOwnerKey, syncOwnerKey]);
+  const shouldRedirectCompletedEntry =
+    canAccessSurvey &&
+    !isHistoryMode &&
+    enteredWithCompletedSurvey &&
+    recommendationReady &&
+    messages.length > 0;
 
   if (authGate.accessStatus === 'unauthorized') {
     return (
@@ -62,6 +77,12 @@ function SurveyPage() {
           redirectTo: `${location.pathname}${location.search}`,
         }}
       />
+    );
+  }
+
+  if (shouldRedirectCompletedEntry) {
+    return (
+      <Navigate to={`/${ROUTES.RECOMMENDATION_LIST}?source=survey`} replace />
     );
   }
 
@@ -80,7 +101,7 @@ function SurveyPage() {
             className="mx-auto max-w-190 sm:py-12"
           />
         ) : canAccessSurvey ? (
-          <SurveyChatPanel />
+          <SurveyChatPanel isHistoryView={isHistoryMode} />
         ) : (
           <AuthGateStatusPanel
             title="로그인 후 설문을 시작할 수 있어요."


### PR DESCRIPTION
## 관련 이슈

- closes #263 

## 변경 내용

- 설문 진행 중에는 기존처럼 대화와 진행률이 유지되도록 두고, 완료된 설문 데이터를 이미 가진 상태에서 `/survey`에 다시 진입한 경우에는 추천 리스트 페이지로 바로 이동하도록 수정
- 방금 설문을 완료한 경우에는 자동으로 추천 페이지로 이동하지 않고, 설문 페이지 안에서 `추천 결과 바로 보기` 버튼을 눌러 이동하도록 유지
- 추천 리스트에서 `이전 설문 보기`를 통해 완료된 설문 질문/답변을 읽기 전용으로 다시 확인할 수 있도록 연결
- 추천 리스트에서 `설문 초기화`를 누르면 reset API 호출 후 설문 상태를 초기화하고 처음부터 다시 시작할 수 있도록 수정
- 설문 페이지에 `history` 진입 모드를 추가해, 추천 리스트에서 완료된 설문 기록을 다시 볼 때는 자동 리다이렉트가 걸리지 않도록 정리
- 설문 페이지의 완료 CTA 문구를 진입 상황에 따라 구분
  - 새로 완료한 경우: `추천 결과 바로 보기`
  - 저장된 완료 설문 기록을 다시 보는 경우: `추천 결과로 돌아가기`

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷


https://github.com/user-attachments/assets/c41e83b2-9644-49fb-83d6-820734cc2c42



## 참고사항

- 이번 PR은 설문 완료 이후 재진입 정책과 추천 리스트 연동 흐름 정리에 집중했습니다.
- 설문 진행 중 이탈 후 재진입은 기존처럼 그대로 이어서 진행할 수 있습니다.
