### PR TITLE
[Fix] 매칭 API 명세 반영 및 크리티컬 버그 수정

### DIFF
--- a/src/features/matching/api/matching.ts
+++ b/src/features/matching/api/matching.ts
@@ -26,8 +26,9 @@ const normalizeMatchCandidate = (item: MatchingApiCandidateItem) => ({
   is_liked: Boolean(item.is_liked),
 });
 
-export const getMatchCandidates = async (genreId: number) => {
-  const getMockFallback = () => getMatchingMockCandidatesSnapshot(genreId);
+export const getMatchCandidates = async (genreId: number, retryNo = 0) => {
+  const getMockFallback = () =>
+    getMatchingMockCandidatesSnapshot(genreId, retryNo);
 
   try {
     const response = await api.get<MatchingApiCandidatesResponse>(
@@ -35,6 +36,7 @@ export const getMatchCandidates = async (genreId: number) => {
       {
         params: {
           genre_id: genreId,
+          retry_no: retryNo,
         },
       },
     );

--- a/src/features/matching/api/useMatchingApi.ts
+++ b/src/features/matching/api/useMatchingApi.ts
@@ -20,12 +20,13 @@ import {
 
 export const useMatchCandidatesQuery = (
   genreId: number | null,
+  retryNo = 0,
   enabled = true,
 ) =>
   useQuery({
-    queryKey: ['match-candidates', genreId],
+    queryKey: ['match-candidates', genreId, retryNo],
     enabled: genreId !== null && enabled,
-    queryFn: () => getMatchCandidates(genreId!),
+    queryFn: () => getMatchCandidates(genreId!, retryNo),
     staleTime: 60_000,
     retry: shouldRetryApiQuery,
   });
@@ -59,13 +60,17 @@ export const useSubmitMatchResponsesMutation = () =>
     mutationFn: submitMatchResponses,
   });
 
-export const useMatchResultsInfinite = (enabled = true) =>
+export const useMatchResultsInfinite = (
+  genreId: number | null,
+  enabled = true,
+) =>
   useInfiniteQuery({
-    queryKey: ['match-results'],
+    queryKey: ['match-results', genreId],
     initialPageParam: null as string | null,
-    enabled,
+    enabled: enabled && genreId !== null,
     queryFn: ({ pageParam }) =>
       getMatchResponseResults({
+        genre_id: genreId!,
         cursor: pageParam ?? undefined,
         page_size: 5,
       }),

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -11,6 +11,7 @@ import {
   matchingMockCandidateMapById,
   matchingMockCandidatesByGenreId,
 } from './data';
+import { getMatchingMockCandidatesForRetry } from './runtime';
 
 const getErrorResponse = (status: number, message: string) =>
   HttpResponse.json(
@@ -28,10 +29,17 @@ type StoredMatchResult = {
   mock_rank_score: number;
 };
 
+type StoredMatchContext = {
+  genre_id: number;
+  retry_no: number;
+  candidate_date?: string;
+  results: StoredMatchResult[];
+};
+
 const DEFAULT_RECOMMENDATION_PAGE_SIZE = 5;
 const DEFAULT_RECOMMENDATION_TOTAL_COUNT = 15;
 
-let storedMatchResults: StoredMatchResult[] = [];
+let storedMatchContext: StoredMatchContext | null = null;
 
 const MATCHING_RESULT_GENRE_FILTERS: Record<number, GameGenreFilter[]> = {
   1: ['액션', '대전 / 격투'],
@@ -66,7 +74,7 @@ const calculateMockRankScore = ({
 };
 
 const getRankedMatchResults = () =>
-  [...storedMatchResults].sort((a, b) => {
+  [...(storedMatchContext?.results ?? [])].sort((a, b) => {
     if (b.mock_rank_score !== a.mock_rank_score) {
       return b.mock_rank_score - a.mock_rank_score;
     }
@@ -80,22 +88,6 @@ const toMockRecommendationRating = (candidateRating: number | null) =>
     : null;
 
 const normalizeGenre = (value: string) => value.trim().toLowerCase();
-
-const getSelectedGenreIdFromStoredResults = () => {
-  const firstStoredResult = storedMatchResults[0];
-
-  if (!firstStoredResult) {
-    return null;
-  }
-
-  return (
-    Object.entries(matchingMockCandidatesByGenreId).find(([, candidates]) =>
-      candidates.some(
-        (candidate) => candidate.game_id === firstStoredResult.game_id,
-      ),
-    )?.[0] ?? null
-  );
-};
 
 const getGenreAffinityScore = (genres: string[], genreId: number | null) => {
   if (!genreId) {
@@ -122,9 +114,9 @@ const getGenreOverlapScore = (
 };
 
 const getMockRecommendationResults = (authorization: string | null) => {
-  const selectedGenreId = Number(getSelectedGenreIdFromStoredResults());
+  const selectedGenreId = storedMatchContext?.genre_id ?? null;
   const evaluatedGameIds = new Set(
-    storedMatchResults.map((result) => result.game_id),
+    (storedMatchContext?.results ?? []).map((result) => result.game_id),
   );
   const currentLikedGameIds =
     getMockLikedGameIdsForAuthorization(authorization);
@@ -227,18 +219,28 @@ export const matchingHandlers = [
   http.get('/api/v1/match/candidates', async ({ request }) => {
     const url = new URL(request.url);
     const genreIdValue = url.searchParams.get('genre_id');
+    const retryNoValue = url.searchParams.get('retry_no');
     const genreId = Number(genreIdValue);
+    const retryNo = retryNoValue !== null ? Number(retryNoValue) : 0;
 
     if (!genreIdValue || Number.isNaN(genreId) || genreId <= 0) {
       return getErrorResponse(400, '유효하지 않은 genre_id 입니다.');
     }
 
-    const candidates = matchingMockCandidatesByGenreId[genreId];
+    if (
+      retryNoValue !== null &&
+      (Number.isNaN(retryNo) || !Number.isInteger(retryNo) || retryNo < 0)
+    ) {
+      return getErrorResponse(400, 'retry_no는 0 이상의 정수여야 합니다.');
+    }
+
+    const candidatesByGenre = matchingMockCandidatesByGenreId[genreId];
+    const candidates = getMatchingMockCandidatesForRetry(genreId, retryNo);
     const currentLikedGameIds = getMockLikedGameIdsForAuthorization(
       request.headers.get('Authorization'),
     );
 
-    if (!candidates) {
+    if (!candidatesByGenre) {
       return getErrorResponse(404, '해당 장르의 게임을 찾을 수 없습니다.');
     }
 
@@ -260,6 +262,9 @@ export const matchingHandlers = [
   }),
   http.post('/api/v1/match/responses', async ({ request }) => {
     const body = (await request.json()) as {
+      genre_id?: number;
+      retry_no?: number;
+      candidate_date?: string;
       match_result?: Array<{
         game_id?: number;
         rating?: number;
@@ -267,41 +272,76 @@ export const matchingHandlers = [
       }>;
     };
 
+    if (
+      typeof body.genre_id !== 'number' ||
+      !Number.isInteger(body.genre_id) ||
+      body.genre_id < 1 ||
+      body.genre_id > 8
+    ) {
+      return getErrorResponse(400, '유효하지 않은 genre_id 입니다.');
+    }
+
+    if (
+      typeof body.retry_no !== 'number' ||
+      !Number.isInteger(body.retry_no) ||
+      body.retry_no < 0
+    ) {
+      return getErrorResponse(400, 'retry_no는 0 이상의 정수여야 합니다.');
+    }
+
     if (!Array.isArray(body.match_result) || body.match_result.length === 0) {
       return getErrorResponse(400, '평가할 match_result가 필요합니다.');
     }
 
+    const currentCandidates = getMatchingMockCandidatesForRetry(
+      body.genre_id,
+      body.retry_no,
+    );
+    const candidateIdSet = new Set(
+      currentCandidates.map((candidate) => candidate.game_id),
+    );
+
     for (const result of body.match_result) {
-      if (
-        typeof result.game_id !== 'number' ||
-        !matchingMockCandidateMapById.has(result.game_id)
-      ) {
-        return getErrorResponse(404, '해당 게임을 찾을 수 없습니다.');
+      const rating = result.rating;
+
+      if (typeof result.game_id !== 'number') {
+        return getErrorResponse(400, 'game_id는 정수여야 합니다.');
       }
 
-      if (
-        typeof result.rating !== 'number' ||
-        !Number.isInteger(result.rating) ||
-        result.rating < 1 ||
-        result.rating > 5
-      ) {
-        return getErrorResponse(400, '1~5 사이 정수여야 합니다.');
+      if (!candidateIdSet.has(result.game_id)) {
+        return getErrorResponse(
+          400,
+          '후보 세트에 없는 game_id가 포함되어 있습니다.',
+        );
+      }
+
+      if (typeof rating !== 'number' || !Number.isInteger(rating)) {
+        return getErrorResponse(400, 'rating은 정수여야 합니다.');
+      }
+
+      if (rating < 1 || rating > 5) {
+        return getErrorResponse(400, 'rating은 1~5 사이의 정수여야 합니다.');
       }
     }
 
-    storedMatchResults = body.match_result.map((result, index, allResults) => ({
-      game_id: result.game_id!,
-      rating: result.rating!,
-      is_liked: Boolean(result.is_liked),
-      created_at_order: index,
-      mock_rank_score: calculateMockRankScore({
-        gameId: result.game_id!,
+    storedMatchContext = {
+      genre_id: body.genre_id,
+      retry_no: body.retry_no,
+      candidate_date: body.candidate_date,
+      results: body.match_result.map((result, index, allResults) => ({
+        game_id: result.game_id!,
         rating: result.rating!,
-        isLiked: Boolean(result.is_liked),
-        createdAtOrder: index,
-        totalCount: allResults.length,
-      }),
-    }));
+        is_liked: Boolean(result.is_liked),
+        created_at_order: index,
+        mock_rank_score: calculateMockRankScore({
+          gameId: result.game_id!,
+          rating: result.rating!,
+          isLiked: Boolean(result.is_liked),
+          createdAtOrder: index,
+          totalCount: allResults.length,
+        }),
+      })),
+    };
 
     syncMockLikedGamesForAuthorization(
       request.headers.get('Authorization'),
@@ -322,7 +362,7 @@ export const matchingHandlers = [
 
     return HttpResponse.json({
       user_id: 1,
-      match_result: storedMatchResults.map((result) => ({
+      match_result: (storedMatchContext?.results ?? []).map((result) => ({
         game_id: result.game_id,
         rating: result.rating,
         is_liked: result.is_liked,
@@ -330,15 +370,31 @@ export const matchingHandlers = [
     });
   }),
   http.get('/api/v1/match/responses/result', async ({ request }) => {
-    if (storedMatchResults.length === 0) {
-      return getErrorResponse(404, '매칭 추천 결과를 찾을 수 없습니다.');
-    }
-
     const url = new URL(request.url);
-    const cursor = Number(url.searchParams.get('cursor') ?? '0');
+    const genreIdValue = url.searchParams.get('genre_id');
+    const genreId = Number(genreIdValue);
+    const cursorParam = url.searchParams.get('cursor');
+    const cursor =
+      cursorParam !== null && !Number.isNaN(Number(cursorParam))
+        ? Number(cursorParam)
+        : 0;
     const pageSize = Number(
       url.searchParams.get('page_size') ?? DEFAULT_RECOMMENDATION_PAGE_SIZE,
     );
+
+    if (
+      !genreIdValue ||
+      Number.isNaN(genreId) ||
+      !Number.isInteger(genreId) ||
+      genreId < 1 ||
+      genreId > 8
+    ) {
+      return getErrorResponse(400, '유효하지 않은 genre_id 입니다.');
+    }
+
+    if (!storedMatchContext || storedMatchContext.genre_id !== genreId) {
+      return getErrorResponse(404, '매칭 추천 결과를 찾을 수 없습니다.');
+    }
 
     const results = getMockRecommendationResults(
       request.headers.get('Authorization'),

--- a/src/features/matching/mocks/runtime.ts
+++ b/src/features/matching/mocks/runtime.ts
@@ -1,10 +1,35 @@
 import type { MatchingCandidatesResponse } from '../types';
 import { matchingMockCandidatesByGenreId } from './data';
 
+export const getMatchingMockCandidatesForRetry = (
+  genreId: number,
+  retryNo = 0,
+) => {
+  const candidates = matchingMockCandidatesByGenreId[genreId] ?? [];
+
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  const normalizedRetryNo =
+    Number.isInteger(retryNo) && retryNo >= 0 ? retryNo : 0;
+  const rotationIndex = normalizedRetryNo % candidates.length;
+
+  if (rotationIndex === 0) {
+    return candidates;
+  }
+
+  return [
+    ...candidates.slice(rotationIndex),
+    ...candidates.slice(0, rotationIndex),
+  ];
+};
+
 export const getMatchingMockCandidatesSnapshot = (
   genreId: number,
+  retryNo = 0,
 ): MatchingCandidatesResponse => {
-  const candidates = matchingMockCandidatesByGenreId[genreId] ?? [];
+  const candidates = getMatchingMockCandidatesForRetry(genreId, retryNo);
 
   return {
     genre_id: genreId,

--- a/src/features/matching/store/useMatchingStore.ts
+++ b/src/features/matching/store/useMatchingStore.ts
@@ -126,5 +126,5 @@ export const useMatchingStore = create<MatchingStoreState>((set) => ({
     set((state) => ({
       currentIndex: state.currentIndex > 0 ? state.currentIndex - 1 : 0,
     })),
-  resetFlow: () => ({ ...initialState }),
+  resetFlow: () => set({ ...initialState }),
 }));

--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -74,6 +74,9 @@ export interface MatchResponseItem {
 }
 
 export interface SubmitMatchResponsesRequest {
+  genre_id: number;
+  retry_no: number;
+  candidate_date?: string;
   match_result: MatchResponseItem[];
 }
 
@@ -83,6 +86,7 @@ export interface SubmitMatchResponsesResponse {
 }
 
 export interface MatchResultQuery {
+  genre_id: number;
   cursor?: string;
   page_size?: number;
 }

--- a/src/features/recommendation/hooks/useRecommendationResultsSource.ts
+++ b/src/features/recommendation/hooks/useRecommendationResultsSource.ts
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router';
 
 import { getPaginatedResults } from '../../../utils/paginatedResults';
 import { useMatchResultsInfinite } from '../../matching/api/useMatchingApi';
+import { useMatchingStore } from '../../matching/store/useMatchingStore';
 import type { MatchResultResponse } from '../../matching/types';
 import { useSurveyStore } from '../../survey/store/useSurveyStore';
 import { useSurveyResultsInfinite } from '../../survey/api/useSurveyApi';
@@ -25,11 +26,21 @@ export const useRecommendationResultsSource = ({
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const source = searchParams.get('source');
+  const matchGenreIdFromUrlValue = searchParams.get('genre_id');
   const surveySessionIdFromUrl = searchParams.get('session_id');
   const storedSurveySessionId = useSurveyStore((state) => state.sessionId);
+  const selectedGenreId = useMatchingStore((state) => state.selectedGenreId);
   const isMatchSource = source === 'match';
   const isSurveySource =
     source === 'survey' || (!source && Boolean(surveySessionIdFromUrl));
+  const matchGenreIdFromUrl =
+    matchGenreIdFromUrlValue !== null ? Number(matchGenreIdFromUrlValue) : null;
+  const resolvedMatchGenreId =
+    typeof matchGenreIdFromUrl === 'number' &&
+    !Number.isNaN(matchGenreIdFromUrl) &&
+    matchGenreIdFromUrl >= 1
+      ? matchGenreIdFromUrl
+      : selectedGenreId;
   const resolvedSurveySessionId =
     surveySessionIdFromUrl ?? storedSurveySessionId;
 
@@ -38,6 +49,7 @@ export const useRecommendationResultsSource = ({
     resolvedSurveySessionId,
   );
   const matchResultsQuery = useMatchResultsInfinite(
+    resolvedMatchGenreId,
     isMatchSource && canAccessPage,
   );
   const activeQuery = isMatchSource ? matchResultsQuery : surveyResultsQuery;
@@ -80,10 +92,10 @@ export const useRecommendationResultsSource = ({
     }
 
     if (isMatchSource) {
-      queryClient.setQueryData<{
+      queryClient.setQueriesData<{
         pages: MatchResultResponse[];
         pageParams: unknown[];
-      }>(['match-results'], (currentData) =>
+      }>({ queryKey: ['match-results'] }, (currentData) =>
         currentData
           ? {
               ...currentData,

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -92,9 +92,20 @@ function MatchingGenreDetailPage() {
   const canAccessPage = authGate.accessStatus === 'authorized';
   const isValidGenreSlug = genreSlug ? isMatchingGenreSlug(genreSlug) : false;
   const genre = genreSlug ? getMatchingGenreBySlug(genreSlug) : undefined;
+  const currentGenreSlug = genre?.slug ?? null;
+  const [retryState, setRetryState] = useState<{
+    genreSlug: string | null;
+    value: number;
+  }>({
+    genreSlug: currentGenreSlug,
+    value: 0,
+  });
+  const retryNo =
+    retryState.genreSlug === currentGenreSlug ? retryState.value : 0;
 
   const matchCandidatesQuery = useMatchCandidatesQuery(
     genre?.genreId ?? null,
+    retryNo,
     canAccessPage,
   );
   const submitMatchResponsesMutation = useSubmitMatchResponsesMutation();
@@ -124,7 +135,7 @@ function MatchingGenreDetailPage() {
 
   useEffect(() => {
     hasInitializedFlowRef.current = false;
-  }, [genre?.slug]);
+  }, [genre?.slug, retryNo]);
 
   useEffect(() => {
     if (!genre || candidates.length === 0 || hasInitializedFlowRef.current) {
@@ -285,19 +296,25 @@ function MatchingGenreDetailPage() {
   }
 
   const handleSubmit = async () => {
-    if (!allCandidatesRated || displayCandidates.length === 0) {
+    if (!genre || !allCandidatesRated || displayCandidates.length === 0) {
       return;
     }
 
+    const currentGenreId = genre.genreId;
+
     try {
       await submitMatchResponsesMutation.mutateAsync({
+        genre_id: currentGenreId,
+        retry_no: retryNo,
         match_result: displayCandidates.map((candidate) => ({
           game_id: candidate.game_id,
           rating: evaluationsByGameId[candidate.game_id]!.rating!,
           is_liked: candidate.is_liked,
         })),
       });
-      navigate(`/${ROUTES.RECOMMENDATION_LIST}?source=match`);
+      navigate(
+        `/${ROUTES.RECOMMENDATION_LIST}?source=match&genre_id=${currentGenreId}`,
+      );
     } catch {
       return;
     }
@@ -361,7 +378,12 @@ function MatchingGenreDetailPage() {
             <div className="mt-7 flex flex-wrap gap-3">
               <button
                 type="button"
-                onClick={() => void matchCandidatesQuery.refetch()}
+                onClick={() =>
+                  setRetryState({
+                    genreSlug: currentGenreSlug,
+                    value: retryNo + 1,
+                  })
+                }
                 className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
               >
                 다시 시도


### PR DESCRIPTION
## 관련 이슈

- closes #292 

## 변경 내용

- 매칭 후보 조회 API에 `retry_no`를 반영하고, query key 및 상세 페이지 재시도 흐름도 함께 정리했습니다.
- 매칭 제출 payload에 `genre_id`, `retry_no` 명세를 반영했습니다.
- 매칭 추천 결과 조회 API에 `genre_id`를 반영하고, 추천 결과 훅에서 선택된 장르 기준으로 결과를 읽도록 수정했습니다.
- `useMatchingStore`의 `resetFlow()`가 실제로 상태를 초기화하지 않던 버그를 수정했습니다.
- MSW 매칭 핸들러도 최신 명세 기준으로 `retry_no`, `genre_id`, 요청 body 검증, 에러 메시지를 정리했습니다.
- 매칭 후보 mock은 `retry_no`에 따라 다른 순서로 반환되도록 보강했고, 매칭 결과 mock의 cursor 파싱도 더 안전하게 수정했습니다.
- 매칭 제출 후 추천 리스트로 이동할 때 `genre_id`를 함께 전달해, 추천 결과 재조회 기준이 분명해지도록 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 실서버 연동 시 400 오류를 막기 위한 매칭 API 계약 반영에 집중했습니다.
- `candidate_date`는 현재 프론트가 후보 응답에서 기준 날짜를 받지 않기 때문에, 타입만 열어두고 실제 전송은 하지 않았습니다.
- 설문/추천 페이지네이션 및 캐시 흐름 보정은 다음 PR로 분리합니다.
