### PR TITLE
[Refactor] 설문 채팅 패널 책임 분리

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -2,90 +2,28 @@ import {
   startTransition,
   type FormEvent,
   type KeyboardEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
   useState,
 } from 'react';
-import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router';
 import {
-  BadgeInfo,
   ChevronRight,
   RotateCcw,
   SendHorizontal,
   TriangleAlert,
-  X,
 } from 'lucide-react';
 
 import { ROUTES } from '../../../constants/routes';
-import { isMockServiceWorkerEnabled } from '../../../lib/env';
-import {
-  useContinueSurveyMutation,
-  useResetSurveyMutation,
-  useStartSurveySessionMutation,
-} from '../api/useSurveyApi';
-import { extractApiErrorMessage } from '../api/survey';
 import { useSurveyStore } from '../store/useSurveyStore';
+import {
+  formatRemainingBlockTime,
+  GAME_RELATED_KEYWORDS,
+  useSurveyModerationGuard,
+} from '../hooks/useSurveyModerationGuard';
+import { useSurveySessionFlow } from '../hooks/useSurveySessionFlow';
+import { useSurveyViewportState } from '../hooks/useSurveyViewportState';
+import SurveyGuardrailLauncher from './SurveyGuardrailLauncher';
 import SurveyMessageBubble from './SurveyMessageBubble';
 import SurveyProgress from './SurveyProgress';
-
-const NON_GAME_CHAT_MAX_STRIKES = 3;
-const NON_GAME_CHAT_BLOCK_DURATION_MS = 5 * 60 * 1000;
-
-const GAME_RELATED_KEYWORDS = [
-  '게임',
-  '장르',
-  '스토리',
-  '전투',
-  '보스',
-  '탐험',
-  '수집',
-  '성장',
-  '플레이',
-  '플레이스타일',
-  '멀티',
-  '싱글',
-  '협동',
-  '그래픽',
-  '분위기',
-  '손맛',
-  'rpg',
-  'fps',
-  '액션',
-  '어드벤처',
-  '슈팅',
-  '전략',
-  '시뮬레이션',
-  '레이싱',
-  '스포츠',
-  '퍼즐',
-  '플랫폼',
-  '격투',
-  '리듬',
-  '비주얼 노벨',
-];
-
-const isLikelyGameRelatedMessage = (content: string) => {
-  const normalized = content.trim().toLowerCase();
-
-  if (!normalized) {
-    return true;
-  }
-
-  return GAME_RELATED_KEYWORDS.some((keyword) =>
-    normalized.includes(keyword.toLowerCase()),
-  );
-};
-
-const formatRemainingBlockTime = (remainingMs: number) => {
-  const totalSeconds = Math.max(0, Math.ceil(remainingMs / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-
-  return `${String(minutes).padStart(1, '0')}:${String(seconds).padStart(2, '0')}`;
-};
 
 type SurveyChatPanelProps = {
   isHistoryView?: boolean;
@@ -93,292 +31,65 @@ type SurveyChatPanelProps = {
 
 function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
   const navigate = useNavigate();
-  const viewportRef = useRef<HTMLDivElement | null>(null);
-  const formRef = useRef<HTMLFormElement | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const shouldRestoreFocusRef = useRef(false);
-  const lastMessageCountRef = useRef(0);
-  const hasResolvedEntryCompletionStateRef = useRef(false);
   const [inputValue, setInputValue] = useState('');
-  const [currentTime, setCurrentTime] = useState(() => Date.now());
   const [isGuardrailPanelOpen, setIsGuardrailPanelOpen] = useState(false);
-  const [enteredWithCompletedSurvey, setEnteredWithCompletedSurvey] =
-    useState(false);
+
+  const sessionId = useSurveyStore((state) => state.sessionId);
+  const messages = useSurveyStore((state) => state.messages);
+  const progress = useSurveyStore((state) => state.progress);
+  const hasBootstrapped = useSurveyStore((state) => state.hasBootstrapped);
+  const isSubmitting = useSurveyStore((state) => state.isSubmitting);
+  const error = useSurveyStore((state) => state.error);
+  const recommendationReady = useSurveyStore(
+    (state) => state.recommendationReady,
+  );
+  const lastSubmittedMessage = useSurveyStore(
+    (state) => state.lastSubmittedMessage,
+  );
 
   const {
-    sessionId,
-    messages,
-    progress,
-    hasBootstrapped,
-    isSubmitting,
-    error,
-    recommendationReady,
-    lastSubmittedMessage,
-    nonGameStrikeCount,
-    chatBlockedUntil,
-    setHasBootstrapped,
-    setSubmitting,
-    setError,
-    clearError,
-    setLastSubmittedMessage,
-    setNonGameStrikeCount,
-    setChatBlockedUntil,
-    clearModerationState,
-    addUserMessage,
-    hydrateInitialSession,
-    applyChatResponse,
-    resetSurveyState,
-  } = useSurveyStore();
-
-  const startSessionMutation = useStartSurveySessionMutation();
-  const continueSurveyMutation = useContinueSurveyMutation();
-  const resetSurveyMutation = useResetSurveyMutation();
-
-  const isRecoverableMockSessionError = (message: string | null) =>
-    isMockServiceWorkerEnabled() &&
-    Boolean(
-      message &&
-      (message.includes('해당 세션') || message.includes('설문 세션이 만료')),
-    );
-
-  const remainingBlockTimeMs = chatBlockedUntil
-    ? Math.max(chatBlockedUntil - currentTime, 0)
-    : 0;
-  const hasReachedNonGameChatLimit =
-    nonGameStrikeCount >= NON_GAME_CHAT_MAX_STRIKES;
-  const isChatTemporarilyBlocked = Boolean(
-    chatBlockedUntil && remainingBlockTimeMs > 0,
-  );
-  const hasExpiredChatBlock = Boolean(
-    chatBlockedUntil && remainingBlockTimeMs <= 0,
-  );
-  const isTextareaDisabled =
-    isSubmitting ||
-    recommendationReady ||
-    isChatTemporarilyBlocked ||
-    hasExpiredChatBlock;
-  const isRecommendationButtonDisabled =
-    !recommendationReady ||
-    isSubmitting ||
-    isChatTemporarilyBlocked ||
-    hasExpiredChatBlock ||
-    hasReachedNonGameChatLimit;
-  const shouldShowGuardrailPanel = import.meta.env.DEV;
-  const guardrailStatusLabel = isChatTemporarilyBlocked
-    ? `${formatRemainingBlockTime(remainingBlockTimeMs)} 남음`
-    : hasExpiredChatBlock
-      ? '제한 종료'
-      : `${nonGameStrikeCount}/${NON_GAME_CHAT_MAX_STRIKES} 누적`;
-  const inputPlaceholder = useMemo(() => {
-    if (isHistoryView && recommendationReady) {
-      return '완료된 설문 기록을 다시 보고 있어요.';
-    }
-
-    if (isChatTemporarilyBlocked) {
-      return '반복된 이상행동으로 인해 5분간 채팅이 정지됩니다.';
-    }
-
-    if (hasExpiredChatBlock) {
-      return '제한 시간이 종료되었습니다. 설문 초기화를 누르고 다시 진행해 주세요.';
-    }
-
-    if (recommendationReady) {
-      return '추천 결과가 준비되었어요. 아래 버튼으로 다음 단계로 이동해 주세요.';
-    }
-
-    return '취향과 관련된 게임 이야기를 입력해 주세요.';
-  }, [
-    hasExpiredChatBlock,
+    remainingBlockTimeMs,
     isChatTemporarilyBlocked,
+    hasExpiredChatBlock,
+    isTextareaDisabled,
+    isRecommendationButtonDisabled,
+    guardrailStatusLabel,
+    inputPlaceholder,
+    applySuccessfulSubmissionModeration,
+  } = useSurveyModerationGuard({
     isHistoryView,
+    isSubmitting,
     recommendationReady,
-  ]);
+  });
+
+  const {
+    viewportRef,
+    formRef,
+    textareaRef,
+    enteredWithCompletedSurvey,
+    queueFocusRestore,
+    cancelFocusRestore,
+  } = useSurveyViewportState({
+    messagesLength: messages.length,
+    error,
+    hasBootstrapped,
+    sessionId,
+    recommendationReady,
+    isSubmitting,
+    isChatTemporarilyBlocked,
+    hasExpiredChatBlock,
+  });
+
+  const { submitMessage, handleRetry, handleReset, handleBlockedSubmission } =
+    useSurveySessionFlow({
+      queueFocusRestore,
+      cancelFocusRestore,
+    });
+
   const recommendationButtonLabel =
     isHistoryView || enteredWithCompletedSurvey
       ? '추천 결과로 돌아가기'
       : '추천 결과 바로 보기';
-
-  useEffect(() => {
-    if (hasResolvedEntryCompletionStateRef.current) {
-      return;
-    }
-
-    if (
-      !hasBootstrapped &&
-      !sessionId &&
-      messages.length === 0 &&
-      !recommendationReady
-    ) {
-      return;
-    }
-
-    hasResolvedEntryCompletionStateRef.current = true;
-    setEnteredWithCompletedSurvey(recommendationReady && messages.length > 0);
-  }, [hasBootstrapped, messages.length, recommendationReady, sessionId]);
-
-  useEffect(() => {
-    if (!isChatTemporarilyBlocked) {
-      return undefined;
-    }
-
-    const timer = window.setInterval(() => {
-      setCurrentTime(Date.now());
-    }, 1000);
-
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [isChatTemporarilyBlocked]);
-
-  useEffect(() => {
-    const viewport = viewportRef.current;
-
-    if (!viewport) {
-      return;
-    }
-
-    const shouldJumpToBottom =
-      lastMessageCountRef.current === 0 && messages.length > 0;
-
-    viewport.scrollTo({
-      top: viewport.scrollHeight,
-      behavior: shouldJumpToBottom ? 'auto' : 'smooth',
-    });
-
-    lastMessageCountRef.current = messages.length;
-  }, [messages, error]);
-
-  const restoreTextareaFocus = useCallback(() => {
-    requestAnimationFrame(() => {
-      const textarea = textareaRef.current;
-
-      if (!textarea || textarea.disabled) {
-        return;
-      }
-
-      textarea.focus();
-      const cursorPosition = textarea.value.length;
-      textarea.setSelectionRange(cursorPosition, cursorPosition);
-    });
-  }, []);
-
-  useEffect(() => {
-    if (
-      !isSubmitting &&
-      !recommendationReady &&
-      !isChatTemporarilyBlocked &&
-      !hasExpiredChatBlock &&
-      shouldRestoreFocusRef.current
-    ) {
-      shouldRestoreFocusRef.current = false;
-      restoreTextareaFocus();
-    }
-  }, [
-    hasExpiredChatBlock,
-    isChatTemporarilyBlocked,
-    isSubmitting,
-    recommendationReady,
-    restoreTextareaFocus,
-  ]);
-
-  const bootstrapSurvey = useCallback(
-    async (force = false) => {
-      if ((hasBootstrapped && !force) || (isSubmitting && !force)) {
-        return;
-      }
-
-      clearError();
-      resetSurveyState();
-      setHasBootstrapped(true);
-      setSubmitting(true);
-
-      try {
-        const response = await startSessionMutation.mutateAsync({
-          is_reset: false,
-        });
-        hydrateInitialSession(response);
-      } catch (requestError) {
-        setHasBootstrapped(false);
-        setError(extractApiErrorMessage(requestError));
-      } finally {
-        setSubmitting(false);
-      }
-    },
-    [
-      clearError,
-      hydrateInitialSession,
-      hasBootstrapped,
-      isSubmitting,
-      resetSurveyState,
-      setError,
-      setHasBootstrapped,
-      setSubmitting,
-      startSessionMutation,
-    ],
-  );
-
-  useEffect(() => {
-    if (!sessionId && !hasBootstrapped) {
-      void bootstrapSurvey();
-    }
-  }, [bootstrapSurvey, hasBootstrapped, sessionId]);
-
-  const submitMessage = async ({
-    content,
-    appendUserMessage,
-  }: {
-    content: string;
-    appendUserMessage: boolean;
-  }) => {
-    const trimmed = content.trim();
-
-    if (!trimmed || isSubmitting) {
-      return false;
-    }
-
-    clearError();
-    setLastSubmittedMessage(trimmed);
-
-    setSubmitting(true);
-
-    try {
-      if (!sessionId) {
-        const sessionResponse = await startSessionMutation.mutateAsync({
-          is_reset: false,
-        });
-        hydrateInitialSession(sessionResponse);
-
-        if (appendUserMessage) {
-          addUserMessage(trimmed);
-        }
-
-        const response = await continueSurveyMutation.mutateAsync({
-          session_id: sessionResponse.session_id,
-          user_answer: trimmed,
-        });
-
-        applyChatResponse(response);
-      } else {
-        if (appendUserMessage) {
-          addUserMessage(trimmed);
-        }
-
-        const response = await continueSurveyMutation.mutateAsync({
-          session_id: sessionId,
-          user_answer: trimmed,
-        });
-
-        applyChatResponse(response);
-      }
-
-      return true;
-    } catch (requestError) {
-      setError(extractApiErrorMessage(requestError));
-      return false;
-    } finally {
-      setSubmitting(false);
-    }
-  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -394,15 +105,9 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
       return;
     }
 
-    const isGameRelatedMessage = isLikelyGameRelatedMessage(nextMessage);
-    const nextStrikeCount = isGameRelatedMessage
-      ? nonGameStrikeCount
-      : nonGameStrikeCount + 1;
-    const shouldBlockAfterResponse =
-      !isGameRelatedMessage && nextStrikeCount >= NON_GAME_CHAT_MAX_STRIKES;
-
-    shouldRestoreFocusRef.current = true;
+    queueFocusRestore();
     setInputValue('');
+
     const didSubmitSucceed = await submitMessage({
       content: nextMessage,
       appendUserMessage: true,
@@ -412,102 +117,14 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
       return;
     }
 
-    if (!isGameRelatedMessage) {
-      setNonGameStrikeCount(nextStrikeCount);
-    }
-
-    if (shouldBlockAfterResponse) {
-      setCurrentTime(Date.now());
-      setChatBlockedUntil(Date.now() + NON_GAME_CHAT_BLOCK_DURATION_MS);
-      shouldRestoreFocusRef.current = false;
-    }
-  };
-
-  const handleRetry = async () => {
-    shouldRestoreFocusRef.current = true;
-
-    if (!lastSubmittedMessage) {
-      await bootstrapSurvey(true);
-      return;
-    }
-
-    if (isRecoverableMockSessionError(error)) {
-      clearError();
-      resetSurveyState();
-      setHasBootstrapped(true);
-      setLastSubmittedMessage(lastSubmittedMessage);
-      setSubmitting(true);
-
-      try {
-        const sessionResponse = await startSessionMutation.mutateAsync({
-          is_reset: true,
-        });
-        hydrateInitialSession(sessionResponse);
-        addUserMessage(lastSubmittedMessage);
-
-        const response = await continueSurveyMutation.mutateAsync({
-          session_id: sessionResponse.session_id,
-          user_answer: lastSubmittedMessage,
-        });
-
-        applyChatResponse(response);
-      } catch (requestError) {
-        setError(extractApiErrorMessage(requestError));
-      } finally {
-        setSubmitting(false);
-      }
-
-      return;
-    }
-
-    await submitMessage({
-      content: lastSubmittedMessage,
-      appendUserMessage: false,
+    applySuccessfulSubmissionModeration(nextMessage, {
+      onBlocked: handleBlockedSubmission,
     });
   };
 
-  const handleReset = async () => {
-    if (isSubmitting) {
-      return;
-    }
-
-    clearError();
-
-    if (!sessionId) {
-      shouldRestoreFocusRef.current = true;
-      setInputValue('');
-      clearModerationState();
-      resetSurveyState();
-      await bootstrapSurvey();
-      return;
-    }
-
-    shouldRestoreFocusRef.current = true;
-    setSubmitting(true);
-
-    try {
-      const response = await resetSurveyMutation.mutateAsync({
-        session_id: sessionId,
-      });
-
-      setInputValue('');
-      clearModerationState();
-      hydrateInitialSession(response);
-    } catch (requestError) {
-      const errorMessage = extractApiErrorMessage(requestError);
-
-      if (isRecoverableMockSessionError(errorMessage)) {
-        setInputValue('');
-        resetSurveyState();
-        setHasBootstrapped(false);
-        await bootstrapSurvey(true);
-        return;
-      }
-
-      setError(errorMessage);
-    } finally {
-      setSubmitting(false);
-    }
+  const handleResetClick = async () => {
+    setInputValue('');
+    await handleReset();
   };
 
   const handleMoveToRecommendation = () => {
@@ -527,73 +144,6 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
     }
   };
 
-  const guardrailLauncher =
-    shouldShowGuardrailPanel && typeof document !== 'undefined'
-      ? createPortal(
-          <div className="pointer-events-none fixed bottom-6 left-2 z-95 hidden lg:block">
-            {isGuardrailPanelOpen ? (
-              <aside className="pointer-events-auto mb-3 ml-3 w-75 rounded-[26px] border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,20,0.84),rgba(8,8,9,0.94))] px-4 py-4 shadow-[0_18px_40px_rgba(0,0,0,0.26)] backdrop-blur-xl">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-[11px] font-semibold tracking-[0.18em] text-[#ff8a8a] uppercase">
-                      Dev Guardrail
-                    </p>
-                    <h3 className="mt-1 text-sm font-semibold text-white">
-                      설문 키워드 휴리스틱
-                    </h3>
-                  </div>
-                  <div className="flex items-start gap-2">
-                    <span className="rounded-full border border-white/10 bg-white/4 px-2.5 py-1 text-[11px] font-medium text-white/64">
-                      {guardrailStatusLabel}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => setIsGuardrailPanelOpen(false)}
-                      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/10 bg-white/3 text-white/58 transition hover:bg-white/6 hover:text-white"
-                      aria-label="개발용 가드레일 패널 닫기"
-                    >
-                      <X size={14} />
-                    </button>
-                  </div>
-                </div>
-
-                <p className="mt-3 text-xs leading-5 break-keep text-white/54">
-                  개발 환경에서만 보이는 설명 패널입니다. 현재 설문은 키워드
-                  `includes()` 휴리스틱으로 게임 관련 질문 여부를 판정하고,
-                  비게임 질문 3회 누적 시 5분 제한을 적용합니다.
-                </p>
-
-                <div className="mt-3 rounded-[18px] border border-white/8 bg-white/3 px-3 py-3">
-                  <p className="text-[11px] font-semibold tracking-[0.18em] text-white/42 uppercase">
-                    허용 키워드
-                  </p>
-                  <div className="mt-2 flex max-h-33 flex-wrap gap-1.5 overflow-y-auto pr-1">
-                    {GAME_RELATED_KEYWORDS.map((keyword) => (
-                      <span
-                        key={keyword}
-                        className="rounded-full border border-white/8 bg-white/4 px-2.5 py-1 text-[11px] font-medium text-white/72"
-                      >
-                        {keyword}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              </aside>
-            ) : null}
-
-            <button
-              type="button"
-              onClick={() => setIsGuardrailPanelOpen((current) => !current)}
-              className="pointer-events-auto flex h-16 w-16 items-center justify-center rounded-full border border-white/10 bg-[linear-gradient(135deg,rgba(255,53,53,0.94),rgba(130,11,11,0.96))] text-white shadow-[0_18px_40px_rgba(130,0,0,0.28)] transition hover:-translate-y-0.5 hover:brightness-105 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
-              aria-label="개발용 설문 키워드 가이드 열기"
-            >
-              <BadgeInfo size={24} />
-            </button>
-          </div>,
-          document.body,
-        )
-      : null;
-
   return (
     <section className="survey-panel relative flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="border-b border-white/8 px-4 py-2.5 sm:px-5 md:px-6">
@@ -610,7 +160,7 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
             <SurveyProgress progress={progress} compact />
             <button
               type="button"
-              onClick={handleReset}
+              onClick={handleResetClick}
               disabled={isSubmitting}
               className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/3 px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-60"
             >
@@ -730,7 +280,13 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
         </div>
       </div>
 
-      {guardrailLauncher}
+      <SurveyGuardrailLauncher
+        isOpen={isGuardrailPanelOpen}
+        onToggle={() => setIsGuardrailPanelOpen((current) => !current)}
+        onClose={() => setIsGuardrailPanelOpen(false)}
+        statusLabel={guardrailStatusLabel}
+        keywords={GAME_RELATED_KEYWORDS}
+      />
     </section>
   );
 }

--- a/src/features/survey/components/SurveyGuardrailLauncher.tsx
+++ b/src/features/survey/components/SurveyGuardrailLauncher.tsx
@@ -1,0 +1,88 @@
+import { createPortal } from 'react-dom';
+import { BadgeInfo, X } from 'lucide-react';
+
+type SurveyGuardrailLauncherProps = {
+  isOpen: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  statusLabel: string;
+  keywords: string[];
+};
+
+function SurveyGuardrailLauncher({
+  isOpen,
+  onToggle,
+  onClose,
+  statusLabel,
+  keywords,
+}: SurveyGuardrailLauncherProps) {
+  if (!import.meta.env.DEV || typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(
+    <div className="pointer-events-none fixed bottom-6 left-2 z-95 hidden lg:block">
+      {isOpen ? (
+        <aside className="pointer-events-auto mb-3 ml-3 w-75 rounded-[26px] border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,20,0.84),rgba(8,8,9,0.94))] px-4 py-4 shadow-[0_18px_40px_rgba(0,0,0,0.26)] backdrop-blur-xl">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-semibold tracking-[0.18em] text-[#ff8a8a] uppercase">
+                Dev Guardrail
+              </p>
+              <h3 className="mt-1 text-sm font-semibold text-white">
+                설문 키워드 휴리스틱
+              </h3>
+            </div>
+            <div className="flex items-start gap-2">
+              <span className="rounded-full border border-white/10 bg-white/4 px-2.5 py-1 text-[11px] font-medium text-white/64">
+                {statusLabel}
+              </span>
+              <button
+                type="button"
+                onClick={onClose}
+                className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/10 bg-white/3 text-white/58 transition hover:bg-white/6 hover:text-white"
+                aria-label="개발용 가드레일 패널 닫기"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          </div>
+
+          <p className="mt-3 text-xs leading-5 break-keep text-white/54">
+            개발 환경에서만 보이는 설명 패널입니다. 현재 설문은 키워드
+            `includes()` 휴리스틱으로 게임 관련 질문 여부를 판정하고, 비게임
+            질문 3회 누적 시 5분 제한을 적용합니다.
+          </p>
+
+          <div className="mt-3 rounded-[18px] border border-white/8 bg-white/3 px-3 py-3">
+            <p className="text-[11px] font-semibold tracking-[0.18em] text-white/42 uppercase">
+              허용 키워드
+            </p>
+            <div className="mt-2 flex max-h-33 flex-wrap gap-1.5 overflow-y-auto pr-1">
+              {keywords.map((keyword) => (
+                <span
+                  key={keyword}
+                  className="rounded-full border border-white/8 bg-white/4 px-2.5 py-1 text-[11px] font-medium text-white/72"
+                >
+                  {keyword}
+                </span>
+              ))}
+            </div>
+          </div>
+        </aside>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={onToggle}
+        className="pointer-events-auto flex h-16 w-16 items-center justify-center rounded-full border border-white/10 bg-[linear-gradient(135deg,rgba(255,53,53,0.94),rgba(130,11,11,0.96))] text-white shadow-[0_18px_40px_rgba(130,0,0,0.28)] transition hover:-translate-y-0.5 hover:brightness-105 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+        aria-label="개발용 설문 키워드 가이드 열기"
+      >
+        <BadgeInfo size={24} />
+      </button>
+    </div>,
+    document.body,
+  );
+}
+
+export default SurveyGuardrailLauncher;

--- a/src/features/survey/hooks/useSurveyModerationGuard.ts
+++ b/src/features/survey/hooks/useSurveyModerationGuard.ts
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useSurveyStore } from '../store/useSurveyStore';
+
+export const NON_GAME_CHAT_MAX_STRIKES = 3;
+const NON_GAME_CHAT_BLOCK_DURATION_MS = 5 * 60 * 1000;
+
+export const GAME_RELATED_KEYWORDS = [
+  '게임',
+  '장르',
+  '스토리',
+  '전투',
+  '보스',
+  '탐험',
+  '수집',
+  '성장',
+  '플레이',
+  '플레이스타일',
+  '멀티',
+  '싱글',
+  '협동',
+  '그래픽',
+  '분위기',
+  '손맛',
+  'rpg',
+  'fps',
+  '액션',
+  '어드벤처',
+  '슈팅',
+  '전략',
+  '시뮬레이션',
+  '레이싱',
+  '스포츠',
+  '퍼즐',
+  '플랫폼',
+  '격투',
+  '리듬',
+  '비주얼 노벨',
+];
+
+export const isLikelyGameRelatedMessage = (content: string) => {
+  const normalized = content.trim().toLowerCase();
+
+  if (!normalized) {
+    return true;
+  }
+
+  return GAME_RELATED_KEYWORDS.some((keyword) =>
+    normalized.includes(keyword.toLowerCase()),
+  );
+};
+
+export const formatRemainingBlockTime = (remainingMs: number) => {
+  const totalSeconds = Math.max(0, Math.ceil(remainingMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${String(minutes).padStart(1, '0')}:${String(seconds).padStart(2, '0')}`;
+};
+
+type UseSurveyModerationGuardOptions = {
+  isHistoryView: boolean;
+  isSubmitting: boolean;
+  recommendationReady: boolean;
+};
+
+export const useSurveyModerationGuard = ({
+  isHistoryView,
+  isSubmitting,
+  recommendationReady,
+}: UseSurveyModerationGuardOptions) => {
+  const nonGameStrikeCount = useSurveyStore(
+    (state) => state.nonGameStrikeCount,
+  );
+  const chatBlockedUntil = useSurveyStore((state) => state.chatBlockedUntil);
+  const setNonGameStrikeCount = useSurveyStore(
+    (state) => state.setNonGameStrikeCount,
+  );
+  const setChatBlockedUntil = useSurveyStore(
+    (state) => state.setChatBlockedUntil,
+  );
+  const [currentTime, setCurrentTime] = useState(() => Date.now());
+
+  const remainingBlockTimeMs = chatBlockedUntil
+    ? Math.max(chatBlockedUntil - currentTime, 0)
+    : 0;
+  const hasReachedNonGameChatLimit =
+    nonGameStrikeCount >= NON_GAME_CHAT_MAX_STRIKES;
+  const isChatTemporarilyBlocked = Boolean(
+    chatBlockedUntil && remainingBlockTimeMs > 0,
+  );
+  const hasExpiredChatBlock = Boolean(
+    chatBlockedUntil && remainingBlockTimeMs <= 0,
+  );
+  const isTextareaDisabled =
+    isSubmitting ||
+    recommendationReady ||
+    isChatTemporarilyBlocked ||
+    hasExpiredChatBlock;
+  const isRecommendationButtonDisabled =
+    !recommendationReady ||
+    isSubmitting ||
+    isChatTemporarilyBlocked ||
+    hasExpiredChatBlock ||
+    hasReachedNonGameChatLimit;
+  const guardrailStatusLabel = isChatTemporarilyBlocked
+    ? `${formatRemainingBlockTime(remainingBlockTimeMs)} 남음`
+    : hasExpiredChatBlock
+      ? '제한 종료'
+      : `${nonGameStrikeCount}/${NON_GAME_CHAT_MAX_STRIKES} 누적`;
+
+  const inputPlaceholder = useMemo(() => {
+    if (isHistoryView && recommendationReady) {
+      return '완료된 설문 기록을 다시 보고 있어요.';
+    }
+
+    if (isChatTemporarilyBlocked) {
+      return '반복된 이상행동으로 인해 5분간 채팅이 정지됩니다.';
+    }
+
+    if (hasExpiredChatBlock) {
+      return '제한 시간이 종료되었습니다. 설문 초기화를 누르고 다시 진행해 주세요.';
+    }
+
+    if (recommendationReady) {
+      return '추천 결과가 준비되었어요. 아래 버튼으로 다음 단계로 이동해 주세요.';
+    }
+
+    return '취향과 관련된 게임 이야기를 입력해 주세요.';
+  }, [
+    hasExpiredChatBlock,
+    isChatTemporarilyBlocked,
+    isHistoryView,
+    recommendationReady,
+  ]);
+
+  useEffect(() => {
+    if (!isChatTemporarilyBlocked) {
+      return undefined;
+    }
+
+    const timer = window.setInterval(() => {
+      setCurrentTime(Date.now());
+    }, 1000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [isChatTemporarilyBlocked]);
+
+  const applySuccessfulSubmissionModeration = useCallback(
+    (
+      content: string,
+      options?: {
+        onBlocked?: () => void;
+      },
+    ) => {
+      const isGameRelatedMessage = isLikelyGameRelatedMessage(content);
+      const nextStrikeCount = isGameRelatedMessage
+        ? nonGameStrikeCount
+        : nonGameStrikeCount + 1;
+      const shouldBlockAfterResponse =
+        !isGameRelatedMessage && nextStrikeCount >= NON_GAME_CHAT_MAX_STRIKES;
+
+      if (!isGameRelatedMessage) {
+        setNonGameStrikeCount(nextStrikeCount);
+      }
+
+      if (shouldBlockAfterResponse) {
+        const now = Date.now();
+        setCurrentTime(now);
+        setChatBlockedUntil(now + NON_GAME_CHAT_BLOCK_DURATION_MS);
+        options?.onBlocked?.();
+      }
+    },
+    [nonGameStrikeCount, setChatBlockedUntil, setNonGameStrikeCount],
+  );
+
+  return {
+    nonGameStrikeCount,
+    remainingBlockTimeMs,
+    hasReachedNonGameChatLimit,
+    isChatTemporarilyBlocked,
+    hasExpiredChatBlock,
+    isTextareaDisabled,
+    isRecommendationButtonDisabled,
+    guardrailStatusLabel,
+    inputPlaceholder,
+    applySuccessfulSubmissionModeration,
+  };
+};

--- a/src/features/survey/hooks/useSurveySessionFlow.ts
+++ b/src/features/survey/hooks/useSurveySessionFlow.ts
@@ -1,0 +1,295 @@
+import { useCallback, useEffect } from 'react';
+
+import { isMockServiceWorkerEnabled } from '../../../lib/env';
+import {
+  useContinueSurveyMutation,
+  useResetSurveyMutation,
+  useStartSurveySessionMutation,
+} from '../api/useSurveyApi';
+import { extractApiErrorMessage } from '../api/survey';
+import { useSurveyStore } from '../store/useSurveyStore';
+
+const isRecoverableMockSessionError = (message: string | null) =>
+  isMockServiceWorkerEnabled() &&
+  Boolean(
+    message &&
+    (message.includes('해당 세션') || message.includes('설문 세션이 만료')),
+  );
+
+type UseSurveySessionFlowOptions = {
+  queueFocusRestore: () => void;
+  cancelFocusRestore: () => void;
+};
+
+export const useSurveySessionFlow = ({
+  queueFocusRestore,
+  cancelFocusRestore,
+}: UseSurveySessionFlowOptions) => {
+  const sessionId = useSurveyStore((state) => state.sessionId);
+  const hasBootstrapped = useSurveyStore((state) => state.hasBootstrapped);
+  const isSubmitting = useSurveyStore((state) => state.isSubmitting);
+  const error = useSurveyStore((state) => state.error);
+  const lastSubmittedMessage = useSurveyStore(
+    (state) => state.lastSubmittedMessage,
+  );
+  const clearError = useSurveyStore((state) => state.clearError);
+  const setHasBootstrapped = useSurveyStore(
+    (state) => state.setHasBootstrapped,
+  );
+  const setSubmitting = useSurveyStore((state) => state.setSubmitting);
+  const setError = useSurveyStore((state) => state.setError);
+  const setLastSubmittedMessage = useSurveyStore(
+    (state) => state.setLastSubmittedMessage,
+  );
+  const clearModerationState = useSurveyStore(
+    (state) => state.clearModerationState,
+  );
+  const addUserMessage = useSurveyStore((state) => state.addUserMessage);
+  const hydrateInitialSession = useSurveyStore(
+    (state) => state.hydrateInitialSession,
+  );
+  const applyChatResponse = useSurveyStore((state) => state.applyChatResponse);
+  const resetSurveyState = useSurveyStore((state) => state.resetSurveyState);
+
+  const startSessionMutation = useStartSurveySessionMutation();
+  const continueSurveyMutation = useContinueSurveyMutation();
+  const resetSurveyMutation = useResetSurveyMutation();
+
+  const bootstrapSurvey = useCallback(
+    async (force = false) => {
+      if ((hasBootstrapped && !force) || (isSubmitting && !force)) {
+        return;
+      }
+
+      clearError();
+      resetSurveyState();
+      setHasBootstrapped(true);
+      setSubmitting(true);
+
+      try {
+        const response = await startSessionMutation.mutateAsync({
+          is_reset: false,
+        });
+        hydrateInitialSession(response);
+      } catch (requestError) {
+        setHasBootstrapped(false);
+        setError(extractApiErrorMessage(requestError));
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [
+      clearError,
+      hasBootstrapped,
+      hydrateInitialSession,
+      isSubmitting,
+      resetSurveyState,
+      setError,
+      setHasBootstrapped,
+      setSubmitting,
+      startSessionMutation,
+    ],
+  );
+
+  useEffect(() => {
+    if (!sessionId && !hasBootstrapped) {
+      void bootstrapSurvey();
+    }
+  }, [bootstrapSurvey, hasBootstrapped, sessionId]);
+
+  const submitMessage = useCallback(
+    async ({
+      content,
+      appendUserMessage,
+    }: {
+      content: string;
+      appendUserMessage: boolean;
+    }) => {
+      const trimmed = content.trim();
+
+      if (!trimmed || isSubmitting) {
+        return false;
+      }
+
+      clearError();
+      setLastSubmittedMessage(trimmed);
+      setSubmitting(true);
+
+      try {
+        if (!sessionId) {
+          const sessionResponse = await startSessionMutation.mutateAsync({
+            is_reset: false,
+          });
+          hydrateInitialSession(sessionResponse);
+
+          if (appendUserMessage) {
+            addUserMessage(trimmed);
+          }
+
+          const response = await continueSurveyMutation.mutateAsync({
+            session_id: sessionResponse.session_id,
+            user_answer: trimmed,
+          });
+
+          applyChatResponse(response);
+        } else {
+          if (appendUserMessage) {
+            addUserMessage(trimmed);
+          }
+
+          const response = await continueSurveyMutation.mutateAsync({
+            session_id: sessionId,
+            user_answer: trimmed,
+          });
+
+          applyChatResponse(response);
+        }
+
+        return true;
+      } catch (requestError) {
+        setError(extractApiErrorMessage(requestError));
+        return false;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [
+      addUserMessage,
+      applyChatResponse,
+      clearError,
+      continueSurveyMutation,
+      hydrateInitialSession,
+      isSubmitting,
+      sessionId,
+      setError,
+      setLastSubmittedMessage,
+      setSubmitting,
+      startSessionMutation,
+    ],
+  );
+
+  const handleRetry = useCallback(async () => {
+    queueFocusRestore();
+
+    if (!lastSubmittedMessage) {
+      await bootstrapSurvey(true);
+      return;
+    }
+
+    if (isRecoverableMockSessionError(error)) {
+      clearError();
+      resetSurveyState();
+      setHasBootstrapped(true);
+      setLastSubmittedMessage(lastSubmittedMessage);
+      setSubmitting(true);
+
+      try {
+        const sessionResponse = await startSessionMutation.mutateAsync({
+          is_reset: true,
+        });
+        hydrateInitialSession(sessionResponse);
+        addUserMessage(lastSubmittedMessage);
+
+        const response = await continueSurveyMutation.mutateAsync({
+          session_id: sessionResponse.session_id,
+          user_answer: lastSubmittedMessage,
+        });
+
+        applyChatResponse(response);
+      } catch (requestError) {
+        setError(extractApiErrorMessage(requestError));
+      } finally {
+        setSubmitting(false);
+      }
+
+      return;
+    }
+
+    await submitMessage({
+      content: lastSubmittedMessage,
+      appendUserMessage: false,
+    });
+  }, [
+    addUserMessage,
+    applyChatResponse,
+    bootstrapSurvey,
+    clearError,
+    continueSurveyMutation,
+    error,
+    hydrateInitialSession,
+    lastSubmittedMessage,
+    queueFocusRestore,
+    resetSurveyState,
+    setError,
+    setHasBootstrapped,
+    setLastSubmittedMessage,
+    setSubmitting,
+    startSessionMutation,
+    submitMessage,
+  ]);
+
+  const handleReset = useCallback(async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    clearError();
+
+    if (!sessionId) {
+      queueFocusRestore();
+      clearModerationState();
+      resetSurveyState();
+      await bootstrapSurvey();
+      return;
+    }
+
+    queueFocusRestore();
+    setSubmitting(true);
+
+    try {
+      const response = await resetSurveyMutation.mutateAsync({
+        session_id: sessionId,
+      });
+
+      clearModerationState();
+      hydrateInitialSession(response);
+    } catch (requestError) {
+      const errorMessage = extractApiErrorMessage(requestError);
+
+      if (isRecoverableMockSessionError(errorMessage)) {
+        resetSurveyState();
+        setHasBootstrapped(false);
+        await bootstrapSurvey(true);
+        return;
+      }
+
+      setError(errorMessage);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    bootstrapSurvey,
+    clearError,
+    clearModerationState,
+    hydrateInitialSession,
+    isSubmitting,
+    queueFocusRestore,
+    resetSurveyMutation,
+    resetSurveyState,
+    sessionId,
+    setError,
+    setHasBootstrapped,
+    setSubmitting,
+  ]);
+
+  const handleBlockedSubmission = useCallback(() => {
+    cancelFocusRestore();
+  }, [cancelFocusRestore]);
+
+  return {
+    submitMessage,
+    handleRetry,
+    handleReset,
+    handleBlockedSubmission,
+  };
+};

--- a/src/features/survey/hooks/useSurveyViewportState.ts
+++ b/src/features/survey/hooks/useSurveyViewportState.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type UseSurveyViewportStateOptions = {
+  messagesLength: number;
+  error: string | null;
+  hasBootstrapped: boolean;
+  sessionId: string | null;
+  recommendationReady: boolean;
+  isSubmitting: boolean;
+  isChatTemporarilyBlocked: boolean;
+  hasExpiredChatBlock: boolean;
+};
+
+export const useSurveyViewportState = ({
+  messagesLength,
+  error,
+  hasBootstrapped,
+  sessionId,
+  recommendationReady,
+  isSubmitting,
+  isChatTemporarilyBlocked,
+  hasExpiredChatBlock,
+}: UseSurveyViewportStateOptions) => {
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const shouldRestoreFocusRef = useRef(false);
+  const lastMessageCountRef = useRef(0);
+  const [enteredWithCompletedSurvey, setEnteredWithCompletedSurvey] = useState<
+    boolean | null
+  >(null);
+
+  useEffect(() => {
+    if (enteredWithCompletedSurvey !== null) {
+      return undefined;
+    }
+
+    if (
+      !hasBootstrapped &&
+      !sessionId &&
+      messagesLength === 0 &&
+      !recommendationReady
+    ) {
+      return undefined;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      setEnteredWithCompletedSurvey(
+        (current) => current ?? (recommendationReady && messagesLength > 0),
+      );
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [
+    enteredWithCompletedSurvey,
+    hasBootstrapped,
+    messagesLength,
+    recommendationReady,
+    sessionId,
+  ]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+
+    if (!viewport) {
+      return;
+    }
+
+    const shouldJumpToBottom =
+      lastMessageCountRef.current === 0 && messagesLength > 0;
+
+    viewport.scrollTo({
+      top: viewport.scrollHeight,
+      behavior: shouldJumpToBottom ? 'auto' : 'smooth',
+    });
+
+    lastMessageCountRef.current = messagesLength;
+  }, [error, messagesLength]);
+
+  const restoreTextareaFocus = useCallback(() => {
+    requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+
+      if (!textarea || textarea.disabled) {
+        return;
+      }
+
+      textarea.focus();
+      const cursorPosition = textarea.value.length;
+      textarea.setSelectionRange(cursorPosition, cursorPosition);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (
+      !isSubmitting &&
+      !recommendationReady &&
+      !isChatTemporarilyBlocked &&
+      !hasExpiredChatBlock &&
+      shouldRestoreFocusRef.current
+    ) {
+      shouldRestoreFocusRef.current = false;
+      restoreTextareaFocus();
+    }
+  }, [
+    hasExpiredChatBlock,
+    isChatTemporarilyBlocked,
+    isSubmitting,
+    recommendationReady,
+    restoreTextareaFocus,
+  ]);
+
+  const queueFocusRestore = useCallback(() => {
+    shouldRestoreFocusRef.current = true;
+  }, []);
+
+  const cancelFocusRestore = useCallback(() => {
+    shouldRestoreFocusRef.current = false;
+  }, []);
+
+  return {
+    viewportRef,
+    formRef,
+    textareaRef,
+    enteredWithCompletedSurvey: enteredWithCompletedSurvey ?? false,
+    queueFocusRestore,
+    cancelFocusRestore,
+  };
+};


### PR DESCRIPTION
## 관련 이슈

- closes #270 

## 변경 내용

- `SurveyChatPanel`에 몰려 있던 설문 세션 시작/이어가기/초기화 흐름을 별도 hook으로 분리
- 비게임 질문 3회 제한, 5분 block, 입력 비활성화/추천 버튼 비활성화 판단을 별도 hook으로 분리
- 메시지 스크롤 이동, 포커스 복원, 완료 설문 재진입 시점 판단을 별도 hook으로 분리
- 개발 환경에서만 보이는 설문 키워드 가드레일 런처를 별도 컴포넌트로 분리
- 그 결과 `SurveyChatPanel`은 화면 렌더링과 상위 이벤트 연결 중심으로 유지되도록 정리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 기능 변경보다 설문 채팅 패널의 구조 정리와 유지보수성 개선에 집중했습니다.
- 기존 설문 진행, 차단, 복원, 추천 이동 동작은 유지하는 방향으로 정리했습니다.

