### PR TITLE
fix(auth-ui,mypage): 인증 폼 모바일 반응형 및 찜 목록 스크롤 레이아웃 보정

### DIFF
--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -39,7 +39,9 @@ function AuthInputField({
   const shouldRenderMessage = Boolean(resolvedMessage) || reserveMessageSpace;
 
   return (
-    <div className={`space-y-2 ${containerClassName} sm:space-y-2.5`}>
+    <div
+      className={`w-full min-w-0 space-y-2 ${containerClassName} sm:space-y-2.5`}
+    >
       <div className="flex items-center justify-between gap-3">
         <label
           htmlFor={id}
@@ -49,7 +51,7 @@ function AuthInputField({
         </label>
         {labelAction ? <div className="shrink-0">{labelAction}</div> : null}
       </div>
-      <div className="relative flex flex-col gap-3 sm:flex-row sm:items-stretch">
+      <div className="relative flex w-full min-w-0 flex-col gap-3 sm:flex-row sm:items-stretch">
         <InputControl
           id={id}
           {...inputProps}

--- a/src/components/auth/AuthRadioGroup.tsx
+++ b/src/components/auth/AuthRadioGroup.tsx
@@ -35,11 +35,11 @@ function AuthRadioGroup({
   const shouldRenderMessage = Boolean(errorMessage) || reserveMessageSpace;
 
   return (
-    <fieldset className="space-y-2.5">
+    <fieldset className="w-full min-w-0 space-y-2.5">
       <legend className="text-login-label block text-sm font-medium">
         {label}
       </legend>
-      <div className="grid grid-cols-2 gap-3 pt-1">
+      <div className="grid min-w-0 grid-cols-2 gap-3 pt-1">
         {options.map((option) => {
           const inputId = `${idPrefix ?? name}-${option.value}`;
 

--- a/src/components/auth/authSharedStyles.ts
+++ b/src/components/auth/authSharedStyles.ts
@@ -1,12 +1,12 @@
 export const AUTH_SHARED_LAYOUT_CLASS_NAMES = {
-  panel: 'max-w-[560px] px-5 py-6 sm:px-9 sm:py-8',
-  content: 'max-w-[428px]',
+  panel: 'min-w-0 max-w-[560px] px-4 py-6 sm:px-9 sm:py-8',
+  content: 'min-w-0 w-full max-w-[428px]',
 } as const;
 
 export const AUTH_SHARED_FORM_CLASS_NAMES = {
   socialGroup: 'mt-4 sm:mt-5',
   divider: 'my-3 sm:my-4',
-  form: 'space-y-2.5 sm:space-y-3',
+  form: 'min-w-0 w-full space-y-2.5 sm:space-y-3',
   feedbackMessage: 'text-sm/5',
   submitButton:
     'mt-1.5 h-12 w-full rounded-2xl text-sm/6 sm:mt-2 sm:h-[3.2rem] sm:text-base/6',

--- a/src/components/common/InputControl.tsx
+++ b/src/components/common/InputControl.tsx
@@ -6,7 +6,7 @@ type InputControlProps = {
 } & InputHTMLAttributes<HTMLInputElement>;
 
 const inputBaseClassName =
-  'auth-input-autofill placeholder-login-muted bg-login-field h-12 min-w-0 w-full rounded-2xl border px-3.5 text-[0.95rem] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition outline-none focus-visible:ring-2 sm:h-[3.2rem] sm:px-4 sm:text-base';
+  'auth-input-autofill placeholder-login-muted bg-login-field h-12 min-w-0 w-full max-w-full rounded-2xl border px-3.5 text-[0.95rem] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition outline-none focus-visible:ring-2 sm:h-[3.2rem] sm:px-4 sm:text-base';
 
 function InputControl({
   hasError = false,

--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -56,12 +56,14 @@ function AuthLayout({
           <section
             className={`auth-layout-panel w-full max-w-130 rounded-[28px] border px-4 py-5 backdrop-blur-sm sm:rounded-3xl sm:px-8 sm:py-8 ${panelClassName}`}
           >
-            <div className={`mx-auto w-full max-w-110 ${contentClassName}`}>
+            <div
+              className={`mx-auto w-full max-w-110 min-w-0 ${contentClassName}`}
+            >
               {content}
             </div>
           </section>
         ) : (
-          <section className={`w-full max-w-110 ${contentClassName}`}>
+          <section className={`w-full max-w-110 min-w-0 ${contentClassName}`}>
             {content}
           </section>
         )}

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -15,7 +15,7 @@ function FavoriteGameCard({
   onFavoriteClick,
 }: FavoriteGameCardProps) {
   return (
-    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex h-full w-[11.75rem] min-w-0 shrink-0 flex-col overflow-hidden rounded-[22px] border transition duration-200 sm:w-[12.75rem] lg:w-[13.75rem] xl:w-[14.25rem]">
+    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex h-full w-full min-w-0 flex-col overflow-hidden rounded-[22px] border transition duration-200">
       <div className="bg-mypage-soft relative aspect-3/4 overflow-hidden">
         <button
           type="button"

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -15,8 +15,8 @@ function FavoriteGameCard({
   onFavoriteClick,
 }: FavoriteGameCardProps) {
   return (
-    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex h-full w-full min-w-0 flex-col overflow-hidden rounded-[22px] border transition duration-200">
-      <div className="bg-mypage-soft relative aspect-3/4 overflow-hidden">
+    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex h-[22rem] w-full min-w-0 flex-col overflow-hidden rounded-[22px] border transition duration-200 sm:h-[24rem] lg:h-[25rem]">
+      <div className="bg-mypage-soft relative h-[15rem] overflow-hidden sm:h-[16.5rem] lg:h-[17.5rem]">
         <button
           type="button"
           onClick={() => onClick?.(game)}
@@ -52,12 +52,12 @@ function FavoriteGameCard({
       <button
         type="button"
         onClick={() => onClick?.(game)}
-        className="flex min-w-0 flex-1 cursor-pointer flex-col gap-2 px-4 py-4 text-left"
+        className="flex min-w-0 flex-1 cursor-pointer flex-col gap-1.5 px-3 py-3 text-left sm:gap-2 sm:px-4 sm:py-4"
       >
-        <h3 className="line-clamp-1 text-base/6 font-semibold text-white sm:text-lg/7">
+        <h3 className="line-clamp-1 text-sm/5 font-semibold text-white sm:text-base/6 lg:text-lg/7">
           {game.title}
         </h3>
-        <p className="text-mypage-muted line-clamp-1 text-xs/5 sm:text-sm/6">
+        <p className="text-mypage-muted line-clamp-1 text-[11px]/4 sm:text-xs/5 lg:text-sm/6">
           {game.summary}
         </p>
       </button>

--- a/src/components/mypage/FavoriteGameCardSkeleton.tsx
+++ b/src/components/mypage/FavoriteGameCardSkeleton.tsx
@@ -7,16 +7,16 @@ function FavoriteGameCardSkeleton({
 }: FavoriteGameCardSkeletonProps) {
   return (
     <div
-      className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3"
+      className="grid grid-cols-4 gap-2 sm:gap-3"
       aria-live="polite"
       aria-busy="true"
     >
       {Array.from({ length: count }).map((_, index) => (
         <article
           key={index}
-          className="border-mypage-card bg-mypage-card box-border h-full w-full min-w-0 overflow-hidden rounded-[22px] border"
+          className="border-mypage-card bg-mypage-card box-border h-[22rem] w-full min-w-0 overflow-hidden rounded-[22px] border sm:h-[24rem] lg:h-[25rem]"
         >
-          <div className="aspect-3/4 animate-pulse bg-white/8" />
+          <div className="h-[15rem] animate-pulse bg-white/8 sm:h-[16.5rem] lg:h-[17.5rem]" />
           <div className="space-y-2 px-4 py-4">
             <div className="h-5 w-3/4 animate-pulse rounded-full bg-white/10" />
             <div className="h-4 w-full animate-pulse rounded-full bg-white/8" />

--- a/src/components/mypage/FavoriteGameCardSkeleton.tsx
+++ b/src/components/mypage/FavoriteGameCardSkeleton.tsx
@@ -7,14 +7,14 @@ function FavoriteGameCardSkeleton({
 }: FavoriteGameCardSkeletonProps) {
   return (
     <div
-      className="flex min-w-max items-stretch gap-3 lg:gap-4"
+      className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3"
       aria-live="polite"
       aria-busy="true"
     >
       {Array.from({ length: count }).map((_, index) => (
         <article
           key={index}
-          className="border-mypage-card bg-mypage-card box-border h-full w-[11.75rem] min-w-0 shrink-0 overflow-hidden rounded-[22px] border sm:w-[12.75rem] lg:w-[13.75rem] xl:w-[14.25rem]"
+          className="border-mypage-card bg-mypage-card box-border h-full w-full min-w-0 overflow-hidden rounded-[22px] border"
         >
           <div className="aspect-3/4 animate-pulse bg-white/8" />
           <div className="space-y-2 px-4 py-4">

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -16,7 +16,6 @@ import { ROUTES } from '../constants/routes';
 import useLoginForm, {
   LOGIN_FORM_FIELD_IDS,
 } from '../features/auth/hooks/useLoginForm';
-import { useSupportChatStore } from '../features/support-chat/store/useSupportChatStore';
 
 const LOGIN_MOCK_FAB_CLASS_NAME =
   'support-chat-fab group relative flex h-14 w-14 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none';
@@ -26,7 +25,6 @@ const LOGIN_MOCK_PANEL_CLASS_NAME =
   'support-chat-panel fixed left-4 bottom-22 z-[90] flex w-[min(92vw,22rem)] origin-bottom-left flex-col overflow-hidden transition-all duration-300 ease-out sm:left-6 sm:bottom-24';
 
 function LoginPage() {
-  const openSupportChat = useSupportChatStore((state) => state.openPanel);
   const {
     formValues,
     resolvedFieldErrors,
@@ -84,15 +82,6 @@ function LoginPage() {
             id={LOGIN_FORM_FIELD_IDS.password}
             name="password"
             label="비밀번호"
-            labelAction={
-              <button
-                type="button"
-                className="text-login-helper text-xs font-medium transition-colors hover:text-white/88 focus-visible:ring-2 focus-visible:ring-[#ff5c60]/25 focus-visible:outline-none"
-                onClick={() => openSupportChat()}
-              >
-                비밀번호 찾기
-              </button>
-            }
             type="password"
             autoComplete="current-password"
             placeholder="PASSWORD"

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -62,11 +62,11 @@ function MyPageLikedGamesSection({
           </p>
         </div>
 
-        <div className="mypage-scrollbar mt-5 box-border max-h-[28rem] max-w-full overflow-x-hidden overflow-y-auto pr-1 sm:max-h-[32rem]">
+        <div className="mypage-scrollbar mt-5 box-border h-[22rem] max-w-full overflow-x-hidden overflow-y-auto pr-1 sm:h-[24rem] lg:h-[25rem]">
           {isFavoriteGamesLoading ? (
             <FavoriteGameCardSkeleton />
           ) : favoriteCount > 0 ? (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            <div className="grid grid-cols-4 gap-2 sm:gap-3">
               {favoriteGames.map((game) => (
                 <FavoriteGameCard
                   key={game.gameId}

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -62,11 +62,11 @@ function MyPageLikedGamesSection({
           </p>
         </div>
 
-        <div className="mypage-scrollbar mt-5 box-border max-w-full overflow-x-auto overflow-y-hidden pb-2">
+        <div className="mypage-scrollbar mt-5 box-border max-h-[28rem] max-w-full overflow-x-hidden overflow-y-auto pr-1 sm:max-h-[32rem]">
           {isFavoriteGamesLoading ? (
             <FavoriteGameCardSkeleton />
           ) : favoriteCount > 0 ? (
-            <div className="flex min-w-max items-stretch gap-3 lg:gap-4">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
               {favoriteGames.map((game) => (
                 <FavoriteGameCard
                   key={game.gameId}


### PR DESCRIPTION
## 관련 이슈

- closes #311

## 변경 내용

- 로그인 화면의 비밀번호 찾기 UI를 제거했습니다.
- 로그인/회원가입 Input 필드가 모바일과 작은 해상도에서 화면 밖으로 삐져나가지 않도록 w-full, min-w-0, max-w-full 기준으로 반응형 레- 이아웃을 보강했습니다.
- 인증 폼 공통 레이아웃과 입력 필드 래퍼를 정리해 브라우저 폭이 줄어들어도 자연스럽게 줄어들도록 수정했습니다.
- 마이페이지 찜한 목록 영역은 고정 높이 안에서 내부 세로 스크롤되도록 변경했습니다.
- 찜 카드와 스켈레톤 레이아웃도 함께 조정해, 항목이 많아져도 전체 페이지 레이아웃이 아래로 밀리거나 깨지지 않도록 보정했습니다.
- 찜 목록은 한 줄에 4개씩 고정되도록 정리했고, 다음 항목은 아래 줄로 내려가되 첫 줄만 정확히 노출되도록 카드 높이와 목록 컨테이너 높이를 함께 보정했습니다.
- 이로 인해 브라우저/배포/로컬 환경에서 다섯 번째 카드가 첫 줄 아래에 반쯤 걸쳐 보이던 현상을 줄였습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="1406" height="1292" alt="image" src="https://github.com/user-attachments/assets/0d12f60c-8d61-4137-b3b0-bdc1ff459d1f" />

<img width="1412" height="1244" alt="image" src="https://github.com/user-attachments/assets/9aba3045-e9f0-4a5d-ab5d-bfb46526dc15" />

<img width="1938" height="850" alt="image" src="https://github.com/user-attachments/assets/2f6ab81c-a0c6-4d0c-a2ff-a16d9bb4692f" />

## 참고사항

-
