### PR TITLE
[Fix] 매칭 후보 응답 필드 및 retry/genre 검증 정합성 수정

### DIFF
--- a/src/features/matching/api/matching.ts
+++ b/src/features/matching/api/matching.ts
@@ -16,7 +16,7 @@ const MATCHING_BASE_PATH = '/api/v1/match';
 
 const normalizeMatchCandidate = (item: MatchingApiCandidateItem) => ({
   game_id: item.game_id,
-  title: item.name?.trim() || '제목 정보 준비 중',
+  title: item.title?.trim() || '제목 정보 준비 중',
   description:
     item.description?.trim() || '게임 설명이 아직 준비되지 않았습니다.',
   genres: Array.isArray(item.genres) ? item.genres : [],

--- a/src/features/matching/api/matching.ts
+++ b/src/features/matching/api/matching.ts
@@ -51,6 +51,7 @@ export const getMatchCandidates = async (genreId: number, retryNo = 0) => {
 
     return {
       genre_id: response.data.genre_id,
+      retry_no: response.data.retry_no,
       count: response.data.count,
       results,
     } satisfies MatchingCandidatesResponse;

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -260,6 +260,7 @@ export const matchingHandlers = [
 
     return HttpResponse.json({
       genre_id: genreId,
+      retry_no: retryNo,
       count: candidates.length,
       results: candidates.map((candidate) => ({
         game_id: candidate.game_id,

--- a/src/features/matching/mocks/handlers.ts
+++ b/src/features/matching/mocks/handlers.ts
@@ -198,7 +198,13 @@ export const matchingHandlers = [
     const genreIdValue = url.searchParams.get('genre_id');
     const genreId = Number(genreIdValue);
 
-    if (!genreIdValue || Number.isNaN(genreId) || genreId <= 0) {
+    if (
+      !genreIdValue ||
+      Number.isNaN(genreId) ||
+      !Number.isInteger(genreId) ||
+      genreId < 1 ||
+      genreId > 8
+    ) {
       return getErrorResponse(400, '유효하지 않은 genre_id 입니다.');
     }
 
@@ -223,7 +229,13 @@ export const matchingHandlers = [
     const genreId = Number(genreIdValue);
     const retryNo = retryNoValue !== null ? Number(retryNoValue) : 0;
 
-    if (!genreIdValue || Number.isNaN(genreId) || genreId <= 0) {
+    if (
+      !genreIdValue ||
+      Number.isNaN(genreId) ||
+      !Number.isInteger(genreId) ||
+      genreId < 1 ||
+      genreId > 8
+    ) {
       return getErrorResponse(400, '유효하지 않은 genre_id 입니다.');
     }
 
@@ -251,7 +263,7 @@ export const matchingHandlers = [
       count: candidates.length,
       results: candidates.map((candidate) => ({
         game_id: candidate.game_id,
-        name: candidate.title,
+        title: candidate.title,
         description: candidate.description,
         genres: candidate.genres,
         trailer_url: candidate.trailer_url,

--- a/src/features/matching/mocks/runtime.ts
+++ b/src/features/matching/mocks/runtime.ts
@@ -33,6 +33,7 @@ export const getMatchingMockCandidatesSnapshot = (
 
   return {
     genre_id: genreId,
+    retry_no: retryNo,
     count: candidates.length,
     results: candidates.map((candidate) => ({
       game_id: candidate.game_id,

--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -37,6 +37,7 @@ export interface MatchingApiCandidateItem {
 
 export interface MatchingApiCandidatesResponse {
   genre_id: number;
+  retry_no: number;
   count: number;
   results: MatchingApiCandidateItem[];
 }
@@ -54,6 +55,7 @@ export interface MatchingCandidateItem {
 
 export interface MatchingCandidatesResponse {
   genre_id: number;
+  retry_no: number;
   count: number;
   results: MatchingCandidateItem[];
 }

--- a/src/features/matching/types.ts
+++ b/src/features/matching/types.ts
@@ -27,7 +27,7 @@ export interface MatchingGenreImageResponse {
 
 export interface MatchingApiCandidateItem {
   game_id: number;
-  name: string;
+  title: string;
   description: string;
   genres: string[];
   trailer_url: string | null;

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -108,6 +108,7 @@ function MatchingGenreDetailPage() {
     retryNo,
     canAccessPage,
   );
+  const candidateRetryNo = matchCandidatesQuery.data?.retry_no ?? retryNo;
   const submitMatchResponsesMutation = useSubmitMatchResponsesMutation();
   const resetSubmitMatchResponsesMutation = submitMatchResponsesMutation.reset;
   const candidates = useMemo(
@@ -305,7 +306,7 @@ function MatchingGenreDetailPage() {
     try {
       await submitMatchResponsesMutation.mutateAsync({
         genre_id: currentGenreId,
-        retry_no: retryNo,
+        retry_no: candidateRetryNo,
         match_result: displayCandidates.map((candidate) => ({
           game_id: candidate.game_id,
           rating: evaluationsByGameId[candidate.game_id]!.rating!,
@@ -381,7 +382,7 @@ function MatchingGenreDetailPage() {
                 onClick={() =>
                   setRetryState({
                     genreSlug: currentGenreSlug,
-                    value: retryNo + 1,
+                    value: candidateRetryNo + 1,
                   })
                 }
                 className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"


### PR DESCRIPTION
## 관련 이슈

- closes #300 

## 변경 내용

- `GET /api/v1/match/candidates` 응답 필드명을 최신 API 명세 기준에 맞춰 `name`에서 `title`로 통일했습니다.
- 매칭 후보 API 응답 타입(`MatchingApiCandidateItem`)도 `title` 기준으로 수정했습니다.
- 매칭 후보 normalize 로직이 `item.name`이 아니라 `item.title`을 읽도록 정리했습니다.
- MSW 매칭 후보 응답도 `title` 필드를 반환하도록 수정해, 실서버와 mock 환경의 응답 shape를 일치시켰습니다.
- `GET /api/v1/match/candidates` 200 응답에 `retry_no`를 추가하고, 프론트가 응답으로 받은 실제 `retry_no`를 이후 `POST /api/v1/match/responses` 제출 시 그대로 전달하도록 수정했습니다.
- “다시 시도” 흐름도 응답 기준 `retry_no + 1`로 움직이도록 정리했습니다.
- MSW 매칭 관련 `genre_id` 검증을 명세 기준에 맞춰 `1~8` 범위로 더 엄격하게 맞췄습니다.
- 범위 밖 `genre_id`는 `400`과 `유효하지 않은 genre_id 입니다.` 메시지를 반환하도록 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 매칭 후보 응답 필드명, `retry_no` 전달 방식, `genre_id` 검증을 최신 명세에 맞추는 작은 정합성 수정입니다.
- `genre_id`, `retry_no`, 매칭 결과 조회 `genre_id` 반영은 이전 매칭 계약 정리 PR에서 이미 반영된 상태입니다.
