### PR TITLE
[Fix] 로딩 UX 정리 및 설문/매칭 흐름 안정화

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -7,7 +7,6 @@ import {
 import { useNavigate } from 'react-router';
 import {
   ChevronRight,
-  LoaderCircle,
   RotateCcw,
   SendHorizontal,
   TriangleAlert,
@@ -31,13 +30,7 @@ type SurveyChatPanelProps = {
   isHistoryView?: boolean;
 };
 
-type SurveyChatLoadingStateProps = {
-  message?: string;
-};
-
-export function SurveyChatLoadingState({
-  message = 'AI가 첫 질문을 준비하고 있습니다.',
-}: SurveyChatLoadingStateProps) {
+export function SurveyChatLoadingState() {
   return (
     <section className="survey-panel relative flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="border-b border-white/8 px-4 py-2.5 sm:px-5 md:px-6">
@@ -50,25 +43,61 @@ export function SurveyChatLoadingState({
             </h2>
           </div>
 
-          <div className="hidden sm:block" />
+          <div className="flex flex-wrap items-center justify-end gap-2.5">
+            <div className="min-w-43 rounded-[22px] border border-white/10 bg-white/3 px-3.5 py-3 shadow-[0_14px_30px_rgba(0,0,0,0.16)] backdrop-blur-md">
+              <div className="flex items-center justify-between gap-3">
+                <div className="h-3.5 w-14 animate-pulse rounded-full bg-white/10" />
+                <div className="h-4 w-9 animate-pulse rounded-full bg-white/12" />
+              </div>
+              <div className="mt-2.5 h-1.5 overflow-hidden rounded-full bg-white/8">
+                <div className="h-full w-1/3 animate-pulse rounded-full bg-white/14" />
+              </div>
+            </div>
+
+            <div className="h-[52px] w-31 animate-pulse rounded-2xl border border-white/10 bg-white/3" />
+          </div>
         </div>
       </div>
 
       <div className="min-h-0 flex-1 px-3 py-2.5 sm:px-4 sm:py-3 md:px-5 md:py-3">
         <div className="survey-panel flex h-full min-h-0 flex-col overflow-hidden border-white/6 bg-[linear-gradient(180deg,rgba(12,12,14,0.86),rgba(7,7,8,0.94))]">
-          <div className="flex min-h-0 flex-1 items-center justify-center px-6 py-10">
-            <div className="flex flex-col items-center gap-4 text-center">
-              <span className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-[#8d2c2c]/28 bg-[#180909]/52 text-[#f1b8b8] shadow-[0_0_0_8px_rgba(255,255,255,0.015)]">
-                <LoaderCircle size={20} className="animate-spin" />
-              </span>
-              <p className="text-sm font-medium break-keep text-white/70 sm:text-[15px]">
-                {message}
-              </p>
+          <div className="survey-message-scroll max-h-none flex-1 space-y-4 px-4 py-4 sm:px-5 sm:py-4.5 md:px-6">
+            <div className="flex justify-start">
+              <div className="flex max-w-[92%] items-start gap-[0.7rem] md:max-w-[78%]">
+                <div className="mt-1 h-[38px] w-[38px] shrink-0 animate-pulse rounded-2xl bg-white/8" />
+                <div className="rounded-[24px] rounded-tl-md border border-white/8 bg-white/4 px-4 py-3.5 shadow-[0_18px_40px_rgba(0,0,0,0.28)]">
+                  <div className="space-y-2.5">
+                    <div className="h-4 w-32 animate-pulse rounded-full bg-white/10" />
+                    <div className="h-4 w-full max-w-92 animate-pulse rounded-full bg-white/8" />
+                    <div className="h-4 w-full max-w-80 animate-pulse rounded-full bg-white/8" />
+                    <div className="h-4 w-48 animate-pulse rounded-full bg-white/8" />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex justify-start">
+              <div className="flex max-w-[92%] items-start gap-2.5 md:max-w-[68%]">
+                <div className="mt-1 h-[38px] w-[38px] shrink-0 animate-pulse rounded-2xl bg-white/8" />
+                <div className="rounded-[24px] rounded-tl-md border border-white/7 bg-white/[0.03] px-4 py-3 shadow-[0_18px_40px_rgba(0,0,0,0.18)]">
+                  <div className="space-y-2.5">
+                    <div className="h-4 w-full max-w-72 animate-pulse rounded-full bg-white/8" />
+                    <div className="h-4 w-40 animate-pulse rounded-full bg-white/8" />
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
 
           <div className="border-t border-white/8 px-4 py-3.5 sm:px-5 sm:py-4 md:px-6">
-            <div className="h-15 rounded-full border border-white/8 bg-white/[0.03]" />
+            <div className="relative block h-15 overflow-hidden rounded-full border border-white/10 bg-[#0e0e10]">
+              <div className="h-full w-full py-4.25 pr-[5.8rem] pl-4 sm:pl-5">
+                <div className="h-6 w-full max-w-110 rounded-full bg-white/8" />
+              </div>
+              <div className="absolute inset-y-0 right-0 flex items-center pr-2">
+                <div className="h-11.5 w-11.5 rounded-full bg-white/10" />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -199,6 +228,10 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
     }
   };
 
+  if (!messages.length && isSubmitting) {
+    return <SurveyChatLoadingState />;
+  }
+
   return (
     <section className="survey-panel relative flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="border-b border-white/8 px-4 py-2.5 sm:px-5 md:px-6">
@@ -232,19 +265,6 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
             ref={viewportRef}
             className="survey-message-scroll max-h-none flex-1 space-y-4 px-4 py-4 sm:px-5 sm:py-4.5 md:px-6"
           >
-            {!messages.length && isSubmitting ? (
-              <div className="flex min-h-full items-center justify-center py-6">
-                <div className="flex flex-col items-center gap-4 text-center">
-                  <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[#8d2c2c]/28 bg-[#180909]/52 text-[#f1b8b8] shadow-[0_0_0_8px_rgba(255,255,255,0.015)]">
-                    <LoaderCircle size={18} className="animate-spin" />
-                  </span>
-                  <p className="text-sm font-medium break-keep text-white/70 sm:text-[15px]">
-                    AI가 첫 질문을 준비하고 있습니다.
-                  </p>
-                </div>
-              </div>
-            ) : null}
-
             {messages.map((message) => (
               <SurveyMessageBubble key={message.id} message={message} />
             ))}

--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -7,11 +7,11 @@ import {
 import { useNavigate } from 'react-router';
 import {
   ChevronRight,
+  LoaderCircle,
   RotateCcw,
   SendHorizontal,
   TriangleAlert,
 } from 'lucide-react';
-import CenteredLoadingState from '../../../components/common/CenteredLoadingState';
 
 import { ROUTES } from '../../../constants/routes';
 import { useSurveyStore } from '../store/useSurveyStore';
@@ -30,6 +30,51 @@ import SurveyProgress from './SurveyProgress';
 type SurveyChatPanelProps = {
   isHistoryView?: boolean;
 };
+
+type SurveyChatLoadingStateProps = {
+  message?: string;
+};
+
+export function SurveyChatLoadingState({
+  message = 'AI가 첫 질문을 준비하고 있습니다.',
+}: SurveyChatLoadingStateProps) {
+  return (
+    <section className="survey-panel relative flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="border-b border-white/8 px-4 py-2.5 sm:px-5 md:px-6">
+        <div className="grid gap-2.5 sm:grid-cols-[1fr_auto_1fr] sm:items-center">
+          <div className="hidden sm:block" />
+
+          <div className="min-w-0 text-center">
+            <h2 className="text-[24px] font-bold tracking-[-0.03em] text-white sm:text-[28px] md:text-[31px]">
+              게임 선호도 설문조사
+            </h2>
+          </div>
+
+          <div className="hidden sm:block" />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 px-3 py-2.5 sm:px-4 sm:py-3 md:px-5 md:py-3">
+        <div className="survey-panel flex h-full min-h-0 flex-col overflow-hidden border-white/6 bg-[linear-gradient(180deg,rgba(12,12,14,0.86),rgba(7,7,8,0.94))]">
+          <div className="flex min-h-0 flex-1 items-center justify-center px-6 py-10">
+            <div className="flex flex-col items-center gap-4 text-center">
+              <span className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-[#8d2c2c]/28 bg-[#180909]/52 text-[#f1b8b8] shadow-[0_0_0_8px_rgba(255,255,255,0.015)]">
+                <LoaderCircle size={20} className="animate-spin" />
+              </span>
+              <p className="text-sm font-medium break-keep text-white/70 sm:text-[15px]">
+                {message}
+              </p>
+            </div>
+          </div>
+
+          <div className="border-t border-white/8 px-4 py-3.5 sm:px-5 sm:py-4 md:px-6">
+            <div className="h-15 rounded-full border border-white/8 bg-white/[0.03]" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
 
 function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
   const navigate = useNavigate();
@@ -195,12 +240,16 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
             className="survey-message-scroll max-h-none flex-1 space-y-4 px-4 py-4 sm:px-5 sm:py-4.5 md:px-6"
           >
             {!messages.length && isSubmitting ? (
-              <CenteredLoadingState
-                label="Survey"
-                title="AI가 첫 질문을 준비하고 있습니다."
-                hint="취향을 더 잘 이해할 수 있도록 질문 흐름을 정리하고 있어요."
-                className="py-6"
-              />
+              <div className="flex min-h-full items-center justify-center py-6">
+                <div className="flex flex-col items-center gap-4 text-center">
+                  <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[#8d2c2c]/28 bg-[#180909]/52 text-[#f1b8b8] shadow-[0_0_0_8px_rgba(255,255,255,0.015)]">
+                    <LoaderCircle size={18} className="animate-spin" />
+                  </span>
+                  <p className="text-sm font-medium break-keep text-white/70 sm:text-[15px]">
+                    AI가 첫 질문을 준비하고 있습니다.
+                  </p>
+                </div>
+              </div>
             ) : null}
 
             {messages.map((message) => (

--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -81,25 +81,18 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
   const [inputValue, setInputValue] = useState('');
   const [isGuardrailPanelOpen, setIsGuardrailPanelOpen] = useState(false);
 
-  const {
-    sessionId,
-    messages,
-    progress,
-    hasBootstrapped,
-    isSubmitting,
-    error,
-    recommendationReady,
-    lastSubmittedMessage,
-  } = useSurveyStore((state) => ({
-    sessionId: state.sessionId,
-    messages: state.messages,
-    progress: state.progress,
-    hasBootstrapped: state.hasBootstrapped,
-    isSubmitting: state.isSubmitting,
-    error: state.error,
-    recommendationReady: state.recommendationReady,
-    lastSubmittedMessage: state.lastSubmittedMessage,
-  }));
+  const sessionId = useSurveyStore((state) => state.sessionId);
+  const messages = useSurveyStore((state) => state.messages);
+  const progress = useSurveyStore((state) => state.progress);
+  const hasBootstrapped = useSurveyStore((state) => state.hasBootstrapped);
+  const isSubmitting = useSurveyStore((state) => state.isSubmitting);
+  const error = useSurveyStore((state) => state.error);
+  const recommendationReady = useSurveyStore(
+    (state) => state.recommendationReady,
+  );
+  const lastSubmittedMessage = useSurveyStore(
+    (state) => state.lastSubmittedMessage,
+  );
 
   const {
     nonGameStrikeCount,

--- a/src/features/survey/hooks/useSurveySessionFlow.ts
+++ b/src/features/survey/hooks/useSurveySessionFlow.ts
@@ -28,41 +28,34 @@ export const useSurveySessionFlow = ({
   queueFocusRestore,
   cancelFocusRestore,
 }: UseSurveySessionFlowOptions) => {
-  const {
-    sessionId,
-    hasBootstrapped,
-    isSubmitting,
-    error,
-    lastSubmittedMessage,
-    clearError,
-    setHasBootstrapped,
-    setSubmitting,
-    setError,
-    setLastSubmittedMessage,
-    clearModerationState,
-    setChatBlockedUntil,
-    addUserMessage,
-    hydrateInitialSession,
-    applyChatResponse,
-    resetSurveyState,
-  } = useSurveyStore((state) => ({
-    sessionId: state.sessionId,
-    hasBootstrapped: state.hasBootstrapped,
-    isSubmitting: state.isSubmitting,
-    error: state.error,
-    lastSubmittedMessage: state.lastSubmittedMessage,
-    clearError: state.clearError,
-    setHasBootstrapped: state.setHasBootstrapped,
-    setSubmitting: state.setSubmitting,
-    setError: state.setError,
-    setLastSubmittedMessage: state.setLastSubmittedMessage,
-    clearModerationState: state.clearModerationState,
-    setChatBlockedUntil: state.setChatBlockedUntil,
-    addUserMessage: state.addUserMessage,
-    hydrateInitialSession: state.hydrateInitialSession,
-    applyChatResponse: state.applyChatResponse,
-    resetSurveyState: state.resetSurveyState,
-  }));
+  const sessionId = useSurveyStore((state) => state.sessionId);
+  const hasBootstrapped = useSurveyStore((state) => state.hasBootstrapped);
+  const isSubmitting = useSurveyStore((state) => state.isSubmitting);
+  const error = useSurveyStore((state) => state.error);
+  const lastSubmittedMessage = useSurveyStore(
+    (state) => state.lastSubmittedMessage,
+  );
+  const clearError = useSurveyStore((state) => state.clearError);
+  const setHasBootstrapped = useSurveyStore(
+    (state) => state.setHasBootstrapped,
+  );
+  const setSubmitting = useSurveyStore((state) => state.setSubmitting);
+  const setError = useSurveyStore((state) => state.setError);
+  const setLastSubmittedMessage = useSurveyStore(
+    (state) => state.setLastSubmittedMessage,
+  );
+  const clearModerationState = useSurveyStore(
+    (state) => state.clearModerationState,
+  );
+  const setChatBlockedUntil = useSurveyStore(
+    (state) => state.setChatBlockedUntil,
+  );
+  const addUserMessage = useSurveyStore((state) => state.addUserMessage);
+  const hydrateInitialSession = useSurveyStore(
+    (state) => state.hydrateInitialSession,
+  );
+  const applyChatResponse = useSurveyStore((state) => state.applyChatResponse);
+  const resetSurveyState = useSurveyStore((state) => state.resetSurveyState);
 
   const startSessionMutation = useStartSurveySessionMutation();
   const continueSurveyMutation = useContinueSurveyMutation();
@@ -85,7 +78,6 @@ export const useSurveySessionFlow = ({
         });
         hydrateInitialSession(response);
       } catch (requestError) {
-        setHasBootstrapped(false);
         setError(extractApiErrorMessage(requestError, 'start'));
       } finally {
         setSubmitting(false);
@@ -105,10 +97,10 @@ export const useSurveySessionFlow = ({
   );
 
   useEffect(() => {
-    if (!sessionId && !hasBootstrapped) {
+    if (!sessionId && !hasBootstrapped && !error) {
       void bootstrapSurvey();
     }
-  }, [bootstrapSurvey, hasBootstrapped, sessionId]);
+  }, [bootstrapSurvey, error, hasBootstrapped, sessionId]);
 
   const ensureSessionId = useCallback(async () => {
     if (sessionId) {

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -143,6 +143,15 @@ function MatchingGenreDetailPage() {
     () => matchCandidatesQuery.data?.results ?? [],
     [matchCandidatesQuery.data?.results],
   );
+  const candidateSetKey = useMemo(
+    () =>
+      genre
+        ? `${genre.slug}:${candidateRetryNo}:${candidates
+            .map((candidate) => candidate.game_id)
+            .join(',')}`
+        : null,
+    [candidateRetryNo, candidates, genre],
+  );
   const currentIndex = useMatchingStore((state) => state.currentIndex);
   const evaluationsByGameId = useMatchingStore(
     (state) => state.evaluationsByGameId,
@@ -164,7 +173,7 @@ function MatchingGenreDetailPage() {
 
   useEffect(() => {
     hasInitializedFlowRef.current = false;
-  }, [genre?.slug, matchCandidatesQuery.dataUpdatedAt]);
+  }, [candidateSetKey]);
 
   useEffect(() => {
     if (!genre || candidates.length === 0 || hasInitializedFlowRef.current) {
@@ -174,7 +183,13 @@ function MatchingGenreDetailPage() {
     restartFlow(genre, candidates);
     hasInitializedFlowRef.current = true;
     resetSubmitMatchResponsesMutation();
-  }, [genre, candidates, restartFlow, resetSubmitMatchResponsesMutation]);
+  }, [
+    candidateSetKey,
+    candidates,
+    genre,
+    restartFlow,
+    resetSubmitMatchResponsesMutation,
+  ]);
 
   const displayCandidates = candidates;
   const totalSteps = displayCandidates.length;

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -11,7 +11,6 @@ import {
 } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
-import CenteredLoadingState from '../../components/common/CenteredLoadingState';
 import LazyHeader from '../../components/common/LazyHeader';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
@@ -73,6 +72,54 @@ const getMatchCandidatesErrorMessage = (error: unknown) => {
 
   return extractApiErrorMessage(error);
 };
+
+function MatchingDetailSkeleton() {
+  return (
+    <section className="mx-auto mt-9 max-w-255 animate-pulse sm:mt-10 md:mt-12">
+      <div className="text-center">
+        <div className="mx-auto h-4 w-20 rounded-full bg-[#792222]/35" />
+        <div className="mx-auto mt-3 h-10 w-72 rounded-full bg-white/9" />
+      </div>
+
+      <div className="mt-8 grid gap-4 lg:grid-cols-[1.32fr_0.92fr] lg:gap-5 xl:mt-9">
+        <div className="overflow-hidden rounded-[28px] border border-white/8 bg-[#0c0c0d] p-3">
+          <div className="aspect-video rounded-[22px] bg-white/[0.05]" />
+          <div className="mt-4 h-4 w-28 rounded-full bg-white/8" />
+          <div className="mt-3 h-4 w-full rounded-full bg-white/7" />
+          <div className="mt-2 h-4 w-5/6 rounded-full bg-white/7" />
+        </div>
+
+        <div className="survey-panel flex flex-col px-5 py-5 sm:px-6 sm:py-6">
+          <div className="h-9 w-2/3 rounded-full bg-white/9" />
+          <div className="mt-4 h-4 w-full rounded-full bg-white/7" />
+          <div className="mt-2 h-4 w-4/5 rounded-full bg-white/7" />
+
+          <div className="mt-5 grid gap-1.5 sm:grid-cols-2">
+            <div className="h-16 rounded-[14px] border border-white/8 bg-white/3" />
+            <div className="h-16 rounded-[14px] border border-white/8 bg-white/3" />
+          </div>
+
+          <div className="mt-7 h-4 w-44 rounded-full bg-white/8" />
+          <div className="mt-4 flex gap-2">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-10 w-10 rounded-full bg-white/[0.06]"
+              />
+            ))}
+          </div>
+
+          <div className="mt-auto pt-8">
+            <div className="flex gap-3">
+              <div className="h-12 flex-1 rounded-full bg-white/[0.05]" />
+              <div className="h-12 flex-1 rounded-full bg-white/[0.08]" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
 
 function MatchingGenreDetailPage() {
   const { genreSlug } = useParams();
@@ -255,12 +302,7 @@ function MatchingGenreDetailPage() {
             </Link>
           </section>
         ) : authGate.accessStatus === 'loading' ? (
-          <CenteredLoadingState
-            label="Matching"
-            title="매칭 화면을 불러오는 중입니다."
-            hint="트레일러와 평가 흐름을 준비하고 있어요."
-            className="mx-auto max-w-190"
-          />
+          <MatchingDetailSkeleton />
         ) : !canAccessPage ? (
           <AuthGateStatusPanel
             title="로그인 후 매칭을 진행할 수 있어요."
@@ -269,12 +311,7 @@ function MatchingGenreDetailPage() {
             align="center"
           />
         ) : matchCandidatesQuery.isLoading ? (
-          <CenteredLoadingState
-            label="Matching"
-            title="매칭 후보 게임을 불러오는 중입니다."
-            hint="이번 장르에 맞는 후보를 정리하고 있어요."
-            className="mx-auto max-w-190"
-          />
+          <MatchingDetailSkeleton />
         ) : matchCandidatesQuery.error ? (
           <section className="survey-panel mx-auto max-w-190 px-6 py-10 sm:px-8 sm:py-12">
             <p className="text-sm font-semibold tracking-[0.2em] text-[#ff8c8c] uppercase">

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -1,18 +1,35 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { ChevronRight } from 'lucide-react';
 import { useLayoutEffect, useMemo } from 'react';
 import { Link, Navigate, useLocation } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
-import CenteredLoadingState from '../../components/common/CenteredLoadingState';
 import LazyHeader from '../../components/common/LazyHeader';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
+import { getMatchCandidates } from '../../features/matching/api/matching';
 import { useMatchingGenreImageQueries } from '../../features/matching/api/useMatchingApi';
 import { MATCHING_GENRES } from '../../features/matching/genres';
 import { useMatchingStore } from '../../features/matching/store/useMatchingStore';
 
+function MatchingGenreCardSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-3xl border border-white/8 bg-[#0c0c0d] p-2.5 shadow-[0_18px_36px_rgba(0,0,0,0.26)]">
+      <div className="animate-pulse overflow-hidden rounded-[18px] border border-white/5 bg-white/[0.02]">
+        <div className="aspect-[16/8.4] w-full bg-[linear-gradient(90deg,rgba(255,255,255,0.03),rgba(255,255,255,0.08),rgba(255,255,255,0.03))]" />
+        <div className="space-y-3 px-4 py-4">
+          <div className="h-6 w-36 rounded-full bg-white/10" />
+          <div className="h-4 w-full rounded-full bg-white/7" />
+          <div className="h-4 w-4/5 rounded-full bg-white/7" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function MatchingListPage() {
   const location = useLocation();
+  const queryClient = useQueryClient();
   const authGate = useAuthGate();
   const canAccessPage = authGate.accessStatus === 'authorized';
   const canFetchGenreImages = canAccessPage;
@@ -21,6 +38,7 @@ function MatchingListPage() {
     MATCHING_GENRES.map((genre) => genre.genreId),
     canFetchGenreImages,
   );
+  const hasGenreImageError = genreImageQueries.some((query) => query.error);
   const genreImageMap = useMemo(
     () =>
       new Map(
@@ -31,6 +49,23 @@ function MatchingListPage() {
       ),
     [genreImageQueries],
   );
+  const areGenreImagesReady =
+    canAccessPage &&
+    MATCHING_GENRES.every((genre) => genreImageMap.has(genre.genreId));
+  const shouldShowGenreImageSkeleton =
+    canAccessPage && !hasGenreImageError && !areGenreImagesReady;
+
+  const prefetchMatchCandidates = (genreId: number) => {
+    if (!canAccessPage) {
+      return;
+    }
+
+    void queryClient.prefetchQuery({
+      queryKey: ['match-candidates', genreId, 'server'],
+      queryFn: () => getMatchCandidates(genreId),
+      staleTime: 60_000,
+    });
+  };
 
   useLayoutEffect(() => {
     resetFlow();
@@ -56,12 +91,20 @@ function MatchingListPage() {
 
       <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-22 pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-25 md:pb-14">
         {authGate.accessStatus === 'loading' ? (
-          <CenteredLoadingState
-            label="Matching"
-            title="장르별 매칭을 준비하고 있어요."
-            hint="취향에 맞는 장르 카드를 정리하고 있습니다."
-            className="mx-auto max-w-190"
-          />
+          <section className="mx-auto max-w-240 animate-pulse">
+            <div className="mb-7 text-center sm:mb-8">
+              <div className="mx-auto h-4 w-24 rounded-full bg-[#792222]/35" />
+              <div className="mx-auto mt-3 h-10 w-72 rounded-full bg-white/9" />
+              <div className="mx-auto mt-3 h-4 w-full max-w-130 rounded-full bg-white/7" />
+              <div className="mx-auto mt-2 h-4 w-4/5 max-w-110 rounded-full bg-white/7" />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {MATCHING_GENRES.map((genre) => (
+                <MatchingGenreCardSkeleton key={genre.slug} />
+              ))}
+            </div>
+          </section>
         ) : !canAccessPage ? (
           <AuthGateStatusPanel
             title="로그인 후 매칭을 시작할 수 있어요."
@@ -84,39 +127,49 @@ function MatchingListPage() {
               </p>
             </div>
 
-            <div className="grid gap-4 md:grid-cols-2">
-              {MATCHING_GENRES.map((genre) => (
-                <Link
-                  key={genre.slug}
-                  to={`/${ROUTES.MATCHING_LIST}/${genre.slug}`}
-                  className="group overflow-hidden rounded-3xl border border-white/8 bg-[#0c0c0d] p-2.5 shadow-[0_18px_36px_rgba(0,0,0,0.26)] transition hover:border-[#a31c1c]/65 hover:bg-[#111112]"
-                >
-                  <div className="relative overflow-hidden rounded-[18px]">
-                    <img
-                      src={
-                        genreImageMap.get(genre.genreId) ?? genre.thumbnailUrl
-                      }
-                      alt={genre.title}
-                      className="aspect-[16/8.4] w-full object-cover transition duration-300 group-hover:scale-[1.025] group-hover:brightness-110"
-                    />
-                    <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,6,8,0.1),rgba(6,6,8,0.28)_34%,rgba(6,6,8,0.86))]" />
-                    <div className="absolute right-3.5 bottom-3.5 left-3.5 flex items-end justify-between gap-3">
-                      <div>
-                        <h2 className="text-[22px] font-semibold tracking-[-0.02em] text-white">
-                          {genre.title}
-                        </h2>
-                        <p className="mt-1.5 max-w-[24ch] text-[13px] leading-5 font-medium break-keep text-white/86 [text-shadow:0_1px_10px_rgba(0,0,0,0.65)]">
-                          {genre.description}
-                        </p>
+            {shouldShowGenreImageSkeleton ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                {MATCHING_GENRES.map((genre) => (
+                  <MatchingGenreCardSkeleton key={genre.slug} />
+                ))}
+              </div>
+            ) : (
+              <div className="grid gap-4 md:grid-cols-2">
+                {MATCHING_GENRES.map((genre) => (
+                  <Link
+                    key={genre.slug}
+                    to={`/${ROUTES.MATCHING_LIST}/${genre.slug}`}
+                    onMouseEnter={() => prefetchMatchCandidates(genre.genreId)}
+                    onFocus={() => prefetchMatchCandidates(genre.genreId)}
+                    className="group overflow-hidden rounded-3xl border border-white/8 bg-[#0c0c0d] p-2.5 shadow-[0_18px_36px_rgba(0,0,0,0.26)] transition hover:border-[#a31c1c]/65 hover:bg-[#111112]"
+                  >
+                    <div className="relative overflow-hidden rounded-[18px]">
+                      <img
+                        src={
+                          genreImageMap.get(genre.genreId) ?? genre.thumbnailUrl
+                        }
+                        alt={genre.title}
+                        className="aspect-[16/8.4] w-full object-cover transition duration-300 group-hover:scale-[1.025] group-hover:brightness-110"
+                      />
+                      <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,6,8,0.1),rgba(6,6,8,0.28)_34%,rgba(6,6,8,0.86))]" />
+                      <div className="absolute right-3.5 bottom-3.5 left-3.5 flex items-end justify-between gap-3">
+                        <div>
+                          <h2 className="text-[22px] font-semibold tracking-[-0.02em] text-white">
+                            {genre.title}
+                          </h2>
+                          <p className="mt-1.5 max-w-[24ch] text-[13px] leading-5 font-medium break-keep text-white/86 [text-shadow:0_1px_10px_rgba(0,0,0,0.65)]">
+                            {genre.description}
+                          </p>
+                        </div>
+                        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-white/10 bg-black/28 text-white/78 transition group-hover:border-[#b02525]/60 group-hover:text-white">
+                          <ChevronRight size={17} />
+                        </span>
                       </div>
-                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-white/10 bg-black/28 text-white/78 transition group-hover:border-[#b02525]/60 group-hover:text-white">
-                        <ChevronRight size={17} />
-                      </span>
                     </div>
-                  </div>
-                </Link>
-              ))}
-            </div>
+                  </Link>
+                ))}
+              </div>
+            )}
           </section>
         )}
       </main>

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -10,7 +10,6 @@ import { Link } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import ActionButton from '../../components/common/ActionButton';
-import CenteredLoadingState from '../../components/common/CenteredLoadingState';
 import LazyHeader from '../../components/common/LazyHeader';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
@@ -134,6 +133,41 @@ function RecommendationRow({
 type RecommendationBackdropProps = {
   items: RecommendationDisplayItem[];
 };
+
+function RecommendationRowSkeleton() {
+  return (
+    <div className="grid animate-pulse gap-4 px-4 py-5 sm:grid-cols-[118px_minmax(0,1fr)] sm:items-center sm:px-6 sm:py-6 lg:grid-cols-[118px_minmax(0,1fr)_auto] lg:gap-6 lg:px-7">
+      <div className="overflow-hidden rounded-[20px] border border-white/6 bg-white/[0.03]">
+        <div className="h-23.5 w-full bg-[linear-gradient(90deg,rgba(255,255,255,0.03),rgba(255,255,255,0.08),rgba(255,255,255,0.03))] sm:h-22" />
+      </div>
+
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <div className="h-7 w-48 rounded-full bg-white/10 sm:h-8 sm:w-56" />
+          <div className="h-6 w-16 rounded-full bg-[#702525]/35" />
+        </div>
+        <div className="mt-3 h-4 w-3/5 rounded-full bg-white/7" />
+      </div>
+
+      <div className="flex items-center justify-end gap-3 lg:min-w-24">
+        <div className="h-10 w-10 rounded-full bg-white/[0.05]" />
+        <div className="h-10 w-10 rounded-full bg-white/[0.05]" />
+      </div>
+    </div>
+  );
+}
+
+function RecommendationListSkeleton() {
+  return (
+    <section className="flex min-h-0 flex-col overflow-hidden rounded-4xl border border-white/8 bg-[linear-gradient(180deg,rgba(16,16,18,0.92),rgba(9,9,10,0.98))] shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-2xl">
+      <div className="divide-y divide-white/8">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <RecommendationRowSkeleton key={index} />
+        ))}
+      </div>
+    </section>
+  );
+}
 
 function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
   const backdropItems =
@@ -267,11 +301,7 @@ function RecommendationListPage() {
           </div>
 
           {authGate.accessStatus === 'loading' ? (
-            <CenteredLoadingState
-              label="Recommendation"
-              title="추천 결과 화면을 불러오는 중입니다."
-              hint="추천 결과와 좋아요 상태를 함께 불러오고 있어요."
-            />
+            <RecommendationListSkeleton />
           ) : !canAccessPage ? (
             <AuthGateStatusPanel
               title="로그인 후 추천 결과를 볼 수 있어요."
@@ -319,12 +349,7 @@ function RecommendationListPage() {
               ) : null}
 
               {isLoading ? (
-                <CenteredLoadingState
-                  label="Recommendation"
-                  title="추천 결과를 불러오는 중입니다."
-                  hint="게임 취향에 맞는 결과를 정리하고 있어요."
-                  className="px-4 py-14 sm:px-6 lg:px-7"
-                />
+                <RecommendationListSkeleton />
               ) : error && !isResultNotFound ? (
                 <div className="px-4 py-12 text-[#ffc2c2] sm:px-6 lg:px-7">
                   {errorMessage}

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react';
 import { Navigate, useLocation, useSearchParams } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
-import CenteredLoadingState from '../../components/common/CenteredLoadingState';
 import LazyHeader from '../../components/common/LazyHeader';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
-import SurveyChatPanel from '../../features/survey/components/SurveyChatPanel';
+import SurveyChatPanel, {
+  SurveyChatLoadingState,
+} from '../../features/survey/components/SurveyChatPanel';
 import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
 import { mockTopGames } from '../../features/games/mockGames';
 import { useAuthStore } from '../../store/useAuthStore';
@@ -140,12 +141,7 @@ function SurveyPage() {
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
         {authGate.accessStatus === 'loading' ? (
-          <CenteredLoadingState
-            label="Survey"
-            title="AI가 첫 질문을 준비하고 있습니다."
-            hint="질문 흐름을 정리하고 있어요."
-            className="mx-auto max-w-190"
-          />
+          <SurveyChatLoadingState />
         ) : canAccessSurvey ? (
           <SurveyChatPanel isHistoryView={isHistoryMode} />
         ) : (

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -42,19 +42,13 @@ function SurveyPage() {
   const authGate = useAuthGate();
   const canAccessSurvey = authGate.accessStatus === 'authorized';
   const account = useAuthStore((state) => state.account);
-  const {
-    syncOwnerKey,
-    storedOwnerKey,
-    surveySessionId,
-    messages,
-    recommendationReady,
-  } = useSurveyStore((state) => ({
-    syncOwnerKey: state.syncOwnerKey,
-    storedOwnerKey: state.ownerKey,
-    surveySessionId: state.sessionId,
-    messages: state.messages,
-    recommendationReady: state.recommendationReady,
-  }));
+  const syncOwnerKey = useSurveyStore((state) => state.syncOwnerKey);
+  const storedOwnerKey = useSurveyStore((state) => state.ownerKey);
+  const surveySessionId = useSurveyStore((state) => state.sessionId);
+  const messages = useSurveyStore((state) => state.messages);
+  const recommendationReady = useSurveyStore(
+    (state) => state.recommendationReady,
+  );
   const isHistoryMode = searchParams.get('mode') === 'history';
   const [enteredWithCompletedSurvey, setEnteredWithCompletedSurvey] = useState<
     boolean | null


### PR DESCRIPTION
## 관련 이슈

- closes #347 

## 변경 내용

- 설문 페이지 로딩 상태를 같은 챗봇 쉘 안에서 `중앙 스피너 + 한 줄 문구` 기준으로 통일했습니다.
- 설문 첫 세션 생성 실패 시 자동 bootstrap 재시도가 반복되며 production에서 React 최대 업데이트 깊이 오류로 이어질 수 있던 흐름을 보강했습니다.
- 이제 초기 bootstrap 요청이 실패하더라도 무한 재시도 루프 없이 에러 상태를 유지하고, 사용자 재시도를 기다리도록 정리했습니다.
- 설문 페이지와 설문 채팅 패널에서 `useSurveyStore((state) => ({ ... }))` 형태의 object selector를 제거하고 개별 selector로 정리해, Zustand 구독으로 인한 render loop 가능성을 줄였습니다.
- 장르별 게임 매칭 첫 진입 시 정적 fallback 이미지가 먼저 보였다가 실서버 이미지로 교체되던 이질감을 줄이기 위해, 실제 장르 이미지가 준비될 때까지 카드 스켈레톤을 노출하도록 수정했습니다.
- 매칭 상세 화면의 후보 로딩 상태도 트레일러/설명/별점 레이아웃에 맞춘 스켈레톤으로 정리했습니다.
- 추천 결과 리스트 로딩 상태 역시 실제 row 크기에 맞춘 스켈레톤으로 정리해 화면 전환 시 이질감을 줄였습니다.
- 장르 카드 hover/focus 시 매칭 후보를 prefetch 하도록 보강해, 상세 진입 후 체감 로딩을 일부 줄였습니다.
- 매칭 진행 중 좋아요 토글 시 `match-candidates` 캐시 업데이트를 새로운 후보 세트로 오인해 flow가 처음으로 리셋되던 문제를 수정했습니다.
- 이제 매칭 flow는 `genre + retry_no + candidate game_id 목록`이 실제로 바뀔 때만 다시 초기화되고, 같은 후보 세트 안의 좋아요 변경으로는 현재 진행 위치가 유지됩니다.



## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 기능 변경보다 로딩 경험의 시각적 일관성과 설문/매칭 화면 안정성 개선에 집중했습니다.
- 설문은 챗봇 흐름 특성상 중앙 스피너와 짧은 문구 조합으로 정리했고, 매칭/추천 결과는 리스트/카드 구조에 맞춰 스켈레톤 기반 로딩으로 정리했습니다.
- 매칭 좋아요 동기화는 유지하되, 후보 세트 자체가 바뀐 경우에만 flow가 재시작되도록 조건을 보강했습니다.
