### PR TITLE
[Fix] 중복확인 토스트 위치와 줄바꿈 표시 정리

### DIFF
--- a/src/components/mypage/ToastMessage.tsx
+++ b/src/components/mypage/ToastMessage.tsx
@@ -5,6 +5,7 @@ type ToastMessageTone = 'success' | 'error';
 type ToastMessageVariant =
   | 'fixed'
   | 'fixedCenter'
+  | 'fixedTopCenter'
   | 'absoluteCenter'
   | 'absoluteTopCenter';
 
@@ -35,11 +36,13 @@ function ToastMessage({
   } else if (variant === 'fixedCenter') {
     positioningClass =
       'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2';
+  } else if (variant === 'fixedTopCenter') {
+    positioningClass = 'fixed top-24 left-1/2 -translate-x-1/2 sm:top-28';
   }
 
   return (
     <div
-      className={`bg-mypage-panel border-mypage-panel shadow-mypage-float z-70 flex w-fit max-w-[min(92vw,360px)] items-start gap-3 rounded-2xl border px-4 py-3 backdrop-blur-xl ${positioningClass} ${className}`}
+      className={`bg-mypage-panel border-mypage-panel shadow-mypage-float z-80 flex w-max items-start gap-3 rounded-2xl border px-4 py-3 backdrop-blur-xl ${positioningClass} ${className}`}
     >
       <span
         className={`mt-0.5 shrink-0 ${
@@ -48,7 +51,7 @@ function ToastMessage({
       >
         <Icon size={18} />
       </span>
-      <p className="min-w-0 text-sm/6 font-medium wrap-break-word text-white">
+      <p className="text-sm/6 font-medium whitespace-nowrap text-white">
         {message}
       </p>
       <button

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -38,191 +38,187 @@ function SignupPage() {
     handleSubmit,
     closeDuplicateCheckToast,
   } = useSignupForm();
+  const duplicateCheckToast = loginIdToast ?? nicknameToast;
 
   return (
-    <AuthLayout
-      title="회원가입"
-      titleClassName="text-[clamp(1.68rem,4vw,2.45rem)]"
-      withPanel
-      panelClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.panel}
-      contentClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.content}
-    >
-      <form
-        className={`${AUTH_SHARED_FORM_CLASS_NAMES.form} mt-5 sm:mt-6`}
-        autoComplete="on"
-        onSubmit={handleSubmit}
+    <>
+      {duplicateCheckToast ? (
+        <ToastMessage
+          message={duplicateCheckToast.message}
+          tone={duplicateCheckToast.tone}
+          onClose={closeDuplicateCheckToast}
+          variant="fixedTopCenter"
+        />
+      ) : null}
+
+      <AuthLayout
+        title="회원가입"
+        titleClassName="text-[clamp(1.68rem,4vw,2.45rem)]"
+        withPanel
+        panelClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.panel}
+        contentClassName={AUTH_SHARED_LAYOUT_CLASS_NAMES.content}
       >
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -z-10 h-0 w-0 overflow-hidden opacity-0"
+        <form
+          className={`${AUTH_SHARED_FORM_CLASS_NAMES.form} mt-5 sm:mt-6`}
+          autoComplete="on"
+          onSubmit={handleSubmit}
         >
-          <input type="text" tabIndex={-1} autoComplete="username" />
-          <input type="password" tabIndex={-1} autoComplete="new-password" />
-        </div>
-
-        <AuthInputField
-          id={SIGNUP_FORM_FIELD_IDS.name}
-          name="name"
-          label="이름"
-          type="text"
-          autoComplete="name"
-          placeholder="이름을 입력하세요"
-          maxLength={SIGNUP_FORM_FIELD_MAX_LENGTHS.name}
-          value={formValues.name}
-          onChange={(event) => handleFieldChange('name', event.target.value)}
-          onBlur={() => handleFieldBlur('name')}
-          errorMessage={resolvedFieldErrors.name}
-          disabled={isSubmitting}
-        />
-
-        <AuthInputField
-          id={SIGNUP_FORM_FIELD_IDS.login_id}
-          name="login_id"
-          label="아이디"
-          type="text"
-          autoComplete="username"
-          placeholder="아이디를 입력하세요"
-          maxLength={SIGNUP_FORM_FIELD_MAX_LENGTHS.login_id}
-          value={formValues.login_id}
-          onChange={(event) =>
-            handleFieldChange('login_id', event.target.value)
-          }
-          onBlur={() => handleFieldBlur('login_id')}
-          errorMessage={resolvedFieldErrors.login_id}
-          helperMessage={loginIdHelperMessage}
-          helperMessageTone="success"
-          disabled={isSubmitting}
-          action={
-            <AuthInputActionButton
-              onClick={handleCheckLoginIdDuplicate}
-              disabled={
-                isCheckingLoginIdDuplicate || isSubmitting || isLoginIdVerified
-              }
-            >
-              {isCheckingLoginIdDuplicate
-                ? '확인 중...'
-                : isLoginIdVerified
-                  ? '확인완료'
-                  : '중복확인'}
-            </AuthInputActionButton>
-          }
-          toast={
-            loginIdToast ? (
-              <ToastMessage
-                message={loginIdToast.message}
-                tone={loginIdToast.tone}
-                onClose={closeDuplicateCheckToast}
-                variant="absoluteCenter"
-              />
-            ) : null
-          }
-        />
-
-        <AuthInputField
-          id={SIGNUP_FORM_FIELD_IDS.nickname}
-          name="nickname"
-          label="닉네임"
-          type="text"
-          autoComplete="nickname"
-          placeholder="닉네임을 입력하세요"
-          maxLength={SIGNUP_FORM_FIELD_MAX_LENGTHS.nickname}
-          value={formValues.nickname}
-          onChange={(event) =>
-            handleFieldChange('nickname', event.target.value)
-          }
-          onBlur={() => handleFieldBlur('nickname')}
-          errorMessage={resolvedFieldErrors.nickname}
-          helperMessage={nicknameHelperMessage}
-          helperMessageTone="success"
-          disabled={isSubmitting}
-          action={
-            <AuthInputActionButton
-              onClick={handleCheckNicknameDuplicate}
-              disabled={
-                isCheckingNicknameDuplicate ||
-                isSubmitting ||
-                isNicknameVerified
-              }
-            >
-              {isCheckingNicknameDuplicate
-                ? '확인 중...'
-                : isNicknameVerified
-                  ? '확인완료'
-                  : '중복확인'}
-            </AuthInputActionButton>
-          }
-          toast={
-            nicknameToast ? (
-              <ToastMessage
-                message={nicknameToast.message}
-                tone={nicknameToast.tone}
-                onClose={closeDuplicateCheckToast}
-                variant="absoluteCenter"
-              />
-            ) : null
-          }
-        />
-
-        <AuthInputField
-          id={SIGNUP_FORM_FIELD_IDS.password}
-          name="password"
-          label="비밀번호"
-          type="password"
-          autoComplete="new-password"
-          placeholder="비밀번호를 입력하세요"
-          value={formValues.password}
-          onChange={(event) =>
-            handleFieldChange('password', event.target.value)
-          }
-          onBlur={() => handleFieldBlur('password')}
-          errorMessage={resolvedFieldErrors.password}
-          disabled={isSubmitting}
-        />
-
-        <AuthInputField
-          id={SIGNUP_FORM_FIELD_IDS.password_check}
-          name="password_check"
-          label="비밀번호 확인"
-          type="password"
-          autoComplete="new-password"
-          placeholder="비밀번호를 한번 더 입력하세요"
-          value={formValues.password_check}
-          onChange={(event) =>
-            handleFieldChange('password_check', event.target.value)
-          }
-          onBlur={() => handleFieldBlur('password_check')}
-          errorMessage={resolvedFieldErrors.password_check}
-          disabled={isSubmitting}
-        />
-
-        <AuthRadioGroup
-          label="성별"
-          name="gender"
-          idPrefix={SIGNUP_FORM_GENDER_ID_PREFIX}
-          value={formValues.gender}
-          options={SIGNUP_FORM_GENDER_OPTIONS}
-          onChange={(event) => handleFieldChange('gender', event.target.value)}
-          errorMessage={resolvedFieldErrors.gender}
-          disabled={isSubmitting}
-        />
-
-        {showFormMessage ? (
-          <AuthFormMessage
-            className={AUTH_SHARED_FORM_CLASS_NAMES.feedbackMessage}
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute -z-10 h-0 w-0 overflow-hidden opacity-0"
           >
-            {formMessage}
-          </AuthFormMessage>
-        ) : null}
+            <input type="text" tabIndex={-1} autoComplete="username" />
+            <input type="password" tabIndex={-1} autoComplete="new-password" />
+          </div>
 
-        <AuthButton
-          type="submit"
-          className={AUTH_SHARED_FORM_CLASS_NAMES.submitButton}
-          disabled={isSubmitting}
-        >
-          {isSubmitting ? '회원가입 중...' : '회원가입'}
-        </AuthButton>
-      </form>
-    </AuthLayout>
+          <AuthInputField
+            id={SIGNUP_FORM_FIELD_IDS.name}
+            name="name"
+            label="이름"
+            type="text"
+            autoComplete="name"
+            placeholder="이름을 입력하세요"
+            maxLength={SIGNUP_FORM_FIELD_MAX_LENGTHS.name}
+            value={formValues.name}
+            onChange={(event) => handleFieldChange('name', event.target.value)}
+            onBlur={() => handleFieldBlur('name')}
+            errorMessage={resolvedFieldErrors.name}
+            disabled={isSubmitting}
+          />
+
+          <AuthInputField
+            id={SIGNUP_FORM_FIELD_IDS.login_id}
+            name="login_id"
+            label="아이디"
+            type="text"
+            autoComplete="username"
+            placeholder="아이디를 입력하세요"
+            maxLength={SIGNUP_FORM_FIELD_MAX_LENGTHS.login_id}
+            value={formValues.login_id}
+            onChange={(event) =>
+              handleFieldChange('login_id', event.target.value)
+            }
+            onBlur={() => handleFieldBlur('login_id')}
+            errorMessage={resolvedFieldErrors.login_id}
+            helperMessage={loginIdHelperMessage}
+            helperMessageTone="success"
+            disabled={isSubmitting}
+            action={
+              <AuthInputActionButton
+                onClick={handleCheckLoginIdDuplicate}
+                disabled={
+                  isCheckingLoginIdDuplicate ||
+                  isSubmitting ||
+                  isLoginIdVerified
+                }
+              >
+                {isCheckingLoginIdDuplicate
+                  ? '확인 중...'
+                  : isLoginIdVerified
+                    ? '확인완료'
+                    : '중복확인'}
+              </AuthInputActionButton>
+            }
+          />
+
+          <AuthInputField
+            id={SIGNUP_FORM_FIELD_IDS.nickname}
+            name="nickname"
+            label="닉네임"
+            type="text"
+            autoComplete="nickname"
+            placeholder="닉네임을 입력하세요"
+            maxLength={SIGNUP_FORM_FIELD_MAX_LENGTHS.nickname}
+            value={formValues.nickname}
+            onChange={(event) =>
+              handleFieldChange('nickname', event.target.value)
+            }
+            onBlur={() => handleFieldBlur('nickname')}
+            errorMessage={resolvedFieldErrors.nickname}
+            helperMessage={nicknameHelperMessage}
+            helperMessageTone="success"
+            disabled={isSubmitting}
+            action={
+              <AuthInputActionButton
+                onClick={handleCheckNicknameDuplicate}
+                disabled={
+                  isCheckingNicknameDuplicate ||
+                  isSubmitting ||
+                  isNicknameVerified
+                }
+              >
+                {isCheckingNicknameDuplicate
+                  ? '확인 중...'
+                  : isNicknameVerified
+                    ? '확인완료'
+                    : '중복확인'}
+              </AuthInputActionButton>
+            }
+          />
+
+          <AuthInputField
+            id={SIGNUP_FORM_FIELD_IDS.password}
+            name="password"
+            label="비밀번호"
+            type="password"
+            autoComplete="new-password"
+            placeholder="비밀번호를 입력하세요"
+            value={formValues.password}
+            onChange={(event) =>
+              handleFieldChange('password', event.target.value)
+            }
+            onBlur={() => handleFieldBlur('password')}
+            errorMessage={resolvedFieldErrors.password}
+            disabled={isSubmitting}
+          />
+
+          <AuthInputField
+            id={SIGNUP_FORM_FIELD_IDS.password_check}
+            name="password_check"
+            label="비밀번호 확인"
+            type="password"
+            autoComplete="new-password"
+            placeholder="비밀번호를 한번 더 입력하세요"
+            value={formValues.password_check}
+            onChange={(event) =>
+              handleFieldChange('password_check', event.target.value)
+            }
+            onBlur={() => handleFieldBlur('password_check')}
+            errorMessage={resolvedFieldErrors.password_check}
+            disabled={isSubmitting}
+          />
+
+          <AuthRadioGroup
+            label="성별"
+            name="gender"
+            idPrefix={SIGNUP_FORM_GENDER_ID_PREFIX}
+            value={formValues.gender}
+            options={SIGNUP_FORM_GENDER_OPTIONS}
+            onChange={(event) =>
+              handleFieldChange('gender', event.target.value)
+            }
+            errorMessage={resolvedFieldErrors.gender}
+            disabled={isSubmitting}
+          />
+
+          {showFormMessage ? (
+            <AuthFormMessage
+              className={AUTH_SHARED_FORM_CLASS_NAMES.feedbackMessage}
+            >
+              {formMessage}
+            </AuthFormMessage>
+          ) : null}
+
+          <AuthButton
+            type="submit"
+            className={AUTH_SHARED_FORM_CLASS_NAMES.submitButton}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? '회원가입 중...' : '회원가입'}
+          </AuthButton>
+        </form>
+      </AuthLayout>
+    </>
   );
 }
 


### PR DESCRIPTION
## 관련 이슈

- closes #335 

## 변경 내용

- 회원가입 화면의 아이디/닉네임 중복확인 토스트를 입력 필드 내부가 아니라 화면 상단 중앙에 공통으로 표시되도록 변경했습니다.
- 토스트 메시지 텍스트에 `whitespace-nowrap`를 적용해 `"사용 가능한 아이디입니다."`, `"사용 가능한 닉네임입니다."`가 두 줄로 꺾이지 않도록 정리했습니다.
- 토스트 컨테이너를 `w-max` 기준으로 조정해 메시지 길이에 맞춰 배경 너비가 자연스럽게 늘어나도록 수정했습니다.
- 토스트 위치를 헤더와 회원가입 타이틀 사이 영역에 오도록 `fixed` 기준으로 조정하고, 가려지지 않도록 z-index를 높였습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

https://github.com/user-attachments/assets/07211de3-3c65-43e9-9854-ce22507d6e33

## 참고사항

-
