### PR TITLE
[Fix] 설문 타임아웃 증가 및 로딩 UI 정리

### DIFF
--- a/src/components/auth/AuthGateStatusPanel.tsx
+++ b/src/components/auth/AuthGateStatusPanel.tsx
@@ -1,8 +1,11 @@
+import { LoaderCircle } from 'lucide-react';
+
 type AuthGateStatusPanelProps = {
   title: string;
-  description: string;
+  description?: string;
   align?: 'left' | 'center';
   className?: string;
+  showSpinner?: boolean;
 };
 
 function AuthGateStatusPanel({
@@ -10,6 +13,7 @@ function AuthGateStatusPanel({
   description,
   align = 'left',
   className = '',
+  showSpinner = false,
 }: AuthGateStatusPanelProps) {
   return (
     <section
@@ -17,10 +21,21 @@ function AuthGateStatusPanel({
         align === 'center' ? 'text-center' : ''
       } ${className}`.trim()}
     >
+      {showSpinner ? (
+        <div
+          className={`mb-4 flex ${align === 'center' ? 'justify-center' : 'justify-start'}`}
+        >
+          <span className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/4 text-white/72">
+            <LoaderCircle size={20} className="animate-spin" />
+          </span>
+        </div>
+      ) : null}
       <h2 className="text-2xl font-bold text-white">{title}</h2>
-      <p className="mt-4 text-base leading-7 break-keep text-white/60">
-        {description}
-      </p>
+      {description ? (
+        <p className="mt-4 text-base leading-7 break-keep text-white/60">
+          {description}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/src/components/common/CenteredLoadingState.tsx
+++ b/src/components/common/CenteredLoadingState.tsx
@@ -1,0 +1,51 @@
+import { LoaderCircle } from 'lucide-react';
+
+type CenteredLoadingStateProps = {
+  title: string;
+  hint?: string;
+  label?: string;
+  className?: string;
+};
+
+function CenteredLoadingState({
+  title,
+  hint,
+  label = 'Loading',
+  className = '',
+}: CenteredLoadingStateProps) {
+  return (
+    <section
+      className={`flex min-h-[min(54vh,30rem)] items-center justify-center ${className}`.trim()}
+    >
+      <div className="relative w-full max-w-xl overflow-hidden rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,20,0.92),rgba(9,9,10,0.98))] px-7 py-9 text-center shadow-[0_28px_80px_rgba(0,0,0,0.34)] backdrop-blur-xl sm:px-9 sm:py-10">
+        <div className="absolute inset-x-10 top-0 h-px bg-[linear-gradient(90deg,transparent,rgba(255,255,255,0.32),transparent)]" />
+
+        <div className="inline-flex items-center rounded-full border border-[#7c2626]/35 bg-[#180909]/55 px-3 py-1 text-[10px] font-semibold tracking-[0.26em] text-white/52 uppercase">
+          {label}
+        </div>
+
+        <div className="mx-auto mt-5 flex h-16 w-16 items-center justify-center rounded-full border border-[#8d2c2c]/35 bg-[radial-gradient(circle_at_30%_30%,rgba(255,120,120,0.18),rgba(255,255,255,0.03))] text-[#f1b8b8] shadow-[0_0_0_8px_rgba(255,255,255,0.02)]">
+          <LoaderCircle size={26} className="animate-spin" />
+        </div>
+
+        <h2 className="mt-5 text-[26px] font-semibold tracking-[-0.03em] break-keep text-white sm:text-[30px]">
+          {title}
+        </h2>
+
+        {hint ? (
+          <p className="mt-3 text-sm leading-6 break-keep text-white/46 sm:text-[15px]">
+            {hint}
+          </p>
+        ) : null}
+
+        <div className="mt-6 flex items-center justify-center gap-2">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white/25" />
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white/40 [animation-delay:120ms]" />
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white/25 [animation-delay:240ms]" />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CenteredLoadingState;

--- a/src/features/survey/api/survey.ts
+++ b/src/features/survey/api/survey.ts
@@ -36,6 +36,7 @@ interface ErrorResponseBody {
 
 const SURVEY_BASE_PATH = '/api/v1/survey';
 const SURVEY_CHATBOT_BASE_PATH = `${SURVEY_BASE_PATH}/chatbot`;
+const SURVEY_CHATBOT_REQUEST_TIMEOUT_MS = 45_000;
 
 const clampProgressRate = (value: number | null | undefined) => {
   if (typeof value !== 'number' || Number.isNaN(value)) {
@@ -147,6 +148,9 @@ export const startSurveySession = async (
     const response = await api.post<SurveyApiSessionResponse>(
       `${SURVEY_CHATBOT_BASE_PATH}/sessions/`,
       payload satisfies SurveyApiSessionStartRequest,
+      {
+        timeout: SURVEY_CHATBOT_REQUEST_TIMEOUT_MS,
+      },
     );
 
     return normalizeSurveySessionResponse(response.data);
@@ -168,6 +172,9 @@ export const continueSurveyChat = async (
       {
         message: payload.user_answer,
       } satisfies SurveyApiChatRequest,
+      {
+        timeout: SURVEY_CHATBOT_REQUEST_TIMEOUT_MS,
+      },
     );
 
     return normalizeSurveySessionResponse(response.data);
@@ -189,6 +196,10 @@ export const resetSurveySession = async () => {
   try {
     const response = await api.post<SurveyApiResetResponse>(
       `${SURVEY_CHATBOT_BASE_PATH}/sessions/reset/`,
+      undefined,
+      {
+        timeout: SURVEY_CHATBOT_REQUEST_TIMEOUT_MS,
+      },
     );
 
     return normalizeSurveyResetResponse(response.data);
@@ -233,6 +244,10 @@ export const getSurveyResults = async (query: SurveyResultQuery) => {
 export const extractApiErrorMessage = (error: unknown) => {
   if (!(error instanceof AxiosError)) {
     return '요청을 처리하는 중 알 수 없는 오류가 발생했습니다.';
+  }
+
+  if (error.code === 'ECONNABORTED') {
+    return '응답 생성이 평소보다 오래 걸리고 있어요. 잠시 후 다시 시도해 주세요.';
   }
 
   if (!error.response) {

--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -11,6 +11,7 @@ import {
   SendHorizontal,
   TriangleAlert,
 } from 'lucide-react';
+import CenteredLoadingState from '../../../components/common/CenteredLoadingState';
 
 import { ROUTES } from '../../../constants/routes';
 import { useSurveyStore } from '../store/useSurveyStore';
@@ -182,11 +183,12 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
             className="survey-message-scroll max-h-none flex-1 space-y-4 px-4 py-4 sm:px-5 sm:py-4.5 md:px-6"
           >
             {!messages.length && isSubmitting ? (
-              <div className="flex w-full justify-start">
-                <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-3.5 text-sm text-white/60">
-                  AI가 첫 질문을 준비하고 있습니다...
-                </div>
-              </div>
+              <CenteredLoadingState
+                label="Survey"
+                title="AI가 첫 질문을 준비하고 있습니다."
+                hint="취향을 더 잘 이해할 수 있도록 질문 흐름을 정리하고 있어요."
+                className="py-6"
+              />
             ) : null}
 
             {messages.map((message) => (

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
+import CenteredLoadingState from '../../components/common/CenteredLoadingState';
 import LazyHeader from '../../components/common/LazyHeader';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
@@ -254,11 +255,11 @@ function MatchingGenreDetailPage() {
             </Link>
           </section>
         ) : authGate.accessStatus === 'loading' ? (
-          <AuthGateStatusPanel
-            title="인증 상태를 확인하는 중입니다."
-            description="잠시만 기다려 주세요. 세션 확인 후 매칭 화면을 불러옵니다."
-            align="center"
-            className="mx-auto max-w-190 sm:py-12"
+          <CenteredLoadingState
+            label="Matching"
+            title="매칭 화면을 불러오는 중입니다."
+            hint="트레일러와 평가 흐름을 준비하고 있어요."
+            className="mx-auto max-w-190"
           />
         ) : !canAccessPage ? (
           <AuthGateStatusPanel
@@ -268,9 +269,12 @@ function MatchingGenreDetailPage() {
             align="center"
           />
         ) : matchCandidatesQuery.isLoading ? (
-          <section className="survey-panel mx-auto max-w-190 px-6 py-10 text-center text-white/68 sm:px-8 sm:py-12">
-            매칭 후보 게임을 불러오는 중입니다...
-          </section>
+          <CenteredLoadingState
+            label="Matching"
+            title="매칭 후보 게임을 불러오는 중입니다."
+            hint="이번 장르에 맞는 후보를 정리하고 있어요."
+            className="mx-auto max-w-190"
+          />
         ) : matchCandidatesQuery.error ? (
           <section className="survey-panel mx-auto max-w-190 px-6 py-10 sm:px-8 sm:py-12">
             <p className="text-sm font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -3,6 +3,7 @@ import { useLayoutEffect, useMemo } from 'react';
 import { Link, Navigate, useLocation } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
+import CenteredLoadingState from '../../components/common/CenteredLoadingState';
 import LazyHeader from '../../components/common/LazyHeader';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
@@ -55,11 +56,11 @@ function MatchingListPage() {
 
       <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-22 pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-25 md:pb-14">
         {authGate.accessStatus === 'loading' ? (
-          <AuthGateStatusPanel
-            title="인증 상태를 확인하는 중입니다."
-            description="잠시만 기다려 주세요. 세션 확인 후 장르별 매칭 화면을 보여드릴게요."
-            align="center"
-            className="mx-auto max-w-190 sm:py-12"
+          <CenteredLoadingState
+            label="Matching"
+            title="장르별 매칭을 준비하고 있어요."
+            hint="취향에 맞는 장르 카드를 정리하고 있습니다."
+            className="mx-auto max-w-190"
           />
         ) : !canAccessPage ? (
           <AuthGateStatusPanel

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -10,6 +10,7 @@ import { Link } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import ActionButton from '../../components/common/ActionButton';
+import CenteredLoadingState from '../../components/common/CenteredLoadingState';
 import LazyHeader from '../../components/common/LazyHeader';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
@@ -95,8 +96,8 @@ function RecommendationRow({
           </div>
         </div>
 
-        <p className="mt-2 text-[11px] font-medium tracking-[0.22em] text-white/32 uppercase">
-          {item.genres.join(' · ') || '장르 정보 준비 중'}
+        <p className="mt-2 text-sm leading-6 break-keep text-white/54">
+          {item.genres.join(' / ') || '장르 정보 준비 중'}
         </p>
       </div>
 
@@ -179,7 +180,6 @@ function RecommendationListPage() {
     isMatchSource,
     isSurveySource,
     recommendationItems,
-    recommendationHighlights,
     errorMessage,
     emptyStateMessage,
     isResultNotFound,
@@ -232,25 +232,17 @@ function RecommendationListPage() {
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-300 flex-col px-3 pt-24 pb-8 sm:px-4 sm:pt-28 sm:pb-10 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
         <section className="mx-auto flex min-h-0 w-full max-w-245 flex-1 flex-col">
           <div className="mb-8">
-            <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-              <div>
+            <div className="grid gap-4 md:grid-cols-[1fr_auto_1fr] md:items-end">
+              <div className="hidden md:block" />
+
+              <div className="text-center">
                 <h1 className="text-3xl font-semibold tracking-[-0.04em] text-white sm:text-4xl md:text-[52px]">
                   게임 추천 리스트
                 </h1>
-                <div className="mt-5 flex flex-wrap gap-2.5">
-                  {recommendationHighlights.map((highlight) => (
-                    <span
-                      key={highlight}
-                      className="inline-flex items-center rounded-full border border-white/8 bg-white/3 px-3 py-1.5 text-xs font-medium text-white/68 backdrop-blur-sm"
-                    >
-                      {highlight}
-                    </span>
-                  ))}
-                </div>
               </div>
 
               {shouldShowSurveyActions ? (
-                <div className="flex flex-wrap items-center gap-2.5 md:justify-end">
+                <div className="flex flex-wrap items-center justify-center gap-2.5 md:justify-end">
                   <button
                     type="button"
                     onClick={handleViewPreviousSurvey}
@@ -268,14 +260,17 @@ function RecommendationListPage() {
                     {isResettingSurvey ? '설문 초기화 중...' : '설문 초기화'}
                   </button>
                 </div>
-              ) : null}
+              ) : (
+                <div className="hidden md:block" />
+              )}
             </div>
           </div>
 
           {authGate.accessStatus === 'loading' ? (
-            <AuthGateStatusPanel
-              title="인증 상태를 확인하는 중입니다."
-              description="잠시만 기다려 주세요. 세션 확인 후 추천 결과를 불러옵니다."
+            <CenteredLoadingState
+              label="Recommendation"
+              title="추천 결과 화면을 불러오는 중입니다."
+              hint="추천 결과와 좋아요 상태를 함께 불러오고 있어요."
             />
           ) : !canAccessPage ? (
             <AuthGateStatusPanel
@@ -324,9 +319,12 @@ function RecommendationListPage() {
               ) : null}
 
               {isLoading ? (
-                <div className="px-4 py-14 text-center text-white/65 sm:px-6 lg:px-7">
-                  추천 결과를 불러오는 중입니다...
-                </div>
+                <CenteredLoadingState
+                  label="Recommendation"
+                  title="추천 결과를 불러오는 중입니다."
+                  hint="게임 취향에 맞는 결과를 정리하고 있어요."
+                  className="px-4 py-14 sm:px-6 lg:px-7"
+                />
               ) : error && !isResultNotFound ? (
                 <div className="px-4 py-12 text-[#ffc2c2] sm:px-6 lg:px-7">
                   {errorMessage}

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Navigate, useLocation, useSearchParams } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
+import CenteredLoadingState from '../../components/common/CenteredLoadingState';
 import LazyHeader from '../../components/common/LazyHeader';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
@@ -133,11 +134,11 @@ function SurveyPage() {
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
         {authGate.accessStatus === 'loading' ? (
-          <AuthGateStatusPanel
-            title="인증 상태를 확인하는 중입니다."
-            description="잠시만 기다려 주세요. 세션 확인 후 설문 화면을 이어서 보여드릴게요."
-            align="center"
-            className="mx-auto max-w-190 sm:py-12"
+          <CenteredLoadingState
+            label="Survey"
+            title="AI가 첫 질문을 준비하고 있습니다."
+            hint="질문 흐름을 정리하고 있어요."
+            className="mx-auto max-w-190"
           />
         ) : canAccessSurvey ? (
           <SurveyChatPanel isHistoryView={isHistoryMode} />


### PR DESCRIPTION
## 관련 이슈

- closes #330 

## 변경 내용

- 설문 챗봇 세션 시작, 메시지 전송, 세션 초기화 요청의 타임아웃을 45초로 늘렸습니다.
- 설문 응답 생성이 오래 걸릴 때 발생하는 `ECONNABORTED` 케이스를 별도 문구로 처리하도록 보강했습니다.
- 설문, 매칭, 추천 결과 페이지의 로딩 상태를 공통된 중앙 정렬 UI 기준으로 정리했습니다.
- 설문 페이지 새로고침 시 로딩 문구를 `AI가 첫 질문을 준비하고 있습니다.` 기준으로 맞춰, 중복 단계처럼 느껴지지 않도록 정리했습니다.
- `장르별 게임 매칭` 진입 전 로딩과 매칭 후보 조회 중 로딩도 같은 스타일로 통일했습니다.
- 추천 결과 페이지 상단의 하이라이트 배너를 제거하고, `게임 추천 리스트` 헤더를 중앙 정렬로 수정했습니다.
- 추천 리스트 카드 내부 장르 표기는 `·` 대신 `/` 기준으로 정리해 가독성을 보강했습니다.

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 기능 변경보다 설문 응답 지연 대응과 로딩 상태의 시각적 완성도 개선에 집중했습니다.
- 설문, 매칭, 추천 결과 화면이 각각 다른 로딩 톤으로 보이지 않도록 공통된 흐름으로 정리했습니다.
