### PR TITLE
[Feat] 게임 상세 모달 줄거리 더보기 UX 개선

### DIFF
--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -33,6 +33,7 @@ const DETAIL_NOT_FOUND_TITLE = '게임 상세 정보 없음';
 const DETAIL_NOT_FOUND_MESSAGE = '해당 게임 상세 정보를 찾을 수 없습니다.';
 const DETAIL_FETCH_ERROR_MESSAGE =
   '상세 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.';
+const DESCRIPTION_TOGGLE_MIN_LENGTH = 140;
 
 const GameDetailModalSkeleton = ({ game }: { game: GameListItem }) => {
   const title = normalizeMeaningfulText(game.name) ?? 'N/A';
@@ -145,6 +146,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
   const [failedImageUrlsByGameId, setFailedImageUrlsByGameId] = useState<
     Record<number, string[]>
   >({});
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const {
     canRenderFallbackSummary,
     clearToast,
@@ -189,6 +191,15 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
     : 'N/A';
   const descriptionField =
     normalizeMeaningfulText(detail?.description) ?? detailFieldFallback;
+  const descriptionText =
+    descriptionField === DETAIL_LOADING_TEXT
+      ? '상세 정보를 불러오는 중입니다.'
+      : formatNullableText(descriptionField);
+  const canToggleDescription =
+    descriptionField !== DETAIL_LOADING_TEXT &&
+    descriptionText !== 'N/A' &&
+    (descriptionText.length >= DESCRIPTION_TOGGLE_MIN_LENGTH ||
+      descriptionText.includes('\n'));
   const detailRows = [
     {
       label: '게임 출시일',
@@ -335,7 +346,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                 )}
               </div>
 
-              <div className="min-w-0 sm:pr-12">
+              <div className="min-w-0 sm:flex sm:h-full sm:flex-col sm:pr-12">
                 <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3 pr-10 sm:items-center sm:pr-0">
                   <h2
                     id="game-detail-modal-title"
@@ -381,11 +392,38 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                     {likeCount.toLocaleString('ko-KR')}
                   </span>
                 </p>
-                <p className="mt-5 line-clamp-5 text-sm leading-6 text-white/60 sm:line-clamp-6">
-                  {descriptionField === DETAIL_LOADING_TEXT
-                    ? '상세 정보를 불러오는 중입니다.'
-                    : formatNullableText(descriptionField)}
-                </p>
+                <div
+                  className={`mt-5 sm:flex sm:flex-1 sm:flex-col ${canToggleDescription && !isDescriptionExpanded ? 'sm:relative' : ''}`}
+                >
+                  <div
+                    className={`relative ${canToggleDescription && !isDescriptionExpanded ? 'sm:pr-0 sm:pb-7' : ''}`}
+                  >
+                    <p
+                      className={`text-sm leading-6 text-white/60 transition-[max-height] duration-200 ease-out ${isDescriptionExpanded ? '' : 'line-clamp-5 sm:line-clamp-6'}`}
+                    >
+                      {descriptionText}
+                    </p>
+                    {canToggleDescription && !isDescriptionExpanded ? (
+                      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-[linear-gradient(180deg,rgba(12,12,14,0),rgba(12,12,14,0.92)_72%,rgba(12,12,14,1))]" />
+                    ) : null}
+                  </div>
+                  {canToggleDescription ? (
+                    <button
+                      type="button"
+                      aria-expanded={isDescriptionExpanded}
+                      onClick={() =>
+                        setIsDescriptionExpanded((current) => !current)
+                      }
+                      className={`mt-1 inline-flex cursor-pointer items-center text-sm font-semibold text-white/78 underline-offset-4 transition hover:text-white hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12] ${
+                        !isDescriptionExpanded
+                          ? 'sm:absolute sm:bottom-0 sm:left-0'
+                          : ''
+                      }`}
+                    >
+                      {isDescriptionExpanded ? '줄거리 접기' : '줄거리 더보기'}
+                    </button>
+                  ) : null}
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
## 관련 이슈

- closes #344

## 변경 내용

- 게임 상세 모달 줄거리 영역에 `더보기 / 접기` 토글을 추가했습니다.
- 접힌 상태에서 줄거리 하단에 페이드 오버레이를 적용해 잘림이 자연스럽게 보이도록 조정했습니다.
- `줄거리 더보기`를 링크형 CTA로 바꾸고, 접힌 상태에서 이미지 하단선과 정렬되도록 배치했습니다.
- 긴 줄거리에서만 토글이 보이도록 조건을 추가하고, `N/A` 및 로딩 상태에서는 숨기도록 처리했습니다.
- CTA에 `cursor-pointer`를 추가해 상호작용성을 명확히 했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷


https://github.com/user-attachments/assets/46b4bb8f-5e86-4367-b47c-07c38602c1f8

## 참고사항

- API 응답 구조나 공개 props 변경은 없습니다.
- 변경 파일은 `src/features/games/components/GameDetailModal.tsx` 한 곳입니다.
