### PR TITLE
[Fix] 게임 API 응답 명세 불일치 수정 

### DIFF
--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -1000,7 +1000,6 @@ const gameLikeHandlers = [
 
     return HttpResponse.json({
       game_id: gameId,
-      is_liked: true,
       like_count: getCurrentLikeCount(gameId),
     } satisfies RawGameLikeResponse);
   }),
@@ -1036,7 +1035,6 @@ const gameLikeHandlers = [
 
     return HttpResponse.json({
       game_id: gameId,
-      is_liked: false,
       like_count: getCurrentLikeCount(gameId),
     } satisfies RawGameLikeResponse);
   }),

--- a/src/features/games/gameApi.ts
+++ b/src/features/games/gameApi.ts
@@ -9,6 +9,7 @@ import type {
   RawGameDetailResponse,
   RawGameLikeResponse,
   RawGameListItem,
+  RawTopGameListItem,
   SearchGamesParams,
   SearchGamesResult,
 } from './types';
@@ -57,25 +58,34 @@ const normalizeGameDetail = (game: RawGameDetailResponse): GameDetail => ({
   isLiked: typeof game.is_liked === 'boolean' ? game.is_liked : null,
 });
 
+const normalizeTopGameListItem = (game: RawTopGameListItem): GameListItem => ({
+  gameId: game.game_id,
+  name: game.name || 'N/A',
+  genres: game.genres?.length ? game.genres : ['N/A'],
+  thumbnailUrl: game.thumbnail_url,
+  rating: game.total_rating,
+});
+
 const normalizeGameLikeResponse = (
   response: RawGameLikeResponse,
+  isLiked: boolean,
 ): GameLikeResponse => ({
   gameId: response.game_id,
-  isLiked: response.is_liked,
+  isLiked,
   likeCount: response.like_count ?? 0,
 });
 
 export const getTopGames = async ({
   genre = '전체',
 }: GetTopGamesParams = {}): Promise<GameListItem[]> => {
-  const response = await api.get<GameListResponse>(
-    '/api/v1/games/list/top100',
-    {
-      params: getGenreQueryParams(genre),
-    },
-  );
+  const response = await api.get<{
+    ranked_at: string;
+    results: RawTopGameListItem[];
+  }>('/api/v1/games/list/top100', {
+    params: getGenreQueryParams(genre),
+  });
 
-  return response.data.results.map(normalizeGameListItem);
+  return response.data.results.map(normalizeTopGameListItem);
 };
 
 export const searchGames = async ({
@@ -116,7 +126,7 @@ export const likeGame = async (gameId: number): Promise<GameLikeResponse> => {
     `/api/v1/games/${gameId}/like`,
   );
 
-  return normalizeGameLikeResponse(response.data);
+  return normalizeGameLikeResponse(response.data, true);
 };
 
 export const unlikeGame = async (gameId: number): Promise<GameLikeResponse> => {
@@ -124,5 +134,5 @@ export const unlikeGame = async (gameId: number): Promise<GameLikeResponse> => {
     `/api/v1/games/${gameId}/like`,
   );
 
-  return normalizeGameLikeResponse(response.data);
+  return normalizeGameLikeResponse(response.data, false);
 };

--- a/src/features/games/types.ts
+++ b/src/features/games/types.ts
@@ -74,7 +74,15 @@ export type GameLikeResponse = {
 
 export type RawGameLikeResponse = {
   game_id: number;
-  is_liked: boolean;
+  like_count: number | null;
+};
+
+export type RawTopGameListItem = {
+  game_id: number;
+  name: string | null;
+  genres: string[] | null;
+  thumbnail_url: string | null;
+  total_rating: number | null;
   like_count: number | null;
 };
 


### PR DESCRIPTION
## 관련 이슈

- closes #287

## 변경 내용

- `RawTopGameListItem` 타입 추가 — `GET /api/v1/games/list/top100` 응답 필드 `total_rating` 전용 타입 분리
- `getTopGames()` 응답 타입을 `RawTopGameListItem[]`으로 변경, `normalizeTopGameListItem()` 함수 추가
- `RawGameLikeResponse`에서 명세에 없는 `is_liked` 필드 제거
- `normalizeGameLikeResponse()`에 `isLiked` 파라미터 추가 — 호출 방향(`likeGame` → `true`, `unlikeGame` → `false`)으로 결정
- `auth/mocks/handlers.ts` MSW 핸들러에서 `is_liked` 필드 제거

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- `GET /api/v1/games/list`는 `rating` 필드를 그대로 사용하므로 변경 없음
- `games/list/top100`과 `games/list`가 기존에 `RawGameListItem` 타입을 공유하고 있었으나, top100은 `total_rating` 필드를 사용하므로 타입을 분리함
- `GameLikeResponse.isLiked`는 `boolean` 타입 유지 → `useGameDetailModal`, `useRecommendationLike` 등 기존 소비 코드 변경 없음