### PR TITLE
[Fix] 챗봇 API 경로 고정 및 세션 만료 처리 로직 반영

### DIFF
--- a/src/features/support-chat/api/chatbot.ts
+++ b/src/features/support-chat/api/chatbot.ts
@@ -252,10 +252,6 @@ export const streamChatbotResponse = async ({
     {
       method: 'GET',
       accept: 'text/event-stream',
-      extraHeaders: {
-        Accept: 'text/event-stream',
-        'Cache-Control': 'no-cache',
-      },
       signal,
     },
   );
@@ -323,6 +319,10 @@ export const streamChatbotResponse = async ({
 export const extractSupportChatErrorMessage = (error: unknown) => {
   if (error instanceof DOMException && error.name === 'AbortError') {
     return '';
+  }
+
+  if (error instanceof TypeError && error.message.includes('Failed to fetch')) {
+    return '실시간 응답 연결에 실패했습니다. 네트워크 또는 CORS 설정을 확인해 주세요.';
   }
 
   if (error instanceof Error) {

--- a/src/features/support-chat/api/chatbot.ts
+++ b/src/features/support-chat/api/chatbot.ts
@@ -9,6 +9,28 @@ import type {
 // 고객센터 챗봇 전용 엔드포인트.
 // 설문 챗봇(`/api/v1/survey/chatbot/*`)과 경로를 명확히 분리해 사용한다.
 const CHATBOT_BASE_PATH = '/api/v1/chatbot';
+const EXPIRED_CHATBOT_SESSION_MESSAGE =
+  '만료되었거나 유효하지 않은 session_id 입니다.';
+
+class ChatbotRequestError extends Error {
+  status: number | null;
+
+  constructor(message: string, status: number | null) {
+    super(message);
+    this.name = 'ChatbotRequestError';
+    this.status = status;
+  }
+}
+
+const normalizeChatbotApiPath = (path: string) => {
+  const prefixedPath = path.startsWith('/api/v1') ? path : `/api/v1${path}`;
+  const normalizedPath = prefixedPath.replace(/\/+$/, '');
+
+  return normalizedPath || CHATBOT_BASE_PATH;
+};
+
+const buildChatbotApiPath = (segment: 'messages' | 'stream') =>
+  normalizeChatbotApiPath(`${CHATBOT_BASE_PATH}/${segment}`);
 
 const createApiUrl = (
   path: string,
@@ -41,7 +63,7 @@ const getDefaultChatbotErrorMessage = (
   fallback = '챗봇 요청을 처리하는 중 오류가 발생했습니다.',
 ) => {
   if (status === 401) {
-    return '챗봇 요청 권한이 없습니다.';
+    return '세션이 만료되었습니다.';
   }
 
   if (status === 400) {
@@ -49,7 +71,7 @@ const getDefaultChatbotErrorMessage = (
   }
 
   if (status === 404) {
-    return '만료되었거나 유효하지 않은 session_id 입니다.';
+    return EXPIRED_CHATBOT_SESSION_MESSAGE;
   }
 
   if (status === 409) {
@@ -128,7 +150,7 @@ const fetchChatbotApi = async (
 
 export const sendChatbotMessage = async (payload: ChatbotMessageRequest) => {
   const response = await fetchChatbotApi(
-    createApiUrl(`${CHATBOT_BASE_PATH}/messages`),
+    createApiUrl(buildChatbotApiPath('messages')),
     {
       method: 'POST',
       accept: 'application/json',
@@ -138,7 +160,10 @@ export const sendChatbotMessage = async (payload: ChatbotMessageRequest) => {
   );
 
   if (!response.ok) {
-    throw new Error(await extractChatbotErrorMessage(response));
+    throw new ChatbotRequestError(
+      await extractChatbotErrorMessage(response),
+      response.status,
+    );
   }
 
   return (await response.json()) as ChatbotMessageResponse;
@@ -223,7 +248,7 @@ export const streamChatbotResponse = async ({
   onEvent: (event: ChatbotStreamEvent) => void;
 }) => {
   const response = await fetchChatbotApi(
-    createApiUrl(`${CHATBOT_BASE_PATH}/stream`, { session_id: sessionId }),
+    createApiUrl(buildChatbotApiPath('stream'), { session_id: sessionId }),
     {
       method: 'GET',
       accept: 'text/event-stream',
@@ -236,7 +261,10 @@ export const streamChatbotResponse = async ({
   );
 
   if (!response.ok) {
-    throw new Error(await extractChatbotErrorMessage(response));
+    throw new ChatbotRequestError(
+      await extractChatbotErrorMessage(response),
+      response.status,
+    );
   }
 
   if (!response.body) {
@@ -302,4 +330,25 @@ export const extractSupportChatErrorMessage = (error: unknown) => {
   }
 
   return '챗봇 요청을 처리하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+};
+
+export const isSupportChatSessionExpiredError = (error: unknown) => {
+  if (error instanceof ChatbotRequestError) {
+    if (error.status === 401) {
+      return true;
+    }
+
+    if (error.status === 404) {
+      return error.message.includes('session_id');
+    }
+  }
+
+  if (error instanceof Error) {
+    return (
+      error.message.includes('세션이 만료') ||
+      error.message.includes(EXPIRED_CHATBOT_SESSION_MESSAGE)
+    );
+  }
+
+  return false;
 };

--- a/src/features/support-chat/hooks/useSupportChatConversation.ts
+++ b/src/features/support-chat/hooks/useSupportChatConversation.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 
 import {
   extractSupportChatErrorMessage,
+  isSupportChatSessionExpiredError,
   streamChatbotResponse,
 } from '@/features/support-chat/api/chatbot';
 import { useSendChatbotMessageMutation } from '@/features/support-chat/api/useSupportChatApi';
@@ -178,6 +179,21 @@ function useSupportChatConversation({
         }
 
         removeMessage(assistantPlaceholderMessageId);
+
+        if (isSupportChatSessionExpiredError(requestError)) {
+          if (typeof window !== 'undefined') {
+            window.alert('세션이 만료되었습니다.');
+          }
+
+          resetConversationState({
+            routeContext,
+            keepPanelOpen: false,
+            preserveBootstrap: true,
+            abortInFlightRequest: true,
+          });
+          return;
+        }
+
         const errorMessage = extractSupportChatErrorMessage(requestError);
 
         if (errorMessage) {
@@ -203,6 +219,8 @@ function useSupportChatConversation({
       sendMessageMutation,
       setSessionId,
       setSubmitting,
+      resetConversationState,
+      routeContext,
     ],
   );
 


### PR DESCRIPTION
## 관련 이슈

- closes #361

## 변경 내용

- 챗봇 API 경로 정규화: `buildChatbotApiPath()`와 `normalizeChatbotApiPath()`를 도입해 고객센터 챗봇 호출 경로가 항상 `/api/v1/chatbot/...` 형식을 따르도록 정리하고, 끝 슬래시도 자동 제거하도록 수정했습니다.
- SSE 스트림 CORS 대응: 챗봇 `stream` 요청에서 불필요한 커스텀 헤더를 제거해 preflight 가능성을 줄이고, `Failed to fetch` 상황에서는 네트워크/CORS 점검이 필요한 에러 메시지를 보여주도록 보완했습니다.
- 에러 핸들링 강화: `ChatbotRequestError` 클래스를 추가해 HTTP 상태 코드를 함께 다루도록 바꾸고, `401`은 세션 만료, `404`는 만료되었거나 유효하지 않은 `session_id`로 구분할 수 있게 했습니다.
- 세션 만료 후처리 추가: `isSupportChatSessionExpiredError`로 세션 만료를 감지하면 사용자에게 알림을 띄우고, 챗봇 패널을 닫은 뒤 대화 상태를 초기화하도록 반영했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷



## 참고사항

- UI 변경은 없습니다.
