### PR TITLE
[Fix] SSE 스트림 Accept 헤더와 응답 형식 검증 추가

### DIFF
--- a/src/features/support-chat/api/chatbot.ts
+++ b/src/features/support-chat/api/chatbot.ts
@@ -95,9 +95,11 @@ const getSupportChatAccessToken = () => {
 const createAuthorizedHeaders = ({
   accept,
   contentType,
+  extraHeaders,
 }: {
   accept: string;
   contentType?: string;
+  extraHeaders?: HeadersInit;
 }) => {
   const headers = new Headers({
     Accept: accept,
@@ -108,6 +110,14 @@ const createAuthorizedHeaders = ({
     headers.set('Content-Type', contentType);
   }
 
+  if (extraHeaders) {
+    const normalizedExtraHeaders = new Headers(extraHeaders);
+
+    normalizedExtraHeaders.forEach((value, key) => {
+      headers.set(key, value);
+    });
+  }
+
   return headers;
 };
 
@@ -116,6 +126,7 @@ const fetchChatbotApi = async (
   init: Omit<RequestInit, 'headers'> & {
     accept: string;
     contentType?: string;
+    extraHeaders?: HeadersInit;
   },
 ) => {
   const request = async () =>
@@ -125,6 +136,7 @@ const fetchChatbotApi = async (
       headers: createAuthorizedHeaders({
         accept: init.accept,
         contentType: init.contentType,
+        extraHeaders: init.extraHeaders,
       }),
     });
 
@@ -246,6 +258,10 @@ export const streamChatbotResponse = async ({
     {
       method: 'GET',
       accept: 'text/event-stream',
+      extraHeaders: {
+        Accept: 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      },
       signal,
     },
   );
@@ -256,6 +272,14 @@ export const streamChatbotResponse = async ({
 
   if (!response.body) {
     throw new Error('챗봇 응답 스트림을 불러오지 못했습니다.');
+  }
+
+  const contentType = response.headers.get('Content-Type')?.toLowerCase() ?? '';
+
+  if (!contentType.includes('text/event-stream')) {
+    throw new Error(
+      '챗봇 스트림 응답 형식이 올바르지 않습니다. 서버 설정을 확인해주세요.',
+    );
   }
 
   const reader = response.body.getReader();


### PR DESCRIPTION
## 관련 이슈

- closes #353 

## 변경 내용

- 고객센터 챗봇 SSE 스트리밍 요청 시 `GET /api/v1/chatbot/stream`에 `Accept: text/event-stream` 헤더가 명시적으로 전달되도록 요청 헤더 구성을 보강했습니다.
- 스트림 요청에도 기존 `Authorization: Bearer ...` 헤더가 그대로 유지되도록 하면서, 추가 헤더를 안전하게 병합할 수 있게 fetch 헤더 생성 로직을 정리했습니다.
- 스트림 응답 수신 후 `Content-Type`이 실제로 `text/event-stream`인지 검사하도록 추가해, 서버가 잘못된 응답 형식을 반환할 경우 사용자에게 더 분명한 오류 메시지를 보여주도록 수정했습니다.
- 이번 수정 기준으로는 프론트 요청이 `application/json`을 보내는 문제보다는, 배포 반영 여부 또는 백엔드/프록시의 `Accept` 협상 처리 가능성을 더 우선 확인할 수 있도록 디버깅 단서를 보강했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

- UI 변경 없음
- 네트워크 탭의 406 응답 및 수정 전후 확인용 스크린샷 첨부 예정

## 참고사항

- 코드상으로는 기존에도 스트림 요청에 `Accept: text/event-stream`를 사용하고 있었고, 이번에는 해당 헤더를 더 명시적으로 고정했습니다.
