### PR TITLE
[Refactor] 설문 흐름 단순화 및 오류 메시지 정리

### DIFF
--- a/src/features/recommendation/hooks/useRecommendationResultsSource.ts
+++ b/src/features/recommendation/hooks/useRecommendationResultsSource.ts
@@ -73,7 +73,12 @@ export const useRecommendationResultsSource = ({
   const isResultNotFound =
     error instanceof AxiosError && error.response?.status === 404;
   const errorMessage =
-    error && !isResultNotFound ? extractApiErrorMessage(error) : null;
+    error && !isResultNotFound
+      ? extractApiErrorMessage(
+          error,
+          isSurveySource ? 'recommendations' : 'generic',
+        )
+      : null;
   const emptyStateMessage =
     isResultNotFound && isMatchSource
       ? '매칭 추천 결과가 아직 없습니다. 먼저 매칭 평가를 완료해 주세요.'

--- a/src/features/recommendation/hooks/useSurveyRecommendationActions.ts
+++ b/src/features/recommendation/hooks/useSurveyRecommendationActions.ts
@@ -65,7 +65,7 @@ export const useSurveyRecommendationActions = ({
       queryClient.removeQueries({ queryKey: ['survey-results'] });
       navigate(`/${ROUTES.SURVEY}`);
     } catch (requestError) {
-      setFeedbackMessage(extractApiErrorMessage(requestError));
+      setFeedbackMessage(extractApiErrorMessage(requestError, 'reset'));
     }
   };
 

--- a/src/features/survey/api/survey.ts
+++ b/src/features/survey/api/survey.ts
@@ -19,7 +19,6 @@ import type {
   SurveyResetResponse,
   SurveyResultQuery,
   SurveyResultResponse,
-  SurveyApiSessionStartRequest,
   SurveySessionStartRequest,
   SurveySessionStartResponse,
   SurveyProgress,
@@ -34,9 +33,53 @@ interface ErrorResponseBody {
   retry_after_seconds?: number;
 }
 
+type SurveyErrorMessageContext =
+  | 'generic'
+  | 'start'
+  | 'continue'
+  | 'reset'
+  | 'recommendations';
+
 const SURVEY_BASE_PATH = '/api/v1/survey';
 const SURVEY_CHATBOT_BASE_PATH = `${SURVEY_BASE_PATH}/chatbot`;
 const SURVEY_CHATBOT_REQUEST_TIMEOUT_MS = 45_000;
+
+const SURVEY_TIMEOUT_ERROR_MESSAGES: Record<SurveyErrorMessageContext, string> =
+  {
+    generic:
+      '응답 생성이 평소보다 오래 걸리고 있어요. 잠시 후 다시 시도해 주세요.',
+    start:
+      '첫 질문 준비가 평소보다 오래 걸리고 있어요. 잠시 후 다시 시도해 주세요.',
+    continue:
+      '다음 질문 준비가 평소보다 오래 걸리고 있어요. 잠시 후 다시 시도해 주세요.',
+    reset:
+      '설문 초기화가 평소보다 오래 걸리고 있어요. 잠시 후 다시 시도해 주세요.',
+    recommendations:
+      '추천 결과를 불러오는 데 평소보다 오래 걸리고 있어요. 잠시 후 다시 시도해 주세요.',
+  };
+
+const SURVEY_CONNECTION_ERROR_MESSAGES: Record<
+  SurveyErrorMessageContext,
+  string
+> = {
+  generic: '서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+  start: '첫 질문을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.',
+  continue: '다음 질문을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.',
+  reset: '설문을 초기화하지 못했어요. 잠시 후 다시 시도해 주세요.',
+  recommendations: '추천 결과를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.',
+};
+
+const SURVEY_FALLBACK_ERROR_MESSAGES: Record<
+  SurveyErrorMessageContext,
+  string
+> = {
+  generic:
+    '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+  start: '첫 질문을 준비하지 못했어요. 잠시 후 다시 시도해 주세요.',
+  continue: '다음 질문을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.',
+  reset: '설문을 초기화하지 못했어요. 잠시 후 다시 시도해 주세요.',
+  recommendations: '추천 결과를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.',
+};
 
 const clampProgressRate = (value: number | null | undefined) => {
   if (typeof value !== 'number' || Number.isNaN(value)) {
@@ -147,7 +190,7 @@ export const startSurveySession = async (
   try {
     const response = await api.post<SurveyApiSessionResponse>(
       `${SURVEY_CHATBOT_BASE_PATH}/sessions/`,
-      payload satisfies SurveyApiSessionStartRequest,
+      payload,
       {
         timeout: SURVEY_CHATBOT_REQUEST_TIMEOUT_MS,
       },
@@ -220,7 +263,6 @@ export const getSurveyResults = async (query: SurveyResultQuery) => {
         params: {
           cursor: query.cursor,
           page_size: query.page_size,
-          sort: query.sort,
         },
       },
     );
@@ -241,17 +283,20 @@ export const getSurveyResults = async (query: SurveyResultQuery) => {
   }
 };
 
-export const extractApiErrorMessage = (error: unknown) => {
+export const extractApiErrorMessage = (
+  error: unknown,
+  context: SurveyErrorMessageContext = 'generic',
+) => {
   if (!(error instanceof AxiosError)) {
-    return '요청을 처리하는 중 알 수 없는 오류가 발생했습니다.';
+    return SURVEY_FALLBACK_ERROR_MESSAGES[context];
   }
 
   if (error.code === 'ECONNABORTED') {
-    return '응답 생성이 평소보다 오래 걸리고 있어요. 잠시 후 다시 시도해 주세요.';
+    return SURVEY_TIMEOUT_ERROR_MESSAGES[context];
   }
 
   if (!error.response) {
-    return '서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+    return SURVEY_CONNECTION_ERROR_MESSAGES[context];
   }
 
   const data = error.response?.data as ErrorResponseBody | undefined;
@@ -276,7 +321,7 @@ export const extractApiErrorMessage = (error: unknown) => {
     }
   }
 
-  return '요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+  return SURVEY_FALLBACK_ERROR_MESSAGES[context];
 };
 
 export const extractApiRetryAfterSeconds = (error: unknown) => {

--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -18,6 +18,7 @@ import { useSurveyStore } from '../store/useSurveyStore';
 import {
   formatRemainingBlockTime,
   GAME_RELATED_KEYWORDS,
+  NON_GAME_CHAT_MAX_STRIKES,
   useSurveyModerationGuard,
 } from '../hooks/useSurveyModerationGuard';
 import { useSurveySessionFlow } from '../hooks/useSurveySessionFlow';
@@ -35,27 +36,33 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
   const [inputValue, setInputValue] = useState('');
   const [isGuardrailPanelOpen, setIsGuardrailPanelOpen] = useState(false);
 
-  const sessionId = useSurveyStore((state) => state.sessionId);
-  const messages = useSurveyStore((state) => state.messages);
-  const progress = useSurveyStore((state) => state.progress);
-  const storedSessionId = useSurveyStore((state) => state.sessionId);
-  const hasBootstrapped = useSurveyStore((state) => state.hasBootstrapped);
-  const isSubmitting = useSurveyStore((state) => state.isSubmitting);
-  const error = useSurveyStore((state) => state.error);
-  const recommendationReady = useSurveyStore(
-    (state) => state.recommendationReady,
-  );
-  const lastSubmittedMessage = useSurveyStore(
-    (state) => state.lastSubmittedMessage,
-  );
+  const {
+    sessionId,
+    messages,
+    progress,
+    hasBootstrapped,
+    isSubmitting,
+    error,
+    recommendationReady,
+    lastSubmittedMessage,
+  } = useSurveyStore((state) => ({
+    sessionId: state.sessionId,
+    messages: state.messages,
+    progress: state.progress,
+    hasBootstrapped: state.hasBootstrapped,
+    isSubmitting: state.isSubmitting,
+    error: state.error,
+    recommendationReady: state.recommendationReady,
+    lastSubmittedMessage: state.lastSubmittedMessage,
+  }));
 
   const {
+    nonGameStrikeCount,
     remainingBlockTimeMs,
     isChatTemporarilyBlocked,
     hasExpiredChatBlock,
     isTextareaDisabled,
     isRecommendationButtonDisabled,
-    guardrailStatusLabel,
     inputPlaceholder,
     applySuccessfulSubmissionModeration,
   } = useSurveyModerationGuard({
@@ -92,6 +99,11 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
     isHistoryView || enteredWithCompletedSurvey
       ? '추천 결과로 돌아가기'
       : '추천 결과 바로 보기';
+  const guardrailStatusLabel = isChatTemporarilyBlocked
+    ? `${formatRemainingBlockTime(remainingBlockTimeMs)} 남음`
+    : hasExpiredChatBlock
+      ? '제한 종료'
+      : `${nonGameStrikeCount}/${NON_GAME_CHAT_MAX_STRIKES} 누적`;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -135,8 +147,8 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
     }
 
     startTransition(() => {
-      const surveySessionQuery = storedSessionId
-        ? `?source=survey&session_id=${storedSessionId}`
+      const surveySessionQuery = sessionId
+        ? `?source=survey&session_id=${sessionId}`
         : '?source=survey';
       navigate(`/${ROUTES.RECOMMENDATION_LIST}${surveySessionQuery}`);
     });

--- a/src/features/survey/hooks/useSurveyModerationGuard.ts
+++ b/src/features/survey/hooks/useSurveyModerationGuard.ts
@@ -103,12 +103,6 @@ export const useSurveyModerationGuard = ({
     isChatTemporarilyBlocked ||
     hasExpiredChatBlock ||
     hasReachedNonGameChatLimit;
-  const guardrailStatusLabel = isChatTemporarilyBlocked
-    ? `${formatRemainingBlockTime(remainingBlockTimeMs)} 남음`
-    : hasExpiredChatBlock
-      ? '제한 종료'
-      : `${nonGameStrikeCount}/${NON_GAME_CHAT_MAX_STRIKES} 누적`;
-
   const inputPlaceholder = useMemo(() => {
     if (isHistoryView && recommendationReady) {
       return '완료된 설문 기록을 다시 보고 있어요.';
@@ -184,7 +178,6 @@ export const useSurveyModerationGuard = ({
     hasExpiredChatBlock,
     isTextareaDisabled,
     isRecommendationButtonDisabled,
-    guardrailStatusLabel,
     inputPlaceholder,
     applySuccessfulSubmissionModeration,
   };

--- a/src/features/survey/hooks/useSurveySessionFlow.ts
+++ b/src/features/survey/hooks/useSurveySessionFlow.ts
@@ -28,34 +28,41 @@ export const useSurveySessionFlow = ({
   queueFocusRestore,
   cancelFocusRestore,
 }: UseSurveySessionFlowOptions) => {
-  const sessionId = useSurveyStore((state) => state.sessionId);
-  const hasBootstrapped = useSurveyStore((state) => state.hasBootstrapped);
-  const isSubmitting = useSurveyStore((state) => state.isSubmitting);
-  const error = useSurveyStore((state) => state.error);
-  const lastSubmittedMessage = useSurveyStore(
-    (state) => state.lastSubmittedMessage,
-  );
-  const clearError = useSurveyStore((state) => state.clearError);
-  const setHasBootstrapped = useSurveyStore(
-    (state) => state.setHasBootstrapped,
-  );
-  const setSubmitting = useSurveyStore((state) => state.setSubmitting);
-  const setError = useSurveyStore((state) => state.setError);
-  const setLastSubmittedMessage = useSurveyStore(
-    (state) => state.setLastSubmittedMessage,
-  );
-  const clearModerationState = useSurveyStore(
-    (state) => state.clearModerationState,
-  );
-  const setChatBlockedUntil = useSurveyStore(
-    (state) => state.setChatBlockedUntil,
-  );
-  const addUserMessage = useSurveyStore((state) => state.addUserMessage);
-  const hydrateInitialSession = useSurveyStore(
-    (state) => state.hydrateInitialSession,
-  );
-  const applyChatResponse = useSurveyStore((state) => state.applyChatResponse);
-  const resetSurveyState = useSurveyStore((state) => state.resetSurveyState);
+  const {
+    sessionId,
+    hasBootstrapped,
+    isSubmitting,
+    error,
+    lastSubmittedMessage,
+    clearError,
+    setHasBootstrapped,
+    setSubmitting,
+    setError,
+    setLastSubmittedMessage,
+    clearModerationState,
+    setChatBlockedUntil,
+    addUserMessage,
+    hydrateInitialSession,
+    applyChatResponse,
+    resetSurveyState,
+  } = useSurveyStore((state) => ({
+    sessionId: state.sessionId,
+    hasBootstrapped: state.hasBootstrapped,
+    isSubmitting: state.isSubmitting,
+    error: state.error,
+    lastSubmittedMessage: state.lastSubmittedMessage,
+    clearError: state.clearError,
+    setHasBootstrapped: state.setHasBootstrapped,
+    setSubmitting: state.setSubmitting,
+    setError: state.setError,
+    setLastSubmittedMessage: state.setLastSubmittedMessage,
+    clearModerationState: state.clearModerationState,
+    setChatBlockedUntil: state.setChatBlockedUntil,
+    addUserMessage: state.addUserMessage,
+    hydrateInitialSession: state.hydrateInitialSession,
+    applyChatResponse: state.applyChatResponse,
+    resetSurveyState: state.resetSurveyState,
+  }));
 
   const startSessionMutation = useStartSurveySessionMutation();
   const continueSurveyMutation = useContinueSurveyMutation();
@@ -79,7 +86,7 @@ export const useSurveySessionFlow = ({
         hydrateInitialSession(response);
       } catch (requestError) {
         setHasBootstrapped(false);
-        setError(extractApiErrorMessage(requestError));
+        setError(extractApiErrorMessage(requestError, 'start'));
       } finally {
         setSubmitting(false);
       }
@@ -102,6 +109,19 @@ export const useSurveySessionFlow = ({
       void bootstrapSurvey();
     }
   }, [bootstrapSurvey, hasBootstrapped, sessionId]);
+
+  const ensureSessionId = useCallback(async () => {
+    if (sessionId) {
+      return sessionId;
+    }
+
+    const sessionResponse = await startSessionMutation.mutateAsync({
+      is_reset: false,
+    });
+    hydrateInitialSession(sessionResponse);
+
+    return sessionResponse.session_id;
+  }, [hydrateInitialSession, sessionId, startSessionMutation]);
 
   const applyServerSideChatBlock = useCallback(
     (requestError: unknown) => {
@@ -135,39 +155,23 @@ export const useSurveySessionFlow = ({
       setSubmitting(true);
 
       try {
-        if (!sessionId) {
-          const sessionResponse = await startSessionMutation.mutateAsync({
-            is_reset: false,
-          });
-          hydrateInitialSession(sessionResponse);
+        const activeSessionId = await ensureSessionId();
 
-          if (appendUserMessage) {
-            addUserMessage(trimmed);
-          }
-
-          const response = await continueSurveyMutation.mutateAsync({
-            session_id: sessionResponse.session_id,
-            user_answer: trimmed,
-          });
-
-          applyChatResponse(response);
-        } else {
-          if (appendUserMessage) {
-            addUserMessage(trimmed);
-          }
-
-          const response = await continueSurveyMutation.mutateAsync({
-            session_id: sessionId,
-            user_answer: trimmed,
-          });
-
-          applyChatResponse(response);
+        if (appendUserMessage) {
+          addUserMessage(trimmed);
         }
+
+        const response = await continueSurveyMutation.mutateAsync({
+          session_id: activeSessionId,
+          user_answer: trimmed,
+        });
+
+        applyChatResponse(response);
 
         return true;
       } catch (requestError) {
         applyServerSideChatBlock(requestError);
-        setError(extractApiErrorMessage(requestError));
+        setError(extractApiErrorMessage(requestError, 'continue'));
         return false;
       } finally {
         setSubmitting(false);
@@ -179,10 +183,52 @@ export const useSurveySessionFlow = ({
       applyChatResponse,
       clearError,
       continueSurveyMutation,
-      hydrateInitialSession,
+      ensureSessionId,
       isSubmitting,
-      sessionId,
       setError,
+      setLastSubmittedMessage,
+      setSubmitting,
+    ],
+  );
+
+  const retryWithFreshSession = useCallback(
+    async (content: string) => {
+      clearError();
+      resetSurveyState();
+      setHasBootstrapped(true);
+      setLastSubmittedMessage(content);
+      setSubmitting(true);
+
+      try {
+        const sessionResponse = await startSessionMutation.mutateAsync({
+          is_reset: true,
+        });
+        hydrateInitialSession(sessionResponse);
+        addUserMessage(content);
+
+        const response = await continueSurveyMutation.mutateAsync({
+          session_id: sessionResponse.session_id,
+          user_answer: content,
+        });
+
+        applyChatResponse(response);
+      } catch (requestError) {
+        applyServerSideChatBlock(requestError);
+        setError(extractApiErrorMessage(requestError, 'continue'));
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [
+      addUserMessage,
+      applyServerSideChatBlock,
+      applyChatResponse,
+      clearError,
+      continueSurveyMutation,
+      hydrateInitialSession,
+      resetSurveyState,
+      setError,
+      setHasBootstrapped,
       setLastSubmittedMessage,
       setSubmitting,
       startSessionMutation,
@@ -198,32 +244,7 @@ export const useSurveySessionFlow = ({
     }
 
     if (isRecoverableMockSessionError(error)) {
-      clearError();
-      resetSurveyState();
-      setHasBootstrapped(true);
-      setLastSubmittedMessage(lastSubmittedMessage);
-      setSubmitting(true);
-
-      try {
-        const sessionResponse = await startSessionMutation.mutateAsync({
-          is_reset: true,
-        });
-        hydrateInitialSession(sessionResponse);
-        addUserMessage(lastSubmittedMessage);
-
-        const response = await continueSurveyMutation.mutateAsync({
-          session_id: sessionResponse.session_id,
-          user_answer: lastSubmittedMessage,
-        });
-
-        applyChatResponse(response);
-      } catch (requestError) {
-        applyServerSideChatBlock(requestError);
-        setError(extractApiErrorMessage(requestError));
-      } finally {
-        setSubmitting(false);
-      }
-
+      await retryWithFreshSession(lastSubmittedMessage);
       return;
     }
 
@@ -232,22 +253,11 @@ export const useSurveySessionFlow = ({
       appendUserMessage: false,
     });
   }, [
-    addUserMessage,
-    applyServerSideChatBlock,
-    applyChatResponse,
     bootstrapSurvey,
-    clearError,
-    continueSurveyMutation,
     error,
-    hydrateInitialSession,
     lastSubmittedMessage,
     queueFocusRestore,
-    resetSurveyState,
-    setError,
-    setHasBootstrapped,
-    setLastSubmittedMessage,
-    setSubmitting,
-    startSessionMutation,
+    retryWithFreshSession,
     submitMessage,
   ]);
 
@@ -275,7 +285,7 @@ export const useSurveySessionFlow = ({
       clearModerationState();
       hydrateInitialSession(response);
     } catch (requestError) {
-      const errorMessage = extractApiErrorMessage(requestError);
+      const errorMessage = extractApiErrorMessage(requestError, 'reset');
 
       if (isRecoverableMockSessionError(errorMessage)) {
         resetSurveyState();

--- a/src/features/survey/store/useSurveyStore.ts
+++ b/src/features/survey/store/useSurveyStore.ts
@@ -35,7 +35,6 @@ interface SurveyStoreState {
   clearModerationState: () => void;
   addUserMessage: (content: string) => void;
   hydrateInitialSession: (payload: SurveySessionStartResponse) => void;
-  beginSession: (payload: SurveySessionStartResponse) => void;
   applyChatResponse: (payload: SurveyChatResponse) => void;
   resetSurveyState: () => void;
 }
@@ -69,6 +68,23 @@ const getInitialMessages = (payload: SurveySessionStartResponse) => {
   }
 
   return [];
+};
+
+const appendAssistantMessageIfNeeded = (
+  messages: SurveyMessage[],
+  content: string | null,
+) => {
+  if (!content) {
+    return messages;
+  }
+
+  const lastMessage = messages.at(-1);
+
+  if (lastMessage?.role === 'assistant' && lastMessage.content === content) {
+    return messages;
+  }
+
+  return [...messages, createMessage('assistant', content)];
 };
 
 const createInitialState = (ownerKey: string | null = null) => ({
@@ -130,36 +146,6 @@ export const useSurveyStore = create<SurveyStoreState>()(
           messages: getInitialMessages(payload),
           ownerKey: state.ownerKey,
         })),
-      beginSession: (payload) =>
-        set((state) => ({
-          sessionId: payload.session_id,
-          status: payload.status,
-          progress: payload.progress ?? state.progress,
-          hasBootstrapped: true,
-          isSubmitting: false,
-          error: null,
-          recommendationReady: payload.recommendation_ready,
-          messages:
-            state.messages.length === 0
-              ? getInitialMessages(payload)
-              : payload.assistant_message
-                ? state.messages.at(-1)?.role === 'assistant' &&
-                  state.messages.at(-1)?.content === payload.assistant_message
-                  ? state.messages
-                  : [
-                      ...state.messages,
-                      createMessage('assistant', payload.assistant_message),
-                    ]
-                : payload.recommendation_ready
-                  ? state.messages.at(-1)?.role === 'assistant' &&
-                    state.messages.at(-1)?.content === COMPLETION_GUIDE_MESSAGE
-                    ? state.messages
-                    : [
-                        ...state.messages,
-                        createMessage('assistant', COMPLETION_GUIDE_MESSAGE),
-                      ]
-                  : state.messages,
-        })),
       applyChatResponse: (payload) =>
         set((state) => ({
           status: payload.status,
@@ -169,23 +155,17 @@ export const useSurveyStore = create<SurveyStoreState>()(
           error: null,
           messages: (() => {
             if (payload.assistant_message) {
-              return state.messages.at(-1)?.role === 'assistant' &&
-                state.messages.at(-1)?.content === payload.assistant_message
-                ? state.messages
-                : [
-                    ...state.messages,
-                    createMessage('assistant', payload.assistant_message),
-                  ];
+              return appendAssistantMessageIfNeeded(
+                state.messages,
+                payload.assistant_message,
+              );
             }
 
             if (payload.recommendation_ready) {
-              return state.messages.at(-1)?.role === 'assistant' &&
-                state.messages.at(-1)?.content === COMPLETION_GUIDE_MESSAGE
-                ? state.messages
-                : [
-                    ...state.messages,
-                    createMessage('assistant', COMPLETION_GUIDE_MESSAGE),
-                  ];
+              return appendAssistantMessageIfNeeded(
+                state.messages,
+                COMPLETION_GUIDE_MESSAGE,
+              );
             }
 
             return state.messages;

--- a/src/features/survey/types/survey.ts
+++ b/src/features/survey/types/survey.ts
@@ -25,10 +25,6 @@ export interface SurveySessionStartRequest {
   is_reset?: boolean;
 }
 
-export interface SurveyApiSessionStartRequest {
-  is_reset?: boolean;
-}
-
 export interface SurveyApiChatRequest {
   message: string;
 }
@@ -80,7 +76,6 @@ export type SurveyResetResponse = SurveySessionResponse;
 
 export interface SurveyResultQuery {
   session_id: string;
-  sort?: string;
   cursor?: string;
   page_size?: number;
 }

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -41,13 +41,19 @@ function SurveyPage() {
   const authGate = useAuthGate();
   const canAccessSurvey = authGate.accessStatus === 'authorized';
   const account = useAuthStore((state) => state.account);
-  const syncOwnerKey = useSurveyStore((state) => state.syncOwnerKey);
-  const storedOwnerKey = useSurveyStore((state) => state.ownerKey);
-  const surveySessionId = useSurveyStore((state) => state.sessionId);
-  const messages = useSurveyStore((state) => state.messages);
-  const recommendationReady = useSurveyStore(
-    (state) => state.recommendationReady,
-  );
+  const {
+    syncOwnerKey,
+    storedOwnerKey,
+    surveySessionId,
+    messages,
+    recommendationReady,
+  } = useSurveyStore((state) => ({
+    syncOwnerKey: state.syncOwnerKey,
+    storedOwnerKey: state.ownerKey,
+    surveySessionId: state.sessionId,
+    messages: state.messages,
+    recommendationReady: state.recommendationReady,
+  }));
   const isHistoryMode = searchParams.get('mode') === 'history';
   const [enteredWithCompletedSurvey, setEnteredWithCompletedSurvey] = useState<
     boolean | null


### PR DESCRIPTION
## 관련 이슈

- closes #341 

## 변경 내용

- 설문 세션 흐름 훅의 분기를 정리하고, `start → submit → retry → reset` 흐름이 더 읽기 쉽게 보이도록 정리했습니다.
- `sessionId` 유무에 따라 중복되던 설문 제출 로직을 공통 흐름으로 정리했습니다.
- 미사용 store 액션을 제거하고, assistant 메시지 중복 추가 로직을 helper로 정리해 store 책임을 조금 더 단순화했습니다.
- survey 타입 정의에서 중복되던 request/interface를 통합하고, 실제 사용하지 않는 query 필드를 제거했습니다.
- 설문 시작, 진행, 초기화, 추천 결과 조회 단계에서 같은 오류 문구가 반복되지 않도록 단계별 메시지로 분리했습니다.
- 첫 질문 생성 실패와 진행 중 다음 질문 실패가 같은 맥락으로 보이지 않도록 timeout / 네트워크 / fallback 문구를 문맥에 맞게 정리했습니다.
- 화면 전용 파생값 일부를 훅 밖으로 옮겨, 훅이 꼭 가져야 할 책임만 남기도록 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 기능 변경보다 설문 코드의 가독성, 유지보수성, 책임 분리, 그리고 오류 메시지 UX 개선에 집중한 리팩터링입니다.
- 설문 API 계약이나 사용자 흐름은 유지한 채, 중복 코드와 과한 분기, 문맥에 맞지 않는 에러 표현을 줄이는 방향으로 진행했습니다.