### PR TITLE
feat(auth): 프로필 이미지·찜 목록 Accounts API 스웨거 계약 동기화

### DIFF
--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -23,6 +23,8 @@ import type {
   LogoutResponse,
   ProfileImagePresignedUrlRequest,
   ProfileImagePresignedUrlResponse,
+  RawLikedGameItemResponse,
+  RawLikedGamesResponse,
   RefreshAccessTokenResponse,
   SignupRequest,
   SignupResponse,
@@ -54,6 +56,26 @@ const createCredentialedAuthRequestConfig = <T = unknown>(
     },
   };
 };
+
+const normalizeLikedGameGenres = (
+  genres: RawLikedGameItemResponse['genres'],
+) =>
+  Array.isArray(genres)
+    ? genres.map((genre) => genre.trim()).filter((genre) => genre.length > 0)
+    : genres
+        .split(',')
+        .map((genre) => genre.trim())
+        .filter((genre) => genre.length > 0);
+
+const normalizeLikedGamesResponse = (
+  response: RawLikedGamesResponse,
+): LikedGamesResponse => ({
+  count: response.count,
+  results: response.results.map((item) => ({
+    ...item,
+    genres: normalizeLikedGameGenres(item.genres),
+  })),
+});
 
 export const requestLogin = async (payload: LoginRequest) => {
   const requestConfig = createCredentialedAuthRequestConfig();
@@ -132,14 +154,14 @@ export const updateUserInfo = async (payload: UpdateUserInfoRequest) => {
 };
 
 export const getLikedGames = async (payload: LikedGamesRequest = {}) => {
-  const response = await api.get<LikedGamesResponse>(
+  const response = await api.get<RawLikedGamesResponse>(
     `${AUTH_BASE_PATH}/me/game-like`,
     createCredentialedAuthRequestConfig({
       params: payload,
     }),
   );
 
-  return response.data;
+  return normalizeLikedGamesResponse(response.data);
 };
 
 export const unlikeLikedGame = async (gameId: number) => {

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -671,6 +671,15 @@ const accountHandlers = [
         );
       }
 
+      if (!contentType.startsWith('image/')) {
+        return HttpResponse.json(
+          {
+            error_detail: '지원하지 않는 파일 형식입니다.',
+          },
+          { status: 400 },
+        );
+      }
+
       const uploadFileName = `${Date.now()}-${sanitizeFileName(fileName)}`;
       const fileKey = getProfileImagePathKey(user.loginId, uploadFileName);
       const responseBody: ProfileImagePresignedUrlResponse = {
@@ -787,8 +796,7 @@ const accountHandlers = [
     await delay(120);
 
     return HttpResponse.json({
-      detail: '프로필 이미지가 변경되었습니다.',
-      profile_img_url: profileImageUrl,
+      detail: '프로필 사진이 등록되었습니다.',
     } satisfies ConfirmProfileImageResponse);
   }),
 

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -18,11 +18,11 @@ import type {
   CurrentUserProfileResponse,
   DeleteLikedGameResponse,
   LikedGameItemResponse,
-  LikedGamesResponse,
   LoginRequest,
   LogoutResponse,
   ProfileImagePresignedUrlRequest,
   ProfileImagePresignedUrlResponse,
+  RawLikedGamesResponse,
   SocialAuthProvider,
   SignupRequest,
   UpdateUserInfoRequest,
@@ -707,8 +707,11 @@ const accountHandlers = [
 
     return HttpResponse.json({
       count: likedGames.length,
-      results: pagedResults,
-    } satisfies LikedGamesResponse);
+      results: pagedResults.map((likedGame) => ({
+        ...likedGame,
+        genres: likedGame.genres.join(', '),
+      })),
+    } satisfies RawLikedGamesResponse);
   }),
 
   http.put(

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -115,8 +115,7 @@ export interface ConfirmProfileImageRequest {
 }
 
 export interface ConfirmProfileImageResponse {
-  detail?: string;
-  profile_img_url?: string;
+  detail: string;
 }
 
 export interface UploadFileToS3Request {

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -47,6 +47,21 @@ export interface LikedGamesRequest {
   page_size?: number;
 }
 
+export type LikedGameGenresResponse = string | string[];
+
+export interface RawLikedGameItemResponse {
+  game_id: number;
+  game_title: string;
+  thumbnail_url: string | null;
+  genres: LikedGameGenresResponse;
+  liked_at: string;
+}
+
+export interface RawLikedGamesResponse {
+  count: number;
+  results: RawLikedGameItemResponse[];
+}
+
 export interface LikedGameItemResponse {
   game_id: number;
   game_title: string;

--- a/src/pages/mypage/hooks/useMyPageProfile.ts
+++ b/src/pages/mypage/hooks/useMyPageProfile.ts
@@ -101,11 +101,10 @@ function useMyPageProfile({ enabled, onToast }: UseMyPageProfileOptions) {
 
       hasOptimisticProfileUpdate = true;
 
-      const confirmResponse = await confirmProfileImageMutation.mutateAsync({
+      await confirmProfileImageMutation.mutateAsync({
         profile_img_url: presignedResponse.img_url,
       });
-      const confirmedProfileImageUrl =
-        confirmResponse.profile_img_url ?? presignedResponse.img_url;
+      const confirmedProfileImageUrl = presignedResponse.img_url;
 
       queryClient.setQueryData<CurrentUserProfileResponse>(
         authKeys.me(),


### PR DESCRIPTION
## 관련 이슈

- closes #313 

## 변경 내용

- GET /api/v1/accounts/me/game-like 응답을 Swagger 기준에 맞춰 정리했습니다.
- genres가 문자열로 내려오는 응답 shape를 프론트에서 안전하게 배열로 정규화하도록 어댑터를 추가했습니다.
- 찜 목록 raw 응답 타입과 UI 소비 타입을 분리해 API 계약 변동을 타입 경계에서 흡수하도록 정리했습니다.
- PATCH /api/v1/accounts/me/profile-image 응답 계약을 Swagger 기준으로 맞췄습니다.
- 성공 응답은 detail만 받도록 타입을 정리했습니다.
- 프로필 이미지 확정 후에는 응답 body의 URL이 아니라 presigned 발급 단계에서 받은 img_url을 기준으로 캐시와 화면을 갱신하도록 수정- 했습니다.
- POST /api/v1/accounts/me/profile-image/presigned-url 흐름도 Swagger 기준으로 정리했습니다.
- presigned URL 응답에서 presigned_url, img_url, key를 그대로 활용하도록 맞췄습니다.
- MSW에서는 이미지가 아닌 content type일 경우 400 에러를 반환하도록 보강했습니다.
- MSW 핸들러도 위 계약에 맞춰 함께 동기화했습니다.
- 프로필 이미지 등록 성공 메시지를 프로필 사진이 등록되었습니다.로 수정했습니다.
- 찜 목록 응답은 Swagger 예시처럼 genres를 문자열 형태로 내려주되, 프론트 어댑터가 이를 정규화하도록 맞췄습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 변경은 Accounts API의 프로필 이미지/찜 목록 관련 Swagger 계약 동기화가 목적이며, 화면 디자인 변경은 없습니다.
