### PR TITLE
[Refactor] 마이페이지 반응형 레이아웃 교정 및 이미지 업로드/렌더링 버그 수정

### DIFF
--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -56,7 +56,7 @@ function AuthInputField({
           id={id}
           {...inputProps}
           hasError={Boolean(errorMessage)}
-          className={`flex-1 ${className}`}
+          className={`w-full min-w-0 flex-1 ${className}`}
         />
         {action}
         {toast}

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { X } from 'lucide-react';
 
 import type { FavoriteGamePreview } from '../../features/mypage/types';
@@ -14,18 +15,29 @@ function FavoriteGameCard({
   onClick,
   onFavoriteClick,
 }: FavoriteGameCardProps) {
+  const [failedThumbnailKey, setFailedThumbnailKey] = useState<string | null>(
+    null,
+  );
+  const currentThumbnailKey = game.thumbnailUrl
+    ? `${game.gameId}:${game.thumbnailUrl}`
+    : null;
+  const hasThumbnail = Boolean(game.thumbnailUrl);
+  const canRenderThumbnail =
+    hasThumbnail && failedThumbnailKey !== currentThumbnailKey;
+
   return (
-    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex h-[21rem] w-full min-w-0 flex-col overflow-hidden rounded-[22px] border transition duration-200 sm:h-[23rem] xl:h-[24rem]">
-      <div className="bg-mypage-soft relative h-[15.75rem] overflow-hidden sm:h-[17.4rem] xl:h-[18.5rem]">
+    <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex w-full min-w-0 flex-col overflow-hidden rounded-[22px] border transition duration-200">
+      <div className="bg-mypage-soft relative aspect-4/5 w-full overflow-hidden">
         <button
           type="button"
           onClick={() => onClick?.(game)}
           className="block h-full w-full cursor-pointer text-left"
         >
-          {game.thumbnailUrl ? (
+          {canRenderThumbnail ? (
             <img
-              src={game.thumbnailUrl}
+              src={game.thumbnailUrl ?? undefined}
               alt={`${game.title} 썸네일`}
+              onError={() => setFailedThumbnailKey(currentThumbnailKey)}
               className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.04]"
               loading="lazy"
             />
@@ -52,7 +64,7 @@ function FavoriteGameCard({
       <button
         type="button"
         onClick={() => onClick?.(game)}
-        className="flex min-w-0 flex-1 cursor-pointer flex-col gap-1 px-3 py-2.5 text-left sm:px-4 sm:py-3"
+        className="flex min-h-[5.75rem] min-w-0 flex-1 cursor-pointer flex-col justify-center gap-1 px-3 pt-3 pb-2.5 text-left sm:min-h-[6.2rem] sm:px-4 sm:pt-3.5 sm:pb-3"
       >
         <h3 className="line-clamp-1 text-sm/5 font-semibold text-white sm:text-base/6 lg:text-lg/7">
           {game.title}

--- a/src/components/mypage/PasswordChangePanel.tsx
+++ b/src/components/mypage/PasswordChangePanel.tsx
@@ -36,7 +36,7 @@ function PasswordChangePanel({
   onSubmit,
 }: PasswordChangePanelProps) {
   return (
-    <section className="bg-mypage-card border-mypage-panel mt-6 w-full rounded-3xl border px-4 py-5 text-left sm:px-5 sm:py-6">
+    <section className="bg-mypage-card border-mypage-panel mt-6 w-full min-w-0 rounded-3xl border px-4 py-5 text-left sm:px-5 sm:py-6">
       <div className="mb-5">
         <h2 className="text-xl font-semibold text-white">비밀번호 변경</h2>
         <p className="text-mypage-muted mt-2 text-sm/6">
@@ -44,7 +44,7 @@ function PasswordChangePanel({
         </p>
       </div>
 
-      <form className="space-y-4" onSubmit={onSubmit}>
+      <form className="w-full min-w-0 space-y-4" onSubmit={onSubmit}>
         <AuthInputField
           id="current-password"
           name="old_password"

--- a/src/features/auth/api/auth.error.handler.ts
+++ b/src/features/auth/api/auth.error.handler.ts
@@ -109,6 +109,10 @@ export const extractAuthApiFieldErrors = (error: unknown) => {
 
 export const extractAuthApiErrorMessage = (error: unknown) => {
   if (!(error instanceof AxiosError)) {
+    if (error instanceof Error && error.message.trim()) {
+      return error.message;
+    }
+
     return '요청을 처리하는 중 알 수 없는 오류가 발생했습니다.';
   }
 

--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -200,15 +200,43 @@ export const uploadFileToS3 = async ({
   file,
   content_type,
 }: UploadFileToS3Request) => {
-  const resolvedContentType =
-    content_type || file.type || 'application/octet-stream';
+  const resolvedContentType = content_type?.trim() || file.type.trim();
 
-  await axios.put(presigned_url, file, {
-    headers: {
-      'Content-Type': resolvedContentType,
-    },
-    withCredentials: false,
-  });
+  try {
+    const uploadResponse = await fetch(presigned_url, {
+      method: 'PUT',
+      body: file,
+      credentials: 'omit',
+      mode: 'cors',
+      cache: 'no-store',
+      headers: resolvedContentType
+        ? {
+            'Content-Type': resolvedContentType,
+          }
+        : undefined,
+    });
+
+    if (!uploadResponse.ok) {
+      throw new Error(
+        '프로필 이미지를 업로드하지 못했습니다. 잠시 후 다시 시도해주세요.',
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      const normalizedMessage = error.message.trim().toLowerCase();
+
+      if (
+        normalizedMessage === 'failed to fetch' ||
+        normalizedMessage.includes('networkerror')
+      ) {
+        throw new Error(
+          '프로필 이미지 업로드 중 네트워크 또는 CORS 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        );
+      }
+    }
+
+    throw error;
+  }
 };
 
 export const confirmProfileImage = async (

--- a/src/pages/mypage/components/MyPageAccountDangerZone.tsx
+++ b/src/pages/mypage/components/MyPageAccountDangerZone.tsx
@@ -57,10 +57,12 @@ function MyPageAccountDangerZone({
         }
         description={
           isSocialAccount ? (
-            <p>
-              소셜 계정은 비밀번호 확인 없이 바로 탈퇴가 진행되며, 완료되면
-              로그인 화면으로 이동합니다.
-            </p>
+            <div className="mx-auto max-w-[23rem]">
+              <p>
+                소셜 계정은 비밀번호 확인 없이 바로 탈퇴가 진행되며, 완료되면
+                로그인 화면으로 이동합니다.
+              </p>
+            </div>
           ) : (
             <div className="space-y-3">
               <p>
@@ -97,6 +99,7 @@ function MyPageAccountDangerZone({
         }
         confirmLabel="회원탈퇴"
         isPending={isDeletePending}
+        align={isSocialAccount ? 'center' : 'left'}
         onClose={onCloseDeleteModal}
         onConfirm={() => {
           void onConfirmDeleteAccount();

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -57,13 +57,13 @@ function MyPageLikedGamesSection({
               </p>
             </div>
           </div>
-          <p className="text-mypage-muted text-sm">
-            {isFavoriteGamesLoading
-              ? '찜 목록을 불러오는 중입니다.'
-              : favoriteCount > 0
-                ? `총 ${favoriteCount}개의 게임이 저장되어 있어요`
-                : '아직 저장된 게임이 없어요'}
-          </p>
+          {isFavoriteGamesLoading || favoriteCount > 0 ? (
+            <p className="text-mypage-muted text-sm">
+              {isFavoriteGamesLoading
+                ? '찜 목록을 불러오는 중입니다.'
+                : `총 ${favoriteCount}개의 게임이 저장되어 있어요`}
+            </p>
+          ) : null}
         </div>
 
         <div className={listContainerClass}>

--- a/src/pages/mypage/hooks/useMyPageLikedGames.ts
+++ b/src/pages/mypage/hooks/useMyPageLikedGames.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { extractAuthApiErrorMessage } from '../../../features/auth/api/auth';
 import {
@@ -30,19 +30,30 @@ function useMyPageLikedGames({
   const unlikeLikedGameMutation = useUnlikeLikedGameMutation();
   const [selectedFavoriteGame, setSelectedFavoriteGame] =
     useState<FavoriteGamePreview | null>(null);
+  const [locallyRemovedGameIds, setLocallyRemovedGameIds] = useState<number[]>(
+    [],
+  );
   const serverFavoriteGames = useMemo(() => {
     return (likedGamesData?.results ?? []).map(toFavoriteGamePreview);
   }, [likedGamesData?.results]);
-  const [favoriteGames, setFavoriteGames] = useState<FavoriteGamePreview[]>([]);
-  const [favoriteCount, setFavoriteCount] = useState(0);
+  const hiddenGameIdSet = useMemo(
+    () => new Set(locallyRemovedGameIds),
+    [locallyRemovedGameIds],
+  );
+  const favoriteGames = useMemo(
+    () =>
+      serverFavoriteGames.filter((game) => !hiddenGameIdSet.has(game.gameId)),
+    [hiddenGameIdSet, serverFavoriteGames],
+  );
+  const favoriteCount = useMemo(() => {
+    const hiddenCount = serverFavoriteGames.reduce(
+      (count, game) => count + Number(hiddenGameIdSet.has(game.gameId)),
+      0,
+    );
+    const serverCount = likedGamesData?.count ?? serverFavoriteGames.length;
 
-  useEffect(() => {
-    setFavoriteGames(serverFavoriteGames);
-  }, [serverFavoriteGames]);
-
-  useEffect(() => {
-    setFavoriteCount(likedGamesData?.count ?? serverFavoriteGames.length);
-  }, [likedGamesData?.count, serverFavoriteGames.length]);
+    return Math.max(0, serverCount - hiddenCount);
+  }, [hiddenGameIdSet, likedGamesData?.count, serverFavoriteGames]);
 
   const refetchFavoriteGames = likedGamesQuery.refetch;
   const isFavoriteGamesLoading =
@@ -69,39 +80,40 @@ function useMyPageLikedGames({
       return;
     }
 
-    const removeFavoriteGameFromState = () => {
-      const isVisibleTarget = favoriteGames.some(
-        (game) => game.gameId === targetGameId,
+    const hideFavoriteGame = () => {
+      setLocallyRemovedGameIds((current) =>
+        current.includes(targetGameId) ? current : [...current, targetGameId],
+      );
+    };
+    const syncRemovedGamesAfterRefetch = async () => {
+      const refetchResult = await refetchFavoriteGames();
+      const nextVisibleGameIds = new Set(
+        (refetchResult.data?.results ?? []).map((game) => game.game_id),
       );
 
-      if (!isVisibleTarget) {
-        return;
-      }
-
-      setFavoriteGames((current) =>
-        current.filter((game) => game.gameId !== targetGameId),
+      setLocallyRemovedGameIds((current) =>
+        current.filter((gameId) => nextVisibleGameIds.has(gameId)),
       );
-      setFavoriteCount((current) => Math.max(0, current - 1));
     };
 
     try {
       await unlikeLikedGameMutation.mutateAsync(targetGameId);
-      removeFavoriteGameFromState();
+      hideFavoriteGame();
       setSelectedFavoriteGame(null);
       onToast({
         tone: 'success',
         message: '찜한 목록에서 삭제되었습니다.',
       });
-      void refetchFavoriteGames();
+      void syncRemovedGamesAfterRefetch();
     } catch (error) {
       if (error instanceof AxiosError && error.response?.status === 404) {
-        removeFavoriteGameFromState();
+        hideFavoriteGame();
         setSelectedFavoriteGame(null);
         onToast({
           tone: 'success',
           message: '이미 삭제된 게임입니다.',
         });
-        void refetchFavoriteGames();
+        void syncRemovedGamesAfterRefetch();
         return;
       }
 

--- a/src/pages/mypage/hooks/useMyPageProfile.ts
+++ b/src/pages/mypage/hooks/useMyPageProfile.ts
@@ -74,9 +74,17 @@ function useMyPageProfile({ enabled, onToast }: UseMyPageProfileOptions) {
           file_name: file.name,
           content_type: file.type || 'application/octet-stream',
         });
+      const presignedUrl = presignedResponse.presigned_url.trim();
+      const profileImageUrl = presignedResponse.img_url.trim();
+
+      if (!presignedUrl || !profileImageUrl) {
+        throw new Error(
+          '프로필 이미지 업로드 경로를 확인하지 못했습니다. 잠시 후 다시 시도해주세요.',
+        );
+      }
 
       await uploadFileToS3Mutation.mutateAsync({
-        presigned_url: presignedResponse.presigned_url,
+        presigned_url: presignedUrl,
         file,
         content_type: file.type || 'application/octet-stream',
       });
@@ -87,7 +95,7 @@ function useMyPageProfile({ enabled, onToast }: UseMyPageProfileOptions) {
           currentProfile
             ? {
                 ...currentProfile,
-                profile_img_url: presignedResponse.img_url,
+                profile_img_url: profileImageUrl,
               }
             : currentProfile,
       );
@@ -95,16 +103,16 @@ function useMyPageProfile({ enabled, onToast }: UseMyPageProfileOptions) {
       if (previousProfile) {
         syncAuthAccount({
           ...previousProfile,
-          profile_img_url: presignedResponse.img_url,
+          profile_img_url: profileImageUrl,
         });
       }
 
       hasOptimisticProfileUpdate = true;
 
       await confirmProfileImageMutation.mutateAsync({
-        profile_img_url: presignedResponse.img_url,
+        profile_img_url: profileImageUrl,
       });
-      const confirmedProfileImageUrl = presignedResponse.img_url;
+      const confirmedProfileImageUrl = profileImageUrl;
 
       queryClient.setQueryData<CurrentUserProfileResponse>(
         authKeys.me(),


### PR DESCRIPTION
## 관련 이슈

- closes #348 

## 변경 내용

- 찜한 목록 카드가 삭제 후 다시 렌더링될 때 남은 썸네일이 깨지지 않도록 로컬 표시 상태와 서버 응답 매핑 흐름을 정리했습니다.
- 찜한 목록 카드의 이미지 영역 비율을 조정해 메인 페이지 카드와 비슷한 인상으로 보이도록 하고, 설명 영역 텍스트는 세로 가운데에 더 가깝게 정렬되도록 수정했습니다.
- 찜한 목록이 비어 있을 때 상단에 중복으로 노출되던 안내 문구를 제거하고, 빈 상태 메시지 노출을 더 단순하게 정리했습니다.
- 소셜 계정 회원탈퇴 모달은 안내 문구와 버튼 그룹이 가운데 정렬되도록 수정했습니다.
- 비밀번호 변경 패널과 공통 입력 필드에 `w-full`, `min-w-0` 기준을 보강해 좁은 화면에서도 인풋 너비가 비정상적으로 줄어들지 않도록 조정했습니다.
- 프로필 이미지 업로드는 `presigned-url 발급 -> S3 PUT 업로드 -> profile-image PATCH 등록` 흐름을 다시 점검하고, presigned URL / 이미지 URL 검증과 업로드 실패 메시지 처리를 보강했습니다.
- S3 업로드 단계에서 네트워크 또는 CORS 오류가 발생할 경우 사용자에게 더 명확한 한국어 오류 메시지가 표시되도록 예외 처리를 추가했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3022" height="1674" alt="image" src="https://github.com/user-attachments/assets/6024e665-236e-4213-8990-7d6995cec8ca" />

## 참고사항

- 프로필 이미지 업로드는 스웨거 기준으로 `multipart/form-data` 직접 전송이 아니라, `presigned-url` 발급 후 파일을 업로드하고 마지막에 `profile_img_url`을 PATCH로 등록하는 방식으로 유지했습니다.
