### PR TITLE
[Fix] 매칭 상세 화면 세로 정렬 및 여백 균형 조정

### DIFF
--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -239,7 +239,7 @@ function MatchingGenreDetailPage() {
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.12),transparent_24%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
       <LazyHeader fixed />
 
-      <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-21 pb-8 sm:px-6 sm:pt-[5.6rem] sm:pb-10 md:px-8 md:pt-[5.9rem] md:pb-12">
+      <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-[6.35rem] pb-10 sm:px-6 sm:pt-[6.8rem] sm:pb-12 md:px-8 md:pt-[7.35rem] md:pb-14">
         {!genre || !isValidGenreSlug ? (
           <section className="survey-panel mx-auto max-w-190 px-6 py-10 sm:px-8 sm:py-12">
             <p className="text-sm font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">
@@ -329,7 +329,7 @@ function MatchingGenreDetailPage() {
           </section>
         ) : (
           <>
-            <div className="pointer-events-none absolute top-[4.85rem] left-1/2 z-20 w-screen -translate-x-1/2 pr-[clamp(1rem,5vw,20rem)] pl-[clamp(0.35rem,3vw,20rem)] sm:top-[5.15rem] md:top-[5.35rem]">
+            <div className="pointer-events-none absolute top-[5.15rem] left-1/2 z-20 w-screen -translate-x-1/2 pr-[clamp(1rem,5vw,20rem)] pl-[clamp(0.35rem,3vw,20rem)] sm:top-[5.45rem] md:top-[5.75rem]">
               <Link
                 to={`/${ROUTES.MATCHING_LIST}`}
                 className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-4 py-2 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
@@ -339,7 +339,7 @@ function MatchingGenreDetailPage() {
               </Link>
             </div>
 
-            <section className="mx-auto max-w-255">
+            <section className="mx-auto mt-9 max-w-255 sm:mt-10 md:mt-12">
               <div className="text-center">
                 <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
                   {safeIndex + 1} / {totalSteps} 단계
@@ -349,7 +349,7 @@ function MatchingGenreDetailPage() {
                 </h1>
               </div>
 
-              <div className="mt-5 grid gap-4 lg:grid-cols-[1.32fr_0.92fr] lg:gap-5">
+              <div className="mt-8 grid gap-4 lg:grid-cols-[1.32fr_0.92fr] lg:gap-5 xl:mt-9">
                 {currentCandidate ? (
                   <MatchingMediaPanel candidate={currentCandidate} />
                 ) : null}


### PR DESCRIPTION
## 관련 이슈

- closes #308 

## 변경 내용

- 매칭 상세 화면이 전체적으로 위로 몰려 보이던 문제를 완화하기 위해, 본문 섹션의 시작 위치와 상하 여백을 재조정했습니다.
- 헤더 아래 제목 블록과 트레일러/평가 카드 그리드가 조금 더 아래에서 시작하도록 조정해, 세로 중심감이 자연스럽게 느껴지도록 정리했습니다.
- `다른 장르 보기` 버튼은 기존 상단 위치를 유지하고, 본문 섹션만 아래로 내리도록 분리해 레이아웃 흐름을 정리했습니다.
- 제목 블록과 본문 카드 사이 간격도 함께 보정해, 화면이 과하게 비거나 반대로 답답해 보이지 않도록 균형을 맞췄습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="1725" height="896" alt="스크린샷 2026-04-28 오후 5 44 27" src="https://github.com/user-attachments/assets/f7ff618a-6b30-4770-9440-5915c0b3ae0f" />


## 참고사항

- 이번 PR은 기능 변경 없이 매칭 상세 화면의 시각적 균형과 시작 위치만 조정하는 UI fix입니다.
- `다른 장르 보기` 버튼 위치는 유지하면서, 본문만 더 아래에서 시작하도록 분리했습니다.
