### PR TITLE
[Refactor] 추천 리스트 페이지 책임 분리

### DIFF
--- a/src/features/recommendation/hooks/useRecommendationLike.ts
+++ b/src/features/recommendation/hooks/useRecommendationLike.ts
@@ -1,0 +1,203 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useEffect, useState } from 'react';
+
+import { authKeys } from '../../auth/api/queryKeys';
+import type { LikedGamesResponse } from '../../auth/types/auth';
+import { getGameDetail, likeGame, unlikeGame } from '../../games/gameApi';
+import {
+  gamesKeys,
+  syncGameLikeStateInQueryCache,
+} from '../../games/queryCache';
+import type { RecommendationDisplayItem } from '../types';
+
+const LIKE_ERROR_MESSAGE =
+  '좋아요 상태를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+const LIKE_LOGIN_REQUIRED_MESSAGE = '로그인 후 좋아요를 사용할 수 있어요.';
+const FEEDBACK_MESSAGE_DURATION_MS = 3000;
+
+type RecommendationLikeMutationVariables = {
+  gameId: number;
+  nextIsLiked: boolean;
+  item: RecommendationDisplayItem;
+};
+
+type UseRecommendationLikeParams = {
+  onSelectedGameLikeChange?: (gameId: number, isLiked: boolean) => void;
+};
+
+const isLikedGamesResponse = (value: unknown): value is LikedGamesResponse => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  return Array.isArray((value as Partial<LikedGamesResponse>).results);
+};
+
+export const useRecommendationLike = ({
+  onSelectedGameLikeChange,
+}: UseRecommendationLikeParams = {}) => {
+  const queryClient = useQueryClient();
+  const [pendingLikeGameId, setPendingLikeGameId] = useState<number | null>(
+    null,
+  );
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!feedbackMessage) {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setFeedbackMessage(null);
+    }, FEEDBACK_MESSAGE_DURATION_MS);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [feedbackMessage]);
+
+  const updateLikedGamesCache = (
+    item: RecommendationDisplayItem,
+    nextIsLiked: boolean,
+  ) => {
+    queryClient.setQueriesData<LikedGamesResponse>(
+      { queryKey: authKeys.likedGames() },
+      (current) => {
+        if (!isLikedGamesResponse(current)) {
+          return current;
+        }
+
+        const currentLikedGames = current as LikedGamesResponse;
+
+        if (nextIsLiked) {
+          const alreadyExists = currentLikedGames.results.some(
+            (likedGame) => likedGame.game_id === item.game_id,
+          );
+
+          if (alreadyExists) {
+            return current;
+          }
+
+          return {
+            ...currentLikedGames,
+            count: currentLikedGames.count + 1,
+            results: [
+              {
+                game_id: item.game_id,
+                game_title: item.title,
+                thumbnail_url: item.thumbnail_url,
+                genres: item.genres,
+                liked_at: new Date().toISOString(),
+              },
+              ...currentLikedGames.results,
+            ],
+          };
+        }
+
+        const nextResults = currentLikedGames.results.filter(
+          (likedGame) => likedGame.game_id !== item.game_id,
+        );
+
+        if (nextResults.length === currentLikedGames.results.length) {
+          return current;
+        }
+
+        return {
+          ...currentLikedGames,
+          count: Math.max(0, currentLikedGames.count - 1),
+          results: nextResults,
+        };
+      },
+    );
+  };
+
+  const likeMutation = useMutation({
+    mutationFn: ({
+      gameId,
+      nextIsLiked,
+    }: RecommendationLikeMutationVariables) =>
+      nextIsLiked ? likeGame(gameId) : unlikeGame(gameId),
+    onMutate: ({ gameId }) => {
+      setPendingLikeGameId(gameId);
+      setFeedbackMessage(null);
+    },
+    onSuccess: async (response, variables) => {
+      updateLikedGamesCache(variables.item, response.isLiked);
+      onSelectedGameLikeChange?.(response.gameId, response.isLiked);
+      syncGameLikeStateInQueryCache(queryClient, {
+        gameId: response.gameId,
+        isLiked: response.isLiked,
+        likeCount: response.likeCount,
+      });
+
+      try {
+        const detail = await queryClient.fetchQuery({
+          queryKey: gamesKeys.detail(response.gameId),
+          queryFn: () => getGameDetail(response.gameId),
+          staleTime: 60_000,
+        });
+
+        queryClient.setQueriesData<LikedGamesResponse>(
+          { queryKey: authKeys.likedGames() },
+          (current) => {
+            if (!isLikedGamesResponse(current) || !response.isLiked) {
+              return current;
+            }
+
+            const currentLikedGames = current as LikedGamesResponse;
+
+            return {
+              ...currentLikedGames,
+              results: currentLikedGames.results.map((likedGame) =>
+                likedGame.game_id === response.gameId
+                  ? {
+                      ...likedGame,
+                      game_title: detail.title.trim() || likedGame.game_title,
+                      thumbnail_url:
+                        detail.coverImageUrl ?? likedGame.thumbnail_url,
+                      genres: detail.genres.length
+                        ? detail.genres
+                        : likedGame.genres,
+                    }
+                  : likedGame,
+              ),
+            };
+          },
+        );
+      } catch {
+        // 상세 조회 실패는 좋아요 토글 결과를 되돌릴 이유가 아니므로 무시합니다.
+      }
+
+      void queryClient.invalidateQueries({
+        queryKey: authKeys.likedGames(),
+      });
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError && error.response?.status === 401) {
+        setFeedbackMessage(LIKE_LOGIN_REQUIRED_MESSAGE);
+        return;
+      }
+
+      setFeedbackMessage(LIKE_ERROR_MESSAGE);
+    },
+    onSettled: () => {
+      setPendingLikeGameId(null);
+    },
+  });
+
+  const handleToggleLike = (item: RecommendationDisplayItem) => {
+    likeMutation.mutate({
+      gameId: item.game_id,
+      nextIsLiked: !item.is_liked,
+      item,
+    });
+  };
+
+  return {
+    pendingLikeGameId,
+    feedbackMessage,
+    setFeedbackMessage,
+    handleToggleLike,
+  };
+};

--- a/src/features/recommendation/hooks/useRecommendationResultsSource.ts
+++ b/src/features/recommendation/hooks/useRecommendationResultsSource.ts
@@ -1,0 +1,109 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useLayoutEffect } from 'react';
+import { useSearchParams } from 'react-router';
+
+import { useMatchResultsInfinite } from '../../matching/api/useMatchingApi';
+import type { MatchResultResponse } from '../../matching/types';
+import { useSurveyResultsInfinite } from '../../survey/api/useSurveyApi';
+import { extractApiErrorMessage } from '../../survey/api/survey';
+import type { SurveyResultResponse } from '../../survey/types/survey';
+import {
+  getRecommendationHighlights,
+  normalizeRecommendationItem,
+} from '../utils/normalizeRecommendationItem';
+
+type UseRecommendationResultsSourceParams = {
+  canAccessPage: boolean;
+};
+
+export const useRecommendationResultsSource = ({
+  canAccessPage,
+}: UseRecommendationResultsSourceParams) => {
+  const [searchParams] = useSearchParams();
+  const queryClient = useQueryClient();
+  const source = searchParams.get('source');
+  const legacySessionId = searchParams.get('session_id');
+  const isMatchSource = source === 'match';
+  const isSurveySource =
+    source === 'survey' || (!source && Boolean(legacySessionId));
+
+  const surveyResultsQuery = useSurveyResultsInfinite(
+    !isMatchSource && isSurveySource && canAccessPage,
+  );
+  const matchResultsQuery = useMatchResultsInfinite(
+    isMatchSource && canAccessPage,
+  );
+  const activeQuery = isMatchSource ? matchResultsQuery : surveyResultsQuery;
+  const { error, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
+    activeQuery;
+
+  const surveyItems =
+    surveyResultsQuery.data?.pages.flatMap((page) => page.results) ?? [];
+  const matchItems =
+    matchResultsQuery.data?.pages.flatMap((page) => page.results) ?? [];
+  const recommendationItems = (isMatchSource ? matchItems : surveyItems).map(
+    normalizeRecommendationItem,
+  );
+  const recommendationHighlights =
+    getRecommendationHighlights(recommendationItems);
+  const errorMessage = error ? extractApiErrorMessage(error) : null;
+  const shouldShowMatchEntryCta =
+    isMatchSource &&
+    !isLoading &&
+    Boolean(
+      errorMessage?.includes('매칭 추천 결과를 찾을 수 없습니다') ||
+      recommendationItems.length === 0,
+    );
+
+  useLayoutEffect(() => {
+    if (!canAccessPage) {
+      return;
+    }
+
+    if (isMatchSource) {
+      queryClient.setQueryData<{
+        pages: MatchResultResponse[];
+        pageParams: unknown[];
+      }>(['match-results'], (currentData) =>
+        currentData
+          ? {
+              ...currentData,
+              pages: currentData.pages.slice(0, 1),
+              pageParams: currentData.pageParams.slice(0, 1),
+            }
+          : currentData,
+      );
+
+      return;
+    }
+
+    if (isSurveySource) {
+      queryClient.setQueryData<{
+        pages: SurveyResultResponse[];
+        pageParams: unknown[];
+      }>(['survey-results'], (currentData) =>
+        currentData
+          ? {
+              ...currentData,
+              pages: currentData.pages.slice(0, 1),
+              pageParams: currentData.pageParams.slice(0, 1),
+            }
+          : currentData,
+      );
+    }
+  }, [canAccessPage, isMatchSource, isSurveySource, queryClient]);
+
+  return {
+    isMatchSource,
+    isSurveySource,
+    recommendationItems,
+    recommendationHighlights,
+    errorMessage,
+    shouldShowMatchEntryCta,
+    error,
+    isLoading,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+  };
+};

--- a/src/features/recommendation/hooks/useRecommendationScrollRestoration.ts
+++ b/src/features/recommendation/hooks/useRecommendationScrollRestoration.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import type { GameListItem } from '../../games/types';
+import type { RecommendationDisplayItem } from '../types';
+import { toGameListItem } from '../utils/normalizeRecommendationItem';
+
+const LOAD_MORE_SCROLL_STEP_FALLBACK = 124;
+
+type UseRecommendationScrollRestorationParams = {
+  itemCount: number;
+  fetchNextPage: () => Promise<unknown>;
+  setSelectedGame: (game: GameListItem | null) => void;
+};
+
+export const useRecommendationScrollRestoration = ({
+  itemCount,
+  fetchNextPage,
+  setSelectedGame,
+}: UseRecommendationScrollRestorationParams) => {
+  const recommendationScrollRef = useRef<HTMLDivElement | null>(null);
+  const loadMoreScrollTopRef = useRef<number | null>(null);
+  const loadMoreWindowScrollYRef = useRef<number | null>(null);
+  const loadMoreStepOffsetRef = useRef<number>(LOAD_MORE_SCROLL_STEP_FALLBACK);
+  const detailListScrollTopRef = useRef<number | null>(null);
+  const detailWindowScrollYRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (loadMoreScrollTopRef.current === null) {
+      return;
+    }
+
+    const scrollContainer = recommendationScrollRef.current;
+
+    if (!scrollContainer) {
+      loadMoreScrollTopRef.current = null;
+      loadMoreWindowScrollYRef.current = null;
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      if (
+        typeof window !== 'undefined' &&
+        loadMoreWindowScrollYRef.current !== null
+      ) {
+        window.scrollTo({
+          top: loadMoreWindowScrollYRef.current,
+          behavior: 'auto',
+        });
+      }
+
+      scrollContainer.scrollTop =
+        (loadMoreScrollTopRef.current ?? scrollContainer.scrollTop) +
+        loadMoreStepOffsetRef.current;
+      loadMoreScrollTopRef.current = null;
+      loadMoreWindowScrollYRef.current = null;
+      loadMoreStepOffsetRef.current = LOAD_MORE_SCROLL_STEP_FALLBACK;
+    });
+  }, [itemCount]);
+
+  const handleOpenDetail = useCallback(
+    (item: RecommendationDisplayItem) => {
+      detailListScrollTopRef.current =
+        recommendationScrollRef.current?.scrollTop ?? null;
+      detailWindowScrollYRef.current =
+        typeof window !== 'undefined' ? window.scrollY : 0;
+      setSelectedGame(toGameListItem(item));
+    },
+    [setSelectedGame],
+  );
+
+  const handleCloseDetail = useCallback(() => {
+    setSelectedGame(null);
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      window.scrollTo({
+        top: detailWindowScrollYRef.current,
+        behavior: 'auto',
+      });
+
+      if (
+        recommendationScrollRef.current &&
+        detailListScrollTopRef.current !== null
+      ) {
+        recommendationScrollRef.current.scrollTop =
+          detailListScrollTopRef.current;
+      }
+    });
+  }, [setSelectedGame]);
+
+  const handleLoadMore = useCallback(() => {
+    const scrollContainer = recommendationScrollRef.current;
+
+    if (scrollContainer) {
+      loadMoreScrollTopRef.current = scrollContainer.scrollTop;
+      const firstRow = scrollContainer.querySelector('article');
+      loadMoreStepOffsetRef.current =
+        firstRow instanceof HTMLElement
+          ? Math.max(
+              80,
+              Math.min(
+                Math.round(firstRow.getBoundingClientRect().height * 0.82),
+                160,
+              ),
+            )
+          : LOAD_MORE_SCROLL_STEP_FALLBACK;
+    }
+
+    loadMoreWindowScrollYRef.current =
+      typeof window !== 'undefined' ? window.scrollY : null;
+
+    void fetchNextPage();
+  }, [fetchNextPage]);
+
+  return {
+    recommendationScrollRef,
+    handleOpenDetail,
+    handleCloseDetail,
+    handleLoadMore,
+  };
+};

--- a/src/features/recommendation/hooks/useSurveyRecommendationActions.ts
+++ b/src/features/recommendation/hooks/useSurveyRecommendationActions.ts
@@ -1,0 +1,80 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
+
+import { ROUTES } from '../../../constants/routes';
+import { useResetSurveyMutation } from '../../survey/api/useSurveyApi';
+import { extractApiErrorMessage } from '../../survey/api/survey';
+import { useSurveyStore } from '../../survey/store/useSurveyStore';
+
+type UseSurveyRecommendationActionsParams = {
+  canAccessPage: boolean;
+  isSurveySource: boolean;
+  onBeforeReset?: () => void;
+  setFeedbackMessage: (message: string | null) => void;
+};
+
+export const useSurveyRecommendationActions = ({
+  canAccessPage,
+  isSurveySource,
+  onBeforeReset,
+  setFeedbackMessage,
+}: UseSurveyRecommendationActionsParams) => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const surveySessionId = useSurveyStore((state) => state.sessionId);
+  const surveyRecommendationReady = useSurveyStore(
+    (state) => state.recommendationReady,
+  );
+  const hydrateInitialSession = useSurveyStore(
+    (state) => state.hydrateInitialSession,
+  );
+  const clearModerationState = useSurveyStore(
+    (state) => state.clearModerationState,
+  );
+  const resetSurveyState = useSurveyStore((state) => state.resetSurveyState);
+  const resetSurveyMutation = useResetSurveyMutation();
+  const shouldShowSurveyActions =
+    isSurveySource && canAccessPage && surveyRecommendationReady;
+
+  const handleViewPreviousSurvey = () => {
+    navigate(`/${ROUTES.SURVEY}?mode=history`);
+  };
+
+  const handleResetSurvey = async () => {
+    if (resetSurveyMutation.isPending) {
+      return;
+    }
+
+    setFeedbackMessage(null);
+
+    if (!surveySessionId) {
+      onBeforeReset?.();
+      clearModerationState();
+      resetSurveyState();
+      queryClient.removeQueries({ queryKey: ['survey-results'] });
+      navigate(`/${ROUTES.SURVEY}`);
+      return;
+    }
+
+    try {
+      const response = await resetSurveyMutation.mutateAsync({
+        session_id: surveySessionId,
+      });
+
+      onBeforeReset?.();
+      clearModerationState();
+      hydrateInitialSession(response);
+      queryClient.removeQueries({ queryKey: ['survey-results'] });
+      navigate(`/${ROUTES.SURVEY}`);
+    } catch (requestError) {
+      setFeedbackMessage(extractApiErrorMessage(requestError));
+    }
+  };
+
+  return {
+    shouldShowSurveyActions,
+    isResettingSurvey: resetSurveyMutation.isPending,
+    handleViewPreviousSurvey,
+    handleResetSurvey,
+  };
+};

--- a/src/features/recommendation/types.ts
+++ b/src/features/recommendation/types.ts
@@ -1,0 +1,8 @@
+export type RecommendationDisplayItem = {
+  game_id: number;
+  title: string;
+  genres: string[];
+  thumbnail_url: string | null;
+  rating: number | null;
+  is_liked: boolean;
+};

--- a/src/features/recommendation/utils/normalizeRecommendationItem.ts
+++ b/src/features/recommendation/utils/normalizeRecommendationItem.ts
@@ -1,0 +1,56 @@
+import type { GameListItem } from '../../games/types';
+import type { MatchResultItem } from '../../matching/types';
+import type { SurveyResultItem } from '../../survey/types/survey';
+import type { RecommendationDisplayItem } from '../types';
+
+const FALLBACK_HIGHLIGHTS = ['몰입감', '스토리', '액션', '전략'];
+
+export const normalizeRecommendationItem = (
+  item: SurveyResultItem | MatchResultItem,
+): RecommendationDisplayItem => ({
+  game_id: item.game_id,
+  title: item.title,
+  genres: item.genres,
+  thumbnail_url: item.thumbnail_url,
+  rating: item.rating,
+  is_liked: item.is_liked,
+});
+
+export const toGameListItem = (
+  item: RecommendationDisplayItem,
+): GameListItem => ({
+  gameId: item.game_id,
+  name: item.title,
+  genres: item.genres,
+  thumbnailUrl: item.thumbnail_url,
+  rating: item.rating,
+  isLiked: item.is_liked,
+});
+
+export const formatRecommendationRating = (rating: number | null) =>
+  typeof rating === 'number' ? `${rating.toFixed(1)}점` : 'N/A';
+
+export const getRecommendationHighlights = (
+  items: RecommendationDisplayItem[],
+) => {
+  const genreCounts = new Map<string, number>();
+
+  items.forEach((item) => {
+    item.genres.forEach((genre) => {
+      const trimmedGenre = genre.trim();
+
+      if (!trimmedGenre) {
+        return;
+      }
+
+      genreCounts.set(trimmedGenre, (genreCounts.get(trimmedGenre) ?? 0) + 1);
+    });
+  });
+
+  const rankedGenres = [...genreCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4)
+    .map(([genre]) => genre);
+
+  return rankedGenres.length > 0 ? rankedGenres : FALLBACK_HIGHLIGHTS;
+};

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -1,5 +1,3 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
 import {
   ChevronDown,
   ChevronRight,
@@ -7,40 +5,22 @@ import {
   RotateCcw,
   Star,
 } from 'lucide-react';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router';
+import { useState } from 'react';
+import { Link } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import ActionButton from '../../components/common/ActionButton';
 import LazyHeader from '../../components/common/LazyHeader';
 import { ROUTES } from '../../constants/routes';
-import { authKeys } from '../../features/auth/api/queryKeys';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
-import type { LikedGamesResponse } from '../../features/auth/types/auth';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
-import {
-  getGameDetail,
-  likeGame,
-  unlikeGame,
-} from '../../features/games/gameApi';
-import {
-  gamesKeys,
-  syncGameLikeStateInQueryCache,
-} from '../../features/games/queryCache';
 import type { GameListItem } from '../../features/games/types';
-import { useMatchResultsInfinite } from '../../features/matching/api/useMatchingApi';
-import type {
-  MatchResultItem,
-  MatchResultResponse,
-} from '../../features/matching/types';
-import { useResetSurveyMutation } from '../../features/survey/api/useSurveyApi';
-import { useSurveyResultsInfinite } from '../../features/survey/api/useSurveyApi';
-import { extractApiErrorMessage } from '../../features/survey/api/survey';
-import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
-import type {
-  SurveyResultItem,
-  SurveyResultResponse,
-} from '../../features/survey/types/survey';
+import { useRecommendationLike } from '../../features/recommendation/hooks/useRecommendationLike';
+import { useRecommendationResultsSource } from '../../features/recommendation/hooks/useRecommendationResultsSource';
+import { useRecommendationScrollRestoration } from '../../features/recommendation/hooks/useRecommendationScrollRestoration';
+import { useSurveyRecommendationActions } from '../../features/recommendation/hooks/useSurveyRecommendationActions';
+import type { RecommendationDisplayItem } from '../../features/recommendation/types';
+import { formatRecommendationRating } from '../../features/recommendation/utils/normalizeRecommendationItem';
 
 const FALLBACK_BACKDROP_ITEMS = [
   {
@@ -68,83 +48,6 @@ const FALLBACK_BACKDROP_ITEMS = [
       'https://images.unsplash.com/photo-1518709268805-4e9042af2176?auto=format&fit=crop&w=800&q=80',
   },
 ];
-
-const FALLBACK_HIGHLIGHTS = ['몰입감', '스토리', '액션', '전략'];
-
-type RecommendationDisplayItem = {
-  game_id: number;
-  title: string;
-  genres: string[];
-  thumbnail_url: string | null;
-  rating: number | null;
-  is_liked: boolean;
-};
-
-type RecommendationLikeMutationVariables = {
-  gameId: number;
-  nextIsLiked: boolean;
-  item: RecommendationDisplayItem;
-};
-
-const LIKE_ERROR_MESSAGE =
-  '좋아요 상태를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.';
-const LIKE_LOGIN_REQUIRED_MESSAGE = '로그인 후 좋아요를 사용할 수 있어요.';
-const FEEDBACK_MESSAGE_DURATION_MS = 3000;
-const LOAD_MORE_SCROLL_STEP_FALLBACK = 124;
-
-const isLikedGamesResponse = (value: unknown): value is LikedGamesResponse => {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-
-  return Array.isArray((value as Partial<LikedGamesResponse>).results);
-};
-
-const normalizeResultItem = (
-  item: SurveyResultItem | MatchResultItem,
-): RecommendationDisplayItem => ({
-  game_id: item.game_id,
-  title: item.title,
-  genres: item.genres,
-  thumbnail_url: item.thumbnail_url,
-  rating: item.rating,
-  is_liked: item.is_liked,
-});
-
-const toGameListItem = (item: RecommendationDisplayItem): GameListItem => ({
-  gameId: item.game_id,
-  name: item.title,
-  genres: item.genres,
-  thumbnailUrl: item.thumbnail_url,
-  rating: item.rating,
-  isLiked: item.is_liked,
-});
-
-const formatRecommendationRating = (rating: number | null) =>
-  typeof rating === 'number' ? `${rating.toFixed(1)}점` : 'N/A';
-
-const getRecommendationHighlights = (items: RecommendationDisplayItem[]) => {
-  const genreCounts = new Map<string, number>();
-
-  items.forEach((item) => {
-    item.genres.forEach((genre) => {
-      const trimmedGenre = genre.trim();
-
-      if (!trimmedGenre) {
-        return;
-      }
-
-      genreCounts.set(trimmedGenre, (genreCounts.get(trimmedGenre) ?? 0) + 1);
-    });
-  });
-
-  const rankedGenres = [...genreCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 4)
-    .map(([genre]) => genre);
-
-  return rankedGenres.length > 0 ? rankedGenres : FALLBACK_HIGHLIGHTS;
-};
 
 type RecommendationRowProps = {
   item: RecommendationDisplayItem;
@@ -269,385 +172,55 @@ function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
 }
 
 function RecommendationListPage() {
-  const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const [selectedGame, setSelectedGame] = useState<GameListItem | null>(null);
-  const [pendingLikeGameId, setPendingLikeGameId] = useState<number | null>(
-    null,
-  );
-  const [likeFeedbackMessage, setLikeFeedbackMessage] = useState<string | null>(
-    null,
-  );
-  const recommendationScrollRef = useRef<HTMLDivElement | null>(null);
-  const loadMoreScrollTopRef = useRef<number | null>(null);
-  const loadMoreWindowScrollYRef = useRef<number | null>(null);
-  const loadMoreStepOffsetRef = useRef<number>(LOAD_MORE_SCROLL_STEP_FALLBACK);
-  const detailListScrollTopRef = useRef<number | null>(null);
-  const detailWindowScrollYRef = useRef<number>(0);
-  const queryClient = useQueryClient();
-  const surveySessionId = useSurveyStore((state) => state.sessionId);
-  const surveyRecommendationReady = useSurveyStore(
-    (state) => state.recommendationReady,
-  );
-  const hydrateInitialSession = useSurveyStore(
-    (state) => state.hydrateInitialSession,
-  );
-  const clearModerationState = useSurveyStore(
-    (state) => state.clearModerationState,
-  );
-  const resetSurveyState = useSurveyStore((state) => state.resetSurveyState);
-  const source = searchParams.get('source');
-  const legacySessionId = searchParams.get('session_id');
-  const isMatchSource = source === 'match';
-  const isSurveySource =
-    source === 'survey' || (!source && Boolean(legacySessionId));
   const authGate = useAuthGate({ allowMockBypass: true });
   const canAccessPage = authGate.accessStatus === 'authorized';
-
-  const surveyResultsQuery = useSurveyResultsInfinite(
-    !isMatchSource && isSurveySource && canAccessPage,
-  );
-  const matchResultsQuery = useMatchResultsInfinite(
-    isMatchSource && canAccessPage,
-  );
-  const resetSurveyMutation = useResetSurveyMutation();
-  const activeQuery = isMatchSource ? matchResultsQuery : surveyResultsQuery;
-  const { error, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
-    activeQuery;
-
-  const surveyItems =
-    surveyResultsQuery.data?.pages.flatMap((page) => page.results) ?? [];
-  const matchItems =
-    matchResultsQuery.data?.pages.flatMap((page) => page.results) ?? [];
-  const recommendationItems = (isMatchSource ? matchItems : surveyItems).map(
-    normalizeResultItem,
-  );
-  const recommendationHighlights =
-    getRecommendationHighlights(recommendationItems);
-  const errorMessage = error ? extractApiErrorMessage(error) : null;
-  const shouldShowMatchEntryCta =
-    isMatchSource &&
-    !isLoading &&
-    Boolean(
-      errorMessage?.includes('매칭 추천 결과를 찾을 수 없습니다') ||
-      recommendationItems.length === 0,
-    );
-  const shouldShowSurveyActions =
-    isSurveySource && canAccessPage && surveyRecommendationReady;
-
-  useLayoutEffect(() => {
-    if (!canAccessPage) {
-      return;
-    }
-
-    if (isMatchSource) {
-      queryClient.setQueryData<{
-        pages: MatchResultResponse[];
-        pageParams: unknown[];
-      }>(['match-results'], (currentData) =>
-        currentData
-          ? {
-              ...currentData,
-              pages: currentData.pages.slice(0, 1),
-              pageParams: currentData.pageParams.slice(0, 1),
-            }
-          : currentData,
-      );
-
-      return;
-    }
-
-    if (isSurveySource) {
-      queryClient.setQueryData<{
-        pages: SurveyResultResponse[];
-        pageParams: unknown[];
-      }>(['survey-results'], (currentData) =>
-        currentData
-          ? {
-              ...currentData,
-              pages: currentData.pages.slice(0, 1),
-              pageParams: currentData.pageParams.slice(0, 1),
-            }
-          : currentData,
-      );
-    }
-  }, [canAccessPage, isMatchSource, isSurveySource, queryClient]);
-
-  useEffect(() => {
-    if (loadMoreScrollTopRef.current === null) {
-      return;
-    }
-
-    const scrollContainer = recommendationScrollRef.current;
-
-    if (!scrollContainer) {
-      loadMoreScrollTopRef.current = null;
-      loadMoreWindowScrollYRef.current = null;
-      return;
-    }
-
-    window.requestAnimationFrame(() => {
-      if (
-        typeof window !== 'undefined' &&
-        loadMoreWindowScrollYRef.current !== null
-      ) {
-        window.scrollTo({
-          top: loadMoreWindowScrollYRef.current,
-          behavior: 'auto',
-        });
-      }
-
-      scrollContainer.scrollTop =
-        (loadMoreScrollTopRef.current ?? scrollContainer.scrollTop) +
-        loadMoreStepOffsetRef.current;
-      loadMoreScrollTopRef.current = null;
-      loadMoreWindowScrollYRef.current = null;
-      loadMoreStepOffsetRef.current = LOAD_MORE_SCROLL_STEP_FALLBACK;
-    });
-  }, [recommendationItems.length]);
-
-  const handleOpenDetail = (item: RecommendationDisplayItem) => {
-    detailListScrollTopRef.current =
-      recommendationScrollRef.current?.scrollTop ?? null;
-    detailWindowScrollYRef.current =
-      typeof window !== 'undefined' ? window.scrollY : 0;
-    setSelectedGame(toGameListItem(item));
-  };
-
-  const handleCloseDetail = () => {
-    setSelectedGame(null);
-
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    window.requestAnimationFrame(() => {
-      window.scrollTo({
-        top: detailWindowScrollYRef.current,
-        behavior: 'auto',
-      });
-
-      if (
-        recommendationScrollRef.current &&
-        detailListScrollTopRef.current !== null
-      ) {
-        recommendationScrollRef.current.scrollTop =
-          detailListScrollTopRef.current;
-      }
-    });
-  };
-
-  const handleLoadMore = () => {
-    const scrollContainer = recommendationScrollRef.current;
-
-    if (scrollContainer) {
-      loadMoreScrollTopRef.current = scrollContainer.scrollTop;
-      const firstRow = scrollContainer.querySelector('article');
-      loadMoreStepOffsetRef.current =
-        firstRow instanceof HTMLElement
-          ? Math.max(
-              80,
-              Math.min(
-                Math.round(firstRow.getBoundingClientRect().height * 0.82),
-                160,
-              ),
-            )
-          : LOAD_MORE_SCROLL_STEP_FALLBACK;
-    }
-    loadMoreWindowScrollYRef.current =
-      typeof window !== 'undefined' ? window.scrollY : null;
-
-    void fetchNextPage();
-  };
-
-  const handleViewPreviousSurvey = () => {
-    navigate(`/${ROUTES.SURVEY}?mode=history`);
-  };
-
-  const handleResetSurvey = async () => {
-    if (resetSurveyMutation.isPending) {
-      return;
-    }
-
-    setLikeFeedbackMessage(null);
-
-    if (!surveySessionId) {
-      clearModerationState();
-      resetSurveyState();
-      queryClient.removeQueries({ queryKey: ['survey-results'] });
-      navigate(`/${ROUTES.SURVEY}`);
-      return;
-    }
-
-    try {
-      const response = await resetSurveyMutation.mutateAsync({
-        session_id: surveySessionId,
-      });
-
-      setSelectedGame(null);
-      clearModerationState();
-      hydrateInitialSession(response);
-      queryClient.removeQueries({ queryKey: ['survey-results'] });
-      navigate(`/${ROUTES.SURVEY}`);
-    } catch (requestError) {
-      setLikeFeedbackMessage(extractApiErrorMessage(requestError));
-    }
-  };
-
-  useEffect(() => {
-    if (!likeFeedbackMessage) {
-      return undefined;
-    }
-
-    const timeout = window.setTimeout(() => {
-      setLikeFeedbackMessage(null);
-    }, FEEDBACK_MESSAGE_DURATION_MS);
-
-    return () => {
-      window.clearTimeout(timeout);
-    };
-  }, [likeFeedbackMessage]);
-
-  const updateLikedGamesCache = (
-    item: RecommendationDisplayItem,
-    nextIsLiked: boolean,
-  ) => {
-    queryClient.setQueriesData<LikedGamesResponse>(
-      { queryKey: authKeys.likedGames() },
-      (current) => {
-        if (!isLikedGamesResponse(current)) {
-          return current;
-        }
-
-        const currentLikedGames = current as LikedGamesResponse;
-
-        if (nextIsLiked) {
-          const alreadyExists = currentLikedGames.results.some(
-            (likedGame) => likedGame.game_id === item.game_id,
-          );
-
-          if (alreadyExists) {
-            return current;
-          }
-
-          return {
-            ...currentLikedGames,
-            count: currentLikedGames.count + 1,
-            results: [
-              {
-                game_id: item.game_id,
-                game_title: item.title,
-                thumbnail_url: item.thumbnail_url,
-                genres: item.genres,
-                liked_at: new Date().toISOString(),
-              },
-              ...currentLikedGames.results,
-            ],
-          };
-        }
-
-        const nextResults = currentLikedGames.results.filter(
-          (likedGame) => likedGame.game_id !== item.game_id,
-        );
-
-        if (nextResults.length === currentLikedGames.results.length) {
-          return current;
-        }
-
-        return {
-          ...currentLikedGames,
-          count: Math.max(0, currentLikedGames.count - 1),
-          results: nextResults,
-        };
-      },
-    );
-  };
-
-  const likeMutation = useMutation({
-    mutationFn: ({
-      gameId,
-      nextIsLiked,
-    }: RecommendationLikeMutationVariables) =>
-      nextIsLiked ? likeGame(gameId) : unlikeGame(gameId),
-    onMutate: ({ gameId }) => {
-      setPendingLikeGameId(gameId);
-      setLikeFeedbackMessage(null);
-    },
-    onSuccess: async (response, variables) => {
-      updateLikedGamesCache(variables.item, response.isLiked);
+  const {
+    isMatchSource,
+    isSurveySource,
+    recommendationItems,
+    recommendationHighlights,
+    errorMessage,
+    shouldShowMatchEntryCta,
+    error,
+    isLoading,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+  } = useRecommendationResultsSource({ canAccessPage });
+  const {
+    pendingLikeGameId,
+    feedbackMessage,
+    setFeedbackMessage,
+    handleToggleLike,
+  } = useRecommendationLike({
+    onSelectedGameLikeChange: (gameId, isLiked) => {
       setSelectedGame((current) =>
-        current?.gameId === response.gameId
-          ? { ...current, isLiked: response.isLiked }
-          : current,
+        current?.gameId === gameId ? { ...current, isLiked } : current,
       );
-      syncGameLikeStateInQueryCache(queryClient, {
-        gameId: response.gameId,
-        isLiked: response.isLiked,
-        likeCount: response.likeCount,
-      });
-
-      try {
-        const detail = await queryClient.fetchQuery({
-          queryKey: gamesKeys.detail(response.gameId),
-          queryFn: () => getGameDetail(response.gameId),
-          staleTime: 60_000,
-        });
-
-        queryClient.setQueriesData<LikedGamesResponse>(
-          { queryKey: authKeys.likedGames() },
-          (current) => {
-            if (!isLikedGamesResponse(current) || !response.isLiked) {
-              return current;
-            }
-
-            const currentLikedGames = current as LikedGamesResponse;
-
-            return {
-              ...currentLikedGames,
-              results: currentLikedGames.results.map((likedGame) =>
-                likedGame.game_id === response.gameId
-                  ? {
-                      ...likedGame,
-                      game_title: detail.title.trim() || likedGame.game_title,
-                      thumbnail_url:
-                        detail.coverImageUrl ?? likedGame.thumbnail_url,
-                      genres: detail.genres.length
-                        ? detail.genres
-                        : likedGame.genres,
-                    }
-                  : likedGame,
-              ),
-            };
-          },
-        );
-      } catch {
-        // 상세 조회 실패는 좋아요 토글 결과를 되돌릴 이유가 아니므로 무시합니다.
-      }
-
-      void queryClient.invalidateQueries({
-        queryKey: authKeys.likedGames(),
-      });
-    },
-    onError: (error) => {
-      if (error instanceof AxiosError && error.response?.status === 401) {
-        setLikeFeedbackMessage(LIKE_LOGIN_REQUIRED_MESSAGE);
-        return;
-      }
-
-      setLikeFeedbackMessage(LIKE_ERROR_MESSAGE);
-    },
-    onSettled: () => {
-      setPendingLikeGameId(null);
     },
   });
-
-  const handleToggleLike = (item: RecommendationDisplayItem) => {
-    likeMutation.mutate({
-      gameId: item.game_id,
-      nextIsLiked: !item.is_liked,
-      item,
-    });
-  };
+  const {
+    recommendationScrollRef,
+    handleOpenDetail,
+    handleCloseDetail,
+    handleLoadMore,
+  } = useRecommendationScrollRestoration({
+    itemCount: recommendationItems.length,
+    fetchNextPage,
+    setSelectedGame,
+  });
+  const {
+    shouldShowSurveyActions,
+    isResettingSurvey,
+    handleViewPreviousSurvey,
+    handleResetSurvey,
+  } = useSurveyRecommendationActions({
+    canAccessPage,
+    isSurveySource,
+    onBeforeReset: () => setSelectedGame(null),
+    setFeedbackMessage,
+  });
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
@@ -686,13 +259,11 @@ function RecommendationListPage() {
                   <button
                     type="button"
                     onClick={() => void handleResetSurvey()}
-                    disabled={resetSurveyMutation.isPending}
+                    disabled={isResettingSurvey}
                     className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/3 px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     <RotateCcw size={16} />
-                    {resetSurveyMutation.isPending
-                      ? '설문 초기화 중...'
-                      : '설문 초기화'}
+                    {isResettingSurvey ? '설문 초기화 중...' : '설문 초기화'}
                   </button>
                 </div>
               ) : null}
@@ -742,10 +313,10 @@ function RecommendationListPage() {
             </section>
           ) : (
             <section className="overflow-hidden rounded-4xl border border-white/8 bg-[linear-gradient(180deg,rgba(16,16,18,0.92),rgba(9,9,10,0.98))] shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-2xl">
-              {likeFeedbackMessage ? (
+              {feedbackMessage ? (
                 <div className="border-b border-white/8 px-4 py-4 sm:px-6 lg:px-7">
                   <p className="text-sm leading-6 break-keep text-[#ffc2c2]">
-                    {likeFeedbackMessage}
+                    {feedbackMessage}
                   </p>
                 </div>
               ) : null}


### PR DESCRIPTION
## 관련 이슈

- closes #268 

## 변경 내용

- `RecommendationListPage`에서 추천 결과 source 판별과 결과 normalize 로직을 별도 hook/helper로 분리
- 추천 리스트의 좋아요 토글, liked cache 보정, game cache sync 후처리를 별도 hook으로 분리
- 더보기 스크롤 보정과 상세 모달 열기/닫기 시 스크롤 복원 로직을 별도 hook으로 분리
- survey source 전용 액션(`이전 설문 보기`, `설문 초기화`) 처리도 별도 hook으로 분리
- 그 결과 추천 리스트 페이지는 화면 조합과 상위 흐름 중심으로 유지되도록 정리

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 UI/기능 변경보다 추천 리스트 페이지의 책임 경계를 정리하는 리팩터링에 집중했습니다.
- 기존 더보기, 좋아요, 상세 모달, survey source 액션 동작은 유지하면서 구조만 분리했습니다.
