### PR TITLE
[Refactor] MSW 전환 토글 UI를 캡슐형으로 개선

### DIFF
--- a/src/components/common/DevApiModeToggle.tsx
+++ b/src/components/common/DevApiModeToggle.tsx
@@ -1,3 +1,5 @@
+import { ArrowRightLeft } from 'lucide-react';
+
 import {
   canToggleDevApiMode,
   configuredApiBaseUrl,
@@ -37,22 +39,70 @@ function DevApiModeToggle({
 
   if (isFab) {
     return (
-      <button
-        type="button"
-        onClick={() => toggleDevApiMode(isMockMode ? 'real' : 'mock')}
-        className={`support-chat-fab group relative flex h-14 w-14 cursor-pointer items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none ${className}`}
-        aria-label={
-          isMockMode
-            ? '현재 MSW 사용 중, 클릭하면 실서버로 전환'
-            : '현재 실서버 사용 중, 클릭하면 MSW로 전환'
-        }
-        title={isMockMode ? '현재 MSW 사용 중' : '현재 실서버 사용 중'}
+      <div
+        className={`relative flex h-14 w-[12rem] items-center rounded-full border border-[#ff6b63]/36 bg-[#120b0b]/92 p-1 shadow-[0_22px_48px_rgba(0,0,0,0.42),0_0_28px_rgba(223,59,51,0.24)] backdrop-blur-xl ${className}`}
+        role="group"
+        aria-label="개발 API 모드 전환"
       >
-        <span className="support-chat-fab-glow" />
-        <span className="relative z-10 text-[10px] font-extrabold tracking-[0.08em]">
-          {isMockMode ? 'MSW' : 'REAL'}
+        <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.1),transparent_54%)]" />
+        <span
+          className="pointer-events-none absolute top-1 left-1 h-12 w-[4.5rem] rounded-full border border-[#ff8d84]/42 bg-[linear-gradient(180deg,#ff6b5f_0%,#d92b22_100%)] shadow-[0_14px_30px_rgba(217,43,34,0.32),inset_0_1px_0_rgba(255,255,255,0.18)] transition-transform duration-300 ease-out motion-reduce:transition-none"
+          style={{
+            transform: `translateX(${isMockMode ? 0 : 112}px)`,
+          }}
+          aria-hidden="true"
+        />
+
+        <button
+          type="button"
+          onClick={() => {
+            if (!isMockMode) {
+              toggleDevApiMode('mock');
+            }
+          }}
+          className={`relative z-10 flex h-full w-[4.5rem] cursor-pointer items-center justify-center rounded-full text-sm font-extrabold tracking-[0.04em] transition-colors duration-300 focus-visible:outline-none motion-reduce:transition-none ${
+            isMockMode ? 'text-white' : 'text-white/58 hover:text-white/82'
+          }`}
+          aria-pressed={isMockMode}
+          aria-label="MSW 모드로 전환"
+          title="MSW 모드"
+        >
+          <span
+            className={
+              isMockMode ? 'drop-shadow-[0_0_10px_rgba(255,255,255,0.22)]' : ''
+            }
+          >
+            MSW
+          </span>
+        </button>
+
+        <span className="relative z-10 inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/8 bg-white/[0.04] text-white/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+          <ArrowRightLeft size={15} />
         </span>
-      </button>
+
+        <button
+          type="button"
+          onClick={() => {
+            if (isMockMode) {
+              toggleDevApiMode('real');
+            }
+          }}
+          className={`relative z-10 flex h-full w-[4.5rem] cursor-pointer items-center justify-center rounded-full text-sm font-extrabold tracking-[0.02em] transition-colors duration-300 focus-visible:outline-none motion-reduce:transition-none ${
+            !isMockMode ? 'text-white' : 'text-white/58 hover:text-white/82'
+          }`}
+          aria-pressed={!isMockMode}
+          aria-label="실 API 모드로 전환"
+          title="실 API 모드"
+        >
+          <span
+            className={
+              !isMockMode ? 'drop-shadow-[0_0_10px_rgba(255,255,255,0.22)]' : ''
+            }
+          >
+            실 API
+          </span>
+        </button>
+      </div>
     );
   }
 


### PR DESCRIPTION
## 관련 이슈

- closes #339 

## 변경 내용

- 로그인 화면의 개발용 API 전환 버튼을 기존 원형 단일 버튼에서 `MSW ↔ 실 API`를 한눈에 읽을 수 있는 캡슐형 토글 UI로 변경했습니다.
- 붉은색 테마를 유지하면서 현재 활성화된 모드 쪽에 슬라이딩 하이라이트가 이동하도록 구성해 상태 인지가 더 쉽도록 개선했습니다.
- 가운데에 전환 아이콘을 배치하고, 활성 상태 텍스트에 시각적 강조를 추가해 현재 모드가 직관적으로 드러나게 정리했습니다.
- 기존 MSW / 실 API 전환 로직은 그대로 유지해, 클릭 시 현재와 동일하게 모드 저장 및 새로고침 전환이 정상 동작하도록 연결했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="428" height="210" alt="image" src="https://github.com/user-attachments/assets/ad64e440-c628-4c5d-8775-f7e9beceaffb" />

## 참고사항

