### PR TITLE
[Feat] 챗봇 메시지 전송 및 SSE 스트리밍 응답 프론트엔드 처리

### DIFF
--- a/src/features/support-chat/api/chatbot.ts
+++ b/src/features/support-chat/api/chatbot.ts
@@ -1,4 +1,9 @@
 import { apiBaseUrl } from '@/lib/env';
+import { useAuthStore } from '@/store/useAuthStore';
+import {
+  expireAuthSession,
+  refreshStoredAccessToken,
+} from '@/features/auth/utils/sessionManager';
 import type {
   ChatbotErrorResponse,
   ChatbotMessageRequest,
@@ -40,12 +45,24 @@ const getDefaultChatbotErrorMessage = (
   status: number | null,
   fallback = '챗봇 요청을 처리하는 중 오류가 발생했습니다.',
 ) => {
+  if (status === 401) {
+    return '로그인 정보가 만료되었거나 유효하지 않습니다. 다시 로그인해 주세요.';
+  }
+
   if (status === 400) {
     return '메시지는 공백일 수 없고 2자 이상이어야 합니다.';
   }
 
   if (status === 404) {
-    return '만료되었거나 유효하지 않은 대화 세션입니다.';
+    return '만료되었거나 유효하지 않은 session_id 입니다.';
+  }
+
+  if (status === 409) {
+    return '이미 스트리밍이 진행 중입니다.';
+  }
+
+  if (status === 500) {
+    return '서버 응답 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
   }
 
   return fallback;
@@ -57,6 +74,7 @@ const extractChatbotErrorMessage = async (response: Response) => {
 
     return (
       data.error_detail ||
+      (typeof data.detail === 'string' ? data.detail : null) ||
       getDefaultChatbotErrorMessage(response.status, data.error_detail)
     );
   } catch {
@@ -64,14 +82,79 @@ const extractChatbotErrorMessage = async (response: Response) => {
   }
 };
 
-export const sendChatbotMessage = async (payload: ChatbotMessageRequest) => {
-  const response = await fetch(createApiUrl(`${CHATBOT_BASE_PATH}/messages`), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
+const getSupportChatAccessToken = () => {
+  const accessToken = useAuthStore.getState().accessToken?.trim();
+
+  if (!accessToken) {
+    throw new Error('로그인 후 챗봇을 이용할 수 있습니다.');
+  }
+
+  return accessToken;
+};
+
+const createAuthorizedHeaders = ({
+  accept,
+  contentType,
+}: {
+  accept: string;
+  contentType?: string;
+}) => {
+  const headers = new Headers({
+    Accept: accept,
+    Authorization: `Bearer ${getSupportChatAccessToken()}`,
   });
+
+  if (contentType) {
+    headers.set('Content-Type', contentType);
+  }
+
+  return headers;
+};
+
+const fetchChatbotApi = async (
+  url: string,
+  init: Omit<RequestInit, 'headers'> & {
+    accept: string;
+    contentType?: string;
+  },
+) => {
+  const request = async () =>
+    fetch(url, {
+      ...init,
+      credentials: 'include',
+      headers: createAuthorizedHeaders({
+        accept: init.accept,
+        contentType: init.contentType,
+      }),
+    });
+
+  let response = await request();
+
+  if (response.status !== 401) {
+    return response;
+  }
+
+  try {
+    await refreshStoredAccessToken();
+  } catch (refreshError) {
+    expireAuthSession();
+    throw refreshError;
+  }
+
+  response = await request();
+  return response;
+};
+
+export const sendChatbotMessage = async (payload: ChatbotMessageRequest) => {
+  const response = await fetchChatbotApi(
+    createApiUrl(`${CHATBOT_BASE_PATH}/messages`),
+    {
+      method: 'POST',
+      accept: 'application/json',
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    },
+  );
 
   if (!response.ok) {
     throw new Error(await extractChatbotErrorMessage(response));
@@ -91,7 +174,8 @@ const parseSseEvent = (chunk: string): ChatbotStreamEvent | null => {
     }
 
     if (line.startsWith('data:')) {
-      dataLines.push(line.replace('data:', '').trim());
+      const rawValue = line.slice('data:'.length);
+      dataLines.push(rawValue.startsWith(' ') ? rawValue.slice(1) : rawValue);
     }
   }
 
@@ -102,6 +186,9 @@ const parseSseEvent = (chunk: string): ChatbotStreamEvent | null => {
   let parsed: {
     session_id?: string;
     content?: string;
+    expires_at?: string;
+    expires_in_seconds?: number;
+    session_ttl_seconds?: number;
   };
 
   try {
@@ -122,6 +209,9 @@ const parseSseEvent = (chunk: string): ChatbotStreamEvent | null => {
     return {
       type: 'start',
       sessionId: parsed.session_id,
+      expiresAt: parsed.expires_at,
+      expiresInSeconds: parsed.expires_in_seconds,
+      sessionTtlSeconds: parsed.session_ttl_seconds,
     };
   }
 
@@ -151,13 +241,11 @@ export const streamChatbotResponse = async ({
   signal?: AbortSignal;
   onEvent: (event: ChatbotStreamEvent) => void;
 }) => {
-  const response = await fetch(
+  const response = await fetchChatbotApi(
     createApiUrl(`${CHATBOT_BASE_PATH}/stream`, { session_id: sessionId }),
     {
       method: 'GET',
-      headers: {
-        Accept: 'text/event-stream',
-      },
+      accept: 'text/event-stream',
       signal,
     },
   );

--- a/src/features/support-chat/hooks/useSupportChatConversation.ts
+++ b/src/features/support-chat/hooks/useSupportChatConversation.ts
@@ -11,9 +11,6 @@ import type { SupportChatRouteContext } from '@/features/support-chat/types/supp
 const SUPPORT_CHAT_INPUT_VALIDATION_MESSAGE =
   '메시지는 공백일 수 없고 2자 이상이어야 합니다.';
 
-const isRecoverableSessionError = (message: string) =>
-  message.includes('session_id') || message.includes('유효하지 않은');
-
 export type SupportChatConversationResetOptions = {
   routeContext?: SupportChatRouteContext;
   keepPanelOpen?: boolean;
@@ -34,7 +31,6 @@ function useSupportChatConversation({
   const sendMessageMutation = useSendChatbotMessageMutation();
 
   const {
-    sessionId,
     messages,
     quickActions,
     showQuickActions,
@@ -130,29 +126,9 @@ function useSupportChatConversation({
       setSubmitting(true);
 
       try {
-        let response;
-
-        try {
-          response = await sendMessageMutation.mutateAsync({
-            message: trimmedMessage,
-            session_id: sessionId ?? undefined,
-          });
-        } catch (requestError) {
-          const errorMessage = extractSupportChatErrorMessage(requestError);
-
-          if (requestGeneration !== requestGenerationRef.current) {
-            return;
-          }
-
-          if (sessionId && isRecoverableSessionError(errorMessage)) {
-            setSessionId(null);
-            response = await sendMessageMutation.mutateAsync({
-              message: trimmedMessage,
-            });
-          } else {
-            throw requestError;
-          }
-        }
+        const response = await sendMessageMutation.mutateAsync({
+          message: trimmedMessage,
+        });
 
         if (requestGeneration !== requestGenerationRef.current) {
           return;
@@ -178,12 +154,24 @@ function useSupportChatConversation({
               );
             }
 
+            if (event.type === 'start') {
+              setSessionId(event.sessionId);
+            }
+
             if (event.type === 'complete') {
+              setSessionId(event.sessionId);
               finalizeAssistantMessage(assistantPlaceholderMessageId);
               setSubmitting(false);
             }
           },
         });
+
+        if (requestGeneration !== requestGenerationRef.current) {
+          return;
+        }
+
+        finalizeAssistantMessage(assistantPlaceholderMessageId);
+        setSubmitting(false);
       } catch (requestError) {
         if (requestGeneration !== requestGenerationRef.current) {
           return;
@@ -213,7 +201,6 @@ function useSupportChatConversation({
       isSubmitting,
       removeMessage,
       sendMessageMutation,
-      sessionId,
       setSessionId,
       setSubmitting,
     ],

--- a/src/features/support-chat/mocks/handlers.ts
+++ b/src/features/support-chat/mocks/handlers.ts
@@ -18,9 +18,32 @@ const CHATBOT_BASE_PATH = '/api/v1/chatbot';
 type MockChatSession = {
   id: string;
   lastReply: string;
+  expiresAt: string;
+  expiresInSeconds: number;
+  sessionTtlSeconds: number;
 };
 
 const chatSessions = new Map<string, MockChatSession>();
+const CHAT_SESSION_TTL_SECONDS = 1800;
+
+const getAuthorizedUser = (authorization: string | null) => {
+  if (!authorization?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authorization.replace('Bearer ', '').trim();
+  const loginId = token.replace(/^mock-access-token-/, '');
+
+  if (!loginId || loginId === token) {
+    return null;
+  }
+
+  return loginId;
+};
+
+const isExpiredSession = (session: MockChatSession) =>
+  Number.isFinite(Date.parse(session.expiresAt)) &&
+  Date.parse(session.expiresAt) <= Date.now();
 
 const splitMessageIntoChunks = (message: string) => {
   const chunks: string[] = [];
@@ -35,9 +58,9 @@ const splitMessageIntoChunks = (message: string) => {
   return chunks;
 };
 
-const createStreamResponse = (sessionId: string, reply: string) => {
+const createStreamResponse = (session: MockChatSession) => {
   const encoder = new TextEncoder();
-  const chunks = splitMessageIntoChunks(reply);
+  const chunks = splitMessageIntoChunks(session.lastReply);
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -50,7 +73,12 @@ const createStreamResponse = (sessionId: string, reply: string) => {
       };
 
       void (async () => {
-        await pushEvent('start', { session_id: sessionId });
+        await pushEvent('start', {
+          session_id: session.id,
+          expires_at: session.expiresAt,
+          expires_in_seconds: session.expiresInSeconds,
+          session_ttl_seconds: session.sessionTtlSeconds,
+        });
 
         for (const chunk of chunks) {
           await delay(140);
@@ -58,7 +86,7 @@ const createStreamResponse = (sessionId: string, reply: string) => {
         }
 
         await delay(100);
-        await pushEvent('complete', { session_id: sessionId });
+        await pushEvent('complete', { session_id: session.id });
         controller.close();
       })().catch((error) => {
         controller.error(error);
@@ -77,6 +105,13 @@ const createStreamResponse = (sessionId: string, reply: string) => {
 
 export const supportChatHandlers = [
   http.post(`${CHATBOT_BASE_PATH}/messages`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+    const loginId = getAuthorizedUser(authorization);
+
+    if (!loginId) {
+      return mockErrorResponse(401, '로그인 후 챗봇을 이용할 수 있습니다.');
+    }
+
     const body = (await request.json()) as ChatbotMessageRequest;
     const message = body.message.trim();
 
@@ -87,37 +122,42 @@ export const supportChatHandlers = [
       );
     }
 
-    let sessionId = body.session_id;
-
-    if (sessionId !== undefined && !chatSessions.has(sessionId)) {
-      return mockErrorResponse(
-        404,
-        '만료되었거나 유효하지 않은 session_id 입니다.',
-      );
-    }
-
-    if (sessionId === undefined) {
-      sessionId = crypto.randomUUID();
-    }
+    const sessionId = crypto.randomUUID();
 
     const matchedEntry = findSupportFaqEntry(message);
     const reply =
       matchedEntry?.answer ??
       buildSupportChatFallbackMessage(createDefaultRouteContext());
+    const expiresAt = new Date(
+      Date.now() + CHAT_SESSION_TTL_SECONDS * 1000,
+    ).toISOString();
 
     chatSessions.set(sessionId, {
       id: sessionId,
       lastReply: reply,
+      expiresAt,
+      expiresInSeconds: CHAT_SESSION_TTL_SECONDS,
+      sessionTtlSeconds: CHAT_SESSION_TTL_SECONDS,
     });
 
     await delay(180);
 
     return HttpResponse.json({
       session_id: sessionId,
+      expires_at: expiresAt,
+      expires_in_seconds: CHAT_SESSION_TTL_SECONDS,
+      session_ttl_seconds: CHAT_SESSION_TTL_SECONDS,
     } satisfies ChatbotMessageResponse);
   }),
 
   http.get(`${CHATBOT_BASE_PATH}/stream`, async ({ request }) => {
+    const authorization = request.headers.get('Authorization');
+    const loginId = getAuthorizedUser(authorization);
+
+    if (!loginId) {
+      return mockErrorResponse(401, '로그인 후 챗봇을 이용할 수 있습니다.');
+    }
+
     const url = new URL(request.url);
     const sessionId = url.searchParams.get('session_id')?.trim() ?? '';
 
@@ -128,9 +168,20 @@ export const supportChatHandlers = [
     const session = chatSessions.get(sessionId);
 
     if (!session) {
-      return mockErrorResponse(404, '스트리밍 대상 세션을 찾을 수 없습니다.');
+      return mockErrorResponse(
+        404,
+        '만료되었거나 유효하지 않은 session_id 입니다.',
+      );
     }
 
-    return createStreamResponse(sessionId, session.lastReply);
+    if (isExpiredSession(session)) {
+      chatSessions.delete(sessionId);
+      return mockErrorResponse(
+        404,
+        '만료되었거나 유효하지 않은 session_id 입니다.',
+      );
+    }
+
+    return createStreamResponse(session);
   }),
 ];

--- a/src/features/support-chat/types/supportChat.ts
+++ b/src/features/support-chat/types/supportChat.ts
@@ -22,20 +22,26 @@ export type SupportChatRouteContext = {
 
 export type ChatbotMessageRequest = {
   message: string;
-  session_id?: string;
 };
 
 export type ChatbotMessageResponse = {
   session_id: string;
+  expires_at?: string;
+  expires_in_seconds?: number;
+  session_ttl_seconds?: number;
 };
 
 export type ChatbotErrorResponse = {
   error_detail: string;
+  detail?: string | Record<string, string[]>;
 };
 
 export type ChatbotStreamStartEvent = {
   type: 'start';
   sessionId: string;
+  expiresAt?: string;
+  expiresInSeconds?: number;
+  sessionTtlSeconds?: number;
 };
 
 export type ChatbotStreamChunkEvent = {


### PR DESCRIPTION
## 관련 이슈

- closes #343 

## 변경 내용

- 고객센터 챗봇 메시지 전송 시 `POST /api/v1/chatbot/messages`를 호출해 `session_id`를 발급받고, 해당 세션으로 `GET /api/v1/chatbot/stream?session_id=...` SSE 스트리밍을 연결하도록 정리했습니다.
- 챗봇 POST / SSE GET 모두 fetch 기반 요청에 `Authorization: Bearer ...` 헤더를 포함하도록 수정하고, fetch 경로에서도 401 발생 시 토큰 갱신 후 재시도할 수 있게 보강했습니다.
- SSE 응답의 `event: chunk` / `data: {"content": ...}` 조각을 파싱해 마지막 챗봇 메시지에 순차적으로 이어붙이도록 수정해, 실시간 타이핑 효과가 자연스럽게 유지되게 했습니다.
- 스트리밍 진행 중에는 기존처럼 입력창과 전송 버튼을 비활성화하고, 스트림 종료 시 입력이 다시 풀리도록 마무리 처리를 정리했습니다.
- 서버 오류, 잘못된 `session_id`, 인증 만료 등 상태코드별 에러 메시지를 실제 명세에 맞춰 다듬었습니다.
- MSW mock도 실서버 계약과 동일하게 `session_id`, 세션 만료 시간, 인증 헤더, SSE 이벤트 구조를 따르도록 함께 업데이트했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

- UI 없음

## 참고사항

- 현재 구현은 `fetch` + `ReadableStream` 기반으로 SSE를 처리하며, 기본 `EventSource`는 인증 헤더를 실을 수 없어 사용하지 않았습니다.