### PR TITLE
fix(auth-ui): 인증 폼 대비 개선 및 로그인 CTA 가시성 보강

### DIFF
--- a/src/components/auth/AuthInputActionButton.tsx
+++ b/src/components/auth/AuthInputActionButton.tsx
@@ -16,7 +16,7 @@ function AuthInputActionButton({
     <AuthButton
       type={type}
       variant="secondary"
-      className={`h-12 w-full border border-[#5b3035] bg-[#1d1215] text-sm font-semibold text-[#f2d8d9] hover:border-[#ff6b6e]/65 hover:bg-[#29161a] hover:text-white focus-visible:ring-[#ff5c60]/25 active:scale-[0.99] sm:h-[3.2rem] sm:w-[5.75rem] sm:shrink-0 ${className}`}
+      className={`h-12 w-full rounded-2xl border border-white/12 bg-white/[0.055] text-sm font-semibold text-white/82 hover:border-[#ff6b6e]/55 hover:bg-[#211316] hover:text-white focus-visible:ring-[#ff5c60]/28 active:scale-[0.99] sm:h-[3.2rem] sm:w-[5.75rem] sm:shrink-0 ${className}`}
       {...props}
     >
       {children}

--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -6,6 +6,7 @@ type AuthInputFieldMessageTone = 'success' | 'muted';
 type AuthInputFieldProps = {
   id: string;
   label: string;
+  labelAction?: ReactNode;
   errorMessage?: string;
   helperMessage?: string;
   helperMessageTone?: AuthInputFieldMessageTone;
@@ -18,6 +19,7 @@ type AuthInputFieldProps = {
 function AuthInputField({
   id,
   label,
+  labelAction,
   errorMessage,
   helperMessage,
   helperMessageTone = 'muted',
@@ -38,12 +40,15 @@ function AuthInputField({
 
   return (
     <div className={`space-y-2 ${containerClassName} sm:space-y-2.5`}>
-      <label
-        htmlFor={id}
-        className="text-login-label block text-sm font-medium"
-      >
-        {label}
-      </label>
+      <div className="flex items-center justify-between gap-3">
+        <label
+          htmlFor={id}
+          className="text-login-label block min-w-0 text-sm font-medium"
+        >
+          {label}
+        </label>
+        {labelAction ? <div className="shrink-0">{labelAction}</div> : null}
+      </div>
       <div className="relative flex flex-col gap-3 sm:flex-row sm:items-stretch">
         <InputControl
           id={id}

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -67,10 +67,10 @@ function AuthRadioGroup({
                 className="peer sr-only"
               />
               <span
-                className={`flex h-12 items-center justify-center rounded-xl border px-4 text-sm font-semibold transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-[#ff5c60]/25 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-black peer-disabled:opacity-60 sm:h-[3.2rem] ${
+                className={`flex h-12 items-center justify-center rounded-2xl border px-4 text-sm font-semibold shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-[#ff5c60]/28 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-black peer-disabled:opacity-60 sm:h-[3.2rem] ${
                   errorMessage
-                    ? 'border-red-500/80 bg-[#1d1215] text-red-200 group-hover:border-red-400/90 group-hover:bg-[#2f1519] group-hover:text-red-100'
-                    : 'bg-login-field text-login-label border-white/16 group-hover:border-white/24 group-hover:bg-[#1d1e22] group-hover:text-white/90 peer-checked:border-[#ff6b6e]/70 peer-checked:bg-[#29161a] peer-checked:text-white'
+                    ? 'border-red-500/80 bg-[#1f1417] text-red-200 group-hover:border-red-400/90 group-hover:bg-[#2c171b] group-hover:text-red-100'
+                    : 'bg-login-field text-login-label border-login-field group-hover:border-white/22 group-hover:bg-[#26282d] group-hover:text-white/88 peer-checked:border-[#ff666a]/78 peer-checked:bg-[#291518] peer-checked:text-white'
                 }`}
               >
                 {option.label}

--- a/src/components/auth/AuthSocialLoginGroup.tsx
+++ b/src/components/auth/AuthSocialLoginGroup.tsx
@@ -110,15 +110,15 @@ function AuthSocialLoginGroup({
       <SocialLoginButton
         label="Google로 로그인하기"
         icon={<GoogleIcon className={iconClassName} />}
-        className={`bg-login-google border-login-google border ${buttonSizeClassName.google}`}
-        labelClassName={`text-white ${buttonSizeClassName.label}`}
+        className={`bg-login-google border-login-google text-black shadow-[0_12px_24px_rgba(0,0,0,0.2)] hover:bg-[#e5e6ea] hover:brightness-[1.01] ${buttonSizeClassName.google}`}
+        labelClassName={`text-black ${buttonSizeClassName.label}`}
         onClick={() => handleSocialLogin('google')}
         disabled={Boolean(redirectingProvider)}
       />
       <SocialLoginButton
         label="카카오로 로그인하기"
         icon={<KakaoIcon className={iconClassName} />}
-        className={`bg-login-kakao ${buttonSizeClassName.kakao}`}
+        className={`bg-login-kakao border-[#9b8b2a]/40 shadow-[0_12px_24px_rgba(0,0,0,0.18)] hover:brightness-[1.03] ${buttonSizeClassName.kakao}`}
         labelClassName={`text-login-kakao-label ${buttonSizeClassName.label}`}
         onClick={() => handleSocialLogin('kakao')}
         disabled={Boolean(redirectingProvider)}
@@ -126,7 +126,7 @@ function AuthSocialLoginGroup({
       <SocialLoginButton
         label="네이버로 로그인하기"
         icon={<NaverIcon className={iconClassName} />}
-        className={`bg-login-naver ${buttonSizeClassName.naver}`}
+        className={`bg-login-naver border-[#2d7b52]/45 shadow-[0_12px_24px_rgba(0,0,0,0.18)] hover:brightness-[1.03] ${buttonSizeClassName.naver}`}
         labelClassName={`text-white ${buttonSizeClassName.label}`}
         onClick={() => handleSocialLogin('naver')}
         disabled={Boolean(redirectingProvider)}

--- a/src/components/auth/authSharedStyles.ts
+++ b/src/components/auth/authSharedStyles.ts
@@ -9,10 +9,11 @@ export const AUTH_SHARED_FORM_CLASS_NAMES = {
   form: 'space-y-2.5 sm:space-y-3',
   feedbackMessage: 'text-sm/5',
   submitButton:
-    'mt-1.5 h-12 w-full text-sm/6 sm:mt-2 sm:h-[3.2rem] sm:text-base/6',
+    'mt-1.5 h-12 w-full rounded-2xl text-sm/6 sm:mt-2 sm:h-[3.2rem] sm:text-base/6',
   auxiliaryLink:
     'text-login-muted text-sm font-medium transition-colors hover:text-white/80',
   footerSection: 'border-login-divider mt-3 border-t pt-3 sm:mt-4 sm:pt-4',
   footerHelperText: 'text-login-helper text-center text-sm/5 font-normal',
-  footerLinkButton: 'mt-2.5 h-12 w-full text-sm/6 sm:h-[3.2rem] sm:text-base/6',
+  footerLinkButton:
+    'mt-2.5 h-12 w-full border-white/18 bg-[linear-gradient(180deg,rgba(46,47,54,0.92)_0%,rgba(31,32,38,0.96)_100%)] text-sm/6 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_12px_30px_rgba(0,0,0,0.22)] hover:border-[#ff6b6e]/50 hover:bg-[linear-gradient(180deg,rgba(57,41,45,0.96)_0%,rgba(39,25,29,0.98)_100%)] sm:h-[3.2rem] sm:text-base/6',
 } as const;

--- a/src/components/common/InputControl.tsx
+++ b/src/components/common/InputControl.tsx
@@ -6,7 +6,7 @@ type InputControlProps = {
 } & InputHTMLAttributes<HTMLInputElement>;
 
 const inputBaseClassName =
-  'auth-input-autofill placeholder-login-muted bg-login-field h-12 min-w-0 w-full rounded-xl border px-3.5 text-[0.95rem] text-white transition outline-none focus-visible:ring-2 sm:h-[3.2rem] sm:px-4 sm:text-base';
+  'auth-input-autofill placeholder-login-muted bg-login-field h-12 min-w-0 w-full rounded-2xl border px-3.5 text-[0.95rem] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition outline-none focus-visible:ring-2 sm:h-[3.2rem] sm:px-4 sm:text-base';
 
 function InputControl({
   hasError = false,
@@ -17,7 +17,7 @@ function InputControl({
   return (
     <input
       aria-invalid={ariaInvalid ?? hasError}
-      className={`${inputBaseClassName} ${hasError ? 'border-red-500 hover:border-red-400 focus-visible:border-red-400 focus-visible:ring-red-500/25' : 'border-login-field hover:border-white/20 focus-visible:border-white/35 focus-visible:ring-white/25'} ${className}`}
+      className={`${inputBaseClassName} ${hasError ? 'border-red-500/90 hover:border-red-400 focus-visible:border-red-400 focus-visible:ring-red-500/30' : 'border-login-field hover:border-white/24 focus-visible:border-[#ff5d61] focus-visible:ring-[#ff5d61]/28'} ${className}`}
       {...props}
     />
   );

--- a/src/components/login/SocialLoginButton.tsx
+++ b/src/components/login/SocialLoginButton.tsx
@@ -22,10 +22,12 @@ function SocialLoginButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`flex w-full items-center justify-center gap-3 rounded-full px-5 transition-all duration-200 hover:-translate-y-0.5 hover:brightness-105 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-70 ${className}`}
+      className={`flex w-full items-center justify-center gap-3 rounded-2xl border px-5 transition-all duration-200 hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-70 ${className}`}
     >
       {icon}
-      <span className={`text-base/6 font-semibold ${labelClassName}`}>
+      <span
+        className={`text-[0.95rem]/6 font-semibold sm:text-base/6 ${labelClassName}`}
+      >
         {label}
       </span>
     </button>

--- a/src/index.css
+++ b/src/index.css
@@ -17,20 +17,20 @@
   --color-header-shadow-depth: rgba(0, 0, 0, 0.32);
 
   --color-login-page: #000000;
-  --color-login-field: #1a1a1a;
-  --color-login-field-border: #262626;
+  --color-login-field: #202227;
+  --color-login-field-border: rgba(255, 255, 255, 0.12);
   --color-login-divider: #262626;
   --color-login-divider-line: #3a3a3a;
   --color-login-divider-text: #a3a3a3;
   --color-login-helper: #a3a3a3;
   --color-login-outline: rgba(255, 255, 255, 0.12);
-  --color-login-label: #8f8f8f;
-  --color-login-muted: #676767;
-  --color-login-google: #1a1a1a;
-  --color-login-google-border: #1a1a1a;
-  --color-login-kakao: #fee500;
+  --color-login-label: #a8a8ae;
+  --color-login-muted: #7f828a;
+  --color-login-google: #dcdde1;
+  --color-login-google-border: rgba(255, 255, 255, 0.16);
+  --color-login-kakao: #d6c33d;
   --color-login-kakao-text: #000000;
-  --color-login-naver: #03c75a;
+  --color-login-naver: #2fa05f;
   --color-login-primary: #f20f17;
   --color-login-primary-hover: #dd0d14;
   --color-auth-panel: rgba(12, 12, 14, 0.88);

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -15,6 +15,7 @@ import { ROUTES } from '../constants/routes';
 import useLoginForm, {
   LOGIN_FORM_FIELD_IDS,
 } from '../features/auth/hooks/useLoginForm';
+import { useSupportChatStore } from '../features/support-chat/store/useSupportChatStore';
 
 const LOGIN_MOCK_FAB_CLASS_NAME =
   'support-chat-fab group fixed left-4 bottom-4 z-[95] flex h-14 w-14 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none sm:left-6 sm:bottom-6';
@@ -22,6 +23,7 @@ const LOGIN_MOCK_PANEL_CLASS_NAME =
   'support-chat-panel fixed left-4 bottom-22 z-[90] flex w-[min(92vw,22rem)] origin-bottom-left flex-col overflow-hidden transition-all duration-300 ease-out sm:left-6 sm:bottom-24';
 
 function LoginPage() {
+  const openSupportChat = useSupportChatStore((state) => state.openPanel);
   const {
     formValues,
     resolvedFieldErrors,
@@ -79,6 +81,15 @@ function LoginPage() {
             id={LOGIN_FORM_FIELD_IDS.password}
             name="password"
             label="비밀번호"
+            labelAction={
+              <button
+                type="button"
+                className="text-login-helper text-xs font-medium transition-colors hover:text-white/88 focus-visible:ring-2 focus-visible:ring-[#ff5c60]/25 focus-visible:outline-none"
+                onClick={() => openSupportChat()}
+              >
+                비밀번호 찾기
+              </button>
+            }
             type="password"
             autoComplete="current-password"
             placeholder="PASSWORD"


### PR DESCRIPTION
## 관련 이슈

- closes #275 

## 변경 내용

- 로그인/회원가입 공통 입력칸 스타일을 어두운 배경에서도 더 잘 보이도록 조정했습니다.
- 입력칸 배경을 폼 배경보다 밝은 톤으로 올리고, 미세 테두리와 더 선명한 포커스 링을 추가했습니다.
- 입력칸, 성별 선택, 중복확인 버튼의 둥글기와 높이를 통일해 전체적인 인증 폼 룩을 정리했습니다.
- 로그인 페이지 소셜 버튼 가시성을 보강했습니다.
- 구글 버튼은 순백보다 톤을 낮춘 밝은 회색 계열 배경으로 조정해 눈부심을 줄였습니다.
- 카카오/네이버 버튼은 기존 브랜드 색을 유지하되 다크 테마에 맞게 톤과 테두리를 정리했습니다.
- 비밀번호 라벨 우측에 비밀번호 찾기 액션을 추가해 접근성을 높였습니다.
- 로그인 하단 CTA 구분감을 강화했습니다.
- 로그인 버튼과 회원가입 버튼이 비슷하게 보이지 않도록 하단 회원가입 버튼의 배경, 테두리, 그림자, hover 상태를 보강했습니다.
- 소셜 버튼, 일반 입력칸, 제출 버튼, 하단 CTA 버튼의 패딩/둥글기/상태 표현을 더 일관되게 맞췄습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3364" height="1592" alt="image" src="https://github.com/user-attachments/assets/166642e4-f82e-47c2-86ab-fa88d8e16d84" />
<img width="3320" height="1588" alt="image" src="https://github.com/user-attachments/assets/8d1e94ad-be40-45a1-85c9-f59f172daea0" />

## 참고사항

-
