### PR TITLE
[Fix] 설문 세션 및 장르별 매칭 후보 MSW 안정화

### DIFF
--- a/src/features/matching/api/matching.ts
+++ b/src/features/matching/api/matching.ts
@@ -1,4 +1,6 @@
 import { api } from '../../../api/axios';
+import { isMockServiceWorkerEnabled } from '../../../lib/env';
+import { getMatchingMockCandidatesSnapshot } from '../mocks/runtime';
 import type {
   MatchingApiCandidateItem,
   MatchingApiCandidatesResponse,
@@ -25,22 +27,38 @@ const normalizeMatchCandidate = (item: MatchingApiCandidateItem) => ({
 });
 
 export const getMatchCandidates = async (genreId: number) => {
-  const response = await api.get<MatchingApiCandidatesResponse>(
-    `${MATCHING_BASE_PATH}/candidates`,
-    {
-      params: {
-        genre_id: genreId,
-      },
-    },
-  );
+  const getMockFallback = () => getMatchingMockCandidatesSnapshot(genreId);
 
-  return {
-    genre_id: response.data.genre_id,
-    count: response.data.count,
-    results: Array.isArray(response.data.results)
+  try {
+    const response = await api.get<MatchingApiCandidatesResponse>(
+      `${MATCHING_BASE_PATH}/candidates`,
+      {
+        params: {
+          genre_id: genreId,
+        },
+      },
+    );
+
+    const results = Array.isArray(response.data.results)
       ? response.data.results.map(normalizeMatchCandidate)
-      : [],
-  } satisfies MatchingCandidatesResponse;
+      : [];
+
+    if (isMockServiceWorkerEnabled() && results.length === 0) {
+      return getMockFallback();
+    }
+
+    return {
+      genre_id: response.data.genre_id,
+      count: response.data.count,
+      results,
+    } satisfies MatchingCandidatesResponse;
+  } catch (error) {
+    if (!isMockServiceWorkerEnabled()) {
+      throw error;
+    }
+
+    return getMockFallback();
+  }
 };
 
 export const getMatchingGenreImage = async (genreId: number) => {

--- a/src/features/matching/mocks/runtime.ts
+++ b/src/features/matching/mocks/runtime.ts
@@ -1,0 +1,23 @@
+import type { MatchingCandidatesResponse } from '../types';
+import { matchingMockCandidatesByGenreId } from './data';
+
+export const getMatchingMockCandidatesSnapshot = (
+  genreId: number,
+): MatchingCandidatesResponse => {
+  const candidates = matchingMockCandidatesByGenreId[genreId] ?? [];
+
+  return {
+    genre_id: genreId,
+    count: candidates.length,
+    results: candidates.map((candidate) => ({
+      game_id: candidate.game_id,
+      title: candidate.title,
+      description: candidate.description,
+      genres: candidate.genres,
+      thumbnail_url: candidate.thumbnail_url,
+      trailer_url: candidate.trailer_url,
+      rating: candidate.rating,
+      is_liked: false,
+    })),
+  };
+};

--- a/src/features/survey/api/survey.ts
+++ b/src/features/survey/api/survey.ts
@@ -1,6 +1,13 @@
 import { AxiosError } from 'axios';
 
 import { api } from '../../../api/axios';
+import { isMockServiceWorkerEnabled } from '../../../lib/env';
+import {
+  continueMockSurveyChat,
+  getMockSurveyResults,
+  resetMockSurveySession,
+  startMockSurveySession,
+} from '../mocks/runtime';
 import type {
   SurveyApiChatRequest,
   SurveyApiResetResponse,
@@ -136,45 +143,90 @@ export const normalizeSurveyResultResponse = (
 export const startSurveySession = async (
   payload: SurveySessionStartRequest,
 ): Promise<SurveySessionStartResponse> => {
-  const response = await api.post<SurveyApiSessionResponse>(
-    `${SURVEY_CHATBOT_BASE_PATH}/sessions`,
-    payload satisfies SurveyApiSessionStartRequest,
-  );
+  try {
+    const response = await api.post<SurveyApiSessionResponse>(
+      `${SURVEY_CHATBOT_BASE_PATH}/sessions`,
+      payload satisfies SurveyApiSessionStartRequest,
+    );
 
-  return normalizeSurveySessionResponse(response.data);
+    return normalizeSurveySessionResponse(response.data);
+  } catch (error) {
+    if (!isMockServiceWorkerEnabled()) {
+      throw error;
+    }
+
+    return normalizeSurveySessionResponse(startMockSurveySession());
+  }
 };
 
 export const continueSurveyChat = async (
   payload: SurveyChatRequest,
 ): Promise<SurveyChatResponse> => {
-  const response = await api.post<SurveyApiSessionResponse>(
-    `${SURVEY_CHATBOT_BASE_PATH}/sessions/${payload.session_id}/messages`,
-    {
-      user_answer: payload.user_answer,
-    } satisfies SurveyApiChatRequest,
-  );
+  try {
+    const response = await api.post<SurveyApiSessionResponse>(
+      `${SURVEY_CHATBOT_BASE_PATH}/sessions/${payload.session_id}/messages`,
+      {
+        user_answer: payload.user_answer,
+      } satisfies SurveyApiChatRequest,
+    );
 
-  return normalizeSurveySessionResponse(response.data);
+    return normalizeSurveySessionResponse(response.data);
+  } catch (error) {
+    if (!isMockServiceWorkerEnabled()) {
+      throw error;
+    }
+
+    return normalizeSurveySessionResponse(
+      continueMockSurveyChat({
+        session_id: payload.session_id,
+        user_answer: payload.user_answer,
+      }),
+    );
+  }
 };
 
 export const resetSurveySession = async (payload: SurveyResetRequest) => {
-  const response = await api.post<SurveyApiResetResponse>(
-    `${SURVEY_BASE_PATH}/sessions/reset`,
-    payload,
-  );
+  try {
+    const response = await api.post<SurveyApiResetResponse>(
+      `${SURVEY_BASE_PATH}/sessions/reset`,
+      payload,
+    );
 
-  return normalizeSurveyResetResponse(response.data);
+    return normalizeSurveyResetResponse(response.data);
+  } catch (error) {
+    if (!isMockServiceWorkerEnabled()) {
+      throw error;
+    }
+
+    return normalizeSurveyResetResponse(
+      resetMockSurveySession(payload.session_id),
+    );
+  }
 };
 
 export const getSurveyResults = async (query: SurveyResultQuery) => {
-  const response = await api.get<SurveyApiResultResponse>(
-    `${SURVEY_BASE_PATH}/result`,
-    {
-      params: query,
-    },
-  );
+  try {
+    const response = await api.get<SurveyApiResultResponse>(
+      `${SURVEY_BASE_PATH}/result`,
+      {
+        params: query,
+      },
+    );
 
-  return normalizeSurveyResultResponse(response.data);
+    return normalizeSurveyResultResponse(response.data);
+  } catch (error) {
+    if (!isMockServiceWorkerEnabled()) {
+      throw error;
+    }
+
+    return normalizeSurveyResultResponse(
+      getMockSurveyResults({
+        cursor: query.cursor ?? null,
+        pageSize: query.page_size,
+        sessionId: query.session_id ?? null,
+      }),
+    );
+  }
 };
 
 export const extractApiErrorMessage = (error: unknown) => {

--- a/src/features/survey/mocks/runtime.ts
+++ b/src/features/survey/mocks/runtime.ts
@@ -1,0 +1,228 @@
+import { mockTopGames } from '../../games/mockGames';
+import type {
+  SurveyApiChatRequest,
+  SurveyApiResetResponse,
+  SurveyApiResultItem,
+  SurveyApiResultResponse,
+  SurveyApiSessionResponse,
+} from '../types/survey';
+
+const MIN_STEPS = 3;
+const DEFAULT_STEPS = 4;
+const MAX_STEPS = 5;
+const DEFAULT_RECOMMENDATION_PAGE_SIZE = 5;
+
+const surveyQuestions = [
+  '스토리 중심의 몰입감을 더 중요하게 보시나요, 아니면 손맛과 시스템 완성도를 더 중요하게 보시나요?',
+  '혼자 오래 파고드는 플레이와 친구들과 함께 즐기는 플레이 중 어느 쪽에 더 끌리시나요?',
+  '그래픽 스타일은 사실적인 쪽과 감성적인 아트 스타일 중 무엇이 더 마음에 드시나요?',
+  '보스 공략 같은 강한 도전, 혹은 편하게 수집과 성장에 집중하는 흐름 중 어느 쪽을 더 선호하시나요?',
+  '플레이 타임은 짧고 강렬한 편이 좋으신가요, 아니면 오래 파고들며 성장하는 흐름이 좋으신가요?',
+] as const;
+
+const SURVEY_RECOMMENDATION_GAME_IDS = [
+  1086940, 1245620, 292030, 1091500, 814380, 2050650, 1868140, 367520, 646570,
+  1551360, 1364780, 1003590, 412830, 620, 553850,
+] as const;
+
+const mockTopGameById = new Map(
+  mockTopGames.map((game) => [game.gameId, game]),
+);
+
+interface MockSurveySession {
+  askedQuestions: number;
+  totalQuestions: number;
+}
+
+const surveySessions = new Map<string, MockSurveySession>();
+let latestCompletedSurveySessionId: string | null = null;
+
+const createSessionId = () => crypto.randomUUID();
+
+const buildProgress = (
+  askedQuestions: number,
+  totalQuestions: number,
+  isCompleted = false,
+) => ({
+  current_step: askedQuestions,
+  total_steps: totalQuestions,
+  completion_rate: isCompleted
+    ? 1
+    : Math.max(0, Math.min((askedQuestions - 1) / totalQuestions, 0.92)),
+});
+
+const getQuestionCountFromAnswer = (answer: string) => {
+  const normalized = answer.trim();
+  const sentenceCount = normalized
+    .split(/[.!?\n]/)
+    .map((segment) => segment.trim())
+    .filter(Boolean).length;
+  const keywordMatches = [
+    '스토리',
+    '전투',
+    '그래픽',
+    '협동',
+    '멀티',
+    '싱글',
+    '보스',
+    '탐험',
+    '수집',
+    '도전',
+    '성장',
+    '장르',
+    '분위기',
+    'RPG',
+    'FPS',
+  ].filter((keyword) =>
+    normalized.toLowerCase().includes(keyword.toLowerCase()),
+  ).length;
+  const hasVaguePhrase = /(그냥|아무거나|다 좋아|무난|두루뭉실)/.test(
+    normalized,
+  );
+
+  const detailScore =
+    (normalized.length >= 100 ? 2 : normalized.length >= 55 ? 1 : 0) +
+    (sentenceCount >= 3 ? 1 : 0) +
+    (keywordMatches >= 3 ? 1 : 0) -
+    (hasVaguePhrase ? 1 : 0);
+
+  if (detailScore >= 3) {
+    return MIN_STEPS;
+  }
+
+  if (detailScore <= 0) {
+    return MAX_STEPS;
+  }
+
+  return DEFAULT_STEPS;
+};
+
+const buildSurveyRecommendations = () =>
+  SURVEY_RECOMMENDATION_GAME_IDS.map((gameId) => mockTopGameById.get(gameId))
+    .filter((game): game is (typeof mockTopGames)[number] => Boolean(game))
+    .map<SurveyApiResultItem>((game) => ({
+      game_id: game.gameId,
+      title: game.name,
+      genres: game.genres,
+      thumbnail_url: game.thumbnailUrl,
+      rating:
+        typeof game.rating === 'number' ? Number(game.rating.toFixed(1)) : null,
+      is_liked: false,
+    }));
+
+export const startMockSurveySession = (): SurveyApiSessionResponse => {
+  const sessionId = createSessionId();
+  surveySessions.set(sessionId, {
+    askedQuestions: 1,
+    totalQuestions: MAX_STEPS,
+  });
+
+  return {
+    session_id: sessionId,
+    ai_question: surveyQuestions[0],
+    status: 'IN_PROGRESS',
+    progress: buildProgress(1, MAX_STEPS),
+    recommendation_ready: false,
+  };
+};
+
+export const continueMockSurveyChat = (
+  payload: SurveyApiChatRequest & { session_id: string },
+): SurveyApiSessionResponse => {
+  const session =
+    surveySessions.get(payload.session_id) ??
+    ({
+      askedQuestions: 1,
+      totalQuestions: DEFAULT_STEPS,
+    } satisfies MockSurveySession);
+
+  if (session.askedQuestions === 1) {
+    session.totalQuestions = getQuestionCountFromAnswer(payload.user_answer);
+  }
+
+  if (session.askedQuestions >= session.totalQuestions) {
+    surveySessions.set(payload.session_id, session);
+    latestCompletedSurveySessionId = payload.session_id;
+
+    return {
+      session_id: payload.session_id,
+      ai_question: null,
+      progress: buildProgress(
+        session.totalQuestions,
+        session.totalQuestions,
+        true,
+      ),
+      status: 'COMPLETED',
+      recommendation_ready: true,
+    };
+  }
+
+  const nextQuestionIndex = session.askedQuestions;
+  session.askedQuestions += 1;
+  surveySessions.set(payload.session_id, session);
+
+  return {
+    session_id: payload.session_id,
+    ai_question: surveyQuestions[nextQuestionIndex] ?? null,
+    progress: buildProgress(session.askedQuestions, session.totalQuestions),
+    status: 'IN_PROGRESS',
+    recommendation_ready: false,
+  };
+};
+
+export const getMockSurveyResults = ({
+  cursor,
+  pageSize = DEFAULT_RECOMMENDATION_PAGE_SIZE,
+  sessionId,
+}: {
+  cursor?: string | null;
+  pageSize?: number;
+  sessionId?: string | null;
+}): SurveyApiResultResponse => {
+  const recommendations = buildSurveyRecommendations();
+
+  if (!latestCompletedSurveySessionId && !sessionId) {
+    return {
+      user_id: 1,
+      count: 0,
+      next: null,
+      results: [],
+    };
+  }
+
+  const startIndex = Number(cursor ?? '0');
+  const safeStartIndex = Number.isNaN(startIndex) ? 0 : startIndex;
+  const nextIndex = safeStartIndex + pageSize;
+  const next = nextIndex < recommendations.length ? String(nextIndex) : null;
+
+  return {
+    user_id: 1,
+    count: recommendations.length,
+    next,
+    results: recommendations.slice(safeStartIndex, nextIndex),
+  };
+};
+
+export const resetMockSurveySession = (
+  sessionId: string,
+): SurveyApiResetResponse => {
+  surveySessions.delete(sessionId);
+  if (latestCompletedSurveySessionId === sessionId) {
+    latestCompletedSurveySessionId = null;
+  }
+
+  const nextSessionId = createSessionId();
+  surveySessions.set(nextSessionId, {
+    askedQuestions: 1,
+    totalQuestions: MAX_STEPS,
+  });
+
+  return {
+    message: '설문이 초기화되었습니다.',
+    session_id: nextSessionId,
+    status: 'IN_PROGRESS',
+    ai_question: surveyQuestions[0],
+    progress: buildProgress(1, MAX_STEPS),
+    recommendation_ready: false,
+  };
+};


### PR DESCRIPTION
## 관련 이슈

- closes #285

## 변경 내용

- 설문조사 API 어댑터에 mock 모드 전용 로컬 fallback을 추가했습니다.
- 세션 시작, 답변 전송, 초기화, 추천 결과 조회가 MSW 환경에서 실패하더라도 survey runtime으로 흐름을 이어갈 수 있도록 정리했습니다.
- 설문 mock runtime을 별도 파일로 분리해 질문 흐름, 진행률, 추천 결과 구성을 프론트 fallback에서도 재사용하도록 정리했습니다.
- 장르별 매칭 후보 조회는 mock 모드에서 응답이 비거나 요청이 실패해도 로컬 후보 snapshot으로 보강되도록 변경했습니다.
- 매칭 mock candidate source를 프론트 fallback에서도 재사용할 수 있도록 분리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 확인 후 첨부 예정입니다.

## 참고사항

- 이번 PR은 외부 API 계약을 바꾸지 않고, MSW 개발환경에서 설문/매칭 기본 흐름이 불안정하게 끊기는 문제를 줄이는 데 목적이 있습니다.
- 실서버 모드에서는 기존 API 요청 경로를 유지하고, mock 모드에서만 로컬 fallback을 사용합니다.
- 브라우저 검증 시 설문 답변 전송과 장르별 매칭 진입이 정상적으로 이어지는지 확인이 필요합니다.
