### PR TITLE
[Fix] 설문·매칭·추천 리스트 통합 QA 버그 수정

### DIFF
--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -201,8 +201,18 @@ function MatchingGenreDetailPage() {
       nextIsLiked: boolean;
     }) =>
       nextIsLiked ? likeGame(candidate.game_id) : unlikeGame(candidate.game_id),
-    onMutate: () => {
+    onMutate: async ({ candidate, nextIsLiked }) => {
       setLikeFeedbackMessage(null);
+
+      updateLikedGamesCache(candidate, nextIsLiked);
+      syncGameLikeStateInQueryCache(queryClient, {
+        gameId: candidate.game_id,
+        isLiked: nextIsLiked,
+      });
+
+      return {
+        gameId: candidate.game_id,
+      };
     },
     onSuccess: (response, variables) => {
       updateLikedGamesCache(variables.candidate, response.isLiked);
@@ -217,6 +227,21 @@ function MatchingGenreDetailPage() {
     },
     onError: (error) => {
       setLikeFeedbackMessage(getMatchingLikeErrorMessage(error));
+      void queryClient.invalidateQueries({
+        queryKey: authKeys.likedGames(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['match-candidates'],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['survey-results'],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['match-results'],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['games'],
+      });
     },
   });
 

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -41,14 +41,15 @@ function SurveyPage() {
   const canAccessSurvey = authGate.accessStatus === 'authorized';
   const account = useAuthStore((state) => state.account);
   const syncOwnerKey = useSurveyStore((state) => state.syncOwnerKey);
+  const storedOwnerKey = useSurveyStore((state) => state.ownerKey);
   const messages = useSurveyStore((state) => state.messages);
   const recommendationReady = useSurveyStore(
     (state) => state.recommendationReady,
   );
   const isHistoryMode = searchParams.get('mode') === 'history';
-  const [enteredWithCompletedSurvey] = useState(
-    () => recommendationReady && messages.length > 0,
-  );
+  const [enteredWithCompletedSurvey, setEnteredWithCompletedSurvey] = useState<
+    boolean | null
+  >(null);
   const surveyOwnerKey = account?.login_id
     ? `survey-user:${account.login_id}`
     : authGate.isAuthenticated
@@ -60,10 +61,35 @@ function SurveyPage() {
   useEffect(() => {
     syncOwnerKey(surveyOwnerKey);
   }, [surveyOwnerKey, syncOwnerKey]);
+  useEffect(() => {
+    if (enteredWithCompletedSurvey !== null) {
+      return undefined;
+    }
+
+    if (storedOwnerKey !== surveyOwnerKey) {
+      return undefined;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      setEnteredWithCompletedSurvey(
+        (current) => current ?? (recommendationReady && messages.length > 0),
+      );
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [
+    enteredWithCompletedSurvey,
+    messages.length,
+    recommendationReady,
+    storedOwnerKey,
+    surveyOwnerKey,
+  ]);
   const shouldRedirectCompletedEntry =
     canAccessSurvey &&
     !isHistoryMode &&
-    enteredWithCompletedSurvey &&
+    enteredWithCompletedSurvey === true &&
     recommendationReady &&
     messages.length > 0;
 


### PR DESCRIPTION
## 관련 이슈

- closes #273

## 변경 내용

- 설문 완료 재진입 판정을 현재 로그인 사용자 기준 `ownerKey` 동기화 이후에만 수행하도록 수정해, 저장된 설문 상태가 잘못 섞여 추천 페이지로 오동작하는 가능성을 줄였습니다.
- 매칭 화면에서 좋아요 클릭 시 응답 성공 이후가 아니라 클릭 즉시 공통 캐시를 먼저 갱신하도록 보강해, 현재 카드/메인/상세/추천 결과/마이페이지에서 더 빠르게 같은 상태가 보이도록 정리했습니다.
- 매칭 좋아요 요청이 실패할 경우 관련 query를 다시 invalidate하도록 보강해, 임시 optimistic 상태가 다른 화면과 어긋난 채 남지 않도록 수정했습니다.


## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 전체 플로우 QA 중 실제 사용 흐름에서 체감되는 재진입/좋아요 일관성 문제를 먼저 보강하는 데 집중했습니다.
- 설문 완료 후 재진입, 매칭 좋아요 즉시 반영, 추천/마이페이지 liked 상태 동기화 흐름을 함께 점검할 수 있습니다.