### PR TITLE
fix(mypage): 프로필과 찜 목록 fallback을 캐시 기준으로 안정화

### DIFF
--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -15,7 +15,7 @@ function FavoriteGameCard({
   onFavoriteClick,
 }: FavoriteGameCardProps) {
   return (
-    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover flex h-full flex-col overflow-hidden rounded-[22px] border transition duration-200">
+    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex h-full min-w-0 flex-col overflow-hidden rounded-[22px] border transition duration-200">
       <div className="bg-mypage-soft relative aspect-3/4 overflow-hidden">
         <button
           type="button"
@@ -52,7 +52,7 @@ function FavoriteGameCard({
       <button
         type="button"
         onClick={() => onClick?.(game)}
-        className="flex flex-1 flex-col gap-2 px-4 py-4 text-left"
+        className="flex min-w-0 flex-1 flex-col gap-2 px-4 py-4 text-left"
       >
         <h3 className="line-clamp-1 text-base/6 font-semibold text-white sm:text-lg/7">
           {game.title}

--- a/src/components/mypage/FavoriteGameCardSkeleton.tsx
+++ b/src/components/mypage/FavoriteGameCardSkeleton.tsx
@@ -7,14 +7,14 @@ function FavoriteGameCardSkeleton({
 }: FavoriteGameCardSkeletonProps) {
   return (
     <div
-      className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 2xl:grid-cols-4"
+      className="grid auto-rows-fr grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4"
       aria-live="polite"
       aria-busy="true"
     >
       {Array.from({ length: count }).map((_, index) => (
         <article
           key={index}
-          className="border-mypage-card bg-mypage-card overflow-hidden rounded-[22px] border"
+          className="border-mypage-card bg-mypage-card box-border min-w-0 overflow-hidden rounded-[22px] border"
         >
           <div className="aspect-3/4 animate-pulse bg-white/8" />
           <div className="space-y-2 px-4 py-4">

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -7,7 +7,6 @@ import InputControl from '../common/InputControl';
 type MyPageProfileSectionProps = {
   nickname: string;
   name: string;
-  email: string | null;
   genderLabel: string;
   profileImageUrl?: string | null;
   isProfileLoading?: boolean;
@@ -22,10 +21,15 @@ type MyPageProfileSectionProps = {
   children?: ReactNode;
 };
 
+type ProfileInfoRow = {
+  label: string;
+  value: string;
+  action?: ReactNode;
+};
+
 function MyPageProfileSection({
   nickname,
   name,
-  email,
   genderLabel,
   profileImageUrl = null,
   isProfileLoading = false,
@@ -78,185 +82,125 @@ function MyPageProfileSection({
     }
   };
 
+  const infoRows: ProfileInfoRow[] = [
+    {
+      label: '별명',
+      value: nickname,
+      action: !isNicknameEditMode ? (
+        <button
+          type="button"
+          className="rounded-2xl border border-white/8 bg-white/[0.04] px-5 py-3 text-sm font-semibold text-white/88 transition hover:border-white/12 hover:bg-white/[0.08]"
+          onClick={() => {
+            setIsNicknameEditMode(true);
+            setNextNickname(nickname);
+            setNicknameFieldError('');
+          }}
+        >
+          수정
+        </button>
+      ) : null,
+    },
+    {
+      label: '사용자명',
+      value: name,
+    },
+    {
+      label: '성별',
+      value: genderLabel,
+    },
+  ];
+
   return (
-    <section className="border-mypage-panel bg-mypage-panel shadow-mypage-float rounded-[28px] border px-5 py-7 text-center backdrop-blur-xl sm:px-8 sm:py-9">
-      <h1 className="text-[clamp(1.75rem,4vw,2.3rem)] font-semibold text-white">
-        마이페이지
-      </h1>
+    <section className="relative overflow-hidden rounded-[32px] border border-white/8 bg-[#19191d] shadow-[0_28px_80px_rgba(0,0,0,0.32)]">
+      <div className="h-[5.5rem] bg-[linear-gradient(135deg,#8b2836_0%,#aa3848_38%,#c84b5e_100%)] sm:h-[6.4rem]" />
+      <div className="absolute inset-x-0 top-0 h-px bg-white/20" />
 
-      <div className="mt-7 grid gap-6 lg:grid-cols-[10.5rem_minmax(0,1fr)] lg:items-start lg:gap-8">
-        <div className="flex flex-col items-center">
-          <div className="group relative h-32 w-32 sm:h-36 sm:w-36">
-            <label className="absolute inset-0 block cursor-pointer">
-              <input
-                type="file"
-                accept="image/*"
-                className="sr-only"
-                disabled={isProfileLoading || isProfileImageUploading}
-                onChange={(event) => {
-                  onProfileImageSelect?.(event.target.files?.[0] ?? null);
-                  event.currentTarget.value = '';
-                  event.currentTarget.blur();
-                }}
-              />
-              <span className="sr-only">
-                {isProfileImageUploading
-                  ? '프로필 이미지 업로드 중'
-                  : '프로필 변경'}
-              </span>
-              <div className="border-mypage-panel bg-mypage-card relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border shadow-[0_24px_50px_rgba(0,0,0,0.46),0_0_0_1px_rgba(255,255,255,0.03)]">
-                {hasProfileImage ? (
-                  <img
-                    src={normalizedProfileImageUrl}
-                    alt={`${nickname} 프로필 이미지`}
-                    onError={() =>
-                      setFailedProfileImageUrl(normalizedProfileImageUrl)
-                    }
-                    className={`h-full w-full object-cover transition duration-200 ${
-                      isProfileImageUploading
-                        ? 'blur-[1.8px] brightness-[0.62]'
-                        : 'group-hover:blur-[1.8px] group-hover:brightness-[0.62]'
-                    }`}
-                  />
-                ) : (
-                  <CircleUserRound
-                    size={48}
-                    className="text-white/85 transition duration-200 group-hover:opacity-70"
-                  />
-                )}
-                <span
-                  className={`pointer-events-none absolute inset-0 flex items-center justify-center rounded-full transition ${
-                    isProfileImageUploading
-                      ? 'bg-black/55 opacity-100'
-                      : 'bg-black/0 opacity-0 group-hover:bg-black/45 group-hover:opacity-100'
-                  }`}
-                >
-                  <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/35 bg-black/45 text-white">
-                    {isProfileImageUploading ? (
-                      <LoaderCircle size={14} className="animate-spin" />
-                    ) : (
-                      <Camera size={14} />
-                    )}
-                  </span>
-                </span>
-              </div>
-            </label>
-          </div>
-        </div>
-
-        {isProfileLoading ? (
-          <div
-            className="flex flex-col items-center gap-3 lg:items-start"
-            aria-live="polite"
-            aria-busy="true"
-          >
-            <div className="h-8 w-36 animate-pulse rounded-full bg-white/10" />
-            <div className="h-4 w-full max-w-sm animate-pulse rounded-full bg-white/8" />
-            <div className="border-mypage-panel bg-mypage-card mt-1 grid w-full gap-3 rounded-2xl border px-4 py-4 text-left sm:grid-cols-3 sm:gap-4 sm:px-5">
-              {Array.from({ length: 3 }).map((_, index) => (
-                <div key={index} className="space-y-2">
-                  <div className="h-3 w-10 animate-pulse rounded-full bg-white/8" />
-                  <div className="h-5 w-full animate-pulse rounded-full bg-white/10" />
+      <div className="relative px-4 pt-0 pb-5 sm:px-6 sm:pb-7 lg:px-8 lg:pb-8">
+        <div className="mt-0 rounded-[28px] bg-[#111114] px-4 pb-5 sm:px-6 sm:pb-6 lg:px-8 lg:pb-7">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-5">
+              <div className="-mt-9 sm:-mt-10">
+                <div className="group relative h-[8.4rem] w-[8.4rem] sm:h-[9.2rem] sm:w-[9.2rem]">
+                  <label className="absolute inset-0 block cursor-pointer">
+                    <input
+                      type="file"
+                      accept="image/*"
+                      className="sr-only"
+                      disabled={isProfileLoading || isProfileImageUploading}
+                      onChange={(event) => {
+                        onProfileImageSelect?.(event.target.files?.[0] ?? null);
+                        event.currentTarget.value = '';
+                        event.currentTarget.blur();
+                      }}
+                    />
+                    <span className="sr-only">
+                      {isProfileImageUploading
+                        ? '프로필 이미지 업로드 중'
+                        : '프로필 변경'}
+                    </span>
+                    <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border-[0.72rem] border-[#111114] bg-[linear-gradient(145deg,#8a4d55_0%,#78424a_100%)] shadow-[0_18px_44px_rgba(0,0,0,0.45)]">
+                      {hasProfileImage ? (
+                        <img
+                          src={normalizedProfileImageUrl}
+                          alt={`${nickname} 프로필 이미지`}
+                          onError={() =>
+                            setFailedProfileImageUrl(normalizedProfileImageUrl)
+                          }
+                          className={`h-full w-full object-cover transition duration-200 ${
+                            isProfileImageUploading
+                              ? 'blur-[1.8px] brightness-[0.58]'
+                              : 'group-hover:blur-[1.8px] group-hover:brightness-[0.58]'
+                          }`}
+                        />
+                      ) : (
+                        <CircleUserRound
+                          size={56}
+                          className="text-white transition duration-200 group-hover:opacity-75"
+                        />
+                      )}
+                      <span
+                        className={`pointer-events-none absolute inset-0 flex items-center justify-center rounded-full transition ${
+                          isProfileImageUploading
+                            ? 'bg-black/45 opacity-100'
+                            : 'bg-black/0 opacity-0 group-hover:bg-black/38 group-hover:opacity-100'
+                        }`}
+                      >
+                        <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-black/45 text-white shadow-[0_10px_24px_rgba(0,0,0,0.35)]">
+                          {isProfileImageUploading ? (
+                            <LoaderCircle size={16} className="animate-spin" />
+                          ) : (
+                            <Camera size={16} />
+                          )}
+                        </span>
+                      </span>
+                    </div>
+                  </label>
                 </div>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <div className="flex flex-col items-center gap-3 lg:items-start">
-            {isNicknameEditMode ? (
-              <div className="w-full max-w-sm space-y-2 lg:max-w-md">
-                <label htmlFor="profile-nickname" className="sr-only">
-                  닉네임
-                </label>
-                <InputControl
-                  id="profile-nickname"
-                  type="text"
-                  value={nextNickname}
-                  onChange={(event) => {
-                    setNextNickname(event.target.value);
+              </div>
 
-                    if (nicknameFieldError) {
-                      setNicknameFieldError('');
-                    }
-                  }}
-                  maxLength={20}
-                  disabled={isProfileUpdating}
-                  hasError={Boolean(nicknameFieldError)}
-                  className="h-12"
-                  placeholder="닉네임을 입력하세요"
-                />
-                {nicknameFieldError ? (
-                  <p className="pl-1 text-left text-sm/5 font-medium text-red-400">
-                    {nicknameFieldError}
+              {isProfileLoading ? (
+                <div
+                  className="min-w-0 space-y-3"
+                  aria-live="polite"
+                  aria-busy="true"
+                >
+                  <div className="mt-2 h-9 w-44 animate-pulse rounded-full bg-white/10" />
+                  <div className="h-5 w-28 animate-pulse rounded-full bg-white/8" />
+                </div>
+              ) : (
+                <div className="min-w-0 pt-2">
+                  <p className="truncate text-[clamp(2rem,3.6vw,2.8rem)] font-semibold tracking-[-0.04em] text-white">
+                    {nickname}
                   </p>
-                ) : null}
-                <div className="flex justify-end gap-2">
-                  <button
-                    type="button"
-                    className="border-mypage-panel bg-mypage-card text-mypage-muted rounded-full border px-3 py-1.5 text-xs font-semibold transition hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
-                    onClick={() => {
-                      setIsNicknameEditMode(false);
-                      setNextNickname(nickname);
-                      setNicknameFieldError('');
-                    }}
-                    disabled={isProfileUpdating}
-                  >
-                    취소
-                  </button>
-                  <button
-                    type="button"
-                    className="bg-login-primary hover:bg-login-primary-hover rounded-full px-3 py-1.5 text-xs font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
-                    onClick={() => {
-                      void handleNicknameSave();
-                    }}
-                    disabled={isProfileUpdating}
-                  >
-                    {isProfileUpdating ? '저장 중...' : '저장'}
-                  </button>
                 </div>
-              </div>
-            ) : (
-              <div className="flex items-center gap-3">
-                <p className="max-w-[18rem] truncate text-2xl font-semibold text-white">
-                  {nickname}
-                </p>
-                <button
-                  type="button"
-                  className="border-mypage-panel bg-mypage-card text-mypage-muted shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold transition hover:text-white"
-                  onClick={() => {
-                    setIsNicknameEditMode(true);
-                    setNextNickname(nickname);
-                    setNicknameFieldError('');
-                  }}
-                >
-                  닉네임 변경
-                </button>
-              </div>
-            )}
-            <p className="text-mypage-muted mt-1 text-sm/6">
-              계정 정보와 찜한 게임 목록을 한곳에서 관리할 수 있습니다.
-            </p>
-            <dl className="border-mypage-panel bg-mypage-card mt-3 grid w-full gap-3 rounded-2xl border px-4 py-4 text-left text-sm/6 sm:grid-cols-3 sm:gap-4 sm:px-5">
-              <div>
-                <dt className="text-mypage-muted text-xs/5">이름</dt>
-                <dd className="mt-1 font-medium text-white">{name}</dd>
-              </div>
-              <div>
-                <dt className="text-mypage-muted text-xs/5">이메일</dt>
-                <dd className="mt-1 truncate font-medium text-white">
-                  {email || 'N/A'}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-mypage-muted text-xs/5">성별</dt>
-                <dd className="mt-1 font-medium text-white">{genderLabel}</dd>
-              </div>
-            </dl>
-            <div className="mt-1 flex w-full flex-col gap-3 sm:flex-row sm:justify-center lg:justify-start">
+              )}
+            </div>
+
+            <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center">
               <AuthButton
                 type="button"
                 variant="secondary"
-                className="w-full sm:w-auto sm:min-w-36"
+                className="w-full border-white/10 bg-white/[0.05] shadow-none hover:bg-white/[0.08] sm:min-w-36"
                 onClick={onPasswordToggle}
               >
                 {isPasswordPanelOpen ? '비밀번호 변경 닫기' : '비밀번호 변경'}
@@ -264,7 +208,7 @@ function MyPageProfileSection({
               <AuthButton
                 type="button"
                 variant="secondary"
-                className="w-full sm:w-auto sm:min-w-28"
+                className="w-full border-white/10 bg-white/[0.05] shadow-none hover:bg-white/[0.08] sm:min-w-28"
                 onClick={onLogout}
                 disabled={isLoggingOut}
               >
@@ -272,10 +216,100 @@ function MyPageProfileSection({
               </AuthButton>
             </div>
           </div>
-        )}
-      </div>
 
-      {children ? <div className="mt-6">{children}</div> : null}
+          <div className="mt-6 rounded-[24px] border border-white/8 bg-white/[0.035] px-4 py-4 sm:px-5 sm:py-5">
+            {isNicknameEditMode ? (
+              <div className="border-b border-white/7 pb-5">
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold text-white/82">별명</p>
+                    <label htmlFor="profile-nickname" className="sr-only">
+                      닉네임
+                    </label>
+                    <div className="mt-3 max-w-xl">
+                      <InputControl
+                        id="profile-nickname"
+                        type="text"
+                        value={nextNickname}
+                        onChange={(event) => {
+                          setNextNickname(event.target.value);
+
+                          if (nicknameFieldError) {
+                            setNicknameFieldError('');
+                          }
+                        }}
+                        maxLength={20}
+                        disabled={isProfileUpdating}
+                        hasError={Boolean(nicknameFieldError)}
+                        className="h-12"
+                        placeholder="닉네임을 입력하세요"
+                      />
+                    </div>
+                    {nicknameFieldError ? (
+                      <p className="mt-2 pl-1 text-left text-sm/5 font-medium text-red-400">
+                        {nicknameFieldError}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="flex gap-2 lg:pt-8">
+                    <button
+                      type="button"
+                      className="rounded-2xl border border-white/8 bg-white/[0.04] px-5 py-3 text-sm font-semibold text-white/72 transition hover:bg-white/[0.08]"
+                      onClick={() => {
+                        setIsNicknameEditMode(false);
+                        setNextNickname(nickname);
+                        setNicknameFieldError('');
+                      }}
+                      disabled={isProfileUpdating}
+                    >
+                      취소
+                    </button>
+                    <button
+                      type="button"
+                      className="bg-login-primary hover:bg-login-primary-hover rounded-2xl px-5 py-3 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+                      onClick={() => {
+                        void handleNicknameSave();
+                      }}
+                      disabled={isProfileUpdating}
+                    >
+                      {isProfileUpdating ? '저장 중...' : '저장'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            <div className="divide-y divide-white/7">
+              {infoRows.map((row, index) => (
+                <div
+                  key={row.label}
+                  className={`flex items-center justify-between gap-4 py-5 ${
+                    index === 0 && isNicknameEditMode
+                      ? 'pt-5'
+                      : index === 0
+                        ? 'pt-1'
+                        : ''
+                  } ${index === infoRows.length - 1 ? 'pb-1' : ''}`}
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-white/76">
+                      {row.label}
+                    </p>
+                    <p className="mt-2 truncate text-[1.05rem] font-medium text-white">
+                      {row.value}
+                    </p>
+                  </div>
+                  {row.action ? (
+                    <div className="shrink-0">{row.action}</div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {children ? <div className="mt-6">{children}</div> : null}
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -65,7 +65,6 @@ function MyPage() {
           <MyPageProfileContainer
             nickname={myPageProfile.profileNickname}
             name={myPageProfile.profileName}
-            email={myPageProfile.profileEmail}
             genderLabel={myPageProfile.profileGenderLabel}
             profileImageUrl={myPageProfile.profileImageUrl}
             isProfileLoading={myPageProfile.isProfileLoading}

--- a/src/pages/mypage/components/MyPageAccountDangerZone.tsx
+++ b/src/pages/mypage/components/MyPageAccountDangerZone.tsx
@@ -30,9 +30,7 @@ function MyPageAccountDangerZone({
       <section className="mt-8 flex flex-col items-center justify-center gap-3 pb-2 text-center">
         <div className="text-mypage-muted flex items-center gap-2 text-sm/6">
           <ShieldAlert size={16} />
-          <span>
-            더 이상 서비스를 이용하지 않으려면 회원탈퇴를 진행할 수 있습니다.
-          </span>
+          <span>현재 비밀번호를 확인한 뒤 회원탈퇴를 진행할 수 있습니다.</span>
         </div>
         <AuthButton
           type="button"
@@ -46,12 +44,12 @@ function MyPageAccountDangerZone({
 
       <ConfirmModal
         open={isDeleteModalOpen}
-        title="회원탈퇴 하시겠습니까?"
+        title="현재 비밀번호 확인 후 회원탈퇴"
         description={
           <div className="space-y-3">
             <p>
-              탈퇴를 진행하면 현재 로그인 세션이 종료되고, 로그인 화면으로
-              이동합니다.
+              현재 비밀번호를 확인한 뒤 탈퇴가 진행되며, 완료되면 로그인
+              화면으로 이동합니다.
             </p>
             <div className="space-y-2">
               <label

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -46,7 +46,7 @@ function MyPageLikedGamesSection({
 
   return (
     <>
-      <section className="bg-mypage-panel border-mypage-panel shadow-mypage-float mt-8 rounded-[28px] border px-4 py-5 backdrop-blur-xl sm:mt-10 sm:px-6 sm:py-6">
+      <section className="bg-mypage-panel border-mypage-panel shadow-mypage-float mt-8 box-border rounded-[28px] border px-4 py-5 backdrop-blur-xl sm:mt-10 sm:px-6 sm:py-6">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
             <span className="bg-mypage-accent-soft text-login-primary inline-flex h-11 w-11 items-center justify-center rounded-full">
@@ -70,13 +70,13 @@ function MyPageLikedGamesSection({
 
         <div
           ref={favoriteGamesScrollRef}
-          className="mypage-scrollbar mt-5 h-[23rem] overflow-y-auto pr-1 sm:h-[25rem] lg:h-[25rem]"
+          className="mypage-scrollbar mt-5 box-border h-[20rem] max-w-full overflow-y-auto pr-1 sm:h-[21.75rem] lg:h-[22.25rem]"
         >
           {isFavoriteGamesLoading ? (
             <FavoriteGameCardSkeleton />
           ) : favoriteCount > 0 ? (
             <div>
-              <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 2xl:grid-cols-4">
+              <div className="grid auto-rows-fr grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
                 {favoriteGames.map((game) => (
                   <FavoriteGameCard
                     key={game.gameId}

--- a/src/pages/mypage/components/MyPageProfileContainer.tsx
+++ b/src/pages/mypage/components/MyPageProfileContainer.tsx
@@ -9,7 +9,6 @@ import PasswordChangePanel, {
 type MyPageProfileContainerProps = {
   nickname: string;
   name: string;
-  email: string | null;
   genderLabel: string;
   profileImageUrl?: string | null;
   isProfileLoading: boolean;
@@ -38,7 +37,6 @@ type MyPageProfileContainerProps = {
 function MyPageProfileContainer({
   nickname,
   name,
-  email,
   genderLabel,
   profileImageUrl,
   isProfileLoading,
@@ -64,7 +62,6 @@ function MyPageProfileContainer({
     <MyPageProfileSection
       nickname={nickname}
       name={name}
-      email={email}
       genderLabel={genderLabel}
       profileImageUrl={profileImageUrl}
       isProfileLoading={isProfileLoading}

--- a/src/pages/mypage/hooks/useMyPageLikedGames.ts
+++ b/src/pages/mypage/hooks/useMyPageLikedGames.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQueryClient, type InfiniteData } from '@tanstack/react-query';
 
 import { extractAuthApiErrorMessage } from '../../../features/auth/api/auth';
 import {
@@ -6,9 +7,13 @@ import {
   useLikedGamesInfiniteQuery,
   useUnlikeLikedGameMutation,
 } from '../../../features/auth/api/useAuthApi';
+import { authKeys } from '../../../features/auth/api/queryKeys';
 import type { GameListItem } from '../../../features/games/types';
 import type { FavoriteGamePreview } from '../../../features/mypage/types';
-import type { LikedGameItemResponse } from '../../../features/auth/types/auth';
+import type {
+  LikedGameItemResponse,
+  LikedGamesResponse,
+} from '../../../features/auth/types/auth';
 import type { MyPageToastPayload } from '../types';
 import { toFavoriteGameListItem, toFavoriteGamePreview } from '../utils';
 
@@ -23,6 +28,7 @@ function useMyPageLikedGames({
   onOpenGameDetail,
   onToast,
 }: UseMyPageLikedGamesOptions) {
+  const queryClient = useQueryClient();
   const likedGamesQuery = useLikedGamesInfiniteQuery(
     enabled,
     DEFAULT_LIKED_GAMES_PAGE_SIZE,
@@ -32,11 +38,19 @@ function useMyPageLikedGames({
     useState<FavoriteGamePreview | null>(null);
   const favoriteGamesScrollRef = useRef<HTMLDivElement | null>(null);
   const favoriteGamesLoadMoreRef = useRef<HTMLDivElement | null>(null);
+  const cachedLikedGamesData = queryClient.getQueryData<
+    InfiniteData<LikedGamesResponse>
+  >(
+    authKeys.likedGamesInfinite({
+      page_size: DEFAULT_LIKED_GAMES_PAGE_SIZE,
+    }),
+  );
+  const resolvedLikedGamesData = likedGamesQuery.data ?? cachedLikedGamesData;
   const likedGameResults = useMemo(() => {
-    const pages = likedGamesQuery.data?.pages ?? [];
+    const pages = resolvedLikedGamesData?.pages ?? [];
 
     return pages.flatMap((page) => page.results);
-  }, [likedGamesQuery.data]);
+  }, [resolvedLikedGamesData]);
   const favoriteGames = useMemo(() => {
     const deduplicatedGames = new Map<number, LikedGameItemResponse>();
 
@@ -46,14 +60,14 @@ function useMyPageLikedGames({
 
     return [...deduplicatedGames.values()].map(toFavoriteGamePreview);
   }, [likedGameResults]);
+  const immediateFavoriteCount =
+    resolvedLikedGamesData?.pages?.[0]?.count ?? favoriteGames.length;
   const hasFavoriteGamesNextPage = Boolean(likedGamesQuery.hasNextPage);
   const isFavoriteGamesFetchNextPageError =
     likedGamesQuery.isFetchNextPageError;
   const isFavoriteGamesFetchingNextPage = likedGamesQuery.isFetchingNextPage;
   const fetchNextFavoriteGamesPage = likedGamesQuery.fetchNextPage;
   const refetchFavoriteGames = likedGamesQuery.refetch;
-  const favoriteCount =
-    likedGamesQuery.data?.pages?.[0]?.count ?? favoriteGames.length;
   const isFavoriteGamesLoading =
     likedGamesQuery.isLoading && !favoriteGames.length;
   const isFavoriteGamesError = likedGamesQuery.isError && !favoriteGames.length;
@@ -130,7 +144,7 @@ function useMyPageLikedGames({
     favoriteGamesScrollRef,
     favoriteGamesLoadMoreRef,
     favoriteGames,
-    favoriteCount,
+    favoriteCount: immediateFavoriteCount,
     isFavoriteGamesLoading,
     isFavoriteGamesError,
     hasFavoriteGamesNextPage,

--- a/src/pages/mypage/hooks/useMyPageProfile.ts
+++ b/src/pages/mypage/hooks/useMyPageProfile.ts
@@ -33,7 +33,10 @@ function useMyPageProfile({ enabled, onToast }: UseMyPageProfileOptions) {
   const uploadFileToS3Mutation = useUploadFileToS3Mutation();
   const confirmProfileImageMutation = useConfirmProfileImageMutation();
   const storedAccount = useAuthStore((state) => state.account);
-  const resolvedProfile = profileQuery.data ?? storedAccount;
+  const cachedProfile = queryClient.getQueryData<CurrentUserProfileResponse>(
+    authKeys.me(),
+  );
+  const resolvedProfile = profileQuery.data ?? storedAccount ?? cachedProfile;
   const isProfileLoading = profileQuery.isLoading && !resolvedProfile;
   const isProfileImageUploading =
     profileImagePresignedUrlMutation.isPending ||


### PR DESCRIPTION
## 관련 이슈

- closes #265 

## 변경 내용

- 마이페이지 상단 프로필 영역을 커버 배경 + 겹치는 프로필 이미지 + 닉네임/액션 버튼 + 정보 패널 구조로 재설계했습니다.
- 상단 커버 색상과 높이를 다크 배경에 맞게 조정하고, 프로필 이미지가 자연스럽게 걸치도록 배치했습니다.
- 내 정보 타이틀, 설명 문구, 상단 프로필 편집 버튼을 제거해 프로필 구성을 더 간결하게 정리했습니다.
- 이메일 노출을 제거하고, 현재 요구사항에 맞는 프로필 정보만 표시하도록 정리했습니다.
- 비밀번호 변경 / 로그아웃 버튼이 새 프로필 레이아웃과 조화되도록 상단 액션 배치를 보정했습니다.
- 찜 목록 카드/스켈레톤/컨테이너 레이아웃을 배포 환경 기준으로 보정했습니다.
- box-border, min-w-0, 반응형 그리드 보정으로 배포 환경에서 카드가 밀리거나 잘려 보이는 현상을 줄였습니다.
- 찜 목록 프로필/목록 데이터가 런타임 중 잠깐 비어도 React Query 캐시에 남아 있는 마지막 정상 데이터를 우선 사용하도록 fallback 로직을 안정화했습니다.
- 회원탈퇴 안내 문구와 모달 제목/설명을 현재 비밀번호 확인 후 탈퇴가 진행된다는 흐름이 분명하게 보이도록 수정했습니다.



## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3264" height="1170" alt="image" src="https://github.com/user-attachments/assets/c0f3dff6-7f9b-4fcc-b20e-fe063445bea1" />

## 참고사항

- 이 브랜치 변경 범위는 마이페이지 UI 개편, 찜 목록 레이아웃 보정, 회원탈퇴 안내 정리, 프로필/찜 목록 fallback 안정화입니다.
