### PR TITLE
[Refactor] 게임 목록 API 계약을 /games/list/top100 기준으로 통합 정렬

### DIFF
--- a/docs/ai/task-template.md
+++ b/docs/ai/task-template.md
@@ -81,7 +81,7 @@
 
 ## Data and State
 
-- API 요청: 전체 조회는 genre_id 미전달, 장르 선택 시 genre_id=1~14 전달
+- API 요청: 전체 조회는 genre_id=0, 장르 선택 시 genre_id=1~14 전달
 - 화면에서 사용할 타입: GameListItem
 - 로딩/에러/빈 상태: skeleton, 에러 메시지, 빈 목록 안내
 

--- a/src/features/games/gameApi.ts
+++ b/src/features/games/gameApi.ts
@@ -9,18 +9,17 @@ import type {
   RawGameDetailResponse,
   RawGameLikeResponse,
   RawGameListItem,
-  RawTopGameListItem,
   SearchGamesParams,
   SearchGamesResult,
 } from './types';
 
 const DEFAULT_PAGE_SIZE = 20;
-const DEFAULT_SORT = 'rating_desc';
+const DEFAULT_TOP_GAMES_PAGE_SIZE = 100;
 
 const getGenreQueryParams = (genre: GetTopGamesParams['genre'] = '전체') => {
   const genreId = getGameGenreId(genre);
 
-  return genreId ? { genre_id: genreId } : {};
+  return { genre_id: genreId };
 };
 
 const normalizeNullableString = (value: string | null | undefined) => {
@@ -36,6 +35,7 @@ const normalizeGameListItem = (game: RawGameListItem): GameListItem => ({
   thumbnailUrl: game.thumbnail_url,
   rating: game.rating,
   isLiked: typeof game.is_liked === 'boolean' ? game.is_liked : undefined,
+  likeCount: game.like_count ?? undefined,
 });
 
 const normalizeGameDetail = (game: RawGameDetailResponse): GameDetail => ({
@@ -58,14 +58,6 @@ const normalizeGameDetail = (game: RawGameDetailResponse): GameDetail => ({
   isLiked: typeof game.is_liked === 'boolean' ? game.is_liked : null,
 });
 
-const normalizeTopGameListItem = (game: RawTopGameListItem): GameListItem => ({
-  gameId: game.game_id,
-  name: game.name || 'N/A',
-  genres: game.genres?.length ? game.genres : ['N/A'],
-  thumbnailUrl: game.thumbnail_url,
-  rating: game.total_rating,
-});
-
 const normalizeGameLikeResponse = (
   response: RawGameLikeResponse,
   isLiked: boolean,
@@ -78,14 +70,18 @@ const normalizeGameLikeResponse = (
 export const getTopGames = async ({
   genre = '전체',
 }: GetTopGamesParams = {}): Promise<GameListItem[]> => {
-  const response = await api.get<{
-    ranked_at: string;
-    results: RawTopGameListItem[];
-  }>('/api/v1/games/list/top100', {
-    params: getGenreQueryParams(genre),
-  });
+  const response = await api.get<GameListResponse>(
+    '/api/v1/games/list/top100',
+    {
+      params: {
+        ...getGenreQueryParams(genre),
+        page: 1,
+        page_size: DEFAULT_TOP_GAMES_PAGE_SIZE,
+      },
+    },
+  );
 
-  return response.data.results.map(normalizeTopGameListItem);
+  return response.data.results.map(normalizeGameListItem);
 };
 
 export const searchGames = async ({
@@ -94,21 +90,23 @@ export const searchGames = async ({
   genre = '전체',
   page = 1,
   pageSize = DEFAULT_PAGE_SIZE,
-  sort = DEFAULT_SORT,
 }: SearchGamesParams): Promise<SearchGamesResult> => {
-  const response = await api.get<GameListResponse>('/api/v1/games/list', {
-    params: {
-      search,
-      fuzzy,
-      sort,
-      page,
-      page_size: pageSize,
-      ...getGenreQueryParams(genre),
+  const response = await api.get<GameListResponse>(
+    '/api/v1/games/list/top100',
+    {
+      params: {
+        search,
+        fuzzy,
+        page,
+        page_size: pageSize,
+        ...getGenreQueryParams(genre),
+      },
     },
-  });
+  );
 
   return {
     count: response.data.count ?? response.data.results.length,
+    next: response.data.next ?? null,
     results: response.data.results.map(normalizeGameListItem),
   };
 };

--- a/src/features/games/genres.ts
+++ b/src/features/games/genres.ts
@@ -58,7 +58,7 @@ const GENRE_ALIASES: Record<Exclude<GameGenreFilter, '전체'>, string[]> = {
 const normalizeGenreKeyword = (value: string) => value.trim().toLowerCase();
 
 export const getGameGenreId = (selectedGenre: GameGenreFilter) =>
-  selectedGenre === '전체' ? undefined : GAME_GENRE_ID_MAP[selectedGenre];
+  selectedGenre === '전체' ? 0 : GAME_GENRE_ID_MAP[selectedGenre];
 
 export const matchesGenreFilter = (
   genres: string[],

--- a/src/features/games/mocks/handlers.ts
+++ b/src/features/games/mocks/handlers.ts
@@ -2,11 +2,7 @@ import { delay, http, HttpResponse } from 'msw';
 
 import { getMockGameLikeStateForAuthorization } from '../../auth/mocks/handlers';
 import { GAME_GENRE_ID_MAP } from '../genres';
-import {
-  getStoredGameDetail,
-  getStoredTop100Games,
-  searchStoredGames,
-} from './state';
+import { getStoredGameDetail, searchStoredGames } from './state';
 import type {
   GameDetail,
   GameListItem,
@@ -15,13 +11,8 @@ import type {
 } from '../types';
 
 const DEFAULT_GAME_PAGE_SIZE = 20;
-const DEFAULT_GAME_SORT = 'rating_desc';
-const VALID_GAME_SORT_VALUES = new Set([
-  'rating_desc',
-  'like_desc',
-  'created_at',
-]);
-const validGenreIds = new Set(Object.values(GAME_GENRE_ID_MAP));
+const DEFAULT_TOP_GAMES_PAGE_SIZE = 100;
+const validGenreIds = new Set([0, ...Object.values(GAME_GENRE_ID_MAP)]);
 
 const getErrorResponse = (status: number, message: string) =>
   HttpResponse.json(
@@ -38,13 +29,13 @@ const parsePositiveInteger = (value: string | null, fallback: number) => {
 };
 
 const parseGenreId = (value: string | null) => {
-  if (!value) {
+  if (value === null || value.trim() === '') {
     return undefined;
   }
 
   const parsed = Number(value);
 
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
 };
 
 const toRawGameListItem = (game: GameListItem): RawGameListItem => ({
@@ -54,6 +45,7 @@ const toRawGameListItem = (game: GameListItem): RawGameListItem => ({
   thumbnail_url: game.thumbnailUrl,
   rating: game.rating,
   is_liked: game.isLiked ?? null,
+  like_count: game.likeCount ?? null,
 });
 
 const toRawGameDetail = (detail: GameDetail): RawGameDetailResponse => ({
@@ -82,48 +74,13 @@ export const gamesHandlers = [
   http.get('/api/v1/games/list/top100', async ({ request }) => {
     const url = new URL(request.url);
     const genreIdValue = url.searchParams.get('genre_id');
-    const genreId = parseGenreId(url.searchParams.get('genre_id'));
-    const resolveStoredGameLikeState = (
-      gameId: number,
-      fallback: { isLiked: boolean | null; likeCount: number },
-    ) => {
-      const likeState = getMockGameLikeStateForAuthorization(
-        request.headers.get('authorization'),
-        gameId,
-        fallback.likeCount,
-      );
-
-      return {
-        isLiked: likeState.is_liked,
-        likeCount: likeState.like_count,
-      };
-    };
-
-    if (genreIdValue && (!genreId || !validGenreIds.has(genreId))) {
-      return getErrorResponse(400, '유효하지 않은 genre_id 입니다. (1~14)');
-    }
-
-    const games = getStoredTop100Games({ genreId, resolveStoredGameLikeState });
-
-    await delay(250);
-
-    return HttpResponse.json({
-      ranked_at: '2026-04-21T00:00:00.000Z',
-      results: games.map(toRawGameListItem),
-    });
-  }),
-
-  http.get('/api/v1/games/list', async ({ request }) => {
-    const url = new URL(request.url);
+    const genreId = parseGenreId(genreIdValue);
     const search = url.searchParams.get('search') ?? '';
     const fuzzy = url.searchParams.get('fuzzy') !== 'false';
-    const genreIdValue = url.searchParams.get('genre_id');
-    const genreId = parseGenreId(genreIdValue);
-    const sortValue = url.searchParams.get('sort');
     const page = parsePositiveInteger(url.searchParams.get('page'), 1);
     const pageSize = parsePositiveInteger(
       url.searchParams.get('page_size'),
-      DEFAULT_GAME_PAGE_SIZE,
+      search.trim() ? DEFAULT_GAME_PAGE_SIZE : DEFAULT_TOP_GAMES_PAGE_SIZE,
     );
     const resolveStoredGameLikeState = (
       gameId: number,
@@ -141,33 +98,34 @@ export const gamesHandlers = [
       };
     };
 
-    if (genreIdValue && (!genreId || !validGenreIds.has(genreId))) {
-      return getErrorResponse(400, '유효하지 않은 genre_id 입니다. (1~14)');
-    }
-
-    if (sortValue && !VALID_GAME_SORT_VALUES.has(sortValue)) {
-      return getErrorResponse(
-        400,
-        '유효하지 않은 sort 값입니다. (rating_desc, like_desc, created_at)',
-      );
+    if (!genreIdValue || genreId === undefined || !validGenreIds.has(genreId)) {
+      return getErrorResponse(400, '유효하지 않은 genre_id 입니다. (0~14)');
     }
 
     const { count, results } = searchStoredGames({
       search,
       fuzzy,
       genreId,
-      sort:
-        (sortValue as 'rating_desc' | 'like_desc' | 'created_at' | null) ??
-        DEFAULT_GAME_SORT,
       page,
       pageSize,
       resolveStoredGameLikeState,
     });
+    const next =
+      page * pageSize < count
+        ? (() => {
+            const nextUrl = new URL(url);
+            nextUrl.searchParams.set('page', String(page + 1));
+            nextUrl.searchParams.set('page_size', String(pageSize));
+            return nextUrl.toString();
+          })()
+        : null;
 
-    await delay(300);
+    await delay(250);
 
     return HttpResponse.json({
+      ranked_at: '2026-04-21T00:00:00.000Z',
       count,
+      next,
       results: results.map(toRawGameListItem),
     });
   }),

--- a/src/features/games/mocks/state.ts
+++ b/src/features/games/mocks/state.ts
@@ -190,9 +190,6 @@ const createFallbackDetail = (game: GameListItem): GameDetail => ({
 });
 
 const storedTopGames = mockTopGames.map((game) => ({ ...game }));
-const topGameOrderById = new Map(
-  storedTopGames.map((game, index) => [game.gameId, index]),
-);
 const storedDetails = new Map(
   Object.values(mockGameDetails).map((detail) => [
     detail.gameId,
@@ -231,7 +228,7 @@ const ensureStoredDetail = (gameId: number) => {
 };
 
 const getGenreFilterById = (genreId?: number) =>
-  genreId ? (genreIdToFilterMap.get(genreId) ?? null) : '전체';
+  genreId === 0 ? '전체' : (genreIdToFilterMap.get(genreId ?? -1) ?? null);
 
 const getStoredLikeFallback = (gameId: number): StoredGameLikeState => ({
   isLiked:
@@ -256,51 +253,16 @@ const getHydratedTopGames = (
   resolveStoredGameLikeState?: ResolveStoredGameLikeState,
 ) =>
   storedTopGames.map((game) => {
-    const { isLiked } = getResolvedGameLikeState(
+    const { isLiked, likeCount } = getResolvedGameLikeState(
       game.gameId,
       resolveStoredGameLikeState,
     );
 
-    return typeof isLiked === 'boolean' ? { ...game, isLiked } : { ...game };
-  });
-
-const sortGames = (
-  games: GameListItem[],
-  sort: 'rating_desc' | 'like_desc' | 'created_at',
-  resolveStoredGameLikeState?: ResolveStoredGameLikeState,
-) =>
-  [...games].sort((left, right) => {
-    if (sort === 'created_at') {
-      return (
-        (topGameOrderById.get(left.gameId) ?? Number.MAX_SAFE_INTEGER) -
-        (topGameOrderById.get(right.gameId) ?? Number.MAX_SAFE_INTEGER)
-      );
-    }
-
-    if (sort === 'like_desc') {
-      const likeCountDiff =
-        getResolvedGameLikeState(right.gameId, resolveStoredGameLikeState)
-          .likeCount -
-        getResolvedGameLikeState(left.gameId, resolveStoredGameLikeState)
-          .likeCount;
-
-      if (likeCountDiff !== 0) {
-        return likeCountDiff;
-      }
-    } else {
-      const leftRating = left.rating ?? Number.NEGATIVE_INFINITY;
-      const rightRating = right.rating ?? Number.NEGATIVE_INFINITY;
-      const ratingDiff = rightRating - leftRating;
-
-      if (ratingDiff !== 0) {
-        return ratingDiff;
-      }
-    }
-
-    return (
-      (topGameOrderById.get(left.gameId) ?? Number.MAX_SAFE_INTEGER) -
-      (topGameOrderById.get(right.gameId) ?? Number.MAX_SAFE_INTEGER)
-    );
+    return {
+      ...game,
+      isLiked: typeof isLiked === 'boolean' ? isLiked : game.isLiked,
+      likeCount,
+    };
   });
 
 const filterGames = ({
@@ -333,19 +295,10 @@ const filterGames = ({
   });
 };
 
-export const getStoredTop100Games = ({
-  genreId,
-  resolveStoredGameLikeState,
-}: {
-  genreId?: number;
-  resolveStoredGameLikeState?: ResolveStoredGameLikeState;
-} = {}) => filterGames({ genreId, resolveStoredGameLikeState }).slice(0, 100);
-
 export const searchStoredGames = ({
   search = '',
   fuzzy = true,
   genreId,
-  sort = 'rating_desc',
   page = 1,
   pageSize = 20,
   resolveStoredGameLikeState,
@@ -353,16 +306,16 @@ export const searchStoredGames = ({
   search?: string;
   fuzzy?: boolean;
   genreId?: number;
-  sort?: 'rating_desc' | 'like_desc' | 'created_at';
   page?: number;
   pageSize?: number;
   resolveStoredGameLikeState?: ResolveStoredGameLikeState;
 }) => {
-  const filteredGames = sortGames(
-    filterGames({ search, fuzzy, genreId, resolveStoredGameLikeState }),
-    sort,
+  const filteredGames = filterGames({
+    search,
+    fuzzy,
+    genreId,
     resolveStoredGameLikeState,
-  );
+  });
   const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
   const safePageSize =
     Number.isFinite(pageSize) && pageSize > 0 ? Math.floor(pageSize) : 20;

--- a/src/features/games/queryCache.ts
+++ b/src/features/games/queryCache.ts
@@ -50,8 +50,22 @@ const getNextLikeCount = (
 const updateGameListItem = (
   item: GameListItem,
   update: GameLikeCacheUpdate,
-): GameListItem =>
-  item.gameId === update.gameId ? { ...item, isLiked: update.isLiked } : item;
+): GameListItem => {
+  if (item.gameId !== update.gameId) {
+    return item;
+  }
+
+  const nextLikeCount =
+    typeof item.likeCount === 'number' || typeof update.likeCount === 'number'
+      ? getNextLikeCount(item.likeCount ?? 0, item.isLiked ?? null, update)
+      : item.likeCount;
+
+  return {
+    ...item,
+    isLiked: update.isLiked,
+    likeCount: nextLikeCount,
+  };
+};
 
 export const syncGameLikeStateInQueryCache = (
   queryClient: QueryClient,

--- a/src/features/games/types.ts
+++ b/src/features/games/types.ts
@@ -7,10 +7,12 @@ export type GameListItem = {
   thumbnailUrl: string | null;
   rating: number | null;
   isLiked?: boolean;
+  likeCount?: number;
 };
 
 export type GameListResponse = {
   count?: number;
+  next?: string | null;
   ranked_at?: string;
   results: RawGameListItem[];
 };
@@ -22,6 +24,7 @@ export type RawGameListItem = {
   thumbnail_url: string | null;
   rating: number | null;
   is_liked?: boolean | null;
+  like_count?: number | null;
 };
 
 export type GameDetail = {
@@ -77,15 +80,6 @@ export type RawGameLikeResponse = {
   like_count: number | null;
 };
 
-export type RawTopGameListItem = {
-  game_id: number;
-  name: string | null;
-  genres: string[] | null;
-  thumbnail_url: string | null;
-  total_rating: number | null;
-  like_count: number | null;
-};
-
 export type GetTopGamesParams = {
   genre?: GameGenreFilter;
 };
@@ -96,10 +90,10 @@ export type SearchGamesParams = {
   genre?: GameGenreFilter;
   page?: number;
   pageSize?: number;
-  sort?: 'rating_desc' | 'like_desc' | 'created_at';
 };
 
 export type SearchGamesResult = {
   count: number;
+  next?: string | null;
   results: GameListItem[];
 };


### PR DESCRIPTION
## 관련 이슈

- closes #301

## 변경 내용

- 게임 목록 API를 홈/검색 모두 `GET /api/v1/games/list/top100` 기준으로 통일했습니다.
- 검색 요청에서 기존 `GET /api/v1/games/list` 경로를 제거했습니다.
- `전체` 장르 선택 시 `genre_id=0`을 보내도록 변경했습니다.
- `sort` 파라미터는 프론트 요청과 타입에서 제거했습니다.
- 홈 목록과 검색 목록 응답 타입을 `rating`, `is_liked`, `like_count`, `count`, `next` 기준의 공통 shape로 정리했습니다.
- `RawTopGameListItem` / `total_rating` 기반 처리를 제거하고 `RawGameListItem` 중심으로 통합했습니다.
- MSW도 최신 계약에 맞게 `/api/v1/games/list/top100` 하나만 사용하도록 정리했습니다.
- `/api/v1/games/list` mock 핸들러를 제거했습니다.
- `genre_id=0` 허용, 미전달/빈값/범위 밖 값 400 처리, `sort` 검증 제거를 반영했습니다.
- 내부 문서의 게임 목록 API 예시와 장르 파라미터 규칙도 최신 계약 기준으로 수정했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

해당 없음

## 참고사항

- 이번 PR은 최신 API 명세 `(3)` 기준으로 프론트와 MSW 계약을 정렬하는 목적의 리팩토링입니다.
- 외부 API 경로는 추가하지 않고, 기존 게임 목록 경계를 `/api/v1/games/list/top100` 하나로 통일했습니다.
- 브라우저 검증 시 홈 진입, 장르 필터 변경, 검색 요청이 모두 같은 엔드포인트를 사용하고 `genre_id=0` 규칙을 따르는지 확인이 필요합니다.
