### PR TITLE
fix(mypage): 프로필 인터랙션과 찜 목록 UI를 정교화

### DIFF
--- a/src/components/common/ActionButton.tsx
+++ b/src/components/common/ActionButton.tsx
@@ -9,7 +9,7 @@ type ActionButtonProps = {
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 const baseClassName =
-  'inline-flex items-center justify-center transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-60';
+  'inline-flex cursor-pointer items-center justify-center transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-60';
 
 const variantClassNames: Record<ActionButtonVariant, string> = {
   primary:

--- a/src/components/mypage/ConfirmModal.tsx
+++ b/src/components/mypage/ConfirmModal.tsx
@@ -9,6 +9,7 @@ type ConfirmModalProps = {
   confirmLabel: string;
   cancelLabel?: string;
   isPending?: boolean;
+  align?: 'left' | 'center';
   onConfirm: () => void;
   onClose: () => void;
 };
@@ -20,6 +21,7 @@ function ConfirmModal({
   confirmLabel,
   cancelLabel = '취소',
   isPending = false,
+  align = 'left',
   onConfirm,
   onClose,
 }: ConfirmModalProps) {
@@ -33,33 +35,46 @@ function ConfirmModal({
         type="button"
         aria-label="모달 닫기"
         onClick={onClose}
-        className="bg-mypage-overlay absolute inset-0"
+        className="bg-mypage-overlay absolute inset-0 cursor-pointer backdrop-blur-[3px]"
       />
 
-      <div className="bg-mypage-panel border-mypage-panel shadow-mypage-float relative z-10 w-full max-w-md rounded-[28px] border px-5 py-6 backdrop-blur-xl sm:px-6">
-        <h2 className="text-2xl font-semibold text-white">{title}</h2>
-        <div className="text-mypage-muted mt-3 text-sm/6 sm:text-base/7">
+      <div className="bg-mypage-panel relative z-10 w-full max-w-md rounded-[28px] border border-white/12 px-5 py-6 shadow-[0_38px_100px_rgba(0,0,0,0.58)] ring-1 ring-white/6 backdrop-blur-xl sm:px-6">
+        <h2
+          className={`text-2xl font-semibold text-white ${align === 'center' ? 'text-center' : ''}`}
+        >
+          {title}
+        </h2>
+        <div
+          className={`text-mypage-muted mt-3 text-sm/6 sm:text-base/7 ${align === 'center' ? 'text-center' : ''}`}
+        >
           {description}
         </div>
 
-        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-          <AuthButton
-            type="button"
-            variant="secondary"
-            className="w-full sm:w-auto sm:min-w-28"
-            onClick={onClose}
-            disabled={isPending}
+        <div
+          className={`mt-6 border-t border-white/8 pt-5 ${align === 'center' ? 'text-center' : ''}`}
+        >
+          <div
+            className={`flex flex-col-reverse gap-3 sm:flex-row ${align === 'center' ? 'sm:justify-center' : 'sm:justify-end'}`}
           >
-            {cancelLabel}
-          </AuthButton>
-          <AuthButton
-            type="button"
-            className="bg-mypage-danger hover:bg-mypage-danger-hover w-full shadow-none sm:w-auto sm:min-w-32"
-            onClick={onConfirm}
-            disabled={isPending}
-          >
-            {isPending ? '처리 중...' : confirmLabel}
-          </AuthButton>
+            <AuthButton
+              type="button"
+              variant="secondary"
+              className={`h-12 w-full rounded-[20px] border-white/12 bg-white/[0.05] px-6 text-sm font-semibold text-white/88 shadow-none hover:translate-y-0 ${align === 'center' ? 'sm:w-40 sm:min-w-40' : 'sm:w-auto sm:min-w-[7.75rem]'}`}
+              onClick={onClose}
+              disabled={isPending}
+            >
+              {cancelLabel}
+            </AuthButton>
+            <AuthButton
+              type="button"
+              variant="secondary"
+              className={`bg-login-primary hover:bg-login-primary-hover h-12 w-full rounded-[20px] border border-transparent px-6 text-sm font-semibold text-white shadow-none hover:translate-y-0 ${align === 'center' ? 'sm:w-40 sm:min-w-40' : 'sm:w-auto sm:min-w-[7.75rem]'}`}
+              onClick={onConfirm}
+              disabled={isPending}
+            >
+              {isPending ? '처리 중...' : confirmLabel}
+            </AuthButton>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -15,12 +15,12 @@ function FavoriteGameCard({
   onFavoriteClick,
 }: FavoriteGameCardProps) {
   return (
-    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex h-full min-w-0 flex-col overflow-hidden rounded-[22px] border transition duration-200">
+    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex h-full w-[11.75rem] min-w-0 shrink-0 flex-col overflow-hidden rounded-[22px] border transition duration-200 sm:w-[12.75rem] lg:w-[13.75rem] xl:w-[14.25rem]">
       <div className="bg-mypage-soft relative aspect-3/4 overflow-hidden">
         <button
           type="button"
           onClick={() => onClick?.(game)}
-          className="block h-full w-full text-left"
+          className="block h-full w-full cursor-pointer text-left"
         >
           {game.thumbnailUrl ? (
             <img
@@ -42,9 +42,9 @@ function FavoriteGameCard({
             variant="icon"
             aria-label={`${game.title} 찜 해제`}
             onClick={() => onFavoriteClick?.(game)}
-            className="hover:border-login-primary! hover:bg-login-primary-hover! border-login-primary! bg-login-primary! text-white! shadow-[0_10px_24px_rgba(0,0,0,0.38)] hover:text-white! focus-visible:ring-red-300/45"
+            className="border-[#ff7a8c]/28! bg-[linear-gradient(145deg,rgba(169,38,60,0.96)_0%,rgba(112,19,37,0.98)_100%)] text-white! shadow-[0_12px_28px_rgba(53,7,18,0.46),inset_0_1px_0_rgba(255,255,255,0.12)] hover:border-[#ff9baa]/46! hover:bg-[linear-gradient(145deg,rgba(195,57,81,0.98)_0%,rgba(130,26,46,0.99)_100%)] hover:text-white! focus-visible:ring-[#ff96a5]/45"
           >
-            <X size={15} strokeWidth={2.25} />
+            <X size={14} strokeWidth={2.4} />
           </ActionButton>
         </div>
       </div>
@@ -52,7 +52,7 @@ function FavoriteGameCard({
       <button
         type="button"
         onClick={() => onClick?.(game)}
-        className="flex min-w-0 flex-1 flex-col gap-2 px-4 py-4 text-left"
+        className="flex min-w-0 flex-1 cursor-pointer flex-col gap-2 px-4 py-4 text-left"
       >
         <h3 className="line-clamp-1 text-base/6 font-semibold text-white sm:text-lg/7">
           {game.title}

--- a/src/components/mypage/FavoriteGameCardSkeleton.tsx
+++ b/src/components/mypage/FavoriteGameCardSkeleton.tsx
@@ -3,18 +3,18 @@ type FavoriteGameCardSkeletonProps = {
 };
 
 function FavoriteGameCardSkeleton({
-  count = 8,
+  count = 4,
 }: FavoriteGameCardSkeletonProps) {
   return (
     <div
-      className="grid auto-rows-fr grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4"
+      className="flex min-w-max items-stretch gap-3 lg:gap-4"
       aria-live="polite"
       aria-busy="true"
     >
       {Array.from({ length: count }).map((_, index) => (
         <article
           key={index}
-          className="border-mypage-card bg-mypage-card box-border min-w-0 overflow-hidden rounded-[22px] border"
+          className="border-mypage-card bg-mypage-card box-border h-full w-[11.75rem] min-w-0 shrink-0 overflow-hidden rounded-[22px] border sm:w-[12.75rem] lg:w-[13.75rem] xl:w-[14.25rem]"
         >
           <div className="aspect-3/4 animate-pulse bg-white/8" />
           <div className="space-y-2 px-4 py-4">

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -21,12 +21,6 @@ type MyPageProfileSectionProps = {
   children?: ReactNode;
 };
 
-type ProfileInfoRow = {
-  label: string;
-  value: string;
-  action?: ReactNode;
-};
-
 function MyPageProfileSection({
   nickname,
   name,
@@ -81,34 +75,6 @@ function MyPageProfileSection({
       setNicknameFieldError('');
     }
   };
-
-  const infoRows: ProfileInfoRow[] = [
-    {
-      label: '별명',
-      value: nickname,
-      action: !isNicknameEditMode ? (
-        <button
-          type="button"
-          className="rounded-2xl border border-white/8 bg-white/[0.04] px-5 py-3 text-sm font-semibold text-white/88 transition hover:border-white/12 hover:bg-white/[0.08]"
-          onClick={() => {
-            setIsNicknameEditMode(true);
-            setNextNickname(nickname);
-            setNicknameFieldError('');
-          }}
-        >
-          수정
-        </button>
-      ) : null,
-    },
-    {
-      label: '사용자명',
-      value: name,
-    },
-    {
-      label: '성별',
-      value: genderLabel,
-    },
-  ];
 
   return (
     <section className="relative overflow-hidden rounded-[32px] border border-white/8 bg-[#19191d] shadow-[0_28px_80px_rgba(0,0,0,0.32)]">
@@ -218,92 +184,104 @@ function MyPageProfileSection({
           </div>
 
           <div className="mt-6 rounded-[24px] border border-white/8 bg-white/[0.035] px-4 py-4 sm:px-5 sm:py-5">
-            {isNicknameEditMode ? (
-              <div className="border-b border-white/7 pb-5">
-                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div className="divide-y divide-white/7">
+              <div className="py-5 pt-1">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
                   <div className="min-w-0 flex-1">
-                    <p className="text-sm font-semibold text-white/82">별명</p>
-                    <label htmlFor="profile-nickname" className="sr-only">
-                      닉네임
-                    </label>
-                    <div className="mt-3 max-w-xl">
-                      <InputControl
-                        id="profile-nickname"
-                        type="text"
-                        value={nextNickname}
-                        onChange={(event) => {
-                          setNextNickname(event.target.value);
-
-                          if (nicknameFieldError) {
-                            setNicknameFieldError('');
-                          }
-                        }}
-                        maxLength={20}
-                        disabled={isProfileUpdating}
-                        hasError={Boolean(nicknameFieldError)}
-                        className="h-12"
-                        placeholder="닉네임을 입력하세요"
-                      />
-                    </div>
-                    {nicknameFieldError ? (
-                      <p className="mt-2 pl-1 text-left text-sm/5 font-medium text-red-400">
-                        {nicknameFieldError}
+                    <p className="text-sm font-semibold text-white/76">별명</p>
+                    {!isNicknameEditMode ? (
+                      <p className="mt-2 truncate text-[1.05rem] font-medium text-white">
+                        {nickname}
                       </p>
-                    ) : null}
+                    ) : (
+                      <>
+                        <label htmlFor="profile-nickname" className="sr-only">
+                          닉네임
+                        </label>
+                        <div className="mt-3 max-w-xl">
+                          <InputControl
+                            id="profile-nickname"
+                            type="text"
+                            value={nextNickname}
+                            onChange={(event) => {
+                              setNextNickname(event.target.value);
+
+                              if (nicknameFieldError) {
+                                setNicknameFieldError('');
+                              }
+                            }}
+                            maxLength={20}
+                            disabled={isProfileUpdating}
+                            hasError={Boolean(nicknameFieldError)}
+                            className="h-12"
+                            placeholder="닉네임을 입력하세요"
+                          />
+                        </div>
+                        {nicknameFieldError ? (
+                          <p className="mt-2 pl-1 text-left text-sm/5 font-medium text-red-400">
+                            {nicknameFieldError}
+                          </p>
+                        ) : null}
+                      </>
+                    )}
                   </div>
-                  <div className="flex gap-2 lg:pt-8">
-                    <button
-                      type="button"
-                      className="rounded-2xl border border-white/8 bg-white/[0.04] px-5 py-3 text-sm font-semibold text-white/72 transition hover:bg-white/[0.08]"
-                      onClick={() => {
-                        setIsNicknameEditMode(false);
-                        setNextNickname(nickname);
-                        setNicknameFieldError('');
-                      }}
-                      disabled={isProfileUpdating}
-                    >
-                      취소
-                    </button>
-                    <button
-                      type="button"
-                      className="bg-login-primary hover:bg-login-primary-hover rounded-2xl px-5 py-3 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
-                      onClick={() => {
-                        void handleNicknameSave();
-                      }}
-                      disabled={isProfileUpdating}
-                    >
-                      {isProfileUpdating ? '저장 중...' : '저장'}
-                    </button>
+
+                  <div className="flex shrink-0 items-center gap-2 sm:min-w-[12rem] sm:justify-end">
+                    {!isNicknameEditMode ? (
+                      <button
+                        type="button"
+                        className="inline-flex cursor-pointer items-center rounded-2xl border border-white/8 bg-white/[0.04] px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/12 hover:bg-white/[0.08]"
+                        onClick={() => {
+                          setIsNicknameEditMode(true);
+                          setNextNickname(nickname);
+                          setNicknameFieldError('');
+                        }}
+                      >
+                        수정
+                      </button>
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          className="inline-flex cursor-pointer items-center justify-center rounded-2xl border border-white/8 bg-white/[0.04] px-4 py-3 text-sm font-semibold text-white/72 transition hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-50"
+                          onClick={() => {
+                            setIsNicknameEditMode(false);
+                            setNextNickname(nickname);
+                            setNicknameFieldError('');
+                          }}
+                          disabled={isProfileUpdating}
+                        >
+                          취소
+                        </button>
+                        <button
+                          type="button"
+                          className="bg-login-primary hover:bg-login-primary-hover inline-flex cursor-pointer items-center justify-center rounded-2xl px-4 py-3 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+                          onClick={() => {
+                            void handleNicknameSave();
+                          }}
+                          disabled={isProfileUpdating}
+                        >
+                          {isProfileUpdating ? '저장 중...' : '저장'}
+                        </button>
+                      </>
+                    )}
                   </div>
                 </div>
               </div>
-            ) : null}
 
-            <div className="divide-y divide-white/7">
-              {infoRows.map((row, index) => (
-                <div
-                  key={row.label}
-                  className={`flex items-center justify-between gap-4 py-5 ${
-                    index === 0 && isNicknameEditMode
-                      ? 'pt-5'
-                      : index === 0
-                        ? 'pt-1'
-                        : ''
-                  } ${index === infoRows.length - 1 ? 'pb-1' : ''}`}
-                >
-                  <div className="min-w-0">
-                    <p className="text-sm font-semibold text-white/76">
-                      {row.label}
-                    </p>
-                    <p className="mt-2 truncate text-[1.05rem] font-medium text-white">
-                      {row.value}
-                    </p>
-                  </div>
-                  {row.action ? (
-                    <div className="shrink-0">{row.action}</div>
-                  ) : null}
-                </div>
-              ))}
+              <div className="py-5">
+                <p className="text-sm font-semibold text-white/76">사용자명</p>
+                <p className="mt-2 truncate text-[1.05rem] font-medium text-white">
+                  {name}
+                </p>
+              </div>
+
+              <div className="py-5 pb-1">
+                <p className="text-sm font-semibold text-white/76">성별</p>
+                <p className="mt-2 truncate text-[1.05rem] font-medium text-white">
+                  {genderLabel}
+                </p>
+              </div>
             </div>
           </div>
 

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -70,13 +70,13 @@ function MyPageLikedGamesSection({
 
         <div
           ref={favoriteGamesScrollRef}
-          className="mypage-scrollbar mt-5 box-border h-[20rem] max-w-full overflow-y-auto pr-1 sm:h-[21.75rem] lg:h-[22.25rem]"
+          className="mypage-scrollbar mt-5 box-border max-w-full overflow-x-auto overflow-y-hidden pb-2"
         >
           {isFavoriteGamesLoading ? (
             <FavoriteGameCardSkeleton />
           ) : favoriteCount > 0 ? (
             <div>
-              <div className="grid auto-rows-fr grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
+              <div className="flex min-w-max items-stretch gap-3 lg:gap-4">
                 {favoriteGames.map((game) => (
                   <FavoriteGameCard
                     key={game.gameId}
@@ -85,13 +85,15 @@ function MyPageLikedGamesSection({
                     onFavoriteClick={setSelectedFavoriteGame}
                   />
                 ))}
+                <div className="flex w-6 shrink-0 items-stretch">
+                  <div
+                    ref={favoriteGamesLoadMoreRef}
+                    aria-hidden="true"
+                    className="h-full w-px self-stretch"
+                  />
+                </div>
               </div>
               <div className="mt-5 flex flex-col items-center gap-2">
-                <div
-                  ref={favoriteGamesLoadMoreRef}
-                  aria-hidden="true"
-                  className="h-0.5 w-full"
-                />
                 {isFavoriteGamesFetchNextPageError ? (
                   <>
                     <p className="text-sm text-red-300">
@@ -115,7 +117,7 @@ function MyPageLikedGamesSection({
                   </p>
                 ) : hasFavoriteGamesNextPage ? (
                   <p className="text-mypage-muted text-sm">
-                    아래로 스크롤하면 찜 목록을 더 볼 수 있어요.
+                    오른쪽으로 스크롤하면 찜 목록을 더 볼 수 있어요.
                   </p>
                 ) : null}
               </div>
@@ -152,6 +154,7 @@ function MyPageLikedGamesSection({
         confirmLabel="예"
         cancelLabel="아니오"
         isPending={isUnlikePending}
+        align="center"
         onClose={() => setSelectedFavoriteGame(null)}
         onConfirm={() => {
           void handleFavoriteGameDeleteConfirm();

--- a/src/pages/mypage/hooks/useMyPageLikedGames.ts
+++ b/src/pages/mypage/hooks/useMyPageLikedGames.ts
@@ -97,7 +97,7 @@ function useMyPageLikedGames({
       },
       {
         root: rootElement,
-        rootMargin: '0px 0px 160px 0px',
+        rootMargin: '0px 280px 0px 0px',
         threshold: 0.1,
       },
     );


### PR DESCRIPTION
## 관련 이슈

- closes #280
## 변경 내용

- 마이페이지 닉네임 수정 방식을 인라인 편집으로 변경했습니다.
- 수정 버튼을 누르면 별도 영역이 아니라 기존 닉네임 텍스트 자리가 바로 입력창으로 전환되도록 수정했습니다.
- 저장/취소 버튼도 같은 행 안에서 처리되도록 정리해 레이아웃이 흔들리지 않게 보완했습니다.
- 공통 액션 버튼에 cursor-pointer를 반영해 마이페이지 내 클릭 가능한 요소의 인터랙션 피드백을 통일했습니다.
- 찜 목록 레이아웃을 브라우저/기기와 관계없이 한 줄 스크롤 구조로 고정했습니다.
- 카드와 스켈레톤에 고정 폭 + shrink-0를 적용하고, 목록 컨테이너를 overflow-x-auto 기반으로 변경했습니다.
- 무한 스크롤 감지 기준도 세로 스크롤이 아닌 가로 스크롤 흐름에 맞게 보정했습니다.
- 찜 목록 안내 문구도 “오른쪽으로 스크롤” 기준으로 변경했습니다.
- 찜 삭제 확인 모달 UI를 더 명확하게 정리했습니다.
- 제목/설명/버튼을 가운데 정렬하고, 본문과 버튼 영역 사이에 구분선을 추가했습니다.
- 예/아니오 버튼의 높이, 둥글기, 너비를 일치시켜 모양 차이가 없도록 통일했습니다.
- 위험 액션인 예 버튼은 저장 버튼과 같은 빨간 계열로 맞추고, 삭제 카드의 X 버튼과도 톤이 어울리도록 조정했습니다.
- 모달 배경에는 더 강한 그림자와 블러를 넣어 화면 위에서 더 잘 구분되도록 보완했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

https://github.com/user-attachments/assets/95555888-68a5-4168-a97d-be33281b4d4d

## 참고사항

-
