### PR TITLE
[Feat] 메인 게임 섹션 간격 조정

### DIFF
--- a/src/pages/main/components/MainGamesSection.tsx
+++ b/src/pages/main/components/MainGamesSection.tsx
@@ -79,18 +79,18 @@ const MainGamesSection = ({
         </label>
       </div>
 
-      {isGamesLoading ? (
-        <GameCardSkeletonList />
-      ) : isGamesError ? (
-        <ErrorGameList
-          message={
-            gamesErrorMessage ??
-            '인기 게임 목록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.'
-          }
-          onRetry={retryGames}
-        />
-      ) : games.length > 0 ? (
-        <>
+      <div className="mt-3 sm:mt-4">
+        {isGamesLoading ? (
+          <GameCardSkeletonList />
+        ) : isGamesError ? (
+          <ErrorGameList
+            message={
+              gamesErrorMessage ??
+              '인기 게임 목록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.'
+            }
+            onRetry={retryGames}
+          />
+        ) : games.length > 0 ? (
           <MainGameCarousel
             key={carouselKey}
             games={games}
@@ -100,10 +100,10 @@ const MainGamesSection = ({
             isFetchingMoreSearchResults={isFetchingMoreSearchResults}
             onRequestMoreSearchResults={fetchMoreSearchResults}
           />
-        </>
-      ) : (
-        <EmptyGameList isFiltered={isFiltered} />
-      )}
+        ) : (
+          <EmptyGameList isFiltered={isFiltered} />
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 관련 이슈

- closes #326

## 변경 내용

- 메인 페이지 게임 섹션에서 상단 컨트롤 영역과 카드 영역 사이에 작은 여백을 추가했습니다.
- 게임 목록이 로딩, 에러, 빈 상태일 때도 동일한 간격 기준을 유지하도록 정리했습니다.
- 카드 UI, 검색 기능, 장르 필터 동작은 변경하지 않았습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="2032" height="1162" alt="스크린샷 2026-04-29 오후 3 04 24" src="https://github.com/user-attachments/assets/dd7a60a4-f044-4081-80ea-ffb798d479a0" />


## 참고사항

- 메인 페이지 게임 섹션의 레이아웃 간격만 조정한 변경입니다.
