### PR TITLE
[Fix] 설문 추천 결과 새로고침 복원 및 더보기 레이아웃 정리

### DIFF
--- a/src/features/games/queryCache.ts
+++ b/src/features/games/queryCache.ts
@@ -114,12 +114,12 @@ export const syncGameLikeStateInQueryCache = (
         }
       : currentData;
 
-  queryClient.setQueryData<InfiniteData<LikeableResultPage>>(
-    ['survey-results'],
+  queryClient.setQueriesData<InfiniteData<LikeableResultPage>>(
+    { queryKey: ['survey-results'] },
     updateRecommendationPages,
   );
-  queryClient.setQueryData<InfiniteData<LikeableResultPage>>(
-    ['match-results'],
+  queryClient.setQueriesData<InfiniteData<LikeableResultPage>>(
+    { queryKey: ['match-results'] },
     updateRecommendationPages,
   );
 

--- a/src/features/recommendation/hooks/useRecommendationResultsSource.ts
+++ b/src/features/recommendation/hooks/useRecommendationResultsSource.ts
@@ -6,6 +6,7 @@ import { useSearchParams } from 'react-router';
 import { getPaginatedResults } from '../../../utils/paginatedResults';
 import { useMatchResultsInfinite } from '../../matching/api/useMatchingApi';
 import type { MatchResultResponse } from '../../matching/types';
+import { useSurveyStore } from '../../survey/store/useSurveyStore';
 import { useSurveyResultsInfinite } from '../../survey/api/useSurveyApi';
 import { extractApiErrorMessage } from '../../survey/api/survey';
 import type { SurveyResultResponse } from '../../survey/types/survey';
@@ -24,13 +25,17 @@ export const useRecommendationResultsSource = ({
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const source = searchParams.get('source');
-  const legacySessionId = searchParams.get('session_id');
+  const surveySessionIdFromUrl = searchParams.get('session_id');
+  const storedSurveySessionId = useSurveyStore((state) => state.sessionId);
   const isMatchSource = source === 'match';
   const isSurveySource =
-    source === 'survey' || (!source && Boolean(legacySessionId));
+    source === 'survey' || (!source && Boolean(surveySessionIdFromUrl));
+  const resolvedSurveySessionId =
+    surveySessionIdFromUrl ?? storedSurveySessionId;
 
   const surveyResultsQuery = useSurveyResultsInfinite(
     !isMatchSource && isSurveySource && canAccessPage,
+    resolvedSurveySessionId,
   );
   const matchResultsQuery = useMatchResultsInfinite(
     isMatchSource && canAccessPage,
@@ -92,10 +97,10 @@ export const useRecommendationResultsSource = ({
     }
 
     if (isSurveySource) {
-      queryClient.setQueryData<{
+      queryClient.setQueriesData<{
         pages: SurveyResultResponse[];
         pageParams: unknown[];
-      }>(['survey-results'], (currentData) =>
+      }>({ queryKey: ['survey-results'] }, (currentData) =>
         currentData
           ? {
               ...currentData,

--- a/src/features/survey/api/useSurveyApi.ts
+++ b/src/features/survey/api/useSurveyApi.ts
@@ -28,15 +28,19 @@ export const useResetSurveyMutation = () =>
     mutationFn: resetSurveySession,
   });
 
-export const useSurveyResultsInfinite = (enabled = true) =>
+export const useSurveyResultsInfinite = (
+  enabled = true,
+  sessionId?: string | null,
+) =>
   useInfiniteQuery({
-    queryKey: ['survey-results'],
+    queryKey: ['survey-results', sessionId ?? 'current'],
     initialPageParam: null as string | null,
     enabled,
     queryFn: ({ pageParam }) =>
       getSurveyResults({
         cursor: pageParam ?? undefined,
         page_size: 5,
+        session_id: sessionId ?? undefined,
       }),
     getNextPageParam: (lastPage, allPages) => {
       const loadedCount = getPaginatedLoadedCount(allPages);

--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -37,6 +37,7 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
   const sessionId = useSurveyStore((state) => state.sessionId);
   const messages = useSurveyStore((state) => state.messages);
   const progress = useSurveyStore((state) => state.progress);
+  const storedSessionId = useSurveyStore((state) => state.sessionId);
   const hasBootstrapped = useSurveyStore((state) => state.hasBootstrapped);
   const isSubmitting = useSurveyStore((state) => state.isSubmitting);
   const error = useSurveyStore((state) => state.error);
@@ -133,7 +134,10 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
     }
 
     startTransition(() => {
-      navigate(`/${ROUTES.RECOMMENDATION_LIST}?source=survey`);
+      const surveySessionQuery = storedSessionId
+        ? `?source=survey&session_id=${storedSessionId}`
+        : '?source=survey';
+      navigate(`/${ROUTES.RECOMMENDATION_LIST}${surveySessionQuery}`);
     });
   };
 

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -206,11 +206,12 @@ export const surveyHandlers = [
     const pageSize = Number(
       url.searchParams.get('page_size') ?? DEFAULT_RECOMMENDATION_PAGE_SIZE,
     );
+    const requestedSessionId = url.searchParams.get('session_id');
     const recommendations = buildSurveyRecommendations(
       request.headers.get('authorization'),
     );
 
-    if (!latestCompletedSurveySessionId) {
+    if (!latestCompletedSurveySessionId && !requestedSessionId) {
       return getErrorResponse(404, '설문 추천 결과를 찾을 수 없습니다.');
     }
 

--- a/src/features/survey/types/survey.ts
+++ b/src/features/survey/types/survey.ts
@@ -86,6 +86,7 @@ export interface SurveyResultQuery {
   sort?: string;
   cursor?: string;
   page_size?: number;
+  session_id?: string;
 }
 
 export interface SurveyApiResultItem {

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -229,8 +229,8 @@ function RecommendationListPage() {
       <RecommendationBackdrop items={recommendationItems} />
       <LazyHeader fixed />
 
-      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-300 flex-col px-3 pt-24 pb-10 sm:px-4 sm:pt-28 sm:pb-12 md:px-8 md:pt-32 md:pb-16">
-        <section className="mx-auto w-full max-w-245">
+      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-300 flex-col px-3 pt-24 pb-8 sm:px-4 sm:pt-28 sm:pb-10 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
+        <section className="mx-auto flex min-h-0 w-full max-w-245 flex-1 flex-col">
           <div className="mb-8">
             <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
               <div>
@@ -314,7 +314,7 @@ function RecommendationListPage() {
               </Link>
             </section>
           ) : (
-            <section className="overflow-hidden rounded-4xl border border-white/8 bg-[linear-gradient(180deg,rgba(16,16,18,0.92),rgba(9,9,10,0.98))] shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-2xl">
+            <section className="flex min-h-0 flex-col overflow-hidden rounded-4xl border border-white/8 bg-[linear-gradient(180deg,rgba(16,16,18,0.92),rgba(9,9,10,0.98))] shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-2xl">
               {feedbackMessage ? (
                 <div className="border-b border-white/8 px-4 py-4 sm:px-6 lg:px-7">
                   <p className="text-sm leading-6 break-keep text-[#ffc2c2]">
@@ -339,7 +339,7 @@ function RecommendationListPage() {
                 <>
                   <div
                     ref={recommendationScrollRef}
-                    className="recommendation-scroll max-h-[62vh] overflow-y-auto"
+                    className="recommendation-scroll min-h-0 flex-1 overflow-y-auto"
                   >
                     <div className="divide-y divide-white/8">
                       {recommendationItems.map((item) => (
@@ -359,24 +359,19 @@ function RecommendationListPage() {
                       type="button"
                       onClick={handleLoadMore}
                       disabled={isFetchingNextPage}
-                      className="flex w-full flex-col items-center justify-center gap-1.5 border-t border-white/8 bg-[linear-gradient(180deg,rgba(255,255,255,0.01),rgba(255,255,255,0.03))] px-4 py-4 text-sm font-medium text-white/82 transition hover:bg-white/4 hover:text-white disabled:cursor-not-allowed disabled:opacity-45 sm:px-6 lg:px-7"
+                      className="flex w-full items-center justify-center gap-2 border-t border-white/8 bg-[linear-gradient(180deg,rgba(255,255,255,0.01),rgba(255,255,255,0.03))] px-4 py-2.5 text-sm font-medium text-white/82 transition hover:bg-white/4 hover:text-white disabled:cursor-not-allowed disabled:opacity-45 sm:px-6 lg:px-7"
                     >
+                      {!isFetchingNextPage ? (
+                        <ChevronDown
+                          size={16}
+                          className="translate-y-px text-white/56"
+                        />
+                      ) : null}
                       <span>
                         {isFetchingNextPage
                           ? '추천 결과를 불러오는 중입니다...'
                           : '더보기'}
                       </span>
-                      <div className="flex flex-col items-center gap-0.5">
-                        {!isFetchingNextPage ? (
-                          <ChevronDown
-                            size={18}
-                            className="translate-y-px text-white/56"
-                          />
-                        ) : null}
-                        <span className="text-[11px] font-normal tracking-[0.14em] text-white/38 uppercase">
-                          {isFetchingNextPage ? 'Loading' : 'More Below'}
-                        </span>
-                      </div>
                     </button>
                   ) : null}
                 </>

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -42,6 +42,7 @@ function SurveyPage() {
   const account = useAuthStore((state) => state.account);
   const syncOwnerKey = useSurveyStore((state) => state.syncOwnerKey);
   const storedOwnerKey = useSurveyStore((state) => state.ownerKey);
+  const surveySessionId = useSurveyStore((state) => state.sessionId);
   const messages = useSurveyStore((state) => state.messages);
   const recommendationReady = useSurveyStore(
     (state) => state.recommendationReady,
@@ -52,11 +53,17 @@ function SurveyPage() {
   >(null);
   const surveyOwnerKey = account?.login_id
     ? `survey-user:${account.login_id}`
-    : authGate.isAuthenticated
-      ? 'survey-user:authenticated'
-      : authGate.canBypassAuth
-        ? 'survey-user:mock'
-        : 'survey-user:guest';
+    : authGate.isAuthenticated &&
+        storedOwnerKey &&
+        storedOwnerKey !== 'survey-user:authenticated' &&
+        storedOwnerKey !== 'survey-user:guest' &&
+        storedOwnerKey !== 'survey-user:mock'
+      ? storedOwnerKey
+      : authGate.isAuthenticated
+        ? 'survey-user:authenticated'
+        : authGate.canBypassAuth
+          ? 'survey-user:mock'
+          : 'survey-user:guest';
 
   useEffect(() => {
     syncOwnerKey(surveyOwnerKey);
@@ -107,8 +114,14 @@ function SurveyPage() {
   }
 
   if (shouldRedirectCompletedEntry) {
+    const recommendationQuery = surveySessionId
+      ? `?source=survey&session_id=${encodeURIComponent(surveySessionId)}`
+      : '?source=survey';
     return (
-      <Navigate to={`/${ROUTES.RECOMMENDATION_LIST}?source=survey`} replace />
+      <Navigate
+        to={`/${ROUTES.RECOMMENDATION_LIST}${recommendationQuery}`}
+        replace
+      />
     );
   }
 


### PR DESCRIPTION
## 관련 이슈

- closes #279 

## 변경 내용

- 설문 완료 후 추천 리스트로 이동할 때 `session_id`를 함께 전달하도록 수정
- 추천 리스트가 survey source일 때 URL의 `session_id` 또는 survey store의 `sessionId`를 기준으로 결과를 다시 조회하도록 정리
- MSW survey result handler도 `session_id` 기준으로 결과를 다시 복원할 수 있도록 수정
- survey result query key가 세션별로 달라져도 좋아요 캐시 동기화가 계속 반영되도록 query cache 갱신 범위를 보강
- 로그인 직후 account bootstrap 과정에서 survey owner key가 흔들리며 설문 상태가 초기화되는 문제를 줄이도록 owner key 복원 로직을 보강
- 추천 리스트 하단 더보기 영역 높이를 줄이고 `More Below` 문구를 제거
- 추천 리스트 페이지를 데스크톱 기준 `dvh` 레이아웃으로 조정해 바깥 페이지 스크롤이 생기지 않도록 정리

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 설문 완료 후 추천 결과 새로고침 복원과 추천 리스트 하단 레이아웃 안정화에 집중했습니다.
- 설문 추천 결과는 이제 메모리 상태가 아닌 `session_id` 기준으로도 다시 불러올 수 있습니다.
