### PR TITLE
[Refactor] 마이페이지 및 찜한 목록 UI 개선, 삭제 API 오류 및 탈퇴 로직 종합 수정

### DIFF
--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -15,8 +15,8 @@ function FavoriteGameCard({
   onFavoriteClick,
 }: FavoriteGameCardProps) {
   return (
-    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex h-[22rem] w-full min-w-0 flex-col overflow-hidden rounded-[22px] border transition duration-200 sm:h-[24rem] lg:h-[25rem]">
-      <div className="bg-mypage-soft relative h-[15rem] overflow-hidden sm:h-[16.5rem] lg:h-[17.5rem]">
+    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex h-[21rem] w-full min-w-0 flex-col overflow-hidden rounded-[22px] border transition duration-200 sm:h-[23rem] xl:h-[24rem]">
+      <div className="bg-mypage-soft relative h-[15.75rem] overflow-hidden sm:h-[17.4rem] xl:h-[18.5rem]">
         <button
           type="button"
           onClick={() => onClick?.(game)}
@@ -52,12 +52,12 @@ function FavoriteGameCard({
       <button
         type="button"
         onClick={() => onClick?.(game)}
-        className="flex min-w-0 flex-1 cursor-pointer flex-col gap-1.5 px-3 py-3 text-left sm:gap-2 sm:px-4 sm:py-4"
+        className="flex min-w-0 flex-1 cursor-pointer flex-col gap-1 px-3 py-2.5 text-left sm:px-4 sm:py-3"
       >
         <h3 className="line-clamp-1 text-sm/5 font-semibold text-white sm:text-base/6 lg:text-lg/7">
           {game.title}
         </h3>
-        <p className="text-mypage-muted line-clamp-1 text-[11px]/4 sm:text-xs/5 lg:text-sm/6">
+        <p className="text-mypage-muted line-clamp-1 text-[11px]/4 sm:text-xs/5">
           {game.summary}
         </p>
       </button>

--- a/src/components/mypage/FavoriteGameCardSkeleton.tsx
+++ b/src/components/mypage/FavoriteGameCardSkeleton.tsx
@@ -3,21 +3,21 @@ type FavoriteGameCardSkeletonProps = {
 };
 
 function FavoriteGameCardSkeleton({
-  count = 4,
+  count = 3,
 }: FavoriteGameCardSkeletonProps) {
   return (
     <div
-      className="grid grid-cols-4 gap-2 sm:gap-3"
+      className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3"
       aria-live="polite"
       aria-busy="true"
     >
       {Array.from({ length: count }).map((_, index) => (
         <article
           key={index}
-          className="border-mypage-card bg-mypage-card box-border h-[22rem] w-full min-w-0 overflow-hidden rounded-[22px] border sm:h-[24rem] lg:h-[25rem]"
+          className="border-mypage-card bg-mypage-card box-border h-[21rem] w-full min-w-0 overflow-hidden rounded-[22px] border sm:h-[23rem] xl:h-[24rem]"
         >
-          <div className="h-[15rem] animate-pulse bg-white/8 sm:h-[16.5rem] lg:h-[17.5rem]" />
-          <div className="space-y-2 px-4 py-4">
+          <div className="h-[15.75rem] animate-pulse bg-white/8 sm:h-[17.4rem] xl:h-[18.5rem]" />
+          <div className="space-y-2 px-4 py-3">
             <div className="h-5 w-3/4 animate-pulse rounded-full bg-white/10" />
             <div className="h-4 w-full animate-pulse rounded-full bg-white/8" />
             <div className="h-4 w-2/3 animate-pulse rounded-full bg-white/8" />

--- a/src/components/mypage/FavoriteGamesEmptyState.tsx
+++ b/src/components/mypage/FavoriteGamesEmptyState.tsx
@@ -2,7 +2,7 @@ import { HeartOff } from 'lucide-react';
 
 function FavoriteGamesEmptyState() {
   return (
-    <div className="border-mypage-divider bg-mypage-card flex min-h-64 flex-col items-center justify-center rounded-3xl border border-dashed px-6 py-10 text-center">
+    <div className="border-mypage-divider bg-mypage-card flex min-h-[18rem] flex-col items-center justify-center rounded-3xl border border-dashed px-6 py-10 text-center sm:min-h-[19rem]">
       <span className="bg-mypage-soft mb-5 inline-flex h-14 w-14 items-center justify-center rounded-full text-white/80">
         <HeartOff size={24} />
       </span>

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -1,18 +1,24 @@
 import { Camera, CircleUserRound, LoaderCircle } from 'lucide-react';
 import { useState, type ReactNode } from 'react';
 
+import type { CurrentUserSocialResponse } from '../../features/auth/types/auth';
+import type { MyPageToast } from '../../pages/mypage/types';
 import AuthButton from '../auth/AuthButton';
 import InputControl from '../common/InputControl';
+import ToastMessage from './ToastMessage';
 
 type MyPageProfileSectionProps = {
   nickname: string;
   name: string;
   genderLabel: string;
+  socialAccount?: CurrentUserSocialResponse | null;
   profileImageUrl?: string | null;
   isProfileLoading?: boolean;
   isProfileImageUploading?: boolean;
   isProfileUpdating?: boolean;
   isLoggingOut: boolean;
+  toast?: MyPageToast;
+  onToastClose?: () => void;
   isPasswordPanelOpen: boolean;
   onPasswordToggle: () => void;
   onLogout: () => void;
@@ -25,11 +31,14 @@ function MyPageProfileSection({
   nickname,
   name,
   genderLabel,
+  socialAccount = null,
   profileImageUrl = null,
   isProfileLoading = false,
   isProfileImageUploading = false,
   isProfileUpdating = false,
   isLoggingOut,
+  toast = null,
+  onToastClose,
   isPasswordPanelOpen,
   onPasswordToggle,
   onLogout,
@@ -47,6 +56,37 @@ function MyPageProfileSection({
   const [isNicknameEditMode, setIsNicknameEditMode] = useState(false);
   const [nextNickname, setNextNickname] = useState(nickname);
   const [nicknameFieldError, setNicknameFieldError] = useState('');
+  const normalizedSocialType = socialAccount?.social_type?.trim().toLowerCase();
+  const accountBadge =
+    socialAccount?.is_social === true
+      ? normalizedSocialType === 'google'
+        ? {
+            label: '구글',
+            className:
+              'border-[#4285F4]/30 bg-[#4285F4]/14 text-[#8ab4ff] shadow-[0_8px_20px_rgba(66,133,244,0.14)]',
+          }
+        : normalizedSocialType === 'naver'
+          ? {
+              label: '네이버',
+              className:
+                'border-[#03C75A]/30 bg-[#03C75A]/14 text-[#68e6a5] shadow-[0_8px_20px_rgba(3,199,90,0.14)]',
+            }
+          : normalizedSocialType === 'kakao'
+            ? {
+                label: '카카오',
+                className:
+                  'border-[#FEE500]/24 bg-[#FEE500]/14 text-[#ffe768] shadow-[0_8px_20px_rgba(254,229,0,0.12)]',
+              }
+            : {
+                label: '소셜회원',
+                className:
+                  'border-white/10 bg-white/[0.05] text-white/78 shadow-[0_8px_20px_rgba(255,255,255,0.05)]',
+              }
+      : {
+          label: '일반회원',
+          className:
+            'border-white/10 bg-white/[0.05] text-white/78 shadow-[0_8px_20px_rgba(255,255,255,0.05)]',
+        };
 
   const handleNicknameSave = async () => {
     const trimmedNickname = nextNickname.trim();
@@ -80,6 +120,17 @@ function MyPageProfileSection({
     <section className="relative overflow-hidden rounded-[32px] border border-white/8 bg-[#19191d] shadow-[0_28px_80px_rgba(0,0,0,0.32)]">
       <div className="h-[5.5rem] bg-[linear-gradient(135deg,#8b2836_0%,#aa3848_38%,#c84b5e_100%)] sm:h-[6.4rem]" />
       <div className="absolute inset-x-0 top-0 h-px bg-white/20" />
+      {toast ? (
+        <div className="pointer-events-none absolute inset-x-0 top-[2.7rem] z-80 flex justify-center px-4 sm:top-[3.05rem]">
+          <ToastMessage
+            message={toast.message}
+            tone={toast.tone}
+            onClose={onToastClose ?? (() => {})}
+            variant="inlineCenter"
+            className="pointer-events-auto"
+          />
+        </div>
+      ) : null}
 
       <div className="relative px-4 pt-0 pb-5 sm:px-6 sm:pb-7 lg:px-8 lg:pb-8">
         <div className="mt-0 rounded-[28px] bg-[#111114] px-4 pb-5 sm:px-6 sm:pb-6 lg:px-8 lg:pb-7">
@@ -155,9 +206,16 @@ function MyPageProfileSection({
                 </div>
               ) : (
                 <div className="min-w-0 pt-2">
-                  <p className="truncate text-[clamp(2rem,3.6vw,2.8rem)] font-semibold tracking-[-0.04em] text-white">
-                    {nickname}
-                  </p>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <p className="max-w-full truncate text-[clamp(2rem,3.6vw,2.8rem)] font-semibold tracking-[-0.04em] text-white">
+                      {nickname}
+                    </p>
+                    <span
+                      className={`inline-flex shrink-0 items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-[-0.01em] ${accountBadge.className}`}
+                    >
+                      {accountBadge.label}
+                    </span>
+                  </div>
                 </div>
               )}
             </div>

--- a/src/components/mypage/ToastMessage.tsx
+++ b/src/components/mypage/ToastMessage.tsx
@@ -6,6 +6,7 @@ type ToastMessageVariant =
   | 'fixed'
   | 'fixedCenter'
   | 'fixedTopCenter'
+  | 'inlineCenter'
   | 'absoluteCenter'
   | 'absoluteTopCenter';
 
@@ -38,6 +39,8 @@ function ToastMessage({
       'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2';
   } else if (variant === 'fixedTopCenter') {
     positioningClass = 'fixed top-24 left-1/2 -translate-x-1/2 sm:top-28';
+  } else if (variant === 'inlineCenter') {
+    positioningClass = 'mx-auto';
   }
 
   return (

--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -176,7 +176,7 @@ export const getLikedGames = async (payload: LikedGamesRequest = {}) => {
 
 export const unlikeLikedGame = async (gameId: number) => {
   const response = await api.delete<DeleteLikedGameResponse>(
-    `${AUTH_BASE_PATH}/me/game-like/${gameId}`,
+    `/api/v1/games/${gameId}/like`,
     createCredentialedAuthRequestConfig(),
   );
 

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -899,7 +899,8 @@ const accountHandlers = [
       await delay(200);
 
       return HttpResponse.json({
-        detail: '찜한 게임이 목록에서 삭제되었습니다.',
+        game_id: gameId,
+        like_count: getCurrentLikeCount(gameId),
       } satisfies DeleteLikedGameResponse);
     },
   ),

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -44,7 +44,8 @@ export interface ChangePasswordResponse {
 }
 
 export interface DeleteLikedGameResponse {
-  detail: string;
+  game_id: number;
+  like_count: number | null;
 }
 
 export interface LikedGamesRequest {

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -1,14 +1,14 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Navigate } from 'react-router';
 
 import AuthWrapper from '../../components/auth/AuthWrapper';
 import LazyHeader from '../../components/common/LazyHeader';
-import ToastMessage from '../../components/mypage/ToastMessage';
 import { ROUTE_PATHS } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
 import type { GameListItem } from '../../features/games/types';
+import { useAuthStore } from '../../store/useAuthStore';
 import MyPageAccountDangerZone from './components/MyPageAccountDangerZone';
 import MyPageLikedGamesSection from './components/MyPageLikedGamesSection';
 import MyPageProfileContainer from './components/MyPageProfileContainer';
@@ -20,7 +20,7 @@ import type { MyPageToast } from './types';
 const loadingFallback = (
   <div className="relative min-h-screen overflow-hidden bg-[#050505]">
     <LazyHeader fixed />
-    <main className="mx-auto flex min-h-screen w-full max-w-[1240px] px-4 pt-[6.1rem] pb-12 sm:px-6 md:px-8 md:pt-[6.4rem]">
+    <main className="mx-auto flex min-h-[calc(100dvh-6.1rem)] w-full max-w-[1240px] px-4 pt-[6.1rem] pb-10 sm:px-6 md:px-8 md:pt-[6.4rem]">
       <section className="survey-panel mx-auto w-full max-w-[920px] px-8 py-12 text-center text-white/68">
         인증 상태를 확인하는 중입니다...
       </section>
@@ -39,6 +39,7 @@ const unauthorizedFallback = (
 function MyPage() {
   const authGate = useAuthGate();
   const { logout, isPending: isLogoutPending } = useLogoutAction();
+  const socialAccount = useAuthStore((state) => state.socialAccount);
   const [toast, setToast] = useState<MyPageToast>(null);
   const [selectedDetailGame, setSelectedDetailGame] =
     useState<GameListItem | null>(null);
@@ -51,6 +52,20 @@ function MyPage() {
     onToast: setToast,
   });
 
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setToast(null);
+    }, 3000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [toast]);
+
   return (
     <AuthWrapper
       gate={authGate}
@@ -61,11 +76,12 @@ function MyPage() {
         <div className="app-aurora pointer-events-none absolute inset-0 opacity-70" />
         <LazyHeader fixed />
 
-        <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-[1280px] flex-col px-4 pt-24 pb-14 sm:px-6 sm:pt-28 sm:pb-16 lg:px-10 lg:pt-32 xl:px-14">
+        <main className="relative z-10 mx-auto flex min-h-[calc(100dvh-6rem)] w-full max-w-[1280px] flex-col px-4 pt-24 pb-10 sm:min-h-[calc(100dvh-7rem)] sm:px-6 sm:pt-28 sm:pb-12 lg:min-h-[calc(100dvh-8rem)] lg:px-10 lg:pt-32 xl:px-14">
           <MyPageProfileContainer
             nickname={myPageProfile.profileNickname}
             name={myPageProfile.profileName}
             genderLabel={myPageProfile.profileGenderLabel}
+            socialAccount={socialAccount}
             profileImageUrl={myPageProfile.profileImageUrl}
             isProfileLoading={myPageProfile.isProfileLoading}
             isProfileImageUploading={myPageProfile.isProfileImageUploading}
@@ -89,6 +105,8 @@ function MyPage() {
             isPasswordChangePending={
               myPagePasswordChange.isChangePasswordPending
             }
+            toast={toast}
+            onToastClose={() => setToast(null)}
             onPasswordValueChange={
               myPagePasswordChange.handlePasswordValueChange
             }
@@ -104,6 +122,7 @@ function MyPage() {
           />
 
           <MyPageAccountDangerZone
+            isSocialAccount={myPageDeleteAccount.isSocialAccount}
             isDeleteModalOpen={myPageDeleteAccount.isDeleteModalOpen}
             deletePassword={myPageDeleteAccount.deletePassword}
             deletePasswordError={myPageDeleteAccount.deletePasswordError}
@@ -116,15 +135,6 @@ function MyPage() {
             onConfirmDeleteAccount={myPageDeleteAccount.handleDeleteAccount}
           />
         </main>
-
-        {toast ? (
-          <ToastMessage
-            message={toast.message}
-            tone={toast.tone}
-            onClose={() => setToast(null)}
-            variant="fixedCenter"
-          />
-        ) : null}
 
         {selectedDetailGame ? (
           <GameDetailModal

--- a/src/pages/mypage/components/MyPageAccountDangerZone.tsx
+++ b/src/pages/mypage/components/MyPageAccountDangerZone.tsx
@@ -5,6 +5,7 @@ import InputControl from '../../../components/common/InputControl';
 import ConfirmModal from '../../../components/mypage/ConfirmModal';
 
 type MyPageAccountDangerZoneProps = {
+  isSocialAccount: boolean;
   isDeleteModalOpen: boolean;
   deletePassword: string;
   deletePasswordError: string;
@@ -16,6 +17,7 @@ type MyPageAccountDangerZoneProps = {
 };
 
 function MyPageAccountDangerZone({
+  isSocialAccount,
   isDeleteModalOpen,
   deletePassword,
   deletePasswordError,
@@ -30,7 +32,11 @@ function MyPageAccountDangerZone({
       <section className="mt-8 flex flex-col items-center justify-center gap-3 pb-2 text-center">
         <div className="text-mypage-muted flex items-center gap-2 text-sm/6">
           <ShieldAlert size={16} />
-          <span>현재 비밀번호를 확인한 뒤 회원탈퇴를 진행할 수 있습니다.</span>
+          <span>
+            {isSocialAccount
+              ? '소셜 계정은 비밀번호 확인 없이 바로 회원탈퇴를 진행할 수 있습니다.'
+              : '현재 비밀번호를 확인한 뒤 회원탈퇴를 진행할 수 있습니다.'}
+          </span>
         </div>
         <AuthButton
           type="button"
@@ -44,39 +50,50 @@ function MyPageAccountDangerZone({
 
       <ConfirmModal
         open={isDeleteModalOpen}
-        title="현재 비밀번호 확인 후 회원탈퇴"
+        title={
+          isSocialAccount
+            ? '소셜 계정을 탈퇴할까요?'
+            : '현재 비밀번호 확인 후 회원탈퇴'
+        }
         description={
-          <div className="space-y-3">
+          isSocialAccount ? (
             <p>
-              현재 비밀번호를 확인한 뒤 탈퇴가 진행되며, 완료되면 로그인
-              화면으로 이동합니다.
+              소셜 계정은 비밀번호 확인 없이 바로 탈퇴가 진행되며, 완료되면
+              로그인 화면으로 이동합니다.
             </p>
-            <div className="space-y-2">
-              <label
-                htmlFor="delete-account-password"
-                className="block text-sm font-medium text-white"
-              >
-                현재 비밀번호
-              </label>
-              <InputControl
-                id="delete-account-password"
-                type="password"
-                autoComplete="current-password"
-                value={deletePassword}
-                onChange={(event) => {
-                  onDeletePasswordChange(event.target.value);
-                }}
-                hasError={Boolean(deletePasswordError)}
-                className="h-12"
-                placeholder="현재 비밀번호를 입력하세요"
-              />
-              {deletePasswordError ? (
-                <p className="pl-1 text-sm/5 font-medium text-red-400">
-                  {deletePasswordError}
-                </p>
-              ) : null}
+          ) : (
+            <div className="space-y-3">
+              <p>
+                현재 비밀번호를 확인한 뒤 탈퇴가 진행되며, 완료되면 로그인
+                화면으로 이동합니다.
+              </p>
+              <div className="space-y-2">
+                <label
+                  htmlFor="delete-account-password"
+                  className="block text-sm font-medium text-white"
+                >
+                  현재 비밀번호
+                </label>
+                <InputControl
+                  id="delete-account-password"
+                  type="password"
+                  autoComplete="current-password"
+                  value={deletePassword}
+                  onChange={(event) => {
+                    onDeletePasswordChange(event.target.value);
+                  }}
+                  hasError={Boolean(deletePasswordError)}
+                  className="h-12"
+                  placeholder="현재 비밀번호를 입력하세요"
+                />
+                {deletePasswordError ? (
+                  <p className="pl-1 text-sm/5 font-medium text-red-400">
+                    {deletePasswordError}
+                  </p>
+                ) : null}
+              </div>
             </div>
-          </div>
+          )
         }
         confirmLabel="회원탈퇴"
         isPending={isDeletePending}

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -37,6 +37,10 @@ function MyPageLikedGamesSection({
     onOpenGameDetail,
     onToast,
   });
+  const hasFavoriteGames = favoriteGames.length > 0;
+  const listContainerClass = hasFavoriteGames
+    ? 'mypage-scrollbar mt-5 max-w-full overflow-x-hidden overflow-y-auto pr-1 max-h-[38rem]'
+    : 'mt-5 max-w-full';
 
   return (
     <>
@@ -62,11 +66,11 @@ function MyPageLikedGamesSection({
           </p>
         </div>
 
-        <div className="mypage-scrollbar mt-5 box-border h-[22rem] max-w-full overflow-x-hidden overflow-y-auto pr-1 sm:h-[24rem] lg:h-[25rem]">
+        <div className={listContainerClass}>
           {isFavoriteGamesLoading ? (
             <FavoriteGameCardSkeleton />
-          ) : favoriteCount > 0 ? (
-            <div className="grid grid-cols-4 gap-2 sm:gap-3">
+          ) : hasFavoriteGames ? (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
               {favoriteGames.map((game) => (
                 <FavoriteGameCard
                   key={game.gameId}

--- a/src/pages/mypage/components/MyPageProfileContainer.tsx
+++ b/src/pages/mypage/components/MyPageProfileContainer.tsx
@@ -5,11 +5,14 @@ import PasswordChangePanel, {
   type PasswordChangeFieldName,
   type PasswordChangeValues,
 } from '../../../components/mypage/PasswordChangePanel';
+import type { CurrentUserSocialResponse } from '../../../features/auth/types/auth';
+import type { MyPageToast } from '../types';
 
 type MyPageProfileContainerProps = {
   nickname: string;
   name: string;
   genderLabel: string;
+  socialAccount?: CurrentUserSocialResponse | null;
   profileImageUrl?: string | null;
   isProfileLoading: boolean;
   isProfileImageUploading: boolean;
@@ -25,6 +28,8 @@ type MyPageProfileContainerProps = {
   passwordPanelMessage?: string;
   passwordPanelMessageTone?: 'success' | 'error';
   isPasswordChangePending: boolean;
+  toast: MyPageToast;
+  onToastClose: () => void;
   onPasswordValueChange: (
     fieldName: PasswordChangeFieldName,
     value: string,
@@ -38,6 +43,7 @@ function MyPageProfileContainer({
   nickname,
   name,
   genderLabel,
+  socialAccount = null,
   profileImageUrl,
   isProfileLoading,
   isProfileImageUploading,
@@ -53,6 +59,8 @@ function MyPageProfileContainer({
   passwordPanelMessage,
   passwordPanelMessageTone = 'error',
   isPasswordChangePending,
+  toast,
+  onToastClose,
   onPasswordValueChange,
   onPasswordBlur,
   onPasswordCancel,
@@ -63,11 +71,14 @@ function MyPageProfileContainer({
       nickname={nickname}
       name={name}
       genderLabel={genderLabel}
+      socialAccount={socialAccount}
       profileImageUrl={profileImageUrl}
       isProfileLoading={isProfileLoading}
       isProfileImageUploading={isProfileImageUploading}
       isProfileUpdating={isProfileUpdating}
       isLoggingOut={isLoggingOut}
+      toast={toast}
+      onToastClose={onToastClose}
       isPasswordPanelOpen={isPasswordPanelOpen}
       onPasswordToggle={onPasswordToggle}
       onLogout={onLogout}

--- a/src/pages/mypage/hooks/useMyPageDeleteAccount.ts
+++ b/src/pages/mypage/hooks/useMyPageDeleteAccount.ts
@@ -11,6 +11,7 @@ import {
   useDeleteAccountMutation,
 } from '../../../features/auth/api/useAuthApi';
 import { clearAuthSession } from '../../../features/auth/utils/sessionManager';
+import { useAuthStore } from '../../../store/useAuthStore';
 import type { MyPageToastPayload } from '../types';
 
 type UseMyPageDeleteAccountOptions = {
@@ -21,9 +22,11 @@ function useMyPageDeleteAccount({ onToast }: UseMyPageDeleteAccountOptions) {
   const navigate = useNavigate();
   const checkPasswordMutation = useCheckPasswordMutation();
   const deleteAccountMutation = useDeleteAccountMutation();
+  const socialAccount = useAuthStore((state) => state.socialAccount);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [deletePassword, setDeletePassword] = useState('');
   const [deletePasswordError, setDeletePasswordError] = useState('');
+  const isSocialAccount = socialAccount?.is_social === true;
 
   const openDeleteModal = () => {
     setDeletePassword('');
@@ -48,18 +51,21 @@ function useMyPageDeleteAccount({ onToast }: UseMyPageDeleteAccountOptions) {
   const handleDeleteAccount = async () => {
     const trimmedPassword = deletePassword.trim();
 
-    if (!trimmedPassword) {
+    if (!isSocialAccount && !trimmedPassword) {
       setDeletePasswordError('현재 비밀번호를 입력해주세요.');
       return;
     }
 
     try {
-      await checkPasswordMutation.mutateAsync({
-        password: trimmedPassword,
-      });
+      if (!isSocialAccount) {
+        await checkPasswordMutation.mutateAsync({
+          password: trimmedPassword,
+        });
+      }
 
       await deleteAccountMutation.mutateAsync();
 
+      closeDeleteModal();
       clearAuthSession();
       navigate(ROUTE_PATHS.LOGIN, {
         replace: true,
@@ -90,6 +96,7 @@ function useMyPageDeleteAccount({ onToast }: UseMyPageDeleteAccountOptions) {
   };
 
   return {
+    isSocialAccount,
     isDeleteModalOpen,
     openDeleteModal,
     closeDeleteModal,

--- a/src/pages/mypage/hooks/useMyPageLikedGames.ts
+++ b/src/pages/mypage/hooks/useMyPageLikedGames.ts
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react';
+import { AxiosError } from 'axios';
+import { useEffect, useMemo, useState } from 'react';
 
 import { extractAuthApiErrorMessage } from '../../../features/auth/api/auth';
 import {
@@ -29,10 +30,20 @@ function useMyPageLikedGames({
   const unlikeLikedGameMutation = useUnlikeLikedGameMutation();
   const [selectedFavoriteGame, setSelectedFavoriteGame] =
     useState<FavoriteGamePreview | null>(null);
-  const favoriteGames = useMemo(() => {
+  const serverFavoriteGames = useMemo(() => {
     return (likedGamesData?.results ?? []).map(toFavoriteGamePreview);
   }, [likedGamesData?.results]);
-  const immediateFavoriteCount = likedGamesData?.count ?? favoriteGames.length;
+  const [favoriteGames, setFavoriteGames] = useState<FavoriteGamePreview[]>([]);
+  const [favoriteCount, setFavoriteCount] = useState(0);
+
+  useEffect(() => {
+    setFavoriteGames(serverFavoriteGames);
+  }, [serverFavoriteGames]);
+
+  useEffect(() => {
+    setFavoriteCount(likedGamesData?.count ?? serverFavoriteGames.length);
+  }, [likedGamesData?.count, serverFavoriteGames.length]);
+
   const refetchFavoriteGames = likedGamesQuery.refetch;
   const isFavoriteGamesLoading =
     likedGamesQuery.isLoading && !favoriteGames.length;
@@ -47,17 +58,53 @@ function useMyPageLikedGames({
       return;
     }
 
-    try {
-      const response = await unlikeLikedGameMutation.mutateAsync(
-        selectedFavoriteGame.gameId,
+    const targetGameId = selectedFavoriteGame.gameId;
+
+    if (!Number.isInteger(targetGameId) || targetGameId <= 0) {
+      onToast({
+        tone: 'error',
+        message:
+          '삭제할 게임 정보를 확인하지 못했습니다. 잠시 후 다시 시도해주세요.',
+      });
+      return;
+    }
+
+    const removeFavoriteGameFromState = () => {
+      const isVisibleTarget = favoriteGames.some(
+        (game) => game.gameId === targetGameId,
       );
 
+      if (!isVisibleTarget) {
+        return;
+      }
+
+      setFavoriteGames((current) =>
+        current.filter((game) => game.gameId !== targetGameId),
+      );
+      setFavoriteCount((current) => Math.max(0, current - 1));
+    };
+
+    try {
+      await unlikeLikedGameMutation.mutateAsync(targetGameId);
+      removeFavoriteGameFromState();
       setSelectedFavoriteGame(null);
       onToast({
         tone: 'success',
-        message: response.detail || '찜한 게임이 목록에서 삭제되었습니다.',
+        message: '찜한 목록에서 삭제되었습니다.',
       });
+      void refetchFavoriteGames();
     } catch (error) {
+      if (error instanceof AxiosError && error.response?.status === 404) {
+        removeFavoriteGameFromState();
+        setSelectedFavoriteGame(null);
+        onToast({
+          tone: 'success',
+          message: '이미 삭제된 게임입니다.',
+        });
+        void refetchFavoriteGames();
+        return;
+      }
+
       onToast({
         tone: 'error',
         message: extractAuthApiErrorMessage(error),
@@ -67,7 +114,7 @@ function useMyPageLikedGames({
 
   return {
     favoriteGames,
-    favoriteCount: immediateFavoriteCount,
+    favoriteCount,
     isFavoriteGamesLoading,
     isFavoriteGamesError,
     isFetchingFavoriteGames: likedGamesQuery.isFetching,

--- a/src/pages/mypage/hooks/useMyPageProfile.ts
+++ b/src/pages/mypage/hooks/useMyPageProfile.ts
@@ -153,7 +153,7 @@ function useMyPageProfile({ enabled, onToast }: UseMyPageProfileOptions) {
       });
       onToast({
         tone: 'success',
-        message: '프로필이 변경되었습니다.',
+        message: '닉네임이 변경되었습니다.',
       });
 
       return true;


### PR DESCRIPTION
## 관련 이슈

- closes #337 

## 변경 내용

- 찜한 목록 삭제 API를 Swagger 기준 `DELETE /api/v1/games/{game_id}/like`로 수정하고, 삭제 성공 시 에러 모달 대신 `"찜한 목록에서 삭제되었습니다."` 토스트가 뜨도록 변경했습니다.
- 찜 삭제 성공 및 404 응답 시 로컬 찜 목록 상태에서 해당 게임을 즉시 제거하도록 처리해, 화면이 바로 갱신되게 정리했습니다.
- 찜한 목록 카드의 썸네일 비중을 키우고 설명 영역을 줄여 시각적 비율을 조정했으며, 리스트/빈 상태 영역의 불필요한 하단 여백도 함께 정리했습니다.
- 마이페이지 토스트를 3초 뒤 자동으로 사라지도록 공통 처리하고, 프로필 카드 상단 붉은 영역 중앙에 뜨도록 위치를 조정했습니다.
- 닉네임 옆에 회원 유형 뱃지를 추가하고, 일반회원/구글/네이버/카카오 계정에 따라 다르게 표시되도록 분기했습니다.
- 회원탈퇴는 일반회원은 비밀번호 확인 후 진행하고, 소셜 회원은 비밀번호 확인 없이 바로 탈퇴되도록 로직을 분리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="1798" height="1646" alt="image" src="https://github.com/user-attachments/assets/a90bec8b-e0ad-412c-9f9b-1b9bc2714af5" />

## 참고사항

- 찜 삭제 404 응답은 사용자 경험을 위해 `"이미 삭제된 게임입니다."` 메시지로 부드럽게 처리했습니다.
