### PR TITLE
[Fix] 설문 챗봇 API 경로 및 응답 계약 정합성 수정

### DIFF
--- a/src/features/recommendation/hooks/useSurveyRecommendationActions.ts
+++ b/src/features/recommendation/hooks/useSurveyRecommendationActions.ts
@@ -57,9 +57,7 @@ export const useSurveyRecommendationActions = ({
     }
 
     try {
-      const response = await resetSurveyMutation.mutateAsync({
-        session_id: surveySessionId,
-      });
+      const response = await resetSurveyMutation.mutateAsync();
 
       onBeforeReset?.();
       clearModerationState();

--- a/src/features/survey/api/survey.ts
+++ b/src/features/survey/api/survey.ts
@@ -16,7 +16,6 @@ import type {
   SurveyApiSessionResponse,
   SurveyChatRequest,
   SurveyChatResponse,
-  SurveyResetRequest,
   SurveyResetResponse,
   SurveyResultQuery,
   SurveyResultResponse,
@@ -32,6 +31,7 @@ import type {
 interface ErrorResponseBody {
   detail?: string;
   error_detail?: string | Record<string, string[]>;
+  retry_after_seconds?: number;
 }
 
 const SURVEY_BASE_PATH = '/api/v1/survey';
@@ -97,7 +97,11 @@ export const normalizeSurveySessionResponse = (
 
   return {
     session_id: payload.session_id,
-    assistant_message: payload.ai_question ?? payload.chatbot_reply ?? null,
+    assistant_message:
+      payload.ai_question ??
+      payload.ai_message ??
+      payload.chatbot_reply ??
+      null,
     progress: normalizeSurveyProgress(payload.progress, payload.progress_rate),
     status: normalizeSurveyStatus(payload.status, isCompleted),
     recommendation_ready: recommendationReady,
@@ -106,10 +110,7 @@ export const normalizeSurveySessionResponse = (
 
 export const normalizeSurveyResetResponse = (
   payload: SurveyApiResetResponse,
-): SurveyResetResponse => ({
-  message: payload.message,
-  ...normalizeSurveySessionResponse(payload),
-});
+): SurveyResetResponse => normalizeSurveySessionResponse(payload);
 
 const normalizeSurveyResultItem = (
   item: SurveyApiResultItem,
@@ -128,7 +129,6 @@ const normalizeSurveyResultItem = (
 export const normalizeSurveyResultResponse = (
   payload: SurveyApiResultResponse,
 ): SurveyResultResponse => ({
-  session_id: payload.session_id,
   user_id: typeof payload.user_id === 'number' ? payload.user_id : undefined,
   count:
     typeof payload.count === 'number'
@@ -145,7 +145,7 @@ export const startSurveySession = async (
 ): Promise<SurveySessionStartResponse> => {
   try {
     const response = await api.post<SurveyApiSessionResponse>(
-      `${SURVEY_CHATBOT_BASE_PATH}/sessions`,
+      `${SURVEY_CHATBOT_BASE_PATH}/sessions/`,
       payload satisfies SurveyApiSessionStartRequest,
     );
 
@@ -164,9 +164,9 @@ export const continueSurveyChat = async (
 ): Promise<SurveyChatResponse> => {
   try {
     const response = await api.post<SurveyApiSessionResponse>(
-      `${SURVEY_CHATBOT_BASE_PATH}/sessions/${payload.session_id}/messages`,
+      `${SURVEY_CHATBOT_BASE_PATH}/sessions/${payload.session_id}/messages/`,
       {
-        user_answer: payload.user_answer,
+        message: payload.user_answer,
       } satisfies SurveyApiChatRequest,
     );
 
@@ -179,17 +179,16 @@ export const continueSurveyChat = async (
     return normalizeSurveySessionResponse(
       continueMockSurveyChat({
         session_id: payload.session_id,
-        user_answer: payload.user_answer,
+        message: payload.user_answer,
       }),
     );
   }
 };
 
-export const resetSurveySession = async (payload: SurveyResetRequest) => {
+export const resetSurveySession = async () => {
   try {
     const response = await api.post<SurveyApiResetResponse>(
-      `${SURVEY_BASE_PATH}/sessions/reset`,
-      payload,
+      `${SURVEY_CHATBOT_BASE_PATH}/sessions/reset/`,
     );
 
     return normalizeSurveyResetResponse(response.data);
@@ -198,18 +197,20 @@ export const resetSurveySession = async (payload: SurveyResetRequest) => {
       throw error;
     }
 
-    return normalizeSurveyResetResponse(
-      resetMockSurveySession(payload.session_id),
-    );
+    return normalizeSurveyResetResponse(resetMockSurveySession());
   }
 };
 
 export const getSurveyResults = async (query: SurveyResultQuery) => {
   try {
     const response = await api.get<SurveyApiResultResponse>(
-      `${SURVEY_BASE_PATH}/result`,
+      `${SURVEY_CHATBOT_BASE_PATH}/sessions/${query.session_id}/recommendations/`,
       {
-        params: query,
+        params: {
+          cursor: query.cursor,
+          page_size: query.page_size,
+          sort: query.sort,
+        },
       },
     );
 
@@ -223,7 +224,7 @@ export const getSurveyResults = async (query: SurveyResultQuery) => {
       getMockSurveyResults({
         cursor: query.cursor ?? null,
         pageSize: query.page_size,
-        sessionId: query.session_id ?? null,
+        sessionId: query.session_id,
       }),
     );
   }
@@ -261,4 +262,17 @@ export const extractApiErrorMessage = (error: unknown) => {
   }
 
   return '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+};
+
+export const extractApiRetryAfterSeconds = (error: unknown) => {
+  if (!(error instanceof AxiosError)) {
+    return null;
+  }
+
+  const data = error.response?.data as ErrorResponseBody | undefined;
+
+  return typeof data?.retry_after_seconds === 'number' &&
+    Number.isFinite(data.retry_after_seconds)
+    ? data.retry_after_seconds
+    : null;
 };

--- a/src/features/survey/api/useSurveyApi.ts
+++ b/src/features/survey/api/useSurveyApi.ts
@@ -29,14 +29,14 @@ export const useSurveyResultsInfinite = (
   sessionId?: string | null,
 ) =>
   useInfiniteQuery({
-    queryKey: ['survey-results', sessionId ?? 'current'],
+    queryKey: ['survey-results', sessionId ?? 'missing'],
     initialPageParam: null as string | null,
-    enabled,
+    enabled: enabled && Boolean(sessionId),
     queryFn: ({ pageParam }) =>
       getSurveyResults({
         cursor: pageParam ?? undefined,
         page_size: 5,
-        session_id: sessionId ?? undefined,
+        session_id: sessionId!,
       }),
     getNextPageParam: (lastPage) => getPaginatedNext(lastPage) ?? undefined,
     retry: shouldRetryApiQuery,

--- a/src/features/survey/hooks/useSurveySessionFlow.ts
+++ b/src/features/survey/hooks/useSurveySessionFlow.ts
@@ -6,7 +6,10 @@ import {
   useResetSurveyMutation,
   useStartSurveySessionMutation,
 } from '../api/useSurveyApi';
-import { extractApiErrorMessage } from '../api/survey';
+import {
+  extractApiErrorMessage,
+  extractApiRetryAfterSeconds,
+} from '../api/survey';
 import { useSurveyStore } from '../store/useSurveyStore';
 
 const isRecoverableMockSessionError = (message: string | null) =>
@@ -43,6 +46,9 @@ export const useSurveySessionFlow = ({
   );
   const clearModerationState = useSurveyStore(
     (state) => state.clearModerationState,
+  );
+  const setChatBlockedUntil = useSurveyStore(
+    (state) => state.setChatBlockedUntil,
   );
   const addUserMessage = useSurveyStore((state) => state.addUserMessage);
   const hydrateInitialSession = useSurveyStore(
@@ -97,6 +103,19 @@ export const useSurveySessionFlow = ({
     }
   }, [bootstrapSurvey, hasBootstrapped, sessionId]);
 
+  const applyServerSideChatBlock = useCallback(
+    (requestError: unknown) => {
+      const retryAfterSeconds = extractApiRetryAfterSeconds(requestError);
+
+      if (retryAfterSeconds === null) {
+        return;
+      }
+
+      setChatBlockedUntil(Date.now() + retryAfterSeconds * 1000);
+    },
+    [setChatBlockedUntil],
+  );
+
   const submitMessage = useCallback(
     async ({
       content,
@@ -147,6 +166,7 @@ export const useSurveySessionFlow = ({
 
         return true;
       } catch (requestError) {
+        applyServerSideChatBlock(requestError);
         setError(extractApiErrorMessage(requestError));
         return false;
       } finally {
@@ -155,6 +175,7 @@ export const useSurveySessionFlow = ({
     },
     [
       addUserMessage,
+      applyServerSideChatBlock,
       applyChatResponse,
       clearError,
       continueSurveyMutation,
@@ -197,6 +218,7 @@ export const useSurveySessionFlow = ({
 
         applyChatResponse(response);
       } catch (requestError) {
+        applyServerSideChatBlock(requestError);
         setError(extractApiErrorMessage(requestError));
       } finally {
         setSubmitting(false);
@@ -211,6 +233,7 @@ export const useSurveySessionFlow = ({
     });
   }, [
     addUserMessage,
+    applyServerSideChatBlock,
     applyChatResponse,
     bootstrapSurvey,
     clearError,
@@ -247,9 +270,7 @@ export const useSurveySessionFlow = ({
     setSubmitting(true);
 
     try {
-      const response = await resetSurveyMutation.mutateAsync({
-        session_id: sessionId,
-      });
+      const response = await resetSurveyMutation.mutateAsync();
 
       clearModerationState();
       hydrateInitialSession(response);

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -5,7 +5,6 @@ import { mockTopGames } from '../../games/mockGames';
 import type {
   SurveyApiChatRequest,
   SurveyApiResultItem,
-  SurveyResetRequest,
 } from '../types/survey';
 import {
   DEFAULT_SURVEY_RECOMMENDATION_PAGE_SIZE,
@@ -107,7 +106,7 @@ const getQuestionCountFromAnswer = (answer: string) => {
 };
 
 export const surveyHandlers = [
-  http.post('/api/v1/survey/chatbot/sessions', async ({ request }) => {
+  http.post('/api/v1/survey/chatbot/sessions/', async ({ request }) => {
     await request.json().catch(() => ({}));
     const sessionId = createSessionId();
     const totalQuestions = SURVEY_MAX_STEPS;
@@ -129,12 +128,12 @@ export const surveyHandlers = [
   }),
 
   http.post(
-    '/api/v1/survey/chatbot/sessions/:sessionId/messages',
+    '/api/v1/survey/chatbot/sessions/:sessionId/messages/',
     async ({ request, params }) => {
       const body = (await request.json()) as SurveyApiChatRequest;
       const sessionId = String(params.sessionId ?? '');
 
-      if (!sessionId || !body.user_answer?.trim()) {
+      if (!sessionId || !body.message?.trim()) {
         return mockErrorResponse(400, '필수 입력 항목입니다.');
       }
 
@@ -146,7 +145,7 @@ export const surveyHandlers = [
         } satisfies MockSurveySession);
 
       if (session.askedQuestions === 1) {
-        session.totalQuestions = getQuestionCountFromAnswer(body.user_answer);
+        session.totalQuestions = getQuestionCountFromAnswer(body.message);
       }
 
       await delay(800);
@@ -157,7 +156,7 @@ export const surveyHandlers = [
 
         return HttpResponse.json({
           session_id: sessionId,
-          ai_question: null,
+          ai_message: null,
           progress: buildProgress(
             session.totalQuestions,
             session.totalQuestions,
@@ -174,7 +173,7 @@ export const surveyHandlers = [
 
       return HttpResponse.json({
         session_id: sessionId,
-        ai_question: surveyQuestions[nextQuestionIndex],
+        ai_message: surveyQuestions[nextQuestionIndex],
         progress: buildProgress(session.askedQuestions, session.totalQuestions),
         status: 'IN_PROGRESS',
         recommendation_ready: false,
@@ -182,47 +181,46 @@ export const surveyHandlers = [
     },
   ),
 
-  http.get('/api/v1/survey/result', async ({ request }) => {
-    const url = new URL(request.url);
-    const cursor = Number(url.searchParams.get('cursor') ?? '0');
-    const pageSize = Number(
-      url.searchParams.get('page_size') ??
-        DEFAULT_SURVEY_RECOMMENDATION_PAGE_SIZE,
-    );
-    const requestedSessionId = url.searchParams.get('session_id');
-    const recommendations = buildSurveyRecommendations(
-      request.headers.get('authorization'),
-    );
+  http.get(
+    '/api/v1/survey/chatbot/sessions/:sessionId/recommendations/',
+    async ({ request, params }) => {
+      const url = new URL(request.url);
+      const cursor = Number(url.searchParams.get('cursor') ?? '0');
+      const pageSize = Number(
+        url.searchParams.get('page_size') ??
+          DEFAULT_SURVEY_RECOMMENDATION_PAGE_SIZE,
+      );
+      const requestedSessionId = String(params.sessionId ?? '');
+      const recommendations = buildSurveyRecommendations(
+        request.headers.get('authorization'),
+      );
 
-    if (!latestCompletedSurveySessionId && !requestedSessionId) {
-      return mockErrorResponse(404, '설문 추천 결과를 찾을 수 없습니다.');
-    }
+      if (
+        !latestCompletedSurveySessionId ||
+        requestedSessionId !== latestCompletedSurveySessionId
+      ) {
+        return mockErrorResponse(404, '설문 추천 결과를 찾을 수 없습니다.');
+      }
 
-    const startIndex = Number.isNaN(cursor) ? 0 : cursor;
-    const nextIndex = startIndex + pageSize;
-    const next = nextIndex < recommendations.length ? String(nextIndex) : null;
+      const startIndex = Number.isNaN(cursor) ? 0 : cursor;
+      const nextIndex = startIndex + pageSize;
+      const next =
+        nextIndex < recommendations.length ? String(nextIndex) : null;
 
-    await delay(500);
+      await delay(500);
 
-    return HttpResponse.json({
-      user_id: 1,
-      count: recommendations.length,
-      next,
-      results: recommendations.slice(startIndex, nextIndex),
-    });
-  }),
+      return HttpResponse.json({
+        user_id: 1,
+        count: recommendations.length,
+        next,
+        results: recommendations.slice(startIndex, nextIndex),
+      });
+    },
+  ),
 
-  http.post('/api/v1/survey/sessions/reset', async ({ request }) => {
-    const body = (await request.json()) as SurveyResetRequest;
-
-    if (!body.session_id) {
-      return mockErrorResponse(400, 'session_id는 필수입니다.');
-    }
-
-    surveySessions.delete(body.session_id);
-    if (latestCompletedSurveySessionId === body.session_id) {
-      latestCompletedSurveySessionId = null;
-    }
+  http.post('/api/v1/survey/chatbot/sessions/reset/', async () => {
+    surveySessions.clear();
+    latestCompletedSurveySessionId = null;
 
     const nextSessionId = createSessionId();
     surveySessions.set(nextSessionId, {
@@ -233,7 +231,6 @@ export const surveyHandlers = [
     await delay(350);
 
     return HttpResponse.json({
-      message: '설문이 초기화되었습니다.',
       session_id: nextSessionId,
       status: 'IN_PROGRESS',
       ai_question: surveyQuestions[0],

--- a/src/features/survey/mocks/runtime.ts
+++ b/src/features/survey/mocks/runtime.ts
@@ -126,7 +126,7 @@ export const continueMockSurveyChat = (
     } satisfies MockSurveySession);
 
   if (session.askedQuestions === 1) {
-    session.totalQuestions = getQuestionCountFromAnswer(payload.user_answer);
+    session.totalQuestions = getQuestionCountFromAnswer(payload.message);
   }
 
   if (session.askedQuestions >= session.totalQuestions) {
@@ -135,7 +135,7 @@ export const continueMockSurveyChat = (
 
     return {
       session_id: payload.session_id,
-      ai_question: null,
+      ai_message: null,
       progress: buildProgress(
         session.totalQuestions,
         session.totalQuestions,
@@ -152,7 +152,7 @@ export const continueMockSurveyChat = (
 
   return {
     session_id: payload.session_id,
-    ai_question: surveyQuestions[nextQuestionIndex] ?? null,
+    ai_message: surveyQuestions[nextQuestionIndex] ?? null,
     progress: buildProgress(session.askedQuestions, session.totalQuestions),
     status: 'IN_PROGRESS',
     recommendation_ready: false,
@@ -192,13 +192,9 @@ export const getMockSurveyResults = ({
   };
 };
 
-export const resetMockSurveySession = (
-  sessionId: string,
-): SurveyApiResetResponse => {
-  surveySessions.delete(sessionId);
-  if (latestCompletedSurveySessionId === sessionId) {
-    latestCompletedSurveySessionId = null;
-  }
+export const resetMockSurveySession = (): SurveyApiResetResponse => {
+  surveySessions.clear();
+  latestCompletedSurveySessionId = null;
 
   const nextSessionId = createSessionId();
   surveySessions.set(nextSessionId, {
@@ -207,7 +203,6 @@ export const resetMockSurveySession = (
   });
 
   return {
-    message: '설문이 초기화되었습니다.',
     session_id: nextSessionId,
     status: 'IN_PROGRESS',
     ai_question: surveyQuestions[0],

--- a/src/features/survey/types/survey.ts
+++ b/src/features/survey/types/survey.ts
@@ -30,7 +30,7 @@ export interface SurveyApiSessionStartRequest {
 }
 
 export interface SurveyApiChatRequest {
-  user_answer: string;
+  message: string;
 }
 
 export interface SurveyApiProgress {
@@ -48,14 +48,16 @@ export interface SurveyApiLegacySessionResponseFields {
 export type SurveyApiSessionResponse = SurveyApiLegacySessionResponseFields & {
   session_id: string;
   ai_question?: string | null;
+  ai_message?: string | null;
+  warning_message?: string | null;
   progress?: SurveyApiProgress | null;
   recommendation_ready?: boolean | null;
   status?: SurveySessionStatus | null;
+  survey_answer?: string | null;
+  excluded_keywords?: string[] | null;
 };
 
-export interface SurveyApiResetResponse extends SurveyApiSessionResponse {
-  message: string;
-}
+export type SurveyApiResetResponse = SurveyApiSessionResponse;
 
 export interface SurveyChatRequest {
   session_id: string;
@@ -74,24 +76,13 @@ export type SurveySessionStartResponse = SurveySessionResponse;
 
 export type SurveyChatResponse = SurveySessionResponse;
 
-export interface SurveyResetRequest {
-  session_id: string;
-}
-
-export interface SurveyResetResponse {
-  message: string;
-  session_id: string;
-  assistant_message: string | null;
-  progress: SurveyProgress;
-  status: SurveySessionStatus;
-  recommendation_ready: boolean;
-}
+export type SurveyResetResponse = SurveySessionResponse;
 
 export interface SurveyResultQuery {
+  session_id: string;
   sort?: string;
   cursor?: string;
   page_size?: number;
-  session_id?: string;
 }
 
 export interface SurveyApiResultItem {
@@ -107,7 +98,6 @@ export interface SurveyApiResultItem {
 export type SurveyResultItem = RecommendationResultItemShape;
 
 export interface SurveyApiResultResponse {
-  session_id?: string;
   user_id?: number;
   count?: number | null;
   next?: string | null;


### PR DESCRIPTION
## 관련 이슈

- closes #322

## 변경 내용

- 설문 세션 시작, 메시지 전송, 추천 결과 조회, 세션 초기화 경로를 실서버 Swagger 기준으로 정리했습니다.
- 설문 메시지 전송 요청 body를 `user_answer`가 아닌 `message` 기준으로 수정했습니다.
- 설문 추천 결과 조회를 `/api/v1/survey/result`가 아닌 세션 기반 recommendations 경로로 변경했습니다.
- 설문 초기화 API를 `/api/v1/survey/chatbot/sessions/reset/` 경로 및 무인자 요청 방식에 맞게 수정했습니다.
- 설문 응답 normalize 로직이 `ai_question`, `ai_message`, legacy `chatbot_reply`를 모두 안전하게 읽도록 보강했습니다.
- 서버 423 잠금 응답의 `retry_after_seconds`를 읽어 프론트 설문 차단 상태에 반영하도록 수정했습니다.
- MSW survey handlers/runtime도 동일한 API 계약으로 맞춰 dev/mock 환경과 실서버 환경의 응답 shape를 일치시켰습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 설문 챗봇 기능 자체를 바꾸기보다, 현재 프론트 survey 흐름이 실서버 Swagger 계약과 같은 경로/필드명을 보도록 맞추는 데 집중했습니다.
- 설문 추천 결과 조회와 세션 초기화 방식이 특히 크게 달라져 해당 흐름을 함께 정리했습니다.