### PR TITLE
[Fix] 챗봇 API 인증 헤더 의존성 제거

### DIFF
--- a/src/features/support-chat/api/chatbot.ts
+++ b/src/features/support-chat/api/chatbot.ts
@@ -1,9 +1,4 @@
 import { apiBaseUrl } from '@/lib/env';
-import { useAuthStore } from '@/store/useAuthStore';
-import {
-  expireAuthSession,
-  refreshStoredAccessToken,
-} from '@/features/auth/utils/sessionManager';
 import type {
   ChatbotErrorResponse,
   ChatbotMessageRequest,
@@ -46,7 +41,7 @@ const getDefaultChatbotErrorMessage = (
   fallback = '챗봇 요청을 처리하는 중 오류가 발생했습니다.',
 ) => {
   if (status === 401) {
-    return '로그인 정보가 만료되었거나 유효하지 않습니다. 다시 로그인해 주세요.';
+    return '챗봇 요청 권한이 없습니다.';
   }
 
   if (status === 400) {
@@ -82,17 +77,7 @@ const extractChatbotErrorMessage = async (response: Response) => {
   }
 };
 
-const getSupportChatAccessToken = () => {
-  const accessToken = useAuthStore.getState().accessToken?.trim();
-
-  if (!accessToken) {
-    throw new Error('로그인 후 챗봇을 이용할 수 있습니다.');
-  }
-
-  return accessToken;
-};
-
-const createAuthorizedHeaders = ({
+const createChatbotHeaders = ({
   accept,
   contentType,
   extraHeaders,
@@ -103,7 +88,6 @@ const createAuthorizedHeaders = ({
 }) => {
   const headers = new Headers({
     Accept: accept,
-    Authorization: `Bearer ${getSupportChatAccessToken()}`,
   });
 
   if (contentType) {
@@ -133,28 +117,14 @@ const fetchChatbotApi = async (
     fetch(url, {
       ...init,
       credentials: 'include',
-      headers: createAuthorizedHeaders({
+      headers: createChatbotHeaders({
         accept: init.accept,
         contentType: init.contentType,
         extraHeaders: init.extraHeaders,
       }),
     });
 
-  let response = await request();
-
-  if (response.status !== 401) {
-    return response;
-  }
-
-  try {
-    await refreshStoredAccessToken();
-  } catch (refreshError) {
-    expireAuthSession();
-    throw refreshError;
-  }
-
-  response = await request();
-  return response;
+  return request();
 };
 
 export const sendChatbotMessage = async (payload: ChatbotMessageRequest) => {

--- a/src/features/support-chat/mocks/handlers.ts
+++ b/src/features/support-chat/mocks/handlers.ts
@@ -26,21 +26,6 @@ type MockChatSession = {
 const chatSessions = new Map<string, MockChatSession>();
 const CHAT_SESSION_TTL_SECONDS = 1800;
 
-const getAuthorizedUser = (authorization: string | null) => {
-  if (!authorization?.startsWith('Bearer ')) {
-    return null;
-  }
-
-  const token = authorization.replace('Bearer ', '').trim();
-  const loginId = token.replace(/^mock-access-token-/, '');
-
-  if (!loginId || loginId === token) {
-    return null;
-  }
-
-  return loginId;
-};
-
 const isExpiredSession = (session: MockChatSession) =>
   Number.isFinite(Date.parse(session.expiresAt)) &&
   Date.parse(session.expiresAt) <= Date.now();
@@ -105,13 +90,6 @@ const createStreamResponse = (session: MockChatSession) => {
 
 export const supportChatHandlers = [
   http.post(`${CHATBOT_BASE_PATH}/messages`, async ({ request }) => {
-    const authorization = request.headers.get('Authorization');
-    const loginId = getAuthorizedUser(authorization);
-
-    if (!loginId) {
-      return mockErrorResponse(401, '로그인 후 챗봇을 이용할 수 있습니다.');
-    }
-
     const body = (await request.json()) as ChatbotMessageRequest;
     const message = body.message.trim();
 
@@ -151,13 +129,6 @@ export const supportChatHandlers = [
   }),
 
   http.get(`${CHATBOT_BASE_PATH}/stream`, async ({ request }) => {
-    const authorization = request.headers.get('Authorization');
-    const loginId = getAuthorizedUser(authorization);
-
-    if (!loginId) {
-      return mockErrorResponse(401, '로그인 후 챗봇을 이용할 수 있습니다.');
-    }
-
     const url = new URL(request.url);
     const sessionId = url.searchParams.get('session_id')?.trim() ?? '';
 


### PR DESCRIPTION
## 관련 이슈

- closes #355 

## 변경 내용

- 고객센터 챗봇 API 명세서를 다시 확인한 뒤, `POST /api/v1/chatbot/messages`와 `GET /api/v1/chatbot/stream` 요청에서 불필요하게 붙고 있던 `Authorization: Bearer ...` 의존성을 제거했습니다.
- 챗봇 SSE 스트리밍 요청은 기존처럼 `Accept: text/event-stream`를 유지하되, 무인증 계약에서도 동일하게 동작하도록 fetch 헤더 구성을 정리했습니다.
- 개발 환경의 MSW mock도 실제 명세와 맞추기 위해 로그인 여부와 무관하게 챗봇 메시지 생성 및 스트리밍이 가능하도록 수정했습니다.
- 이번 확인으로 챗봇 API는 비회원 사용 가능, `Authorization 헤더 미사용` 계약이라는 점을 프론트 코드와 일치시키도록 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

- UI 변경 없음
- 필요 시 네트워크 탭에서 챗봇 메시지/스트림 요청 헤더 확인 스크린샷 첨부 예정

## 참고사항

