### PR TITLE
[Fix] 마이페이지 인풋 반응형 깨짐 및 찜한 목록 삭제 시 이미지 초기화 현상 수정

### DIFF
--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -40,23 +40,23 @@ function AuthInputField({
 
   return (
     <div
-      className={`w-full min-w-0 space-y-2 ${containerClassName} sm:space-y-2.5`}
+      className={`w-full max-w-none min-w-0 space-y-2.5 ${containerClassName} sm:space-y-2.5`}
     >
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex min-w-0 items-center justify-between gap-3">
         <label
           htmlFor={id}
-          className="text-login-label block min-w-0 text-sm font-medium"
+          className="text-login-label block min-w-0 text-[0.95rem] font-medium sm:text-sm"
         >
           {label}
         </label>
         {labelAction ? <div className="shrink-0">{labelAction}</div> : null}
       </div>
-      <div className="relative flex w-full max-w-full min-w-0 flex-col gap-3 sm:flex-row sm:items-stretch">
+      <div className="relative flex w-full max-w-none min-w-0 flex-col items-stretch gap-3.5 sm:flex-row sm:items-stretch sm:gap-3">
         <InputControl
           id={id}
           {...inputProps}
           hasError={Boolean(errorMessage)}
-          className={`w-full min-w-0 flex-1 ${className}`}
+          className={`w-full max-w-none min-w-0 flex-1 ${className}`}
         />
         {action}
         {toast}

--- a/src/components/common/InputControl.tsx
+++ b/src/components/common/InputControl.tsx
@@ -6,7 +6,7 @@ type InputControlProps = {
 } & InputHTMLAttributes<HTMLInputElement>;
 
 const inputBaseClassName =
-  'auth-input-autofill placeholder-login-muted bg-login-field h-12 min-w-0 w-full max-w-full rounded-2xl border px-3.5 text-[0.95rem] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition outline-none focus-visible:ring-2 sm:h-[3.2rem] sm:px-4 sm:text-base';
+  'auth-input-autofill placeholder-login-muted bg-login-field block h-[3.15rem] min-h-[3.15rem] w-full min-w-0 max-w-none rounded-2xl border px-4 text-[0.98rem] leading-normal text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition outline-none focus-visible:ring-2 sm:h-[3.25rem] sm:min-h-[3.25rem] sm:text-base';
 
 function InputControl({
   hasError = false,

--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -1,7 +1,11 @@
-import { useState } from 'react';
 import { X } from 'lucide-react';
+import { useState } from 'react';
 
 import type { FavoriteGamePreview } from '../../features/mypage/types';
+import {
+  isIgdbImageId,
+  normalizeThumbnailUrl,
+} from '../../lib/normalizeThumbnailUrl';
 import ActionButton from '../common/ActionButton';
 
 type FavoriteGameCardProps = {
@@ -15,15 +19,22 @@ function FavoriteGameCard({
   onClick,
   onFavoriteClick,
 }: FavoriteGameCardProps) {
+  const [igdbExtension, setIgdbExtension] = useState<'jpg' | 'png'>('jpg');
+  const normalizedThumbnailUrl =
+    normalizeThumbnailUrl(game.thumbnailUrl, {
+      igdbExtension,
+    }) ?? '';
   const [failedThumbnailKey, setFailedThumbnailKey] = useState<string | null>(
     null,
   );
-  const currentThumbnailKey = game.thumbnailUrl
-    ? `${game.gameId}:${game.thumbnailUrl}`
+  const currentThumbnailKey = normalizedThumbnailUrl
+    ? `${game.gameId}:${normalizedThumbnailUrl}`
     : null;
-  const hasThumbnail = Boolean(game.thumbnailUrl);
+  const hasThumbnail = normalizedThumbnailUrl.length > 0;
   const canRenderThumbnail =
     hasThumbnail && failedThumbnailKey !== currentThumbnailKey;
+  const canRetryWithPng =
+    igdbExtension === 'jpg' && isIgdbImageId(game.thumbnailUrl);
 
   return (
     <article className="group border-mypage-card bg-mypage-card shadow-mypage-float hover:bg-mypage-card-hover box-border flex w-full min-w-0 flex-col overflow-hidden rounded-[22px] border transition duration-200">
@@ -35,10 +46,18 @@ function FavoriteGameCard({
         >
           {canRenderThumbnail ? (
             <img
-              src={game.thumbnailUrl ?? undefined}
+              key={currentThumbnailKey ?? `thumbnail-fallback-${game.gameId}`}
+              src={normalizedThumbnailUrl || undefined}
               alt={`${game.title} 썸네일`}
               onLoad={() => setFailedThumbnailKey(null)}
-              onError={() => setFailedThumbnailKey(currentThumbnailKey)}
+              onError={() => {
+                if (canRetryWithPng) {
+                  setIgdbExtension('png');
+                  return;
+                }
+
+                setFailedThumbnailKey(currentThumbnailKey);
+              }}
               className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.04]"
               loading="lazy"
             />

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -132,9 +132,9 @@ function MyPageProfileSection({
         </div>
       ) : null}
 
-      <div className="relative px-4 pt-0 pb-5 sm:px-6 sm:pb-7 lg:px-8 lg:pb-8">
-        <div className="mt-0 rounded-[28px] bg-[#111114] px-4 pb-5 sm:px-6 sm:pb-6 lg:px-8 lg:pb-7">
-          <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+      <div className="relative w-full min-w-0 px-3.5 pt-0 pb-5 sm:px-6 sm:pb-7 lg:px-8 lg:pb-8">
+        <div className="mt-0 w-full min-w-0 rounded-[28px] bg-[#111114] px-3.5 pb-5 sm:px-6 sm:pb-6 lg:px-8 lg:pb-7">
+          <div className="flex w-full min-w-0 flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-5">
               <div className="-mt-9 sm:-mt-10">
                 <div className="group relative h-[8.4rem] w-[8.4rem] sm:h-[9.2rem] sm:w-[9.2rem]">
@@ -241,7 +241,7 @@ function MyPageProfileSection({
             </div>
           </div>
 
-          <div className="mt-6 rounded-[24px] border border-white/8 bg-white/[0.035] px-4 py-4 sm:px-5 sm:py-5">
+          <div className="mt-6 rounded-[24px] border border-white/8 bg-white/[0.035] px-3.5 py-4 sm:px-5 sm:py-5">
             <div className="divide-y divide-white/7">
               <div className="py-5 pt-1">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
@@ -343,7 +343,9 @@ function MyPageProfileSection({
             </div>
           </div>
 
-          {children ? <div className="mt-6">{children}</div> : null}
+          {children ? (
+            <div className="mt-6 w-full min-w-0">{children}</div>
+          ) : null}
         </div>
       </div>
     </section>

--- a/src/components/mypage/PasswordChangePanel.tsx
+++ b/src/components/mypage/PasswordChangePanel.tsx
@@ -36,15 +36,18 @@ function PasswordChangePanel({
   onSubmit,
 }: PasswordChangePanelProps) {
   return (
-    <section className="bg-mypage-card border-mypage-panel mt-6 w-full max-w-full min-w-0 overflow-hidden rounded-3xl border px-4 py-5 text-left sm:px-5 sm:py-6">
-      <div className="mb-5">
+    <section className="bg-mypage-card border-mypage-panel mt-5 w-full max-w-full min-w-0 overflow-hidden rounded-[28px] border px-3.5 py-5 text-left sm:mt-6 sm:rounded-3xl sm:px-5 sm:py-6">
+      <div className="mb-6 sm:mb-5">
         <h2 className="text-xl font-semibold text-white">비밀번호 변경</h2>
         <p className="text-mypage-muted mt-2 text-sm/6">
           현재 비밀번호를 확인한 뒤 새 비밀번호로 변경할 수 있습니다.
         </p>
       </div>
 
-      <form className="grid w-full min-w-0 gap-4" onSubmit={onSubmit}>
+      <form
+        className="grid w-full min-w-0 grid-cols-1 gap-5 sm:gap-4"
+        onSubmit={onSubmit}
+      >
         <AuthInputField
           id="current-password"
           name="old_password"
@@ -58,6 +61,8 @@ function PasswordChangePanel({
           onBlur={() => onFieldBlur('currentPassword')}
           errorMessage={errors.currentPassword}
           disabled={isPending}
+          containerClassName="w-full min-w-0 max-w-none"
+          className="w-full max-w-none min-w-0"
         />
 
         <AuthInputField
@@ -71,6 +76,8 @@ function PasswordChangePanel({
           onBlur={() => onFieldBlur('newPassword')}
           errorMessage={errors.newPassword}
           disabled={isPending}
+          containerClassName="w-full min-w-0 max-w-none"
+          className="w-full max-w-none min-w-0"
         />
 
         <AuthInputField
@@ -86,13 +93,15 @@ function PasswordChangePanel({
           onBlur={() => onFieldBlur('newPasswordConfirm')}
           errorMessage={errors.newPasswordConfirm}
           disabled={isPending}
+          containerClassName="w-full min-w-0 max-w-none"
+          className="w-full max-w-none min-w-0"
         />
 
         {message ? (
           <AuthFormMessage tone={messageTone}>{message}</AuthFormMessage>
         ) : null}
 
-        <div className="flex w-full min-w-0 flex-col gap-3 pt-2 sm:flex-row sm:flex-nowrap sm:justify-end">
+        <div className="flex w-full min-w-0 flex-col gap-3 pt-3 sm:flex-row sm:flex-nowrap sm:justify-end sm:pt-2">
           <AuthButton
             type="button"
             variant="secondary"

--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosRequestConfig } from 'axios';
 
 import { api } from '@/api/axios';
 import { apiBaseUrl } from '@/lib/env';
+import { normalizeThumbnailUrl } from '@/lib/normalizeThumbnailUrl';
 import { AUTH_BASE_PATH } from '../constants/auth';
 import { logCredentialedAuthRequestDiagnostics } from './auth.diagnostics';
 import type {
@@ -74,6 +75,7 @@ const normalizeLikedGamesResponse = (
   count: response.count,
   results: response.results.map((item) => ({
     ...item,
+    thumbnail_url: normalizeThumbnailUrl(item.thumbnail_url),
     genres: normalizeLikedGameGenres(item.genres),
   })),
 });

--- a/src/lib/normalizeThumbnailUrl.ts
+++ b/src/lib/normalizeThumbnailUrl.ts
@@ -1,0 +1,59 @@
+import { apiBaseUrl } from './env';
+
+const INVALID_THUMBNAIL_URL_VALUES = new Set([
+  'n/a',
+  'null',
+  'undefined',
+  'none',
+]);
+const IGDB_IMAGE_ID_REGEX = /^co[a-z0-9]+$/i;
+const IGDB_IMAGE_BASE_URL = 'https://images.igdb.com/igdb/image/upload';
+const IGDB_COVER_SIZE = 't_cover_big';
+
+const resolveThumbnailBaseUrl = () =>
+  apiBaseUrl ||
+  (typeof window !== 'undefined' ? window.location.origin : 'http://localhost');
+
+export const isIgdbImageId = (value: string | null | undefined) => {
+  const trimmedValue = value?.trim();
+
+  return Boolean(trimmedValue && IGDB_IMAGE_ID_REGEX.test(trimmedValue));
+};
+
+type NormalizeThumbnailUrlOptions = {
+  igdbExtension?: 'jpg' | 'png';
+};
+
+export const normalizeThumbnailUrl = (
+  value: string | null | undefined,
+  options: NormalizeThumbnailUrlOptions = {},
+) => {
+  const { igdbExtension = 'jpg' } = options;
+  const trimmedValue = value?.trim();
+
+  if (!trimmedValue) {
+    return null;
+  }
+
+  if (INVALID_THUMBNAIL_URL_VALUES.has(trimmedValue.toLowerCase())) {
+    return null;
+  }
+
+  if (isIgdbImageId(trimmedValue)) {
+    return `${IGDB_IMAGE_BASE_URL}/${IGDB_COVER_SIZE}/${trimmedValue}.${igdbExtension}`;
+  }
+
+  if (trimmedValue.startsWith('//')) {
+    return `https:${trimmedValue}`;
+  }
+
+  if (trimmedValue.startsWith('images.igdb.com/')) {
+    return `https://${trimmedValue}`;
+  }
+
+  try {
+    return new URL(trimmedValue, resolveThumbnailBaseUrl()).toString();
+  } catch {
+    return null;
+  }
+};

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -23,6 +23,7 @@ function MyPageLikedGamesSection({
   const {
     favoriteGames,
     favoriteCount,
+    favoriteListRenderVersion,
     isFavoriteGamesLoading,
     isFavoriteGamesError,
     isFetchingFavoriteGames,
@@ -73,7 +74,7 @@ function MyPageLikedGamesSection({
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
               {favoriteGames.map((game) => (
                 <FavoriteGameCard
-                  key={game.gameId}
+                  key={`${game.gameId}:${game.thumbnailUrl ?? 'none'}:${favoriteListRenderVersion}`}
                   game={game}
                   onClick={handleFavoriteGameCardClick}
                   onFavoriteClick={setSelectedFavoriteGame}

--- a/src/pages/mypage/hooks/useMyPageLikedGames.ts
+++ b/src/pages/mypage/hooks/useMyPageLikedGames.ts
@@ -12,6 +12,7 @@ import type { LikedGamesResponse } from '../../../features/auth/types/auth';
 import type { GameListItem } from '../../../features/games/types';
 import { syncLikedGamesStateInQueryCache } from '../../../features/games/queryCache';
 import type { FavoriteGamePreview } from '../../../features/mypage/types';
+import { normalizeThumbnailUrl } from '../../../lib/normalizeThumbnailUrl';
 import type { MyPageToastPayload } from '../types';
 import { toFavoriteGameListItem, toFavoriteGamePreview } from '../utils';
 
@@ -35,6 +36,7 @@ function useMyPageLikedGames({
   const unlikeLikedGameMutation = useUnlikeLikedGameMutation();
   const [selectedFavoriteGame, setSelectedFavoriteGame] =
     useState<FavoriteGamePreview | null>(null);
+  const [favoriteListRenderVersion, setFavoriteListRenderVersion] = useState(0);
   const serverFavoriteGames = useMemo(() => {
     return (likedGamesData?.results ?? []).map(toFavoriteGamePreview);
   }, [likedGamesData?.results]);
@@ -72,7 +74,9 @@ function useMyPageLikedGames({
         game_title:
           game.game_title.trim() || previousGame?.game_title?.trim() || 'N/A',
         thumbnail_url:
-          game.thumbnail_url ?? previousGame?.thumbnail_url ?? null,
+          normalizeThumbnailUrl(game.thumbnail_url) ??
+          normalizeThumbnailUrl(previousGame?.thumbnail_url) ??
+          null,
         genres:
           game.genres.length > 0 ? game.genres : (previousGame?.genres ?? []),
       };
@@ -110,6 +114,7 @@ function useMyPageLikedGames({
 
     try {
       await unlikeLikedGameMutation.mutateAsync(targetGameId);
+      setFavoriteListRenderVersion((current) => current + 1);
       setSelectedFavoriteGame(null);
       onToast({
         tone: 'success',
@@ -122,6 +127,7 @@ function useMyPageLikedGames({
           gameId: targetGameId,
           isLiked: false,
         });
+        setFavoriteListRenderVersion((current) => current + 1);
         setSelectedFavoriteGame(null);
         onToast({
           tone: 'success',
@@ -141,6 +147,7 @@ function useMyPageLikedGames({
   return {
     favoriteGames,
     favoriteCount,
+    favoriteListRenderVersion,
     isFavoriteGamesLoading,
     isFavoriteGamesError,
     isFetchingFavoriteGames: likedGamesQuery.isFetching,


### PR DESCRIPTION
## 관련 이슈

- closes #363

## 변경 내용

- 찜한 목록 썸네일 정규화: `thumbnail_url`이 일반 URL뿐 아니라 IGDB 커버 ID(`co...`) 형태로 내려오는 경우도 처리할 수 있도록 정규화 로직을 추가했습니다.
- 찜한 목록 삭제 후 이미지 유지: 첫 번째 찜 항목을 삭제한 뒤 남은 카드가 재사용되면서 `이미지 준비 중`으로 바뀌던 문제를 수정했습니다.
- 비밀번호 변경 반응형 개선: 마이페이지 비밀번호 변경 패널에서 모바일/좁은 화면 기준으로 인풋 높이, 내부 여백, 필드 간 간격을 조정해 답답하게 보이던 레이아웃을 개선했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="1606" height="1484" alt="image" src="https://github.com/user-attachments/assets/bd0ff3fe-02a1-40db-9fcd-1e0be51cbae2" />

<img width="1630" height="814" alt="image" src="https://github.com/user-attachments/assets/53f9d649-f038-4990-b085-fbace3b2c489" />


## 참고사항

- 찜한 목록 조회 응답의 `thumbnail_url`이 완전한 이미지 URL이 아닌 IGDB 커버 ID 형태로 내려오는 케이스를 프론트 정규화 레이어에서 흡수하도록 처리했습니다.
- 관련 커밋은 아래 2건으로 분리했습니다.
- `fix(mypage): 찜한 목록 썸네일 정규화 및 삭제 후 이미지 유지`
- `fix(mypage): 비밀번호 변경 패널 모바일 반응형 레이아웃 개선`
