### PR TITLE
[Feat] 소셜 로그인 리다이렉트 및 In-Memory 세션 복구 흐름 구현

### DIFF
--- a/src/components/auth/AuthSocialLoginGroup.tsx
+++ b/src/components/auth/AuthSocialLoginGroup.tsx
@@ -95,7 +95,7 @@ function AuthSocialLoginGroup({
       setPendingSocialAuthProvider(provider);
       setRedirectingProvider(provider);
       setErrorMessage('');
-      window.location.assign(redirectUrl);
+      window.location.href = redirectUrl;
     } catch {
       clearPendingSocialAuthProvider();
       setRedirectingProvider(null);

--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -14,6 +14,7 @@ import type {
   ConfirmProfileImageRequest,
   ConfirmProfileImageResponse,
   CurrentUserProfileResponse,
+  CurrentUserSocialResponse,
   DeleteLikedGameResponse,
   DuplicateCheckResponse,
   LikedGamesRequest,
@@ -137,6 +138,15 @@ export const requestRefreshAccessToken = async (
 export const getCurrentUserProfile = async () => {
   const response = await api.get<CurrentUserProfileResponse>(
     `${AUTH_BASE_PATH}/me`,
+    createCredentialedAuthRequestConfig(),
+  );
+
+  return response.data;
+};
+
+export const getCurrentUserSocialProfile = async () => {
+  const response = await api.get<CurrentUserSocialResponse>(
+    `${AUTH_BASE_PATH}/me/social`,
     createCredentialedAuthRequestConfig(),
   );
 

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -24,6 +24,7 @@ export {
   confirmProfileImage,
   deleteAccount,
   getCurrentUserProfile,
+  getCurrentUserSocialProfile,
   getLikedGames,
   getProfileImagePresignedUrl,
   signup,

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
-import { useLocation } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 
+import { ROUTES } from '../../../constants/routes';
 import { shouldSkipAuthBootstrapPath } from '../../../constants/routeResolver';
 import { isMockServiceWorkerEnabled } from '../../../lib/env';
 import {
@@ -8,6 +9,11 @@ import {
   useAuthStore,
 } from '../../../store/useAuthStore';
 import { hasMockRefreshToken } from '../api/auth.session.helper';
+import { extractAuthApiErrorMessage } from '../api/auth';
+import {
+  clearPendingSocialAuthProvider,
+  hasPendingSocialAuthProvider,
+} from '../utils/socialAuth';
 import {
   restoreAuthSession,
   setAuthBootstrapLoading,
@@ -15,6 +21,8 @@ import {
 } from '../utils/sessionManager';
 
 let authBootstrapPromise: Promise<void> | null = null;
+const DEFAULT_SOCIAL_AUTH_ERROR_MESSAGE =
+  '세션을 확인하지 못했습니다. 다시 로그인해 주세요.';
 
 const ensureAuthBootstrap = (): Promise<void> => {
   if (!authBootstrapPromise) {
@@ -30,6 +38,7 @@ const ensureAuthBootstrap = (): Promise<void> => {
 
 function useAuthBootstrap() {
   const location = useLocation();
+  const navigate = useNavigate();
   const authBootstrapStatus = useAuthStore(
     (state) => state.authBootstrapStatus,
   );
@@ -58,7 +67,13 @@ function useAuthBootstrap() {
       return;
     }
 
-    if (isMockServiceWorkerEnabled() && !hasMockRefreshToken()) {
+    const hasPendingSocialProvider = hasPendingSocialAuthProvider();
+
+    if (
+      isMockServiceWorkerEnabled() &&
+      !hasMockRefreshToken() &&
+      !hasPendingSocialProvider
+    ) {
       setAuthBootstrapReady();
       return;
     }
@@ -66,16 +81,35 @@ function useAuthBootstrap() {
     let isMounted = true;
     setAuthBootstrapLoading();
 
-    void ensureAuthBootstrap().finally(() => {
-      if (isMounted) {
-        setAuthBootstrapReady();
-      }
-    });
+    void ensureAuthBootstrap()
+      .catch((error) => {
+        if (!hasPendingSocialProvider || !isMounted) {
+          return;
+        }
+
+        navigate(`/${ROUTES.LOGIN}`, {
+          replace: true,
+          state: {
+            errorMessage:
+              extractAuthApiErrorMessage(error) ||
+              DEFAULT_SOCIAL_AUTH_ERROR_MESSAGE,
+          },
+        });
+      })
+      .finally(() => {
+        if (hasPendingSocialProvider) {
+          clearPendingSocialAuthProvider();
+        }
+
+        if (isMounted) {
+          setAuthBootstrapReady();
+        }
+      });
 
     return () => {
       isMounted = false;
     };
-  }, [location.pathname]);
+  }, [location.pathname, navigate]);
 
   return {
     authBootstrapStatus,

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -16,6 +16,7 @@ import type {
   ConfirmProfileImageRequest,
   ConfirmProfileImageResponse,
   CurrentUserProfileResponse,
+  CurrentUserSocialResponse,
   DeleteLikedGameResponse,
   LikedGameItemResponse,
   LoginRequest,
@@ -31,9 +32,10 @@ import type {
 import { createMockUserMap, type MockUserRecord } from './mockUsers';
 
 const mockUsers = createMockUserMap();
-const AUTH_CALLBACK_PATH = ROUTE_PATHS.AUTH_CALLBACK;
 
 const validGenders: AuthGender[] = ['M', 'W'];
+const DEFAULT_MOCK_SOCIAL_TYPE = 'nomal';
+type MockSocialType = SocialAuthProvider | typeof DEFAULT_MOCK_SOCIAL_TYPE;
 
 const createAccessToken = (loginId: string) => `mock-access-token-${loginId}`;
 const parseLoginIdFromRefreshToken = (refreshToken: string) => {
@@ -50,7 +52,9 @@ const parseLoginIdFromRefreshToken = (refreshToken: string) => {
 };
 const MOCK_S3_HOST = 'https://mock-s3.oz-union-16.com';
 let refreshSessionLoginId: string | null = null;
+let refreshSessionSocialType: MockSocialType | null = null;
 let pendingSocialLoginId: string | null = null;
+let pendingSocialProvider: SocialAuthProvider | null = null;
 
 const mockLikedGamesByLoginId = new Map<string, LikedGameItemResponse[]>(
   [...mockUsers.keys()].map((loginId) => [loginId, []]),
@@ -143,6 +147,19 @@ const getMockSocialLoginId = (provider: SocialAuthProvider) => {
 
   return 'pgti-demo';
 };
+
+const getCurrentMockSocialAccount = (
+  user: MockUserRecord,
+): CurrentUserSocialResponse => ({
+  is_social:
+    refreshSessionLoginId === user.loginId && !!refreshSessionSocialType
+      ? refreshSessionSocialType !== DEFAULT_MOCK_SOCIAL_TYPE
+      : false,
+  social_type:
+    refreshSessionLoginId === user.loginId && refreshSessionSocialType
+      ? refreshSessionSocialType
+      : DEFAULT_MOCK_SOCIAL_TYPE,
+});
 
 const sanitizeFileName = (fileName: string) => {
   const normalizedFileName = fileName.trim().replace(/\s+/g, '-');
@@ -314,13 +331,14 @@ const loginHandlers = [
     }
 
     pendingSocialLoginId = getMockSocialLoginId(provider);
+    pendingSocialProvider = provider;
 
     await delay(120);
 
     return new HttpResponse(null, {
       status: 302,
       headers: {
-        Location: AUTH_CALLBACK_PATH,
+        Location: ROUTE_PATHS.HOME,
       },
     });
   }),
@@ -354,6 +372,9 @@ const loginHandlers = [
 
     await delay(500);
     refreshSessionLoginId = user.loginId;
+    refreshSessionSocialType = DEFAULT_MOCK_SOCIAL_TYPE;
+    pendingSocialLoginId = null;
+    pendingSocialProvider = null;
 
     return HttpResponse.json({
       access_token: createAccessToken(user.loginId),
@@ -371,6 +392,10 @@ const loginHandlers = [
       : null;
     const loginId =
       pendingSocialLoginId ?? loginIdFromRefreshToken ?? refreshSessionLoginId;
+    const nextSocialType =
+      pendingSocialProvider ??
+      refreshSessionSocialType ??
+      DEFAULT_MOCK_SOCIAL_TYPE;
 
     if (!loginId) {
       return HttpResponse.json(
@@ -383,6 +408,8 @@ const loginHandlers = [
 
     pendingSocialLoginId = null;
     refreshSessionLoginId = loginId;
+    refreshSessionSocialType = nextSocialType;
+    pendingSocialProvider = null;
 
     await delay(180);
 
@@ -564,6 +591,19 @@ const accountHandlers = [
     };
 
     return HttpResponse.json(responseBody);
+  }),
+
+  http.get(`${AUTH_BASE_PATH}/me/social`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+    const user = getAuthorizedUser(authorization);
+
+    if (!user) {
+      return getUnauthorizedError('로그인이 필요합니다.');
+    }
+
+    await delay(160);
+
+    return HttpResponse.json(getCurrentMockSocialAccount(user));
   }),
 
   http.patch(`${AUTH_BASE_PATH}/me`, async ({ request }) => {
@@ -1007,9 +1047,13 @@ const accountHandlers = [
     mockLikedGamesByLoginId.delete(user.loginId);
     if (refreshSessionLoginId === user.loginId) {
       refreshSessionLoginId = null;
+      refreshSessionSocialType = null;
     }
     if (pendingSocialLoginId === user.loginId) {
       pendingSocialLoginId = null;
+    }
+    if (pendingSocialProvider) {
+      pendingSocialProvider = null;
     }
     [...mockUploadedProfileImagesByPath.keys()]
       .filter((key) => key.startsWith(`${user.loginId}/`))
@@ -1120,7 +1164,9 @@ const logoutHandlers = [
 
     await delay(200);
     refreshSessionLoginId = null;
+    refreshSessionSocialType = null;
     pendingSocialLoginId = null;
+    pendingSocialProvider = null;
 
     return HttpResponse.json({
       detail: '로그아웃 되었습니다.',

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -16,6 +16,11 @@ export interface RefreshAccessTokenResponse {
   refresh_token?: string | null;
 }
 
+export interface CurrentUserSocialResponse {
+  is_social: boolean;
+  social_type: string;
+}
+
 export interface LogoutResponse {
   detail: string;
 }

--- a/src/features/auth/utils/sessionManager.ts
+++ b/src/features/auth/utils/sessionManager.ts
@@ -5,9 +5,16 @@ import {
   createAuthSessionExpiredEvent,
   type AuthSessionExpiredDetail,
 } from '../constants/session';
-import { getCurrentUserProfile, refreshAccessToken } from '../api/auth';
+import {
+  getCurrentUserProfile,
+  getCurrentUserSocialProfile,
+  refreshAccessToken,
+} from '../api/auth';
 import { logRefreshStoreSync } from '../api/auth.diagnostics';
-import type { CurrentUserProfileResponse } from '../types/auth';
+import type {
+  CurrentUserProfileResponse,
+  CurrentUserSocialResponse,
+} from '../types/auth';
 
 export const setAuthBootstrapLoading = () => {
   useAuthStore.getState().setAuthBootstrapStatus('loading');
@@ -21,6 +28,12 @@ export const syncAuthAccount = (account: CurrentUserProfileResponse | null) => {
   useAuthStore.getState().setAccount(account);
 };
 
+export const syncAuthSocialAccount = (
+  socialAccount: CurrentUserSocialResponse | null,
+) => {
+  useAuthStore.getState().setSocialAccount(socialAccount);
+};
+
 export const applyAccessToken = (accessToken: string) => {
   useAuthStore.getState().setAccessToken(accessToken);
 };
@@ -28,8 +41,9 @@ export const applyAccessToken = (accessToken: string) => {
 export const applyAuthenticatedSession = (
   accessToken: string,
   account: CurrentUserProfileResponse,
+  socialAccount: CurrentUserSocialResponse,
 ) => {
-  useAuthStore.getState().setAuth(accessToken, account);
+  useAuthStore.getState().setAuth(accessToken, account, socialAccount);
   setAuthBootstrapReady();
 };
 
@@ -54,12 +68,16 @@ export const hydrateAuthSessionFromAccessToken = async (
   applyAccessToken(accessToken);
 
   try {
-    const profile = await getCurrentUserProfile();
-    applyAuthenticatedSession(accessToken, profile);
+    const [profile, socialAccount] = await Promise.all([
+      getCurrentUserProfile(),
+      getCurrentUserSocialProfile(),
+    ]);
+    applyAuthenticatedSession(accessToken, profile, socialAccount);
 
     return {
       accessToken,
       profile,
+      socialAccount,
     };
   } catch (error) {
     clearAuthSession();

--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -6,41 +6,15 @@ export type { SocialAuthProvider } from '../types/auth';
 
 const PENDING_SOCIAL_PROVIDER_STORAGE_KEY = 'pending-social-auth-provider';
 
-const SOCIAL_AUTH_START_URL_ENV_KEYS: Record<SocialAuthProvider, string[]> = {
-  google: ['VITE_GOOGLE_LOGIN_URL', 'VITE_SOCIAL_LOGIN_GOOGLE_URL'],
-  kakao: ['VITE_KAKAO_LOGIN_URL', 'VITE_SOCIAL_LOGIN_KAKAO_URL'],
-  naver: ['VITE_NAVER_LOGIN_URL', 'VITE_SOCIAL_LOGIN_NAVER_URL'],
-};
-
 const SOCIAL_AUTH_START_PATHS: Record<SocialAuthProvider, string> = {
   google: `${AUTH_BASE_PATH}/social-login/google`,
   kakao: `${AUTH_BASE_PATH}/social-login/kakao`,
   naver: `${AUTH_BASE_PATH}/social-login/naver`,
 };
 
-const getSocialLoginStartUrlFromEnv = (provider: SocialAuthProvider) => {
-  const env = import.meta.env as Record<string, string | undefined>;
-
-  for (const envKey of SOCIAL_AUTH_START_URL_ENV_KEYS[provider]) {
-    const value = env[envKey]?.trim();
-
-    if (value) {
-      return value;
-    }
-  }
-
-  return null;
-};
-
 export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
   if (mockServiceWorkerEnabled) {
     return SOCIAL_AUTH_START_PATHS[provider];
-  }
-
-  const configuredUrl = getSocialLoginStartUrlFromEnv(provider);
-
-  if (configuredUrl) {
-    return configuredUrl;
   }
 
   const normalizedApiBaseUrl = apiBaseUrl.trim().replace(/\/$/, '');
@@ -67,6 +41,25 @@ export const clearPendingSocialAuthProvider = () => {
 
   window.sessionStorage.removeItem(PENDING_SOCIAL_PROVIDER_STORAGE_KEY);
 };
+
+export const getPendingSocialAuthProvider = (): SocialAuthProvider | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const provider = window.sessionStorage
+    .getItem(PENDING_SOCIAL_PROVIDER_STORAGE_KEY)
+    ?.trim();
+
+  if (provider === 'google' || provider === 'kakao' || provider === 'naver') {
+    return provider;
+  }
+
+  return null;
+};
+
+export const hasPendingSocialAuthProvider = () =>
+  Boolean(getPendingSocialAuthProvider());
 
 const getSocialCallbackErrorMessageFromCode = (errorCode: string | null) => {
   if (!errorCode) {

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,5 +1,8 @@
 import { create } from 'zustand';
-import type { CurrentUserProfileResponse } from '../features/auth/types/auth';
+import type {
+  CurrentUserProfileResponse,
+  CurrentUserSocialResponse,
+} from '../features/auth/types/auth';
 
 /**
  * [Auth] 쿠키 기반 세션 복구 업데이트
@@ -42,12 +45,18 @@ const persistProfilePreviewImageUrl = (profileImageUrl?: string | null) => {
 interface AuthState {
   accessToken: string | null;
   account: CurrentUserProfileResponse | null;
+  socialAccount: CurrentUserSocialResponse | null;
   profilePreviewImageUrl: string | null;
   isAuthenticated: boolean;
   authBootstrapStatus: AuthBootstrapStatus;
   setAccessToken: (token: string) => void;
   setAccount: (account: CurrentUserProfileResponse | null) => void;
-  setAuth: (token: string, account: CurrentUserProfileResponse) => void;
+  setSocialAccount: (socialAccount: CurrentUserSocialResponse | null) => void;
+  setAuth: (
+    token: string,
+    account: CurrentUserProfileResponse,
+    socialAccount: CurrentUserSocialResponse,
+  ) => void;
   clearAuth: () => void;
   setAuthBootstrapStatus: (status: AuthBootstrapStatus) => void;
 }
@@ -62,6 +71,7 @@ export type AuthSessionStateSnapshot = {
 export const useAuthStore = create<AuthState>((set) => ({
   accessToken: null,
   account: null,
+  socialAccount: null,
   profilePreviewImageUrl: readPersistedProfilePreviewImageUrl(),
   isAuthenticated: false,
   authBootstrapStatus: 'idle',
@@ -80,11 +90,18 @@ export const useAuthStore = create<AuthState>((set) => ({
     });
   },
 
-  setAuth: (token, account) => {
+  setSocialAccount: (socialAccount) => {
+    set({
+      socialAccount,
+    });
+  },
+
+  setAuth: (token, account, socialAccount) => {
     persistProfilePreviewImageUrl(account?.profile_img_url);
     set({
       accessToken: token,
       account: account,
+      socialAccount,
       profilePreviewImageUrl: account?.profile_img_url?.trim() ?? null,
       isAuthenticated: true,
     });
@@ -95,6 +112,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({
       accessToken: null,
       account: null,
+      socialAccount: null,
       profilePreviewImageUrl: null,
       isAuthenticated: false,
     });


### PR DESCRIPTION
## 관련 이슈

- closes #319 

## 변경 내용

- 구글, 카카오, 네이버 소셜 로그인 시작을 `window.location.href` 기반 리다이렉트로 변경했습니다.
- 앱 최상단 bootstrap에서 `POST /api/v1/accounts/token/refresh`를 호출해 access token을 복구하고, 이를 Zustand In-Memory 상태에 저장하도록 구현했습니다.
- 토큰 복구 직후 `GET /api/v1/accounts/me/social`을 호출해 `is_social`, `social_type`을 전역 상태에 반영하도록 연결했습니다.
- Axios 인터셉터에서 메모리의 access token을 `Authorization` 헤더에 주입하고, 401 발생 시 refresh 후 원 요청을 재시도하는 silent refresh 흐름을 정리했습니다.
- MSW mock도 소셜 로그인 302, refresh, `/api/v1/accounts/me/social` 응답 구조에 맞게 함께 정리했습니다.
- 기존 `/callback` 호환 경로는 유지하면서, 홈 진입 bootstrap에서도 소셜 세션 복구가 가능하도록 보완했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

-
