### PR TITLE
[Fix] 매칭 retry_no 서버 기준 흐름 정리

### DIFF
--- a/src/features/matching/api/matching.ts
+++ b/src/features/matching/api/matching.ts
@@ -26,9 +26,9 @@ const normalizeMatchCandidate = (item: MatchingApiCandidateItem) => ({
   is_liked: Boolean(item.is_liked),
 });
 
-export const getMatchCandidates = async (genreId: number, retryNo = 0) => {
+export const getMatchCandidates = async (genreId: number, retryNo?: number) => {
   const getMockFallback = () =>
-    getMatchingMockCandidatesSnapshot(genreId, retryNo);
+    getMatchingMockCandidatesSnapshot(genreId, retryNo ?? 0);
 
   try {
     const response = await api.get<MatchingApiCandidatesResponse>(
@@ -36,7 +36,7 @@ export const getMatchCandidates = async (genreId: number, retryNo = 0) => {
       {
         params: {
           genre_id: genreId,
-          retry_no: retryNo,
+          ...(typeof retryNo === 'number' ? { retry_no: retryNo } : {}),
         },
       },
     );

--- a/src/features/matching/api/useMatchingApi.ts
+++ b/src/features/matching/api/useMatchingApi.ts
@@ -16,11 +16,11 @@ import {
 
 export const useMatchCandidatesQuery = (
   genreId: number | null,
-  retryNo = 0,
+  retryNo?: number,
   enabled = true,
 ) =>
   useQuery({
-    queryKey: ['match-candidates', genreId, retryNo],
+    queryKey: ['match-candidates', genreId, retryNo ?? 'server'],
     enabled: genreId !== null && enabled,
     queryFn: () => getMatchCandidates(genreId!, retryNo),
     staleTime: 60_000,

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -82,23 +82,13 @@ function MatchingGenreDetailPage() {
   const canAccessPage = authGate.accessStatus === 'authorized';
   const isValidGenreSlug = genreSlug ? isMatchingGenreSlug(genreSlug) : false;
   const genre = genreSlug ? getMatchingGenreBySlug(genreSlug) : undefined;
-  const currentGenreSlug = genre?.slug ?? null;
-  const [retryState, setRetryState] = useState<{
-    genreSlug: string | null;
-    value: number;
-  }>({
-    genreSlug: currentGenreSlug,
-    value: 0,
-  });
-  const retryNo =
-    retryState.genreSlug === currentGenreSlug ? retryState.value : 0;
 
   const matchCandidatesQuery = useMatchCandidatesQuery(
     genre?.genreId ?? null,
-    retryNo,
+    undefined,
     canAccessPage,
   );
-  const candidateRetryNo = matchCandidatesQuery.data?.retry_no ?? retryNo;
+  const candidateRetryNo = matchCandidatesQuery.data?.retry_no ?? 0;
   const submitMatchResponsesMutation = useSubmitMatchResponsesMutation();
   const resetSubmitMatchResponsesMutation = submitMatchResponsesMutation.reset;
   const candidates = useMemo(
@@ -126,7 +116,7 @@ function MatchingGenreDetailPage() {
 
   useEffect(() => {
     hasInitializedFlowRef.current = false;
-  }, [genre?.slug, retryNo]);
+  }, [genre?.slug, matchCandidatesQuery.dataUpdatedAt]);
 
   useEffect(() => {
     if (!genre || candidates.length === 0 || hasInitializedFlowRef.current) {
@@ -292,12 +282,7 @@ function MatchingGenreDetailPage() {
             <div className="mt-7 flex flex-wrap gap-3">
               <button
                 type="button"
-                onClick={() =>
-                  setRetryState({
-                    genreSlug: currentGenreSlug,
-                    value: candidateRetryNo + 1,
-                  })
-                }
+                onClick={() => void matchCandidatesQuery.refetch()}
                 className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909]"
               >
                 다시 시도


### PR DESCRIPTION
## 관련 이슈

- closes #314 

## 변경 내용

- 매칭 상세 페이지에서 `retry_no`를 프론트가 직접 증가시키는 방식 대신, candidates 응답으로 받은 값을 기준으로 사용하는 흐름으로 정리했습니다.
- `다시 시도`는 회차를 프론트에서 계산하는 동작이 아니라, 후보 목록을 다시 조회하는 액션으로 정리했습니다.
- 매칭 제출(`POST /api/v1/match/responses`) 시에는 현재 화면에 표시된 candidates 응답의 `retry_no`를 그대로 전달하도록 수정했습니다.
- candidates 조회 query 흐름도 서버 기준 회차 관리에 맞게 정리해, 프론트 계산값과 실제 후보 세트 기준이 어긋나지 않도록 보강했습니다.


## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 매칭 후보 회차(`retry_no`)를 프론트 계산값이 아닌 서버 응답 기준으로 맞추는 흐름 정리에 집중했습니다.
- 매칭 후보 재조회와 제출이 같은 후보 세트 기준을 바라보도록 맞추는 것이 목적입니다.
