### PR TITLE
[Fix] 로컬 소셜 로그인 콜백 흐름 수정

### DIFF
--- a/docs/ai/api-contract/auth.md
+++ b/docs/ai/api-contract/auth.md
@@ -101,6 +101,7 @@
 
 - 기본 개발 서버는 `https://localhost:5173`를 사용합니다.
 - 로컬 소셜 로그인과 `Secure` refresh 쿠키 검증은 HTTPS 개발 서버 기준으로 확인합니다.
+- 로컬 프론트에서 소셜 로그인을 시작할 때는 backend의 `/api/v1/accounts/social-login/{provider}/local` 시작 경로를 사용합니다.
 - backend CORS 허용 origin에 `https://localhost:5173`가 포함되어야 합니다.
 - 소셜 로그인 로컬 redirect URI를 사용한다면 `https://localhost:5173/callback` 기준으로 등록합니다.
 

--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -12,18 +12,38 @@ const SOCIAL_AUTH_START_PATHS: Record<SocialAuthProvider, string> = {
   naver: `${AUTH_BASE_PATH}/social-login/naver`,
 };
 
+const SOCIAL_AUTH_LOCAL_START_PATHS: Record<SocialAuthProvider, string> = {
+  google: `${AUTH_BASE_PATH}/social-login/google/local`,
+  kakao: `${AUTH_BASE_PATH}/social-login/kakao/local`,
+  naver: `${AUTH_BASE_PATH}/social-login/naver/local`,
+};
+
+const LOCAL_FRONTEND_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+const isLocalFrontendRuntime = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return LOCAL_FRONTEND_HOSTNAMES.has(window.location.hostname);
+};
+
 export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
+  const socialLoginStartPath = isLocalFrontendRuntime()
+    ? SOCIAL_AUTH_LOCAL_START_PATHS[provider]
+    : SOCIAL_AUTH_START_PATHS[provider];
+
   if (mockServiceWorkerEnabled) {
-    return SOCIAL_AUTH_START_PATHS[provider];
+    return socialLoginStartPath;
   }
 
   const normalizedApiBaseUrl = apiBaseUrl.trim().replace(/\/$/, '');
 
   if (normalizedApiBaseUrl) {
-    return `${normalizedApiBaseUrl}${SOCIAL_AUTH_START_PATHS[provider]}`;
+    return `${normalizedApiBaseUrl}${socialLoginStartPath}`;
   }
 
-  return SOCIAL_AUTH_START_PATHS[provider];
+  return socialLoginStartPath;
 };
 
 export const setPendingSocialAuthProvider = (provider: SocialAuthProvider) => {

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -19,19 +19,25 @@ const DEFAULT_REFRESH_ERROR_MESSAGE =
 function AuthCallbackPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const handledSearchRef = useRef<string | null>(null);
+  const restorePromiseRef = useRef<Promise<void> | null>(null);
   const [statusMessage, setStatusMessage] = useState(
     '소셜 로그인 세션을 확인하는 중입니다.',
   );
 
   useEffect(() => {
-    if (handledSearchRef.current === location.search) {
-      return;
-    }
-
-    handledSearchRef.current = location.search;
-
     let isMounted = true;
+
+    const ensureRestorePromise = () => {
+      if (!restorePromiseRef.current) {
+        restorePromiseRef.current = restoreAuthSession()
+          .then(() => undefined)
+          .finally(() => {
+            restorePromiseRef.current = null;
+          });
+      }
+
+      return restorePromiseRef.current;
+    };
 
     const handleAuthCallback = async () => {
       const searchParams = new URLSearchParams(location.search);
@@ -48,13 +54,19 @@ function AuthCallbackPage() {
       }
 
       try {
-        await restoreAuthSession();
+        await ensureRestorePromise();
 
         if (!isMounted) {
           return;
         }
 
         clearPendingSocialAuthProvider();
+
+        if (typeof window !== 'undefined') {
+          window.location.replace(ROUTES.HOME);
+          return;
+        }
+
         navigate(ROUTES.HOME, { replace: true });
       } catch (error) {
         if (!isMounted) {


### PR DESCRIPTION
## 관련 이슈

- closes #350

## 변경 내용

- 로컬 프론트(`localhost`, `127.0.0.1`, `::1`)에서 소셜 로그인 시작 시 provider별 로컬용 시작 경로를 사용하도록 수정했습니다.
- 배포 환경에서는 기존 운영용 소셜 로그인 시작 경로를 그대로 유지하도록 분기했습니다.
- 소셜 로그인 콜백 페이지에서 세션 복구 Promise를 재사용하도록 정리해 개발 모드 `StrictMode`에서도 콜백 처리 후 홈 이동이 누락되지 않도록 수정했습니다.
- 로컬 소셜 로그인 전제 조건과 경로 기준을 인증 문서에 반영했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- 로컬 Google/Kakao/Naver 소셜 로그인은 각 provider 콘솔에 백엔드의 local callback URI가 등록되어 있어야 정상 동작합니다.
- 프론트 기준 로컬 콜백 복귀 주소는 `https://localhost:5173/callback` 입니다.
