### PR TITLE
[Feat] 게임 API 스웨거 정합성 반영 및 검색 캐러셀 자동 로딩 적용

### DIFF
--- a/docs/ai/api-contract.md
+++ b/docs/ai/api-contract.md
@@ -258,6 +258,97 @@ GET    /api/v1/chatbot/stream       # AI 응답 스트리밍 (SSE, query: sessio
 - **State**: `useSupportChatStore`를 통한 대화 내역 및 위젯 상태 관리.
 - **Boundary**: 고객센터 챗봇 API(`/api/v1/chatbot/*`)는 설문 챗봇 API(`/api/v1/survey/chatbot/*`)와 별개로 운영하며, 경로를 혼용하지 않습니다.
 
+## Games
+
+게임 목록/상세/좋아요 관련 명세는 최신 Swagger를 canonical contract로 사용합니다.
+화면 컴포넌트는 raw API 필드명에 직접 의존하지 않고, `src/features/games/gameApi.ts`의 normalize 경계에서 화면용 타입으로 변환합니다.
+
+### API Endpoints
+
+```text
+GET    /api/v1/games/list/top100
+GET    /api/v1/games/list/{game_id}
+POST   /api/v1/games/{game_id}/like
+DELETE /api/v1/games/{game_id}/like
+```
+
+### 1. 인기 TOP 100 / 검색 목록 Contract
+
+인기 목록과 검색은 같은 엔드포인트를 사용하며, query parameter 조합으로 동작합니다.
+
+```json
+{
+  "ranked_at": "2026-04-08T20:10:00+09:00",
+  "count": 100,
+  "next": 2,
+  "results": [
+    {
+      "game_id": 1942,
+      "name": "Example Game",
+      "genres": ["전략", "시뮬레이션"],
+      "thumbnail_url": "https://cdn.example.com/1942.jpg",
+      "rating": 88.4,
+      "is_liked": false,
+      "like_count": 123
+    }
+  ]
+}
+```
+
+- canonical query params: `genre_id`, `page`, `page_size`, `search`, `fuzzy`
+- `next` 는 다음 페이지 번호를 의미하는 `number | null` 입니다. 게임 목록은 URL 문자열을 canonical contract로 사용하지 않습니다.
+- 프론트 검색 pagination은 `next` 숫자를 우선 사용하고, 서버가 `next`를 비워 보낼 때만 `count` 기반 fallback 계산을 허용합니다.
+- 화면용 목록 타입은 아래 기준으로 정규화합니다.
+  - `game_id` -> `gameId`
+  - `name` -> `name`
+  - `thumbnail_url` -> `thumbnailUrl`
+  - `is_liked` -> `isLiked`
+  - `like_count` -> `likeCount`
+- 누락 텍스트/배열은 기존 규칙대로 `N/A` 또는 `null` 기반으로 정규화합니다.
+
+### 2. 게임 상세 Contract
+
+```json
+{
+  "game_id": 501,
+  "title": "엘든 링: 황금 나무의 그림자",
+  "genres": ["액션", "역할수행(RPG)"],
+  "release_date": "2024-06-21",
+  "developer": "FromSoftware",
+  "publisher": "Bandai Namco",
+  "media": {
+    "promo_video_url": "https://www.youtube.com/watch?v=example",
+    "promo_embed_url": "https://www.youtube.com/embed/example",
+    "cover_image_url": "https://images.igdb.com/igdb/image/upload/t_1080p/co1234.jpg"
+  },
+  "description": "그림자의 땅에서 펼쳐지는 새로운 모험과 강력한 보스들과의 전투.",
+  "external_links": {
+    "official_site": "https://www.eldenring.com",
+    "steam": "https://store.steampowered.com/app/eldenring",
+    "epic_store": null
+  },
+  "is_liked": false,
+  "like_count": 1250
+}
+```
+
+- 상세 응답의 `media`, `external_links`, `is_liked`, `like_count` 는 Swagger schema를 우선 기준으로 사용합니다.
+- 다만 프론트는 실서버의 nullable/누락 가능성에 대비해 normalize 단계에서만 방어하고, 컴포넌트에는 정규화된 `GameDetail` 타입만 전달합니다.
+- 상세 누락 필드는 기존 UX 규칙대로 `N/A` 또는 `null` 로 표시합니다.
+
+### 3. 게임 좋아요 Contract
+
+```json
+{
+  "game_id": 501,
+  "like_count": 1251
+}
+```
+
+- 좋아요 등록은 `POST`, 취소는 `DELETE /api/v1/games/{game_id}/like` 를 사용합니다.
+- 응답 본문은 `game_id`, `like_count` 만 canonical field로 보고, 현재 좋아요 여부는 요청 의도에 따라 프론트에서 `isLiked` 를 합성합니다.
+- 좋아요 반영은 목록/상세/추천/매칭/마이페이지 찜 목록 cache를 공통 query sync 경계에서 함께 갱신합니다.
+
 ---
 
 _(이하 기존 게임 목록/상세 API 명세 생략 가능하나 문서 무결성을 위해 유지 권장)_

--- a/src/features/games/gameApi.ts
+++ b/src/features/games/gameApi.ts
@@ -67,6 +67,9 @@ const normalizeGameLikeResponse = (
   likeCount: response.like_count ?? 0,
 });
 
+const normalizeGameListNextPage = (next: number | null | undefined) =>
+  typeof next === 'number' && Number.isInteger(next) && next > 0 ? next : null;
+
 export const getTopGames = async ({
   genre = '전체',
 }: GetTopGamesParams = {}): Promise<GameListItem[]> => {
@@ -106,7 +109,7 @@ export const searchGames = async ({
 
   return {
     count: response.data.count ?? response.data.results.length,
-    next: response.data.next ?? null,
+    next: normalizeGameListNextPage(response.data.next),
     results: response.data.results.map(normalizeGameListItem),
   };
 };

--- a/src/features/games/mocks/handlers.ts
+++ b/src/features/games/mocks/handlers.ts
@@ -100,15 +100,7 @@ export const gamesHandlers = [
       pageSize,
       resolveStoredGameLikeState,
     });
-    const next =
-      page * pageSize < count
-        ? (() => {
-            const nextUrl = new URL(url);
-            nextUrl.searchParams.set('page', String(page + 1));
-            nextUrl.searchParams.set('page_size', String(pageSize));
-            return nextUrl.toString();
-          })()
-        : null;
+    const next = page * pageSize < count ? page + 1 : null;
 
     await delay(250);
 

--- a/src/features/games/types.ts
+++ b/src/features/games/types.ts
@@ -12,7 +12,7 @@ export type GameListItem = {
 
 export type GameListResponse = {
   count?: number;
-  next?: string | null;
+  next?: number | null;
   ranked_at?: string;
   results: RawGameListItem[];
 };
@@ -94,6 +94,6 @@ export type SearchGamesParams = {
 
 export type SearchGamesResult = {
   count: number;
-  next?: string | null;
+  next?: number | null;
   results: GameListItem[];
 };

--- a/src/pages/main/components/MainGameCarousel.tsx
+++ b/src/pages/main/components/MainGameCarousel.tsx
@@ -40,19 +40,55 @@ const GAME_CARD_SWIPER_BREAKPOINTS = {
   },
 } as const;
 const GAME_CARD_SKELETON_COUNT = 6;
+const SEARCH_RESULT_PREFETCH_GROUP_COUNT = 2;
 
 type MainGameCarouselProps = {
   games: GameListItem[];
   onSelectGame: (game: GameListItem) => void;
   showUpdatingOverlay?: boolean;
+  hasMoreSearchResults?: boolean;
+  isFetchingMoreSearchResults?: boolean;
+  onRequestMoreSearchResults?: () => void;
 };
 
 const MainGameCarousel = ({
   games,
   onSelectGame,
   showUpdatingOverlay = false,
+  hasMoreSearchResults = false,
+  isFetchingMoreSearchResults = false,
+  onRequestMoreSearchResults,
 }: MainGameCarouselProps) => {
   const swiperRef = useRef<SwiperInstance | null>(null);
+
+  const canRequestMoreSearchResults = Boolean(
+    hasMoreSearchResults &&
+    !isFetchingMoreSearchResults &&
+    onRequestMoreSearchResults,
+  );
+
+  const requestMoreSearchResultsIfNeeded = (swiper: SwiperInstance) => {
+    if (!canRequestMoreSearchResults) {
+      return;
+    }
+
+    const slidesPerView =
+      typeof swiper.params.slidesPerView === 'number'
+        ? swiper.params.slidesPerView
+        : 1;
+    const slidesPerGroup =
+      typeof swiper.params.slidesPerGroup === 'number'
+        ? swiper.params.slidesPerGroup
+        : 1;
+    const viewedUntilIndex = swiper.activeIndex + slidesPerView;
+    const remainingSlides = games.length - viewedUntilIndex;
+    const prefetchThreshold =
+      slidesPerGroup * SEARCH_RESULT_PREFETCH_GROUP_COUNT;
+
+    if (remainingSlides <= prefetchThreshold) {
+      onRequestMoreSearchResults?.();
+    }
+  };
 
   const scrollCards = (direction: 'previous' | 'next') => {
     const swiper = swiperRef.current;
@@ -66,6 +102,7 @@ const MainGameCarousel = ({
       return;
     }
 
+    requestMoreSearchResultsIfNeeded(swiper);
     swiper.slideNext();
   };
 
@@ -75,6 +112,7 @@ const MainGameCarousel = ({
       showUpdatingOverlay={showUpdatingOverlay}
       onPrevious={() => scrollCards('previous')}
       onNext={() => scrollCards('next')}
+      onSlideChange={requestMoreSearchResultsIfNeeded}
       onSwiper={(swiper) => {
         swiperRef.current = swiper;
       }}
@@ -94,6 +132,7 @@ type GameCardSwiperFrameProps = {
   showUpdatingOverlay?: boolean;
   onPrevious?: () => void;
   onNext?: () => void;
+  onSlideChange?: (swiper: SwiperInstance) => void;
   onSwiper?: (swiper: SwiperInstance) => void;
 };
 
@@ -103,6 +142,7 @@ const GameCardSwiperFrame = ({
   showUpdatingOverlay = false,
   onPrevious,
   onNext,
+  onSlideChange,
   onSwiper,
 }: GameCardSwiperFrameProps) => (
   <div className="group/carousel relative left-1/2 w-screen -translate-x-1/2">
@@ -114,6 +154,7 @@ const GameCardSwiperFrame = ({
       <div className="relative">
         <Swiper
           onSwiper={onSwiper}
+          onSlideChange={onSlideChange}
           slidesPerView={1}
           slidesPerGroup={1}
           spaceBetween={20}

--- a/src/pages/main/components/MainGamesSection.tsx
+++ b/src/pages/main/components/MainGamesSection.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Search, X } from 'lucide-react';
+import { Search, X } from 'lucide-react';
 import { useRef } from 'react';
 import type { GameListItem } from '../../../features/games/types';
 import type { MainPageGamesState } from '../hooks/useMainPageGames';
@@ -96,13 +96,10 @@ const MainGamesSection = ({
             games={games}
             onSelectGame={onSelectGame}
             showUpdatingOverlay={isGamesUpdating}
+            hasMoreSearchResults={hasMoreSearchResults}
+            isFetchingMoreSearchResults={isFetchingMoreSearchResults}
+            onRequestMoreSearchResults={fetchMoreSearchResults}
           />
-          {hasMoreSearchResults ? (
-            <SearchResultMoreAction
-              isLoading={isFetchingMoreSearchResults}
-              onClick={fetchMoreSearchResults}
-            />
-          ) : null}
         </>
       ) : (
         <EmptyGameList isFiltered={isFiltered} />
@@ -110,29 +107,5 @@ const MainGamesSection = ({
     </div>
   );
 };
-
-type SearchResultMoreActionProps = {
-  isLoading: boolean;
-  onClick: () => void;
-};
-
-const SearchResultMoreAction = ({
-  isLoading,
-  onClick,
-}: SearchResultMoreActionProps) => (
-  <div className="mt-4 flex justify-end px-[clamp(1rem,5vw,20rem)]">
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={isLoading}
-      className="inline-flex min-w-30 cursor-pointer items-center justify-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white/82 transition hover:border-[#6f2525] hover:bg-[#160b0b] hover:text-white disabled:cursor-not-allowed disabled:opacity-45"
-    >
-      {isLoading ? '불러오는 중...' : '더보기'}
-      {!isLoading ? (
-        <ChevronRight aria-hidden="true" className="h-4 w-4" />
-      ) : null}
-    </button>
-  </div>
-);
 
 export default MainGamesSection;

--- a/src/pages/main/hooks/useMainPageGames.ts
+++ b/src/pages/main/hooks/useMainPageGames.ts
@@ -98,6 +98,10 @@ export const useMainPageGames = (): MainPageGamesState => {
         pageSize: SEARCH_RESULT_PAGE_SIZE,
       }),
     getNextPageParam: (lastPage, allPages) => {
+      if (typeof lastPage.next === 'number') {
+        return lastPage.next;
+      }
+
       const loadedCount = getPaginatedLoadedCount(allPages);
       const totalCount = getPaginatedCount(lastPage, loadedCount);
 

--- a/src/utils/paginatedResults.ts
+++ b/src/utils/paginatedResults.ts
@@ -1,7 +1,7 @@
 type ResultsPage<T> =
   | {
       count?: number | null;
-      next?: string | null;
+      next?: string | number | null;
       results?: T[] | null;
     }
   | null


### PR DESCRIPTION
## 관련 이슈

- closes #320

## 변경 내용

- game 목록/상세/좋아요 API를 Swagger 기준으로 정리했습니다.
- `GameListResponse.next`, `SearchGamesResult.next`를 `number | null` 기준으로 맞추고, 메인 검색 pagination이 서버 `next`를 우선 사용하도록 수정했습니다.
- game MSW mock 응답과 `docs/ai/api-contract.md`를 실서버 계약 기준으로 동기화했습니다.
- 메인 검색 결과 하단 `더보기` 버튼을 제거하고, 캐러셀 네비게이션 흐름 안에서 검색 결과를 탐색할 수 있도록 변경했습니다.
- 검색 결과가 끝에 가까워지면 다음 페이지를 미리 불러오도록 prefetch를 적용해, 카드가 순간적으로 붙는 느낌을 줄였습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 브라우저 수동 확인과 스크린샷 첨부는 PR 올리기 전에 추가로 진행하면 됩니다.
- 검색 캐러셀 자동 로딩은 mock/real 모드 모두 같은 흐름으로 동작하도록 맞췄습니다.
