### PR TITLE
[Fix] 마이페이지 반응형 UI 교정 및 찜한 목록 삭제 시 이미지 렌더링 에러 수정

### DIFF
--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -51,7 +51,7 @@ function AuthInputField({
         </label>
         {labelAction ? <div className="shrink-0">{labelAction}</div> : null}
       </div>
-      <div className="relative flex w-full min-w-0 flex-col gap-3 sm:flex-row sm:items-stretch">
+      <div className="relative flex w-full max-w-full min-w-0 flex-col gap-3 sm:flex-row sm:items-stretch">
         <InputControl
           id={id}
           {...inputProps}

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -37,6 +37,7 @@ function FavoriteGameCard({
             <img
               src={game.thumbnailUrl ?? undefined}
               alt={`${game.title} 썸네일`}
+              onLoad={() => setFailedThumbnailKey(null)}
               onError={() => setFailedThumbnailKey(currentThumbnailKey)}
               className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.04]"
               loading="lazy"

--- a/src/components/mypage/PasswordChangePanel.tsx
+++ b/src/components/mypage/PasswordChangePanel.tsx
@@ -36,7 +36,7 @@ function PasswordChangePanel({
   onSubmit,
 }: PasswordChangePanelProps) {
   return (
-    <section className="bg-mypage-card border-mypage-panel mt-6 w-full min-w-0 rounded-3xl border px-4 py-5 text-left sm:px-5 sm:py-6">
+    <section className="bg-mypage-card border-mypage-panel mt-6 w-full max-w-full min-w-0 overflow-hidden rounded-3xl border px-4 py-5 text-left sm:px-5 sm:py-6">
       <div className="mb-5">
         <h2 className="text-xl font-semibold text-white">비밀번호 변경</h2>
         <p className="text-mypage-muted mt-2 text-sm/6">
@@ -44,7 +44,7 @@ function PasswordChangePanel({
         </p>
       </div>
 
-      <form className="w-full min-w-0 space-y-4" onSubmit={onSubmit}>
+      <form className="grid w-full min-w-0 gap-4" onSubmit={onSubmit}>
         <AuthInputField
           id="current-password"
           name="old_password"
@@ -92,11 +92,11 @@ function PasswordChangePanel({
           <AuthFormMessage tone={messageTone}>{message}</AuthFormMessage>
         ) : null}
 
-        <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
+        <div className="flex w-full min-w-0 flex-col gap-3 pt-2 sm:flex-row sm:flex-nowrap sm:justify-end">
           <AuthButton
             type="button"
             variant="secondary"
-            className="w-full sm:w-auto sm:min-w-28"
+            className="w-full sm:w-auto sm:min-w-28 sm:flex-none"
             onClick={onCancel}
             disabled={isPending}
           >
@@ -104,7 +104,7 @@ function PasswordChangePanel({
           </AuthButton>
           <AuthButton
             type="submit"
-            className="w-full sm:w-auto sm:min-w-32"
+            className="w-full sm:w-auto sm:min-w-32 sm:flex-none"
             disabled={isPending}
           >
             {isPending ? '변경 중...' : '저장'}

--- a/src/pages/mypage/hooks/useMyPageLikedGames.ts
+++ b/src/pages/mypage/hooks/useMyPageLikedGames.ts
@@ -1,12 +1,16 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useMemo, useState } from 'react';
 
 import { extractAuthApiErrorMessage } from '../../../features/auth/api/auth';
+import { authKeys } from '../../../features/auth/api/queryKeys';
 import {
   useLikedGamesQuery,
   useUnlikeLikedGameMutation,
 } from '../../../features/auth/api/useAuthApi';
+import type { LikedGamesResponse } from '../../../features/auth/types/auth';
 import type { GameListItem } from '../../../features/games/types';
+import { syncLikedGamesStateInQueryCache } from '../../../features/games/queryCache';
 import type { FavoriteGamePreview } from '../../../features/mypage/types';
 import type { MyPageToastPayload } from '../types';
 import { toFavoriteGameListItem, toFavoriteGamePreview } from '../utils';
@@ -22,6 +26,7 @@ function useMyPageLikedGames({
   onOpenGameDetail,
   onToast,
 }: UseMyPageLikedGamesOptions) {
+  const queryClient = useQueryClient();
   const likedGamesQuery = useLikedGamesQuery(enabled, {
     page_size: 20,
     page: 1,
@@ -30,30 +35,12 @@ function useMyPageLikedGames({
   const unlikeLikedGameMutation = useUnlikeLikedGameMutation();
   const [selectedFavoriteGame, setSelectedFavoriteGame] =
     useState<FavoriteGamePreview | null>(null);
-  const [locallyRemovedGameIds, setLocallyRemovedGameIds] = useState<number[]>(
-    [],
-  );
   const serverFavoriteGames = useMemo(() => {
     return (likedGamesData?.results ?? []).map(toFavoriteGamePreview);
   }, [likedGamesData?.results]);
-  const hiddenGameIdSet = useMemo(
-    () => new Set(locallyRemovedGameIds),
-    [locallyRemovedGameIds],
-  );
-  const favoriteGames = useMemo(
-    () =>
-      serverFavoriteGames.filter((game) => !hiddenGameIdSet.has(game.gameId)),
-    [hiddenGameIdSet, serverFavoriteGames],
-  );
-  const favoriteCount = useMemo(() => {
-    const hiddenCount = serverFavoriteGames.reduce(
-      (count, game) => count + Number(hiddenGameIdSet.has(game.gameId)),
-      0,
-    );
-    const serverCount = likedGamesData?.count ?? serverFavoriteGames.length;
 
-    return Math.max(0, serverCount - hiddenCount);
-  }, [hiddenGameIdSet, likedGamesData?.count, serverFavoriteGames]);
+  const favoriteGames = serverFavoriteGames;
+  const favoriteCount = likedGamesData?.count ?? serverFavoriteGames.length;
 
   const refetchFavoriteGames = likedGamesQuery.refetch;
   const isFavoriteGamesLoading =
@@ -62,6 +49,45 @@ function useMyPageLikedGames({
 
   const handleFavoriteGameCardClick = (game: FavoriteGamePreview) => {
     onOpenGameDetail(toFavoriteGameListItem(game));
+  };
+
+  const refetchFavoriteGamesWithPreservedThumbnails = async (
+    previousLikedGames: LikedGamesResponse['results'],
+  ) => {
+    const refetchResult = await refetchFavoriteGames();
+    const nextLikedGames = refetchResult.data;
+
+    if (!nextLikedGames) {
+      return;
+    }
+
+    const previousLikedGameMap = new Map(
+      previousLikedGames.map((game) => [game.game_id, game]),
+    );
+    const nextResults = nextLikedGames.results.map((game) => {
+      const previousGame = previousLikedGameMap.get(game.game_id);
+
+      return {
+        ...game,
+        game_title:
+          game.game_title.trim() || previousGame?.game_title?.trim() || 'N/A',
+        thumbnail_url:
+          game.thumbnail_url ?? previousGame?.thumbnail_url ?? null,
+        genres:
+          game.genres.length > 0 ? game.genres : (previousGame?.genres ?? []),
+      };
+    });
+
+    queryClient.setQueryData(
+      authKeys.likedGamesList({
+        page_size: 20,
+        page: 1,
+      }),
+      {
+        ...nextLikedGames,
+        results: nextResults,
+      },
+    );
   };
 
   const handleFavoriteGameDeleteConfirm = async () => {
@@ -80,40 +106,28 @@ function useMyPageLikedGames({
       return;
     }
 
-    const hideFavoriteGame = () => {
-      setLocallyRemovedGameIds((current) =>
-        current.includes(targetGameId) ? current : [...current, targetGameId],
-      );
-    };
-    const syncRemovedGamesAfterRefetch = async () => {
-      const refetchResult = await refetchFavoriteGames();
-      const nextVisibleGameIds = new Set(
-        (refetchResult.data?.results ?? []).map((game) => game.game_id),
-      );
-
-      setLocallyRemovedGameIds((current) =>
-        current.filter((gameId) => nextVisibleGameIds.has(gameId)),
-      );
-    };
+    const previousLikedGames = likedGamesData?.results ?? [];
 
     try {
       await unlikeLikedGameMutation.mutateAsync(targetGameId);
-      hideFavoriteGame();
       setSelectedFavoriteGame(null);
       onToast({
         tone: 'success',
         message: '찜한 목록에서 삭제되었습니다.',
       });
-      void syncRemovedGamesAfterRefetch();
+      void refetchFavoriteGamesWithPreservedThumbnails(previousLikedGames);
     } catch (error) {
       if (error instanceof AxiosError && error.response?.status === 404) {
-        hideFavoriteGame();
+        syncLikedGamesStateInQueryCache(queryClient, {
+          gameId: targetGameId,
+          isLiked: false,
+        });
         setSelectedFavoriteGame(null);
         onToast({
           tone: 'success',
           message: '이미 삭제된 게임입니다.',
         });
-        void syncRemovedGamesAfterRefetch();
+        void refetchFavoriteGamesWithPreservedThumbnails(previousLikedGames);
         return;
       }
 


### PR DESCRIPTION
## 관련 이슈

- closes #359 

## 변경 내용

- 마이페이지 비밀번호 변경 패널의 입력 필드와 래퍼 레이아웃을 조정해, 화면 폭이 줄어들어도 `현재 비밀번호`, `새 비밀번호`, `새 비밀번호 확인` 인풋이 부모 너비를 따라 안정적으로 꽉 차도록 수정했습니다.
- 비밀번호 변경 패널의 버튼 영역도 좁은 화면에서 입력창 너비를 밀어내지 않도록 `w-full`, `min-w-0`, `max-w-full` 흐름을 정리했습니다.
- 찜한 목록 삭제 후 refetch 과정에서 남아 있는 게임 카드의 썸네일 URL이 비정상적으로 비어 보이면서 `이미지 준비 중`으로 바뀌는 현상을 완화하기 위해, refetch 결과에 이전 정상 썸네일 데이터를 안전하게 보강하도록 수정했습니다.
- 찜 목록 404 삭제 응답 처리 시에도 쿼리 캐시에서 해당 게임만 제거하고, 남은 카드들의 썸네일/장르 데이터는 유지되도록 상태 업데이트 로직을 정리했습니다.
- 찜한 목록 카드 이미지 로드 실패 상태도 삭제 후 재렌더링 과정에서 과도하게 남지 않도록 카드 컴포넌트의 썸네일 렌더링 흐름을 보강했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

- UI 변경 있음
- 비밀번호 변경 모바일 반응형 화면, 찜 목록 삭제 전후 렌더링 화면 스크린샷 첨부 예정

## 참고사항


