### PR TITLE
[Fix] 홈 카드 상세 MSW 및 홈 목록 상태 안정화

### DIFF
--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -33,7 +33,6 @@ const DETAIL_NOT_FOUND_TITLE = '게임 상세 정보 없음';
 const DETAIL_NOT_FOUND_MESSAGE = '해당 게임 상세 정보를 찾을 수 없습니다.';
 const DETAIL_FETCH_ERROR_MESSAGE =
   '상세 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.';
-const PROMO_VIDEO_FETCH_ERROR_MESSAGE = '프로모션 영상을 불러오지 못했습니다.';
 
 const GameDetailModalSkeleton = ({ game }: { game: GameListItem }) => {
   const title = normalizeMeaningfulText(game.name) ?? 'N/A';
@@ -45,7 +44,7 @@ const GameDetailModalSkeleton = ({ game }: { game: GameListItem }) => {
       {/* 상단: 커버 이미지 + 기본 정보 */}
       <div className="grid gap-5 px-5 pt-5 pb-6 sm:grid-cols-[216px_minmax(0,1fr)] sm:px-7 sm:pt-7">
         {/* 커버 이미지: 리스트 썸네일로 즉시 표시 */}
-        <div className="relative isolate aspect-4/5 w-[min(56vw,13.5rem)] max-w-full overflow-hidden rounded-lg border border-white/10 bg-[#1a1a1a] sm:w-54">
+        <div className="bg-header-button-border relative isolate aspect-4/5 w-[min(56vw,13.5rem)] max-w-full overflow-hidden rounded-lg border border-white/10 sm:w-54">
           {game.thumbnailUrl ? (
             <img
               src={game.thumbnailUrl}
@@ -184,15 +183,12 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
     detail?.promoEmbedUrl?.trim() || null,
     promoVideoUrl,
   );
-  const detailFieldFallback =
-    detailErrorKind === 'error' && !hasResolvedDetail
-      ? DETAIL_FETCH_ERROR_MESSAGE
-      : detailErrorKind === 'not-found' && !hasResolvedDetail
-        ? 'N/A'
-        : DETAIL_LOADING_TEXT;
+  const isInitialDetailLoading = detailQuery.isPending && !hasResolvedDetail;
+  const detailFieldFallback = isInitialDetailLoading
+    ? DETAIL_LOADING_TEXT
+    : 'N/A';
   const descriptionField =
-    normalizeMeaningfulText(detail?.description) ??
-    (hasResolvedDetail ? 'N/A' : detailFieldFallback);
+    normalizeMeaningfulText(detail?.description) ?? detailFieldFallback;
   const detailRows = [
     {
       label: '게임 출시일',
@@ -311,7 +307,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
         ) : (
           <>
             <div className="grid gap-5 px-5 pt-5 pb-6 sm:grid-cols-[216px_minmax(0,1fr)] sm:px-7 sm:pt-7">
-              <div className="relative isolate aspect-4/5 w-[min(56vw,13.5rem)] max-w-full overflow-hidden rounded-lg border border-white/10 bg-[#1a1a1a] sm:w-54">
+              <div className="bg-header-button-border relative isolate aspect-4/5 w-[min(56vw,13.5rem)] max-w-full overflow-hidden rounded-lg border border-white/10 sm:w-54">
                 {imageUrl ? (
                   <img
                     src={imageUrl}
@@ -388,9 +384,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                 <p className="mt-5 line-clamp-5 text-sm leading-6 text-white/60 sm:line-clamp-6">
                   {descriptionField === DETAIL_LOADING_TEXT
                     ? '상세 정보를 불러오는 중입니다.'
-                    : descriptionField === DETAIL_FETCH_ERROR_MESSAGE
-                      ? DETAIL_FETCH_ERROR_MESSAGE
-                      : formatNullableText(detail?.description)}
+                    : formatNullableText(descriptionField)}
                 </p>
               </div>
             </div>
@@ -424,7 +418,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                       {title} 관련 영상 페이지로 이동합니다.
                     </p>
                   </a>
-                ) : hasResolvedDetail ? (
+                ) : hasResolvedDetail || detailQuery.isError ? (
                   <div className="px-4 text-center">
                     <PlayCircle
                       aria-hidden="true"
@@ -435,32 +429,6 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                     </p>
                     <p className="mt-2 text-xs text-white/45 sm:text-sm">
                       제공된 영상 정보가 없습니다.
-                    </p>
-                  </div>
-                ) : detailErrorKind === 'not-found' ? (
-                  <div className="px-4 text-center">
-                    <PlayCircle
-                      aria-hidden="true"
-                      className="mx-auto h-12 w-12 text-white/55 sm:h-16 sm:w-16"
-                    />
-                    <p className="mt-4 text-sm font-semibold text-white/75 sm:text-base">
-                      프로모션 영상 N/A
-                    </p>
-                    <p className="mt-2 text-xs text-white/45 sm:text-sm">
-                      제공된 영상 정보가 없습니다.
-                    </p>
-                  </div>
-                ) : detailErrorKind === 'error' ? (
-                  <div className="px-4 text-center">
-                    <PlayCircle
-                      aria-hidden="true"
-                      className="mx-auto h-12 w-12 text-white/55 sm:h-16 sm:w-16"
-                    />
-                    <p className="mt-4 text-sm font-semibold text-white/75 sm:text-base">
-                      {PROMO_VIDEO_FETCH_ERROR_MESSAGE}
-                    </p>
-                    <p className="mt-2 text-xs text-white/45 sm:text-sm">
-                      잠시 후 다시 시도해 주세요.
                     </p>
                   </div>
                 ) : (

--- a/src/features/games/detailCachePriming.ts
+++ b/src/features/games/detailCachePriming.ts
@@ -1,0 +1,59 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+import { isMockServiceWorkerEnabled } from '../../lib/env';
+import { gamesKeys } from './queryCache';
+import type { GameDetail, GameListItem } from './types';
+
+let mockStateModulePromise: Promise<typeof import('./mocks/state')> | null =
+  null;
+
+const loadMockStateModule = () => {
+  if (!mockStateModulePromise) {
+    mockStateModulePromise = import('./mocks/state');
+  }
+
+  return mockStateModulePromise;
+};
+
+const createPrimedDetailSnapshot = (
+  detail: GameDetail,
+  game: GameListItem,
+): GameDetail => ({
+  ...detail,
+  title: detail.title?.trim() ? detail.title : game.name.trim() || 'N/A',
+  genres: detail.genres.length ? detail.genres : game.genres,
+  coverImageUrl: detail.coverImageUrl ?? game.thumbnailUrl,
+  isLiked: typeof game.isLiked === 'boolean' ? game.isLiked : detail.isLiked,
+});
+
+export const primeGameDetailCacheFromList = async (
+  queryClient: QueryClient,
+  games: GameListItem[],
+) => {
+  if (!isMockServiceWorkerEnabled() || games.length === 0) {
+    return;
+  }
+
+  const { getStoredGameDetailSnapshot } = await loadMockStateModule();
+
+  games.forEach((game) => {
+    const currentDetail = queryClient.getQueryData<GameDetail>(
+      gamesKeys.detail(game.gameId),
+    );
+
+    if (currentDetail) {
+      return;
+    }
+
+    const snapshot = getStoredGameDetailSnapshot(game.gameId);
+
+    if (!snapshot) {
+      return;
+    }
+
+    queryClient.setQueryData<GameDetail>(
+      gamesKeys.detail(game.gameId),
+      createPrimedDetailSnapshot(snapshot, game),
+    );
+  });
+};

--- a/src/features/games/hooks/useGameDetailModal.ts
+++ b/src/features/games/hooks/useGameDetailModal.ts
@@ -3,6 +3,7 @@ import { AxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 
 import { useAuthStore } from '../../../store/useAuthStore';
+import { shouldRetryApiQuery } from '../../../api/queryRetry';
 import { authKeys } from '../../auth/api/queryKeys';
 import type { LikedGamesResponse } from '../../auth/types/auth';
 import {
@@ -144,7 +145,7 @@ export const useGameDetailModal = (game: GameListItem) => {
     gcTime: GAME_DETAIL_GC_TIME,
     refetchOnMount: true,
     refetchOnWindowFocus: false,
-    retry: false,
+    retry: shouldRetryApiQuery,
   });
 
   const detail = detailQuery.data;

--- a/src/features/games/mocks/state.ts
+++ b/src/features/games/mocks/state.ts
@@ -396,3 +396,9 @@ export const getStoredGameDetail = (
     likeCount: resolvedLikeState.likeCount,
   };
 };
+
+export const getStoredGameDetailSnapshot = (gameId: number) => {
+  const detail = ensureStoredDetail(gameId);
+
+  return detail ? cloneGameDetail(detail) : null;
+};

--- a/src/pages/main/components/MainGameCarousel.tsx
+++ b/src/pages/main/components/MainGameCarousel.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import type { Swiper as SwiperInstance } from 'swiper';
@@ -182,7 +182,7 @@ type EmptyGameListProps = {
   isFiltered: boolean;
 };
 
-export const EmptyGameList = ({ isFiltered }: EmptyGameListProps) => {
+const useGameCardEmptyStateHeight = () => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [cardHeight, setCardHeight] = useState<number | null>(null);
 
@@ -232,6 +232,12 @@ export const EmptyGameList = ({ isFiltered }: EmptyGameListProps) => {
     };
   }, []);
 
+  return { cardHeight, containerRef };
+};
+
+export const EmptyGameList = ({ isFiltered }: EmptyGameListProps) => {
+  const { cardHeight, containerRef } = useGameCardEmptyStateHeight();
+
   return (
     <div className="relative left-1/2 w-screen -translate-x-1/2">
       <div className="px-[clamp(1rem,5vw,20rem)] py-2">
@@ -252,12 +258,45 @@ export const EmptyGameList = ({ isFiltered }: EmptyGameListProps) => {
   );
 };
 
+type ErrorGameListProps = {
+  message: string;
+  onRetry: () => void;
+};
+
+export const ErrorGameList = ({ message, onRetry }: ErrorGameListProps) => {
+  const { cardHeight, containerRef } = useGameCardEmptyStateHeight();
+
+  return (
+    <div className="relative left-1/2 w-screen -translate-x-1/2">
+      <div className="px-[clamp(1rem,5vw,20rem)] py-2">
+        <div ref={containerRef}>
+          <div
+            className="bg-mypage-soft flex flex-col items-center justify-center gap-5 rounded-lg border border-[#5a1115]/60 px-6 text-center"
+            style={cardHeight ? { minHeight: `${cardHeight}px` } : undefined}
+          >
+            <p className="max-w-xl text-base leading-7 text-white/70">
+              {message}
+            </p>
+            <button
+              type="button"
+              onClick={onRetry}
+              className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-white/12 bg-white/3 px-5 py-3 text-sm font-medium text-white/85 transition hover:border-[#d20b12]/60 hover:bg-[#160b0b] hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#d20b12]"
+            >
+              <RefreshCw aria-hidden="true" className="h-4 w-4" />
+              다시 시도
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const GameListUpdatingOverlay = () => (
   <div className="pointer-events-none absolute inset-0 z-10 overflow-hidden rounded-lg">
-    <div className="absolute inset-0 bg-black/20 backdrop-blur-[1px]" />
     <div className="absolute top-3 right-3 flex items-center gap-2">
-      <div className="h-2.5 w-14 animate-pulse rounded-full bg-white/20" />
-      <div className="h-2.5 w-8 animate-pulse rounded-full bg-white/15" />
+      <div className="h-2.5 w-14 animate-pulse rounded-full bg-white/22 shadow-[0_0_12px_rgba(255,255,255,0.08)]" />
+      <div className="h-2.5 w-8 animate-pulse rounded-full bg-white/16 shadow-[0_0_12px_rgba(255,255,255,0.05)]" />
     </div>
   </div>
 );

--- a/src/pages/main/components/MainGamesSection.tsx
+++ b/src/pages/main/components/MainGamesSection.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import type { GameListItem } from '../../../features/games/types';
 import type { MainPageGamesState } from '../hooks/useMainPageGames';
 import MainGameCarousel, {
+  ErrorGameList,
   EmptyGameList,
   GameCardSkeletonList,
 } from './MainGameCarousel';
@@ -19,13 +20,16 @@ const MainGamesSection = ({
   carouselKey,
   games,
   isGamesLoading,
+  isGamesError,
   isGamesUpdating,
   isFiltered,
+  gamesErrorMessage,
   hasMoreSearchResults,
   isFetchingMoreSearchResults,
   setSearchText,
   setSelectedGenre,
   fetchMoreSearchResults,
+  retryGames,
   onSelectGame,
 }: MainGamesSectionProps) => {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
@@ -77,6 +81,14 @@ const MainGamesSection = ({
 
       {isGamesLoading ? (
         <GameCardSkeletonList />
+      ) : isGamesError ? (
+        <ErrorGameList
+          message={
+            gamesErrorMessage ??
+            '인기 게임 목록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.'
+          }
+          onRetry={retryGames}
+        />
       ) : games.length > 0 ? (
         <>
           <MainGameCarousel

--- a/src/pages/main/hooks/useMainPageGames.ts
+++ b/src/pages/main/hooks/useMainPageGames.ts
@@ -1,6 +1,13 @@
-import { useState } from 'react';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
+import { shouldRetryApiQuery } from '../../../api/queryRetry';
+import { primeGameDetailCacheFromList } from '../../../features/games/detailCachePriming';
 import { getTopGames, searchGames } from '../../../features/games/gameApi';
 import type { GameGenreFilter } from '../../../features/games/genres';
 import { useDebouncedValue } from '../../../features/games/hooks/useDebouncedValue';
@@ -23,16 +30,44 @@ export type MainPageGamesState = {
   carouselKey: string;
   games: GameListItem[];
   isGamesLoading: boolean;
+  isGamesError: boolean;
   isGamesUpdating: boolean;
   isFiltered: boolean;
+  gamesErrorMessage: string | null;
   hasMoreSearchResults: boolean;
   isFetchingMoreSearchResults: boolean;
   setSearchText: (value: string) => void;
   setSelectedGenre: (genre: GameGenreFilter) => void;
   fetchMoreSearchResults: () => void;
+  retryGames: () => void;
+};
+
+const getMainGamesErrorMessage = (error: unknown, isSearchMode: boolean) => {
+  const subject = isSearchMode ? '검색 결과' : '인기 게임 목록';
+
+  if (error instanceof AxiosError) {
+    if (!error.response) {
+      return `${subject} 서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.`;
+    }
+
+    const data = error.response.data as
+      | { detail?: string; error_detail?: string }
+      | undefined;
+
+    if (typeof data?.detail === 'string') {
+      return data.detail;
+    }
+
+    if (typeof data?.error_detail === 'string') {
+      return data.error_detail;
+    }
+  }
+
+  return `${subject}을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.`;
 };
 
 export const useMainPageGames = (): MainPageGamesState => {
+  const queryClient = useQueryClient();
   const [searchText, setSearchText] = useState('');
   const [selectedGenre, setSelectedGenre] = useState<GameGenreFilter>('전체');
   const debouncedSearchText = useDebouncedValue(
@@ -46,7 +81,9 @@ export const useMainPageGames = (): MainPageGamesState => {
     enabled: !isSearchMode,
     queryFn: () => getTopGames({ genre: selectedGenre }),
     staleTime: 60_000,
+    refetchOnMount: false,
     refetchOnWindowFocus: false,
+    retry: shouldRetryApiQuery,
   });
 
   const searchGamesQuery = useInfiniteQuery({
@@ -71,17 +108,26 @@ export const useMainPageGames = (): MainPageGamesState => {
       return allPages.length + 1;
     },
     staleTime: 60_000,
+    refetchOnMount: false,
     refetchOnWindowFocus: false,
+    retry: shouldRetryApiQuery,
   });
 
-  const games = isSearchMode
-    ? (searchGamesQuery.data?.pages.flatMap((page) =>
-        getPaginatedResults(page),
-      ) ?? [])
-    : (topGamesQuery.data ?? []);
+  const games = useMemo(
+    () =>
+      isSearchMode
+        ? (searchGamesQuery.data?.pages.flatMap((page) =>
+            getPaginatedResults(page),
+          ) ?? [])
+        : (topGamesQuery.data ?? []),
+    [isSearchMode, searchGamesQuery.data?.pages, topGamesQuery.data],
+  );
   const isGamesLoading = isSearchMode
     ? searchGamesQuery.isLoading
     : topGamesQuery.isLoading;
+  const isGamesError = isSearchMode
+    ? searchGamesQuery.isError && games.length === 0
+    : topGamesQuery.isError && games.length === 0;
   const isGamesUpdating = isSearchMode
     ? searchGamesQuery.isFetching &&
       !searchGamesQuery.isLoading &&
@@ -95,6 +141,20 @@ export const useMainPageGames = (): MainPageGamesState => {
   const sectionTitle = isSearchMode
     ? `"${debouncedSearchText}" 검색 결과`
     : '인기 TOP 100 🔥';
+  const gamesErrorMessage = isGamesError
+    ? getMainGamesErrorMessage(
+        isSearchMode ? searchGamesQuery.error : topGamesQuery.error,
+        isSearchMode,
+      )
+    : null;
+
+  useEffect(() => {
+    if (games.length === 0) {
+      return;
+    }
+
+    void primeGameDetailCacheFromList(queryClient, games);
+  }, [games, queryClient]);
 
   return {
     searchText,
@@ -103,8 +163,10 @@ export const useMainPageGames = (): MainPageGamesState => {
     carouselKey: `${debouncedSearchText}-${selectedGenre}`,
     games,
     isGamesLoading,
+    isGamesError,
     isGamesUpdating,
     isFiltered: isSearchMode || selectedGenre !== '전체',
+    gamesErrorMessage,
     hasMoreSearchResults,
     isFetchingMoreSearchResults: searchGamesQuery.isFetchingNextPage,
     setSearchText,
@@ -115,6 +177,14 @@ export const useMainPageGames = (): MainPageGamesState => {
       }
 
       void searchGamesQuery.fetchNextPage();
+    },
+    retryGames: () => {
+      if (isSearchMode) {
+        void searchGamesQuery.refetch();
+        return;
+      }
+
+      void topGamesQuery.refetch();
     },
   };
 };


### PR DESCRIPTION
## 관련 이슈

- closes #282

## 변경 내용

- MSW 모드에서 홈/검색 카드의 상세 cache를 미리 프라이밍하도록 정리했습니다.
- 아직 한 번도 클릭하지 않은 카드도 첫 클릭 시 상세 cache를 활용해 안정적으로 상세 모달이 열리도록 보강했습니다.
- 게임 상세 모달은 최초 fetch 실패 시 필드 단위 에러 문구를 직접 노출하지 않고, 카드 기반 요약 정보와 중립 fallback을 우선 유지하도록 정리했습니다.
- 홈 목록은 실제 빈 상태와 요청 실패 상태를 분리했습니다.
- 요청 실패 시 `표시할 인기 게임 목록이 없습니다.` 대신 에러 상태와 다시 시도 버튼이 보이도록 변경했습니다.
- infinite query page shape 방어 유틸을 추가해 `results`가 없는 응답이 들어와도 크래시하지 않도록 정리했습니다.
- 4xx 응답은 불필요하게 재시도하지 않도록 query retry 정책을 공통화했습니다.
- 홈 카드 이미지와 업데이트 overlay 표현을 조정해, 마이페이지에서 오래 머문 뒤 홈으로 돌아왔을 때 카드가 기본 상태에서 탁하게 보이는 현상을 줄였습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 확인 후 첨부 예정입니다.

## 참고사항

- 이번 PR은 외부 API 계약 변경 없이 프론트의 상태 분기, 상세 fallback, infinite query 방어, MSW 개발환경 안정화를 목표로 한 수정입니다.
- 실서버 경로에는 MSW 전용 상세 프라이밍 로직이 직접 섞이지 않도록 구분했습니다.
- 상세 모달은 여전히 카드 정보로 즉시 열리며, 상세 전용 필드는 백그라운드 보강 흐름을 유지합니다.
