### PR TITLE
[Feat] 매칭 화면 UI 수정 및 가독성 개선

### DIFF
--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -119,7 +119,6 @@ function MatchingGenreDetailPage() {
 
   const displayCandidates = candidates;
   const totalSteps = displayCandidates.length;
-  const totalGamesLabel = `${totalSteps}개의 게임`;
   const safeIndex =
     totalSteps > 0 ? Math.min(currentIndex, totalSteps - 1) : currentIndex;
   const currentCandidate = displayCandidates[safeIndex];
@@ -361,14 +360,9 @@ function MatchingGenreDetailPage() {
                 <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[40px]">
                   매칭 과정을 따라가세요
                 </h1>
-                <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
-                  트레일러와 분위기를 보며 {totalGamesLabel}에 별점을
-                  남겨보세요. 좋아요는 마음에 든 게임을 표시해 두고
-                  마이페이지에서 다시 확인할 수 있게 함께 저장돼요.
-                </p>
               </div>
 
-              <div className="mt-7">
+              <div className="mt-6">
                 <MatchingGuideCards />
               </div>
 

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -98,16 +98,13 @@ function MatchingListPage() {
                       alt={genre.title}
                       className="aspect-[16/8.4] w-full object-cover transition duration-300 group-hover:scale-[1.025] group-hover:brightness-110"
                     />
-                    <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,6,8,0.18),rgba(6,6,8,0.72))]" />
-                    <p className="absolute top-3.5 left-3.5 text-[10px] font-medium tracking-[0.2em] text-white/76 uppercase">
-                      {genre.subtitle}
-                    </p>
+                    <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,6,8,0.1),rgba(6,6,8,0.28)_34%,rgba(6,6,8,0.86))]" />
                     <div className="absolute right-3.5 bottom-3.5 left-3.5 flex items-end justify-between gap-3">
                       <div>
                         <h2 className="text-[22px] font-semibold tracking-[-0.02em] text-white">
                           {genre.title}
                         </h2>
-                        <p className="mt-1.5 max-w-[24ch] text-[13px] leading-5 break-keep text-white/72">
+                        <p className="mt-1.5 max-w-[24ch] text-[13px] leading-5 font-medium break-keep text-white/86 [text-shadow:0_1px_10px_rgba(0,0,0,0.65)]">
                           {genre.description}
                         </p>
                       </div>


### PR DESCRIPTION
## 관련 이슈

- closes #266 

## 변경 내용

- 장르별 매칭 카드 상단의 흰색 subtitle을 제거해 카드 정보 밀도를 정리
- 장르 카드 하단 설명 문구는 유지하되, 하단 overlay와 텍스트 대비를 조정해 가독성을 개선
- 매칭 상세 화면 상단의 긴 설명 문구를 제거해 화면 집중도를 높이고 세로 밀도를 줄임
- 상단 설명 제거에 맞춰 가이드 카드 시작 간격도 함께 정리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 기능/상태 로직은 변경하지 않았습니다.