### PR TITLE
[Fix] 추천 결과 페이지네이션 및 캐시 흐름 보정

### DIFF
--- a/src/features/matching/api/useMatchingApi.ts
+++ b/src/features/matching/api/useMatchingApi.ts
@@ -6,11 +6,7 @@ import {
 } from '@tanstack/react-query';
 
 import { shouldRetryApiQuery } from '../../../api/queryRetry';
-import {
-  getPaginatedCount,
-  getPaginatedLoadedCount,
-  getPaginatedNext,
-} from '../../../utils/paginatedResults';
+import { getPaginatedNext } from '../../../utils/paginatedResults';
 import {
   getMatchCandidates,
   getMatchingGenreImage,
@@ -74,15 +70,6 @@ export const useMatchResultsInfinite = (
         cursor: pageParam ?? undefined,
         page_size: 5,
       }),
-    getNextPageParam: (lastPage, allPages) => {
-      const loadedCount = getPaginatedLoadedCount(allPages);
-      const totalCount = getPaginatedCount(lastPage, 15);
-
-      if (loadedCount >= totalCount) {
-        return undefined;
-      }
-
-      return getPaginatedNext(lastPage);
-    },
+    getNextPageParam: (lastPage) => getPaginatedNext(lastPage) ?? undefined,
     retry: shouldRetryApiQuery,
   });

--- a/src/features/recommendation/hooks/useRecommendationResultsSource.ts
+++ b/src/features/recommendation/hooks/useRecommendationResultsSource.ts
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { useLayoutEffect } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router';
 
 import { getPaginatedResults } from '../../../utils/paginatedResults';
@@ -43,6 +43,12 @@ export const useRecommendationResultsSource = ({
       : selectedGenreId;
   const resolvedSurveySessionId =
     surveySessionIdFromUrl ?? storedSurveySessionId;
+  const hasTrimmedOnEntryRef = useRef<string | null>(null);
+  const activeTrimKey = isMatchSource
+    ? `match:${resolvedMatchGenreId ?? 'none'}`
+    : isSurveySource
+      ? `survey:${resolvedSurveySessionId ?? 'current'}`
+      : null;
 
   const surveyResultsQuery = useSurveyResultsInfinite(
     !isMatchSource && isSurveySource && canAccessPage,
@@ -87,22 +93,30 @@ export const useRecommendationResultsSource = ({
     (isResultNotFound || recommendationItems.length === 0);
 
   useLayoutEffect(() => {
-    if (!canAccessPage) {
+    if (!canAccessPage || !activeTrimKey) {
       return;
     }
 
-    if (isMatchSource) {
+    if (hasTrimmedOnEntryRef.current === activeTrimKey) {
+      return;
+    }
+
+    hasTrimmedOnEntryRef.current = activeTrimKey;
+
+    if (isMatchSource && resolvedMatchGenreId !== null) {
       queryClient.setQueriesData<{
         pages: MatchResultResponse[];
         pageParams: unknown[];
-      }>({ queryKey: ['match-results'] }, (currentData) =>
-        currentData
-          ? {
-              ...currentData,
-              pages: currentData.pages.slice(0, 1),
-              pageParams: currentData.pageParams.slice(0, 1),
-            }
-          : currentData,
+      }>(
+        { queryKey: ['match-results', resolvedMatchGenreId] },
+        (currentData) =>
+          currentData
+            ? {
+                ...currentData,
+                pages: currentData.pages.slice(0, 1),
+                pageParams: currentData.pageParams.slice(0, 1),
+              }
+            : currentData,
       );
 
       return;
@@ -112,17 +126,27 @@ export const useRecommendationResultsSource = ({
       queryClient.setQueriesData<{
         pages: SurveyResultResponse[];
         pageParams: unknown[];
-      }>({ queryKey: ['survey-results'] }, (currentData) =>
-        currentData
-          ? {
-              ...currentData,
-              pages: currentData.pages.slice(0, 1),
-              pageParams: currentData.pageParams.slice(0, 1),
-            }
-          : currentData,
+      }>(
+        { queryKey: ['survey-results', resolvedSurveySessionId ?? 'current'] },
+        (currentData) =>
+          currentData
+            ? {
+                ...currentData,
+                pages: currentData.pages.slice(0, 1),
+                pageParams: currentData.pageParams.slice(0, 1),
+              }
+            : currentData,
       );
     }
-  }, [canAccessPage, isMatchSource, isSurveySource, queryClient]);
+  }, [
+    activeTrimKey,
+    canAccessPage,
+    isMatchSource,
+    isSurveySource,
+    queryClient,
+    resolvedMatchGenreId,
+    resolvedSurveySessionId,
+  ]);
 
   return {
     isMatchSource,

--- a/src/features/survey/api/useSurveyApi.ts
+++ b/src/features/survey/api/useSurveyApi.ts
@@ -1,11 +1,7 @@
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 
 import { shouldRetryApiQuery } from '../../../api/queryRetry';
-import {
-  getPaginatedCount,
-  getPaginatedLoadedCount,
-  getPaginatedNext,
-} from '../../../utils/paginatedResults';
+import { getPaginatedNext } from '../../../utils/paginatedResults';
 import {
   continueSurveyChat,
   getSurveyResults,
@@ -42,15 +38,6 @@ export const useSurveyResultsInfinite = (
         page_size: 5,
         session_id: sessionId ?? undefined,
       }),
-    getNextPageParam: (lastPage, allPages) => {
-      const loadedCount = getPaginatedLoadedCount(allPages);
-      const totalCount = getPaginatedCount(lastPage, 15);
-
-      if (loadedCount >= totalCount) {
-        return undefined;
-      }
-
-      return getPaginatedNext(lastPage);
-    },
+    getNextPageParam: (lastPage) => getPaginatedNext(lastPage) ?? undefined,
     retry: shouldRetryApiQuery,
   });


### PR DESCRIPTION
## 관련 이슈

- closes #296 

## 변경 내용

- 매칭/설문 추천 결과 infinite query의 다음 페이지 판단을 `count` 하드코딩 fallback 대신 `next` 기준으로 정리했습니다.
- 추천 결과 페이지 진입 시 쿼리 캐시를 무조건 1페이지로 자르던 로직을 재조정해, 현재 진입한 source/key에 대해서만 1회 trim 되도록 수정했습니다.
- 그 결과 추천 결과 페이지는 새로 진입하면 기본 5개부터 시작하되, 다른 source/session/genre 캐시까지 함께 잘리는 부작용을 줄이도록 개선했습니다.
- survey source와 match source 모두 같은 기준으로 캐시 trim 동작을 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 추천 결과 리스트의 페이지네이션과 캐시 흐름 안정화에 집중했습니다.
- 추천 리스트 UI 변경이나 추가 리팩터링은 이번 범위에 포함하지 않았습니다.