### PR TITLE
[Fix] 매칭 제출 후 stale candidates cache 제거

### DIFF
--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -216,6 +216,9 @@ function MatchingGenreDetailPage() {
           is_liked: candidate.is_liked,
         })),
       });
+      queryClient.removeQueries({
+        queryKey: ['match-candidates', currentGenreId],
+      });
       navigate(
         `/${ROUTES.RECOMMENDATION_LIST}?source=match&genre_id=${currentGenreId}`,
       );


### PR DESCRIPTION
## 관련 이슈

- closes #317 

## 변경 내용

- 매칭 제출 성공 후 현재 장르의 `match-candidates` 캐시를 제거하도록 수정했습니다.
- 그 결과 사용자가 새로고침 없이 다른 페이지로 이동했다가 같은 장르 매칭을 다시 시작해도, 이전 후보 세트와 이전 `retry_no`를 재사용하지 않고 서버에서 새 candidates를 다시 받아오도록 정리했습니다.
- 동일 장르 재진입 시 이전 캐시 때문에 `유효하지 않은 retry_no 입니다.` 에러가 발생하던 흐름을 보강했습니다.

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 매칭 제출 이후 같은 장르 재진입 시 발생하는 캐시 기반 회차 불일치 문제를 해결하는 후속 버그픽스입니다.
- 제출 성공 직후에만 현재 장르 candidates 캐시를 제거하며, 다른 장르의 매칭 흐름에는 영향을 주지 않습니다.
