### PR TITLE
[Fix] 상세 모달 및 추천/매칭/마이페이지 안정화

### DIFF
--- a/src/api/queryRetry.ts
+++ b/src/api/queryRetry.ts
@@ -1,0 +1,15 @@
+import { AxiosError } from 'axios';
+
+const MAX_RETRY_COUNT = 1;
+
+export const shouldRetryApiQuery = (failureCount: number, error: unknown) => {
+  if (error instanceof AxiosError) {
+    const status = error.response?.status;
+
+    if (typeof status === 'number' && status >= 400 && status < 500) {
+      return false;
+    }
+  }
+
+  return failureCount < MAX_RETRY_COUNT;
+};

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -5,6 +5,11 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
+import { shouldRetryApiQuery } from '../../../api/queryRetry';
+import {
+  getPaginatedCount,
+  getPaginatedLoadedCount,
+} from '../../../utils/paginatedResults';
 import {
   checkIdDuplicate,
   checkNicknameDuplicate,
@@ -90,17 +95,16 @@ export const useLikedGamesInfiniteQuery = (
     staleTime: 60_000,
     initialPageParam: 1,
     getNextPageParam: (lastPage, allPages) => {
-      const loadedGameCount = allPages.reduce(
-        (count, page) => count + page.results.length,
-        0,
-      );
+      const loadedGameCount = getPaginatedLoadedCount(allPages);
+      const totalCount = getPaginatedCount(lastPage, loadedGameCount);
 
-      if (loadedGameCount >= lastPage.count) {
+      if (loadedGameCount >= totalCount) {
         return undefined;
       }
 
       return allPages.length + 1;
     },
+    retry: shouldRetryApiQuery,
   });
 
 export const useUnlikeLikedGameMutation = () => {

--- a/src/features/games/components/GameCard.tsx
+++ b/src/features/games/components/GameCard.tsx
@@ -31,7 +31,7 @@ const GameCard = ({ game, onSelectGame }: GameCardProps) => {
           <img
             src={thumbnailUrl}
             alt={`${game.name} 썸네일`}
-            className="h-full w-full object-cover opacity-80 transition duration-300 group-hover:scale-105 group-hover:opacity-100"
+            className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
             loading="lazy"
             onError={() => setIsImageUnavailable(true)}
           />
@@ -40,7 +40,7 @@ const GameCard = ({ game, onSelectGame }: GameCardProps) => {
             이미지 N/A
           </div>
         )}
-        <div className="absolute inset-0 bg-linear-to-t from-black/70 via-black/20 to-transparent" />
+        <div className="absolute inset-0 bg-linear-to-t from-black/58 via-black/12 to-transparent" />
       </div>
 
       <div className={GAME_CARD_BODY_CLASS}>

--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import ToastMessage from '../../../components/mypage/ToastMessage';
 import {
   DETAIL_LOADING_TEXT,
-  formatDetailField,
   normalizeMeaningfulText,
   normalizeMeaningfulTextList,
 } from '../detailUtils';
@@ -32,6 +31,9 @@ const formatNullableText = (value: string | null | undefined) =>
 
 const DETAIL_NOT_FOUND_TITLE = '게임 상세 정보 없음';
 const DETAIL_NOT_FOUND_MESSAGE = '해당 게임 상세 정보를 찾을 수 없습니다.';
+const DETAIL_FETCH_ERROR_MESSAGE =
+  '상세 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.';
+const PROMO_VIDEO_FETCH_ERROR_MESSAGE = '프로모션 영상을 불러오지 못했습니다.';
 
 const GameDetailModalSkeleton = ({ game }: { game: GameListItem }) => {
   const title = normalizeMeaningfulText(game.name) ?? 'N/A';
@@ -66,7 +68,7 @@ const GameDetailModalSkeleton = ({ game }: { game: GameListItem }) => {
             >
               {title}
             </h2>
-            <div className="h-10 w-[4.5rem] shrink-0 animate-pulse rounded-md bg-white/8" />
+            <div className="h-10 w-18 shrink-0 animate-pulse rounded-md bg-white/8" />
           </div>
 
           {/* 장르: 리스트 값으로 즉시 표시, 없으면 스켈레톤 */}
@@ -145,8 +147,10 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
     Record<number, string[]>
   >({});
   const {
+    canRenderFallbackSummary,
     clearToast,
     detail,
+    detailErrorKind,
     detailQuery,
     handleToggleLike,
     hasResolvedDetail,
@@ -180,22 +184,33 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
     detail?.promoEmbedUrl?.trim() || null,
     promoVideoUrl,
   );
-  const descriptionField = formatDetailField(
-    detail?.description,
-    hasResolvedDetail,
-  );
+  const detailFieldFallback =
+    detailErrorKind === 'error' && !hasResolvedDetail
+      ? DETAIL_FETCH_ERROR_MESSAGE
+      : detailErrorKind === 'not-found' && !hasResolvedDetail
+        ? 'N/A'
+        : DETAIL_LOADING_TEXT;
+  const descriptionField =
+    normalizeMeaningfulText(detail?.description) ??
+    (hasResolvedDetail ? 'N/A' : detailFieldFallback);
   const detailRows = [
     {
       label: '게임 출시일',
-      value: formatDetailField(detail?.releaseDate, hasResolvedDetail),
+      value:
+        normalizeMeaningfulText(detail?.releaseDate) ??
+        (hasResolvedDetail ? 'N/A' : detailFieldFallback),
     },
     {
       label: '게임 개발사',
-      value: formatDetailField(detail?.developer, hasResolvedDetail),
+      value:
+        normalizeMeaningfulText(detail?.developer) ??
+        (hasResolvedDetail ? 'N/A' : detailFieldFallback),
     },
     {
       label: '게임 배급사',
-      value: formatDetailField(detail?.publisher, hasResolvedDetail),
+      value:
+        normalizeMeaningfulText(detail?.publisher) ??
+        (hasResolvedDetail ? 'N/A' : detailFieldFallback),
     },
   ];
   const externalLinks = EXTERNAL_LINK_LABELS.map(({ key, label }) => ({
@@ -204,6 +219,16 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
   })).filter((link): link is { label: string; url: string } =>
     Boolean(normalizeMeaningfulText(link.url)),
   );
+  const shouldShowNotFoundState =
+    detailErrorKind === 'not-found' &&
+    !hasResolvedDetail &&
+    !canRenderFallbackSummary;
+  const shouldShowFatalErrorState =
+    detailErrorKind === 'error' &&
+    !hasResolvedDetail &&
+    !canRenderFallbackSummary;
+  const shouldShowErrorState =
+    shouldShowNotFoundState || shouldShowFatalErrorState;
 
   useEffect(() => {
     const previousBodyOverflow = document.body.style.overflow;
@@ -267,16 +292,20 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
 
         {detailQuery.isPending ? (
           <GameDetailModalSkeleton game={game} />
-        ) : detailQuery.isError ? (
+        ) : shouldShowErrorState ? (
           <div className="flex min-h-96 flex-col items-center justify-center px-6 py-16 text-center sm:px-10">
             <h2
               id="game-detail-modal-title"
               className="text-2xl font-bold text-white sm:text-3xl"
             >
-              {DETAIL_NOT_FOUND_TITLE}
+              {shouldShowNotFoundState
+                ? DETAIL_NOT_FOUND_TITLE
+                : '상세 정보를 불러오지 못했습니다.'}
             </h2>
             <p className="mt-4 max-w-md text-sm leading-6 text-white/60 sm:text-base">
-              {DETAIL_NOT_FOUND_MESSAGE}
+              {shouldShowNotFoundState
+                ? DETAIL_NOT_FOUND_MESSAGE
+                : DETAIL_FETCH_ERROR_MESSAGE}
             </p>
           </div>
         ) : (
@@ -359,7 +388,9 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                 <p className="mt-5 line-clamp-5 text-sm leading-6 text-white/60 sm:line-clamp-6">
                   {descriptionField === DETAIL_LOADING_TEXT
                     ? '상세 정보를 불러오는 중입니다.'
-                    : formatNullableText(detail?.description)}
+                    : descriptionField === DETAIL_FETCH_ERROR_MESSAGE
+                      ? DETAIL_FETCH_ERROR_MESSAGE
+                      : formatNullableText(detail?.description)}
                 </p>
               </div>
             </div>
@@ -404,6 +435,32 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                     </p>
                     <p className="mt-2 text-xs text-white/45 sm:text-sm">
                       제공된 영상 정보가 없습니다.
+                    </p>
+                  </div>
+                ) : detailErrorKind === 'not-found' ? (
+                  <div className="px-4 text-center">
+                    <PlayCircle
+                      aria-hidden="true"
+                      className="mx-auto h-12 w-12 text-white/55 sm:h-16 sm:w-16"
+                    />
+                    <p className="mt-4 text-sm font-semibold text-white/75 sm:text-base">
+                      프로모션 영상 N/A
+                    </p>
+                    <p className="mt-2 text-xs text-white/45 sm:text-sm">
+                      제공된 영상 정보가 없습니다.
+                    </p>
+                  </div>
+                ) : detailErrorKind === 'error' ? (
+                  <div className="px-4 text-center">
+                    <PlayCircle
+                      aria-hidden="true"
+                      className="mx-auto h-12 w-12 text-white/55 sm:h-16 sm:w-16"
+                    />
+                    <p className="mt-4 text-sm font-semibold text-white/75 sm:text-base">
+                      {PROMO_VIDEO_FETCH_ERROR_MESSAGE}
+                    </p>
+                    <p className="mt-2 text-xs text-white/45 sm:text-sm">
+                      잠시 후 다시 시도해 주세요.
                     </p>
                   </div>
                 ) : (
@@ -456,7 +513,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                     ) : hasResolvedDetail ? (
                       'N/A'
                     ) : (
-                      DETAIL_LOADING_TEXT
+                      detailFieldFallback
                     )}
                   </dd>
                 </div>

--- a/src/features/games/hooks/useGameDetailModal.ts
+++ b/src/features/games/hooks/useGameDetailModal.ts
@@ -25,6 +25,8 @@ type GameDetailModalToast = {
   tone: 'error';
 };
 
+type DetailErrorKind = 'not-found' | 'error' | null;
+
 const isLikedGamesResponse = (value: unknown): value is LikedGamesResponse => {
   if (!value || typeof value !== 'object') {
     return false;
@@ -45,6 +47,18 @@ const getLikeErrorMessage = (error: unknown) => {
   }
 
   return LIKE_ERROR_MESSAGE;
+};
+
+const getDetailErrorKind = (error: unknown): DetailErrorKind => {
+  if (!(error instanceof AxiosError)) {
+    return error ? 'error' : null;
+  }
+
+  if (error.response?.status === 404) {
+    return 'not-found';
+  }
+
+  return 'error';
 };
 
 const syncLikedGamesQueryCache = (
@@ -134,6 +148,14 @@ export const useGameDetailModal = (game: GameListItem) => {
   });
 
   const detail = detailQuery.data;
+  const detailErrorKind = getDetailErrorKind(detailQuery.error);
+  const hasFallbackSummary = Boolean(
+    game.name.trim() ||
+    game.thumbnailUrl ||
+    game.genres.length > 0 ||
+    typeof game.rating === 'number' ||
+    typeof game.isLiked === 'boolean',
+  );
   const activeLikeState = likeState?.gameId === game.gameId ? likeState : null;
   const currentLiked =
     activeLikeState?.isLiked ??
@@ -196,8 +218,10 @@ export const useGameDetailModal = (game: GameListItem) => {
   }, [toast]);
 
   return {
+    canRenderFallbackSummary: hasFallbackSummary,
     clearToast: () => setToast(null),
     detail,
+    detailErrorKind,
     detailQuery,
     handleToggleLike,
     hasResolvedDetail: Boolean(detail),

--- a/src/features/matching/api/useMatchingApi.ts
+++ b/src/features/matching/api/useMatchingApi.ts
@@ -5,6 +5,12 @@ import {
   useQuery,
 } from '@tanstack/react-query';
 
+import { shouldRetryApiQuery } from '../../../api/queryRetry';
+import {
+  getPaginatedCount,
+  getPaginatedLoadedCount,
+  getPaginatedNext,
+} from '../../../utils/paginatedResults';
 import {
   getMatchCandidates,
   getMatchingGenreImage,
@@ -21,6 +27,7 @@ export const useMatchCandidatesQuery = (
     enabled: genreId !== null && enabled,
     queryFn: () => getMatchCandidates(genreId!),
     staleTime: 60_000,
+    retry: shouldRetryApiQuery,
   });
 
 export const useMatchingGenreImageQuery = (
@@ -63,15 +70,14 @@ export const useMatchResultsInfinite = (enabled = true) =>
         page_size: 5,
       }),
     getNextPageParam: (lastPage, allPages) => {
-      const loadedCount = allPages.reduce(
-        (count, page) => count + page.results.length,
-        0,
-      );
+      const loadedCount = getPaginatedLoadedCount(allPages);
+      const totalCount = getPaginatedCount(lastPage, 15);
 
-      if (loadedCount >= 15) {
+      if (loadedCount >= totalCount) {
         return undefined;
       }
 
-      return lastPage.next;
+      return getPaginatedNext(lastPage);
     },
+    retry: shouldRetryApiQuery,
   });

--- a/src/features/recommendation/hooks/useRecommendationResultsSource.ts
+++ b/src/features/recommendation/hooks/useRecommendationResultsSource.ts
@@ -1,7 +1,9 @@
 import { useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { useLayoutEffect } from 'react';
 import { useSearchParams } from 'react-router';
 
+import { getPaginatedResults } from '../../../utils/paginatedResults';
 import { useMatchResultsInfinite } from '../../matching/api/useMatchingApi';
 import type { MatchResultResponse } from '../../matching/types';
 import { useSurveyResultsInfinite } from '../../survey/api/useSurveyApi';
@@ -38,22 +40,34 @@ export const useRecommendationResultsSource = ({
     activeQuery;
 
   const surveyItems =
-    surveyResultsQuery.data?.pages.flatMap((page) => page.results) ?? [];
+    surveyResultsQuery.data?.pages.flatMap((page) =>
+      getPaginatedResults(page),
+    ) ?? [];
   const matchItems =
-    matchResultsQuery.data?.pages.flatMap((page) => page.results) ?? [];
+    matchResultsQuery.data?.pages.flatMap((page) =>
+      getPaginatedResults(page),
+    ) ?? [];
   const recommendationItems = (isMatchSource ? matchItems : surveyItems).map(
     normalizeRecommendationItem,
   );
   const recommendationHighlights =
     getRecommendationHighlights(recommendationItems);
-  const errorMessage = error ? extractApiErrorMessage(error) : null;
+  const isResultNotFound =
+    error instanceof AxiosError && error.response?.status === 404;
+  const errorMessage =
+    error && !isResultNotFound ? extractApiErrorMessage(error) : null;
+  const emptyStateMessage =
+    isResultNotFound && isMatchSource
+      ? '매칭 추천 결과가 아직 없습니다. 먼저 매칭 평가를 완료해 주세요.'
+      : isResultNotFound && isSurveySource
+        ? '설문 추천 결과가 아직 준비되지 않았습니다. 설문을 먼저 완료해 주세요.'
+        : isMatchSource
+          ? '매칭 추천 결과가 아직 없습니다.'
+          : '추천 결과가 아직 없습니다.';
   const shouldShowMatchEntryCta =
     isMatchSource &&
     !isLoading &&
-    Boolean(
-      errorMessage?.includes('매칭 추천 결과를 찾을 수 없습니다') ||
-      recommendationItems.length === 0,
-    );
+    (isResultNotFound || recommendationItems.length === 0);
 
   useLayoutEffect(() => {
     if (!canAccessPage) {
@@ -99,6 +113,8 @@ export const useRecommendationResultsSource = ({
     recommendationItems,
     recommendationHighlights,
     errorMessage,
+    emptyStateMessage,
+    isResultNotFound,
     shouldShowMatchEntryCta,
     error,
     isLoading,

--- a/src/features/survey/api/survey.ts
+++ b/src/features/survey/api/survey.ts
@@ -182,6 +182,10 @@ export const extractApiErrorMessage = (error: unknown) => {
     return '요청을 처리하는 중 알 수 없는 오류가 발생했습니다.';
   }
 
+  if (!error.response) {
+    return '서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+  }
+
   const data = error.response?.data as ErrorResponseBody | undefined;
 
   if (typeof data?.detail === 'string') {

--- a/src/features/survey/api/useSurveyApi.ts
+++ b/src/features/survey/api/useSurveyApi.ts
@@ -1,5 +1,11 @@
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 
+import { shouldRetryApiQuery } from '../../../api/queryRetry';
+import {
+  getPaginatedCount,
+  getPaginatedLoadedCount,
+  getPaginatedNext,
+} from '../../../utils/paginatedResults';
 import {
   continueSurveyChat,
   getSurveyResults,
@@ -33,15 +39,14 @@ export const useSurveyResultsInfinite = (enabled = true) =>
         page_size: 5,
       }),
     getNextPageParam: (lastPage, allPages) => {
-      const loadedCount = allPages.reduce(
-        (count, page) => count + page.results.length,
-        0,
-      );
+      const loadedCount = getPaginatedLoadedCount(allPages);
+      const totalCount = getPaginatedCount(lastPage, 15);
 
-      if (loadedCount >= 15) {
+      if (loadedCount >= totalCount) {
         return undefined;
       }
 
-      return lastPage.next;
+      return getPaginatedNext(lastPage);
     },
+    retry: shouldRetryApiQuery,
   });

--- a/src/pages/main/hooks/useMainPageGames.ts
+++ b/src/pages/main/hooks/useMainPageGames.ts
@@ -7,6 +7,11 @@ import { useDebouncedValue } from '../../../features/games/hooks/useDebouncedVal
 import { gamesKeys } from '../../../features/games/queryCache';
 import { normalizeSearchText } from '../../../features/games/search';
 import type { GameListItem } from '../../../features/games/types';
+import {
+  getPaginatedCount,
+  getPaginatedLoadedCount,
+  getPaginatedResults,
+} from '../../../utils/paginatedResults';
 
 const SEARCH_DEBOUNCE_MS = 300;
 const SEARCH_RESULT_PAGE_SIZE = 20;
@@ -56,12 +61,10 @@ export const useMainPageGames = (): MainPageGamesState => {
         pageSize: SEARCH_RESULT_PAGE_SIZE,
       }),
     getNextPageParam: (lastPage, allPages) => {
-      const loadedCount = allPages.reduce(
-        (count, page) => count + page.results.length,
-        0,
-      );
+      const loadedCount = getPaginatedLoadedCount(allPages);
+      const totalCount = getPaginatedCount(lastPage, loadedCount);
 
-      if (loadedCount >= lastPage.count) {
+      if (loadedCount >= totalCount) {
         return undefined;
       }
 
@@ -72,7 +75,9 @@ export const useMainPageGames = (): MainPageGamesState => {
   });
 
   const games = isSearchMode
-    ? (searchGamesQuery.data?.pages.flatMap((page) => page.results) ?? [])
+    ? (searchGamesQuery.data?.pages.flatMap((page) =>
+        getPaginatedResults(page),
+      ) ?? [])
     : (topGamesQuery.data ?? []);
   const isGamesLoading = isSearchMode
     ? searchGamesQuery.isLoading

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -37,6 +37,8 @@ const MATCHING_LIKE_LOGIN_REQUIRED_MESSAGE =
   '로그인 후 좋아요를 사용할 수 있어요.';
 const MATCHING_LIKE_ERROR_MESSAGE =
   '좋아요 상태를 변경하지 못했어요. 잠시 후 다시 시도해 주세요.';
+const MATCHING_CANDIDATES_NETWORK_ERROR_MESSAGE =
+  '매칭 후보 서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.';
 
 const formatMatchingCandidateRating = (rating: number | null) => {
   if (typeof rating !== 'number') {
@@ -62,6 +64,24 @@ const getMatchingLikeErrorMessage = (error: unknown) => {
   }
 
   return MATCHING_LIKE_ERROR_MESSAGE;
+};
+
+const getMatchCandidatesErrorMessage = (error: unknown) => {
+  if (error instanceof AxiosError) {
+    if (!error.response) {
+      return MATCHING_CANDIDATES_NETWORK_ERROR_MESSAGE;
+    }
+
+    if (error.response.status === 400) {
+      return '요청한 장르 정보가 올바르지 않습니다. 장르를 다시 선택해 주세요.';
+    }
+
+    if (error.response.status === 404) {
+      return '해당 장르의 매칭 후보 게임이 아직 준비되지 않았습니다.';
+    }
+  }
+
+  return extractApiErrorMessage(error);
 };
 
 function MatchingGenreDetailPage() {
@@ -330,7 +350,7 @@ function MatchingGenreDetailPage() {
               매칭 후보를 불러오지 못했어요.
             </h1>
             <p className="mt-4 max-w-[52ch] text-sm leading-7 break-keep text-white/60 sm:text-base">
-              {extractApiErrorMessage(matchCandidatesQuery.error)}
+              {getMatchCandidatesErrorMessage(matchCandidatesQuery.error)}
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
               <button

--- a/src/pages/mypage/hooks/useMyPageLikedGames.ts
+++ b/src/pages/mypage/hooks/useMyPageLikedGames.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../../features/auth/types/auth';
 import type { MyPageToastPayload } from '../types';
 import { toFavoriteGameListItem, toFavoriteGamePreview } from '../utils';
+import { getPaginatedResults } from '../../../utils/paginatedResults';
 
 type UseMyPageLikedGamesOptions = {
   enabled: boolean;
@@ -49,7 +50,7 @@ function useMyPageLikedGames({
   const likedGameResults = useMemo(() => {
     const pages = resolvedLikedGamesData?.pages ?? [];
 
-    return pages.flatMap((page) => page.results);
+    return pages.flatMap((page) => getPaginatedResults(page));
   }, [resolvedLikedGamesData]);
   const favoriteGames = useMemo(() => {
     const deduplicatedGames = new Map<number, LikedGameItemResponse>();

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -181,6 +181,8 @@ function RecommendationListPage() {
     recommendationItems,
     recommendationHighlights,
     errorMessage,
+    emptyStateMessage,
+    isResultNotFound,
     shouldShowMatchEntryCta,
     error,
     isLoading,
@@ -325,15 +327,13 @@ function RecommendationListPage() {
                 <div className="px-4 py-14 text-center text-white/65 sm:px-6 lg:px-7">
                   추천 결과를 불러오는 중입니다...
                 </div>
-              ) : error ? (
+              ) : error && !isResultNotFound ? (
                 <div className="px-4 py-12 text-[#ffc2c2] sm:px-6 lg:px-7">
                   {errorMessage}
                 </div>
               ) : recommendationItems.length === 0 ? (
                 <div className="px-4 py-12 text-white/55 sm:px-6 lg:px-7">
-                  {isMatchSource
-                    ? '매칭 추천 결과가 아직 없습니다.'
-                    : '추천 결과가 아직 없습니다.'}
+                  {emptyStateMessage}
                 </div>
               ) : (
                 <>

--- a/src/utils/paginatedResults.ts
+++ b/src/utils/paginatedResults.ts
@@ -1,0 +1,25 @@
+type ResultsPage<T> =
+  | {
+      count?: number | null;
+      next?: string | null;
+      results?: T[] | null;
+    }
+  | null
+  | undefined;
+
+export const getPaginatedResults = <T>(page: ResultsPage<T>) =>
+  Array.isArray(page?.results) ? page.results : [];
+
+export const getPaginatedLoadedCount = <T>(pages: ResultsPage<T>[] = []) =>
+  pages.reduce((count, page) => count + getPaginatedResults(page).length, 0);
+
+export const getPaginatedCount = <T>(page: ResultsPage<T>, fallback = 0) => {
+  if (typeof page?.count === 'number' && Number.isFinite(page.count)) {
+    return page.count;
+  }
+
+  return fallback;
+};
+
+export const getPaginatedNext = <T>(page: ResultsPage<T>) =>
+  typeof page?.next === 'string' && page.next.trim() ? page.next : null;


### PR DESCRIPTION
## 관련 이슈

- closes #276

## 변경 내용

- 게임 상세 모달의 404와 일반 fetch 실패를 분리해서 처리하도록 정리했습니다.
- 카드 기반 fallback이 가능한 경우에는 상세 조회 실패만으로 전체 not-found 화면으로 전환되지 않도록 했습니다.
- 한 번 정상적으로 받은 상세값은 이후 빈 응답이나 부분 응답으로 쉽게 사라지지 않도록 유지했습니다.
- 무한쿼리 결과 page shape 방어 유틸을 추가해 `results`가 없는 page가 들어와도 앱이 크래시하지 않도록 정리했습니다.
- 마이페이지 좋아요 목록, 추천 결과 source, 메인 검색 결과, 설문/매칭 infinite query에 공통 방어를 적용했습니다.
- 4xx 응답은 불필요하게 재시도하지 않도록 공통 query retry 정책을 추가했습니다.
- 추천 결과 source에서 로딩/조회 실패/404/결과 없음 상태를 더 명확히 분리했습니다.
- 장르별 매칭 후보 조회 실패 시 400/404/네트워크 실패에 맞는 안내 문구가 보이도록 정리했습니다.
- 메인 게임 카드 이미지는 기본 opacity와 overlay 강도를 조정해 hover 전 상태가 지나치게 흐릿하지 않도록 개선했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

변경없음

## 참고사항

- 이번 PR은 외부 API 계약 변경 없이 프론트의 에러 분기, 상태 표현, 무한쿼리 방어 로직을 안정화하는 작업입니다.
- 상세 모달은 카드 정보로 즉시 열리는 기존 UX를 유지하면서, 일시 실패/부분 응답에도 더 안정적으로 동작하도록 정리했습니다.
- 메인 카드 이미지 흐림 문제는 서버/MSW 문제가 아니라 프론트 스타일 이슈로 판단해 함께 조정했습니다.
