### PR TITLE
[Feat] 매칭 상세 화면 트레일러 중심 레이아웃 정리

### DIFF
--- a/src/features/matching/components/MatchingMediaPanel.tsx
+++ b/src/features/matching/components/MatchingMediaPanel.tsx
@@ -2,18 +2,6 @@ import type { MatchingCandidateItem } from '../types';
 
 type MatchingMediaPanelProps = {
   candidate: MatchingCandidateItem;
-  genreTitle: string;
-  stepLabel: string;
-};
-
-const formatMatchingCandidateRating = (rating: number | null) => {
-  if (typeof rating !== 'number') {
-    return 'N/A';
-  }
-
-  const normalizedRating = rating <= 5 ? rating * 20 : rating;
-
-  return `${normalizedRating.toFixed(1)}점`;
 };
 
 const getYoutubeEmbedUrl = (trailerUrl: string | null) => {
@@ -47,22 +35,13 @@ const getYoutubeEmbedUrl = (trailerUrl: string | null) => {
   return null;
 };
 
-function MatchingMediaPanel({
-  candidate,
-  genreTitle,
-  stepLabel,
-}: MatchingMediaPanelProps) {
+function MatchingMediaPanel({ candidate }: MatchingMediaPanelProps) {
   const embedUrl = getYoutubeEmbedUrl(candidate.trailer_url);
   const imageUrl = candidate.thumbnail_url;
-  const candidateSummary =
-    candidate.description?.trim() ||
-    `${genreTitle} 흐름에서 ${candidate.title}은 ${candidate.genres.join(
-      ' · ',
-    )} 감각을 대표하는 후보예요. 영상과 이미지를 보고 취향에 얼마나 맞는지 편하게 판단해보세요.`;
 
   return (
-    <article className="flex h-full flex-col overflow-hidden rounded-[26px] border border-white/8 bg-[#0d0d0f] shadow-[0_24px_48px_rgba(0,0,0,0.28)]">
-      <div className="relative aspect-[16/8.1] shrink-0">
+    <article className="h-full overflow-hidden rounded-[26px] border border-white/8 bg-[#0d0d0f] shadow-[0_24px_48px_rgba(0,0,0,0.28)]">
+      <div className="relative h-full min-h-[360px] sm:min-h-[420px]">
         {embedUrl ? (
           <iframe
             src={embedUrl}
@@ -82,47 +61,6 @@ function MatchingMediaPanel({
             미디어가 준비되지 않았습니다.
           </div>
         )}
-      </div>
-      <div className="flex flex-1 flex-col border-t border-white/8 bg-[linear-gradient(180deg,rgba(18,18,20,0.94),rgba(11,11,12,0.98))] px-5 py-4.5 sm:px-6 sm:py-5">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
-            이 카드에서 볼 포인트
-          </p>
-          <span className="rounded-full border border-white/10 bg-white/3 px-3 py-1.5 text-xs font-medium text-white/52">
-            {stepLabel}
-          </span>
-        </div>
-
-        <p className="mt-2.5 text-sm leading-6 break-keep text-white/62">
-          {candidateSummary}
-        </p>
-
-        <div className="mt-3.5 grid gap-2.5 sm:grid-cols-3">
-          <div className="rounded-[18px] border border-white/8 bg-white/3 px-3.5 py-3">
-            <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
-              평균 평점
-            </p>
-            <p className="mt-1.5 text-lg font-semibold text-white">
-              {formatMatchingCandidateRating(candidate.rating)}
-            </p>
-          </div>
-          <div className="rounded-[18px] border border-white/8 bg-white/3 px-3.5 py-3">
-            <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
-              미디어
-            </p>
-            <p className="mt-1.5 text-sm font-medium text-white/78">
-              {candidate.trailer_url ? '유튜브 트레일러' : '이미지 미리보기'}
-            </p>
-          </div>
-          <div className="rounded-[18px] border border-white/8 bg-white/3 px-3.5 py-3">
-            <p className="text-[10px] font-medium tracking-[0.18em] text-white/34 uppercase">
-              장르 감각
-            </p>
-            <p className="mt-1.5 text-sm font-medium text-white/78">
-              {candidate.genres[0] ?? genreTitle}
-            </p>
-          </div>
-        </div>
       </div>
     </article>
   );

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -23,7 +23,6 @@ import {
   useMatchCandidatesQuery,
   useSubmitMatchResponsesMutation,
 } from '../../features/matching/api/useMatchingApi';
-import MatchingGuideCards from '../../features/matching/components/MatchingGuideCards';
 import MatchingMediaPanel from '../../features/matching/components/MatchingMediaPanel';
 import MatchingRatingStars from '../../features/matching/components/MatchingRatingStars';
 import {
@@ -158,6 +157,13 @@ function MatchingGenreDetailPage() {
   const submitErrorMessage = submitMatchResponsesMutation.error
     ? extractApiErrorMessage(submitMatchResponsesMutation.error)
     : null;
+  const genreTitle = genre?.title ?? '선택한 장르';
+  const currentCandidateSummary = currentCandidate
+    ? currentCandidate.description?.trim() ||
+      `${genreTitle} 흐름에서 ${currentCandidate.title}은 ${currentCandidate.genres.join(
+        ' · ',
+      )} 감각을 대표하는 후보예요. 트레일러를 보고 취향에 얼마나 맞는지 편하게 판단해보세요.`
+    : '';
   const updateLikedGamesCache = (
     candidate: MatchingCandidateItem,
     nextIsLiked: boolean,
@@ -397,7 +403,7 @@ function MatchingGenreDetailPage() {
               </Link>
             </div>
 
-            <section className="mx-auto max-w-240">
+            <section className="mx-auto max-w-255">
               <div className="text-center">
                 <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
                   {safeIndex + 1} / {totalSteps} 단계
@@ -407,29 +413,42 @@ function MatchingGenreDetailPage() {
                 </h1>
               </div>
 
-              <div className="mt-6">
-                <MatchingGuideCards />
-              </div>
-
-              <div className="mt-6 grid gap-4 lg:grid-cols-[1.08fr_0.92fr]">
+              <div className="mt-5 grid gap-4 lg:grid-cols-[1.32fr_0.92fr] lg:gap-5">
                 {currentCandidate ? (
-                  <MatchingMediaPanel
-                    candidate={currentCandidate}
-                    genreTitle={genre.title}
-                    stepLabel={`${safeIndex + 1} / ${totalSteps} 단계`}
-                  />
+                  <MatchingMediaPanel candidate={currentCandidate} />
                 ) : null}
 
                 {currentCandidate && currentEvaluation ? (
-                  <article className="survey-panel flex flex-col px-5 py-5 sm:px-6 sm:py-5">
+                  <article className="survey-panel flex flex-col px-5 py-5 sm:px-6 sm:py-6">
                     <div className="flex items-start justify-between gap-4">
                       <div className="min-w-0 flex-1">
-                        <p className="text-xs font-semibold tracking-[0.2em] text-[#f06b6b] uppercase">
-                          Candidate {safeIndex + 1}
-                        </p>
-                        <h2 className="mt-2 text-2xl font-semibold tracking-[-0.02em] break-keep text-white sm:text-[28px]">
+                        <h2 className="text-2xl font-semibold tracking-[-0.02em] break-keep text-white sm:text-[30px]">
                           {currentCandidate.title}
                         </h2>
+                        <p className="mt-3 text-sm leading-6 break-keep text-white/62">
+                          {currentCandidateSummary}
+                        </p>
+                        <div className="mt-4 grid gap-1.5 border-t border-white/8 pt-2.5 sm:grid-cols-2">
+                          <div className="flex h-full flex-col rounded-[14px] border border-white/8 bg-white/3 px-2.5 py-2">
+                            <p className="text-[10px] font-medium text-white/38">
+                              장르
+                            </p>
+                            <p className="mt-1 text-[13px] leading-5 font-medium break-keep text-white/78">
+                              {currentCandidate.genres.join(' · ') ||
+                                genreTitle}
+                            </p>
+                          </div>
+                          <div className="flex h-full flex-col rounded-[14px] border border-white/8 bg-white/3 px-2.5 py-2">
+                            <p className="text-[10px] font-medium text-white/38">
+                              평균 평점
+                            </p>
+                            <p className="mt-1 text-[13px] leading-5 font-medium text-white/78">
+                              {formatMatchingCandidateRating(
+                                currentCandidate.rating,
+                              )}
+                            </p>
+                          </div>
+                        </div>
                       </div>
                       <button
                         type="button"
@@ -461,24 +480,11 @@ function MatchingGenreDetailPage() {
                       </button>
                     </div>
 
-                    <div className="mt-2.5 flex flex-wrap items-center gap-1.5 text-xs text-white/46">
-                      <span className="rounded-full border border-white/8 bg-white/3 px-3 py-1.5">
-                        장르 {currentCandidate.genres.join(' · ')}
-                      </span>
-                      <span className="rounded-full border border-white/8 bg-white/3 px-3 py-1.5">
-                        평균 평점{' '}
-                        {formatMatchingCandidateRating(currentCandidate.rating)}
-                      </span>
-                    </div>
-
-                    <div className="mt-5">
+                    <div className="mt-7">
                       <p className="text-sm font-semibold text-white">
                         이 게임이 내 취향에 얼마나 가까운가요?
                       </p>
-                      <p className="mt-1 text-sm leading-6 break-keep text-white/55">
-                        별점은 추천을 더 정교하게 만드는 선호도 평가로 반영돼요.
-                      </p>
-                      <div className="mt-3.5">
+                      <div className="mt-3">
                         <MatchingRatingStars
                           value={currentEvaluation.rating}
                           onRate={(rating) =>
@@ -488,17 +494,11 @@ function MatchingGenreDetailPage() {
                       </div>
                     </div>
 
-                    <div className="mt-5 rounded-[20px] border border-white/8 bg-white/3 px-4 py-3.5">
-                      <p className="text-sm leading-7 break-keep text-white/64">
-                        {isLastCard
-                          ? currentEvaluation.rating === null
-                            ? '마지막 후보예요. 별점을 남기면 지금까지의 선호도 평가를 제출하고 추천 결과로 바로 이어갈 수 있어요.'
-                            : '모든 선호도 평가가 준비됐어요. 제출하면 취향에 맞는 추천 결과를 바로 확인할 수 있어요.'
-                          : currentEvaluation.rating === null
-                            ? '트레일러와 분위기를 보고 지금 카드의 별점을 남겨 주세요.'
-                            : '별점은 취향 분석에 반영되고, 좋아요는 마이페이지에서 다시 볼 게임을 표시해 두는 용도로 저장돼요.'}
-                      </p>
-                    </div>
+                    <p className="mt-4 text-sm leading-6 break-keep text-white/54">
+                      {isLastCard
+                        ? '별점을 매기면 제출 버튼을 사용할 수 있어요.'
+                        : '별점을 매기면 다음 게임으로 넘어갈 수 있어요.'}
+                    </p>
 
                     {submitErrorMessage ? (
                       <p className="mt-2.5 text-sm leading-6 break-keep text-[#ffc2c2]">


### PR DESCRIPTION
## 관련 이슈

- closes #283 

## 변경 내용

- 매칭 상세 화면에서 중복되는 안내/메타 정보를 정리하고, 트레일러 중심으로 레이아웃을 재구성했습니다.
- 상단 가이드 카드와 중복 step/candidate 정보를 제거해 화면 진입 시 바로 트레일러와 평가 영역에 집중할 수 있도록 정리했습니다.
- 왼쪽 미디어 패널은 트레일러 중심으로 단순화하고, 설명과 메타 정보는 오른쪽 카드로 이동했습니다.
- 본문 최대 폭과 좌우 컬럼 비율을 조정해 트레일러 세로/가로 체감 크기를 키우고, 오른쪽 평가 카드도 함께 넓혀 균형을 맞췄습니다.
- 오른쪽 카드의 메타 정보는 `장르`, `평균 평점` 두 블록만 남기고 크기와 정렬을 통일해 더 정돈된 형태로 수정했습니다.
- 별점 아래 안내는 박스형 문구 대신 helper text로 바꿔, 화면 흐름을 덜 끊으면서 다음/제출 동작을 자연스럽게 안내하도록 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 기능 변경보다 매칭 상세 화면의 정보 밀도와 시선 흐름 개선에 집중했습니다.
- 좋아요/별점/제출 동작 로직은 유지한 상태에서, 트레일러와 평가 행동이 더 먼저 보이도록 정리했습니다.
