### PR TITLE
[Feat] 로컬 HTTPS 개발 환경 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist-ssr
 *.sw?
 
 .claude/
+certs/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,36 @@ npm install
 npm run dev
 ```
 
-로컬 개발 서버가 출력하는 URL로 접속합니다.
+기본 개발 서버는 `https://localhost:5173` 기준으로 실행합니다.
+
+처음 한 번은 로컬 인증서를 생성합니다.
+
+```bash
+brew install mkcert
+mkcert -install
+mkdir -p certs
+mkcert -key-file certs/localhost-key.pem -cert-file certs/localhost.pem localhost 127.0.0.1 ::1
+```
+
+이후 아래 명령으로 개발 서버를 실행합니다.
+
+```bash
+npm run dev
+```
+
+브라우저에서 `https://localhost:5173`로 접속합니다.
+
+인증/소셜 로그인과 무관한 단순 UI 작업 등으로 HTTP가 필요하면 예외적으로 아래 명령을 사용할 수 있습니다.
+
+```bash
+npm run dev:http
+```
+
+백엔드 연동 시에는 아래 조건도 함께 맞아야 합니다.
+
+- backend CORS 허용 origin에 `https://localhost:5173` 추가
+- `Access-Control-Allow-Credentials: true` 유지
+- 소셜 로그인 로컬 redirect URI가 있다면 `https://localhost:5173` 기준으로 등록
 
 ## Verification
 

--- a/docs/ai/api-contract/auth.md
+++ b/docs/ai/api-contract/auth.md
@@ -97,6 +97,13 @@
 - refresh 쿠키는 `SameSite=None; Secure; HttpOnly`를 전제로 하며, 프론트와 백엔드는 모두 `https:` 환경이어야 합니다.
 - 브라우저 런타임 코드에서는 `Set-Cookie` 응답 헤더와 실제 `Cookie` 요청 헤더 원문을 읽을 수 없으므로, 배포 검증은 DevTools와 DEV 진단 로그를 함께 사용합니다.
 
+### 로컬 HTTPS 소셜 로그인 전제 조건
+
+- 기본 개발 서버는 `https://localhost:5173`를 사용합니다.
+- 로컬 소셜 로그인과 `Secure` refresh 쿠키 검증은 HTTPS 개발 서버 기준으로 확인합니다.
+- backend CORS 허용 origin에 `https://localhost:5173`가 포함되어야 합니다.
+- 소셜 로그인 로컬 redirect URI를 사용한다면 `https://localhost:5173/callback` 기준으로 등록합니다.
+
 ## 5. 마이페이지 프로필 표시 필드
 
 - `GET /api/v1/accounts/me` 응답은 최소 `nickname`, `name`, `gender`, `email`을 포함한다고 가정합니다.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "VITE_DEV_HTTPS=true vite",
+    "dev:http": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { fileURLToPath, URL } from 'node:url';
 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+
+const LOCAL_HTTPS_KEY_PATH = path.resolve('certs/localhost-key.pem');
+const LOCAL_HTTPS_CERT_PATH = path.resolve('certs/localhost.pem');
+const isLocalHttpsEnabled = process.env.VITE_DEV_HTTPS === 'true';
+
+const readLocalHttpsConfig = () => {
+  if (
+    !fs.existsSync(LOCAL_HTTPS_KEY_PATH) ||
+    !fs.existsSync(LOCAL_HTTPS_CERT_PATH)
+  ) {
+    throw new Error(
+      [
+        '로컬 HTTPS 인증서를 찾을 수 없습니다.',
+        '`npm run dev` 전에 아래 명령을 먼저 실행해주세요.',
+        'mkcert -install',
+        'mkdir -p certs',
+        'mkcert -key-file certs/localhost-key.pem -cert-file certs/localhost.pem localhost 127.0.0.1 ::1',
+      ].join('\n'),
+    );
+  }
+
+  return {
+    key: fs.readFileSync(LOCAL_HTTPS_KEY_PATH),
+    cert: fs.readFileSync(LOCAL_HTTPS_CERT_PATH),
+  };
+};
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -12,4 +40,11 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  server: isLocalHttpsEnabled
+    ? {
+        host: 'localhost',
+        port: 5173,
+        https: readLocalHttpsConfig(),
+      }
+    : undefined,
 });


### PR DESCRIPTION
## 관련 이슈

- closes #328

## 변경 내용

- 로컬 개발 서버 기본 실행을 HTTPS 기준으로 전환했습니다.
- `npm run dev`는 `https://localhost:5173` 기준으로 실행되도록 설정했고, 예외적으로 HTTP가 필요할 때는 `npm run dev:http`를 사용할 수 있도록 정리했습니다.
- 로컬 HTTPS 인증서(`mkcert`) 생성 방식과 실행 절차를 README에 추가했습니다.
- 인증 문서에 로컬 소셜 로그인 및 `Secure` refresh 쿠키 검증을 위한 전제 조건을 정리했습니다.
- `certs/` 디렉터리는 로컬 전용으로 사용하도록 `.gitignore`에 제외 처리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 로컬 소셜 로그인까지 정상 동작하려면 백엔드에서 `https://localhost:5173`를 CORS 허용 origin에 추가하고, 소셜 로그인 callback URL도 로컬/배포 환경별로 분기되어야 합니다.
