### PR TITLE
[Fix] 챗봇 API CORS 오류 대응을 위해 credentials 옵션 제거

### DIFF
--- a/src/features/support-chat/api/chatbot.ts
+++ b/src/features/support-chat/api/chatbot.ts
@@ -116,7 +116,6 @@ const fetchChatbotApi = async (
   const request = async () =>
     fetch(url, {
       ...init,
-      credentials: 'include',
       headers: createChatbotHeaders({
         accept: init.accept,
         contentType: init.contentType,


### PR DESCRIPTION
## 관련 이슈

- closes #357

## 변경 내용

- 고객센터 챗봇 API 요청에서 `credentials: 'include'` 옵션을 제거해, 배포 환경에서 교차 출처 요청 시 불필요한 쿠키 전송 때문에 CORS 조건이 더 엄격해지는 문제를 완화했습니다.
- 챗봇 API는 명세상 비회원 사용 가능, `Authorization` 미사용 계약이므로, 이번 수정은 무인증 요청 흐름과도 일관되도록 정리한 변경입니다.
- 특히 `GET /api/v1/chatbot/stream` SSE 요청에서 `Failed to fetch`가 발생할 때 프론트가 불필요하게 credentialed request를 보내지 않도록 조정했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

- UI 변경 없음
- 필요 시 배포 환경 네트워크 탭의 챗봇 요청/응답 스크린샷 첨부 예정

## 참고사항

- 이번 수정은 프론트에서 credentialed CORS 요청을 피하도록 정리한 대응입니다.
