### PR TITLE
fix(chat): 챗봇 session_id 타입을 UUID 문자열로 통일

### DIFF
--- a/src/features/support-chat/api/chatbot.ts
+++ b/src/features/support-chat/api/chatbot.ts
@@ -100,13 +100,13 @@ const parseSseEvent = (chunk: string): ChatbotStreamEvent | null => {
   }
 
   let parsed: {
-    session_id?: number;
+    session_id?: string;
     content?: string;
   };
 
   try {
     parsed = JSON.parse(dataLines.join('\n')) as {
-      session_id?: number;
+      session_id?: string;
       content?: string;
     };
   } catch (error) {
@@ -118,7 +118,7 @@ const parseSseEvent = (chunk: string): ChatbotStreamEvent | null => {
     return null;
   }
 
-  if (eventName === 'start' && typeof parsed.session_id === 'number') {
+  if (eventName === 'start' && typeof parsed.session_id === 'string') {
     return {
       type: 'start',
       sessionId: parsed.session_id,
@@ -132,7 +132,7 @@ const parseSseEvent = (chunk: string): ChatbotStreamEvent | null => {
     };
   }
 
-  if (eventName === 'complete' && typeof parsed.session_id === 'number') {
+  if (eventName === 'complete' && typeof parsed.session_id === 'string') {
     return {
       type: 'complete',
       sessionId: parsed.session_id,
@@ -147,7 +147,7 @@ export const streamChatbotResponse = async ({
   signal,
   onEvent,
 }: {
-  sessionId: number;
+  sessionId: string;
   signal?: AbortSignal;
   onEvent: (event: ChatbotStreamEvent) => void;
 }) => {

--- a/src/features/support-chat/mocks/handlers.ts
+++ b/src/features/support-chat/mocks/handlers.ts
@@ -15,12 +15,11 @@ import type {
 const CHATBOT_BASE_PATH = '/api/v1/chatbot';
 
 type MockChatSession = {
-  id: number;
+  id: string;
   lastReply: string;
 };
 
-const chatSessions = new Map<number, MockChatSession>();
-let nextSessionId = 1;
+const chatSessions = new Map<string, MockChatSession>();
 
 const toJsonError = (status: number, message: string) =>
   HttpResponse.json(
@@ -43,7 +42,7 @@ const splitMessageIntoChunks = (message: string) => {
   return chunks;
 };
 
-const createStreamResponse = (sessionId: number, reply: string) => {
+const createStreamResponse = (sessionId: string, reply: string) => {
   const encoder = new TextEncoder();
   const chunks = splitMessageIntoChunks(reply);
 
@@ -99,8 +98,7 @@ export const supportChatHandlers = [
     }
 
     if (sessionId === undefined) {
-      sessionId = nextSessionId;
-      nextSessionId += 1;
+      sessionId = crypto.randomUUID();
     }
 
     const matchedEntry = findSupportFaqEntry(message);
@@ -122,9 +120,9 @@ export const supportChatHandlers = [
 
   http.get(`${CHATBOT_BASE_PATH}/stream`, async ({ request }) => {
     const url = new URL(request.url);
-    const sessionId = Number(url.searchParams.get('session_id'));
+    const sessionId = url.searchParams.get('session_id')?.trim() ?? '';
 
-    if (Number.isNaN(sessionId) || sessionId <= 0) {
+    if (!sessionId) {
       return toJsonError(400, '잘못된 session_id 입니다.');
     }
 

--- a/src/features/support-chat/store/useSupportChatStore.ts
+++ b/src/features/support-chat/store/useSupportChatStore.ts
@@ -12,7 +12,7 @@ import type {
 } from '../types/supportChat';
 
 type SupportChatStoreState = {
-  sessionId: number | null;
+  sessionId: string | null;
   messages: SupportChatMessage[];
   quickActions: SupportChatQuickAction[];
   showQuickActions: boolean;
@@ -33,7 +33,7 @@ type SupportChatStoreState = {
   closeAndResetConversation: (routeContext?: SupportChatRouteContext) => void;
   togglePanel: () => void;
   setRouteContext: (routeContext: SupportChatRouteContext) => void;
-  setSessionId: (sessionId: number | null) => void;
+  setSessionId: (sessionId: string | null) => void;
   setPinnedToBottom: (isPinnedToBottom: boolean) => void;
   setSubmitting: (isSubmitting: boolean) => void;
   hideQuickActions: () => void;
@@ -70,7 +70,7 @@ const capMessages = (messages: SupportChatMessage[]) =>
     : messages;
 
 const initialState = {
-  sessionId: null as number | null,
+  sessionId: null as string | null,
   messages: createInitialMessages(),
   quickActions: SUPPORT_CHAT_QUICK_ACTIONS,
   showQuickActions: true,

--- a/src/features/support-chat/types/supportChat.ts
+++ b/src/features/support-chat/types/supportChat.ts
@@ -22,11 +22,11 @@ export type SupportChatRouteContext = {
 
 export type ChatbotMessageRequest = {
   message: string;
-  session_id?: number;
+  session_id?: string;
 };
 
 export type ChatbotMessageResponse = {
-  session_id: number;
+  session_id: string;
 };
 
 export type ChatbotErrorResponse = {
@@ -35,7 +35,7 @@ export type ChatbotErrorResponse = {
 
 export type ChatbotStreamStartEvent = {
   type: 'start';
-  sessionId: number;
+  sessionId: string;
 };
 
 export type ChatbotStreamChunkEvent = {
@@ -45,7 +45,7 @@ export type ChatbotStreamChunkEvent = {
 
 export type ChatbotStreamCompleteEvent = {
   type: 'complete';
-  sessionId: number;
+  sessionId: string;
 };
 
 export type ChatbotStreamEvent =


### PR DESCRIPTION
## 관련 이슈

- closes #285

## 변경 내용

- 고객센터 챗봇의 session_id 타입을 number에서 UUID 형태의 string으로 통일했습니다.
- ChatbotMessageRequest, ChatbotMessageResponse, SSE start/complete 이벤트 타입 등 session_id를 참조하는 연관 타입을 -모두 문자열 기준으로 변경했습니다.
- 챗봇 스토어의 sessionId 상태와 setter 시그니처를 string | null 기준으로 정리했습니다.
- 챗봇 메시지 전송 및 스트리밍 API에서 session_id를 문자열로 처리하도록 파서와 함수 시그니처를 수정했습니다.
- MSW 핸들러도 실서버 응답 방향에 맞춰 세션 키를 문자열로 저장하고, 새 세션은 crypto.randomUUID()로 생성하도록 동기화했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
