### PR TITLE
[Refactor] 설문/추천 타입 및 mock 중복 정리

### DIFF
--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -1,3 +1,5 @@
+import type { RecommendationResultItemShape } from '../recommendation/types';
+
 export type MatchingGenreSlug =
   | 'action-fighting'
   | 'adventure-platform'
@@ -91,14 +93,7 @@ export interface MatchResultQuery {
   page_size?: number;
 }
 
-export interface MatchResultItem {
-  game_id: number;
-  title: string;
-  genres: string[];
-  thumbnail_url: string | null;
-  rating: number;
-  is_liked: boolean;
-}
+export type MatchResultItem = RecommendationResultItemShape;
 
 export interface MatchResultResponse {
   user_id: number;

--- a/src/features/recommendation/types.ts
+++ b/src/features/recommendation/types.ts
@@ -1,4 +1,4 @@
-export type RecommendationDisplayItem = {
+export type RecommendationResultItemShape = {
   game_id: number;
   title: string;
   genres: string[];
@@ -6,3 +6,5 @@ export type RecommendationDisplayItem = {
   rating: number | null;
   is_liked: boolean;
 };
+
+export type RecommendationDisplayItem = RecommendationResultItemShape;

--- a/src/features/recommendation/utils/normalizeRecommendationItem.ts
+++ b/src/features/recommendation/utils/normalizeRecommendationItem.ts
@@ -1,12 +1,13 @@
 import type { GameListItem } from '../../games/types';
-import type { MatchResultItem } from '../../matching/types';
-import type { SurveyResultItem } from '../../survey/types/survey';
-import type { RecommendationDisplayItem } from '../types';
+import type {
+  RecommendationDisplayItem,
+  RecommendationResultItemShape,
+} from '../types';
 
 const FALLBACK_HIGHLIGHTS = ['몰입감', '스토리', '액션', '전략'];
 
 export const normalizeRecommendationItem = (
-  item: SurveyResultItem | MatchResultItem,
+  item: RecommendationResultItemShape,
 ): RecommendationDisplayItem => ({
   game_id: item.game_id,
   title: item.title,

--- a/src/features/survey/mocks/constants.ts
+++ b/src/features/survey/mocks/constants.ts
@@ -1,0 +1,4 @@
+export const SURVEY_MIN_STEPS = 3;
+export const SURVEY_DEFAULT_STEPS = 4;
+export const SURVEY_MAX_STEPS = 5;
+export const DEFAULT_SURVEY_RECOMMENDATION_PAGE_SIZE = 5;

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -7,11 +7,12 @@ import type {
   SurveyApiResultItem,
   SurveyResetRequest,
 } from '../types/survey';
-
-const MIN_STEPS = 3;
-const DEFAULT_STEPS = 4;
-const MAX_STEPS = 5;
-const DEFAULT_RECOMMENDATION_PAGE_SIZE = 5;
+import {
+  DEFAULT_SURVEY_RECOMMENDATION_PAGE_SIZE,
+  SURVEY_DEFAULT_STEPS,
+  SURVEY_MAX_STEPS,
+  SURVEY_MIN_STEPS,
+} from './constants';
 
 const surveyQuestions = [
   '스토리 중심의 몰입감을 더 중요하게 보시나요, 아니면 손맛과 시스템 완성도를 더 중요하게 보시나요?',
@@ -106,14 +107,14 @@ const getQuestionCountFromAnswer = (answer: string) => {
     (hasVaguePhrase ? 1 : 0);
 
   if (detailScore >= 3) {
-    return MIN_STEPS;
+    return SURVEY_MIN_STEPS;
   }
 
   if (detailScore <= 0) {
-    return MAX_STEPS;
+    return SURVEY_MAX_STEPS;
   }
 
-  return DEFAULT_STEPS;
+  return SURVEY_DEFAULT_STEPS;
 };
 
 const getErrorResponse = (status: number, message: string) =>
@@ -128,7 +129,7 @@ export const surveyHandlers = [
   http.post('/api/v1/survey/chatbot/sessions', async ({ request }) => {
     await request.json().catch(() => ({}));
     const sessionId = createSessionId();
-    const totalQuestions = MAX_STEPS;
+    const totalQuestions = SURVEY_MAX_STEPS;
 
     surveySessions.set(sessionId, {
       askedQuestions: 1,
@@ -160,7 +161,7 @@ export const surveyHandlers = [
         surveySessions.get(sessionId) ??
         ({
           askedQuestions: 1,
-          totalQuestions: DEFAULT_STEPS,
+          totalQuestions: SURVEY_DEFAULT_STEPS,
         } satisfies MockSurveySession);
 
       if (session.askedQuestions === 1) {
@@ -204,7 +205,8 @@ export const surveyHandlers = [
     const url = new URL(request.url);
     const cursor = Number(url.searchParams.get('cursor') ?? '0');
     const pageSize = Number(
-      url.searchParams.get('page_size') ?? DEFAULT_RECOMMENDATION_PAGE_SIZE,
+      url.searchParams.get('page_size') ??
+        DEFAULT_SURVEY_RECOMMENDATION_PAGE_SIZE,
     );
     const requestedSessionId = url.searchParams.get('session_id');
     const recommendations = buildSurveyRecommendations(
@@ -244,7 +246,7 @@ export const surveyHandlers = [
     const nextSessionId = createSessionId();
     surveySessions.set(nextSessionId, {
       askedQuestions: 1,
-      totalQuestions: MAX_STEPS,
+      totalQuestions: SURVEY_MAX_STEPS,
     });
 
     await delay(350);
@@ -254,7 +256,7 @@ export const surveyHandlers = [
       session_id: nextSessionId,
       status: 'IN_PROGRESS',
       ai_question: surveyQuestions[0],
-      progress: buildProgress(1, MAX_STEPS),
+      progress: buildProgress(1, SURVEY_MAX_STEPS),
       recommendation_ready: false,
     });
   }),

--- a/src/features/survey/mocks/runtime.ts
+++ b/src/features/survey/mocks/runtime.ts
@@ -6,11 +6,12 @@ import type {
   SurveyApiResultResponse,
   SurveyApiSessionResponse,
 } from '../types/survey';
-
-const MIN_STEPS = 3;
-const DEFAULT_STEPS = 4;
-const MAX_STEPS = 5;
-const DEFAULT_RECOMMENDATION_PAGE_SIZE = 5;
+import {
+  DEFAULT_SURVEY_RECOMMENDATION_PAGE_SIZE,
+  SURVEY_DEFAULT_STEPS,
+  SURVEY_MAX_STEPS,
+  SURVEY_MIN_STEPS,
+} from './constants';
 
 const surveyQuestions = [
   '스토리 중심의 몰입감을 더 중요하게 보시나요, 아니면 손맛과 시스템 완성도를 더 중요하게 보시나요?',
@@ -87,14 +88,14 @@ const getQuestionCountFromAnswer = (answer: string) => {
     (hasVaguePhrase ? 1 : 0);
 
   if (detailScore >= 3) {
-    return MIN_STEPS;
+    return SURVEY_MIN_STEPS;
   }
 
   if (detailScore <= 0) {
-    return MAX_STEPS;
+    return SURVEY_MAX_STEPS;
   }
 
-  return DEFAULT_STEPS;
+  return SURVEY_DEFAULT_STEPS;
 };
 
 const buildSurveyRecommendations = () =>
@@ -114,14 +115,14 @@ export const startMockSurveySession = (): SurveyApiSessionResponse => {
   const sessionId = createSessionId();
   surveySessions.set(sessionId, {
     askedQuestions: 1,
-    totalQuestions: MAX_STEPS,
+    totalQuestions: SURVEY_MAX_STEPS,
   });
 
   return {
     session_id: sessionId,
     ai_question: surveyQuestions[0],
     status: 'IN_PROGRESS',
-    progress: buildProgress(1, MAX_STEPS),
+    progress: buildProgress(1, SURVEY_MAX_STEPS),
     recommendation_ready: false,
   };
 };
@@ -133,7 +134,7 @@ export const continueMockSurveyChat = (
     surveySessions.get(payload.session_id) ??
     ({
       askedQuestions: 1,
-      totalQuestions: DEFAULT_STEPS,
+      totalQuestions: SURVEY_DEFAULT_STEPS,
     } satisfies MockSurveySession);
 
   if (session.askedQuestions === 1) {
@@ -172,7 +173,7 @@ export const continueMockSurveyChat = (
 
 export const getMockSurveyResults = ({
   cursor,
-  pageSize = DEFAULT_RECOMMENDATION_PAGE_SIZE,
+  pageSize = DEFAULT_SURVEY_RECOMMENDATION_PAGE_SIZE,
   sessionId,
 }: {
   cursor?: string | null;
@@ -214,7 +215,7 @@ export const resetMockSurveySession = (
   const nextSessionId = createSessionId();
   surveySessions.set(nextSessionId, {
     askedQuestions: 1,
-    totalQuestions: MAX_STEPS,
+    totalQuestions: SURVEY_MAX_STEPS,
   });
 
   return {
@@ -222,7 +223,7 @@ export const resetMockSurveySession = (
     session_id: nextSessionId,
     status: 'IN_PROGRESS',
     ai_question: surveyQuestions[0],
-    progress: buildProgress(1, MAX_STEPS),
+    progress: buildProgress(1, SURVEY_MAX_STEPS),
     recommendation_ready: false,
   };
 };

--- a/src/features/survey/types/survey.ts
+++ b/src/features/survey/types/survey.ts
@@ -1,3 +1,5 @@
+import type { RecommendationResultItemShape } from '../../recommendation/types';
+
 export type SurveySessionStatus =
   | 'IDLE'
   | 'IN_PROGRESS'
@@ -37,16 +39,19 @@ export interface SurveyApiProgress {
   completion_rate?: number | null;
 }
 
-export interface SurveyApiSessionResponse {
+export interface SurveyApiLegacySessionResponseFields {
+  chatbot_reply?: string | null;
+  progress_rate?: number | null;
+  is_completed?: boolean | null;
+}
+
+export type SurveyApiSessionResponse = SurveyApiLegacySessionResponseFields & {
   session_id: string;
   ai_question?: string | null;
   progress?: SurveyApiProgress | null;
   recommendation_ready?: boolean | null;
   status?: SurveySessionStatus | null;
-  chatbot_reply?: string | null;
-  progress_rate?: number | null;
-  is_completed?: boolean | null;
-}
+};
 
 export interface SurveyApiResetResponse extends SurveyApiSessionResponse {
   message: string;
@@ -99,14 +104,7 @@ export interface SurveyApiResultItem {
   is_liked: boolean;
 }
 
-export interface SurveyResultItem {
-  game_id: number;
-  title: string;
-  genres: string[];
-  thumbnail_url: string | null;
-  rating: number | null;
-  is_liked: boolean;
-}
+export type SurveyResultItem = RecommendationResultItemShape;
 
 export interface SurveyApiResultResponse {
   session_id?: string;


### PR DESCRIPTION
## 관련 이슈

- closes #298 

## 변경 내용

- survey mock과 runtime에 중복 정의되어 있던 단계/페이지 크기 상수를 공통 파일로 분리했습니다.
- 설문 세션 응답 타입의 구버전 호환 필드는 제거하지 않고 `legacy` 성격이 드러나는 타입 경계로 분리했습니다.
- 추천 결과 공통 구조를 `RecommendationResultItemShape`로 정리해 survey 결과, match 결과, recommendation display 타입이 같은 기준을 바라보도록 통합했습니다.
- `normalizeRecommendationItem`도 공통 recommendation result shape를 기준으로 동작하도록 단순화했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 기능 변경보다 설문/추천 영역의 타입 정리와 중복 감소에 집중했습니다.
- `chatbot_reply`, `progress_rate`, `is_completed`는 현재 설문 normalize 로직에서 여전히 호환 처리에 사용 중이어서, 이번에는 제거하지 않고 legacy 필드로 분리해 의도를 명확히 했습니다.
- 챗봇, 파일 업로드, 공용 인프라 영역은 이번 범위에 포함하지 않았습니다.
