### PR TITLE
[Refactor] 인증 페이지 불필요한 알림창 제거 및 메인 페이지 통일감 로딩 추가

### DIFF
--- a/src/components/common/MainPageLoadingFallback.tsx
+++ b/src/components/common/MainPageLoadingFallback.tsx
@@ -1,0 +1,32 @@
+import LazyHeader from './LazyHeader';
+import { GameCardSkeletonList } from '../../pages/main/components/MainGameCarousel';
+
+type MainPageLoadingFallbackProps = {
+  className?: string;
+};
+
+function MainPageLoadingFallback({
+  className = '',
+}: MainPageLoadingFallbackProps) {
+  return (
+    <div
+      className={`relative min-h-screen overflow-hidden bg-[#050505] text-white ${className}`.trim()}
+    >
+      <LazyHeader fixed />
+      <main
+        aria-busy="true"
+        aria-live="polite"
+        className="min-h-screen pt-24 pb-10 sm:pt-28 sm:pb-14 lg:h-screen lg:overflow-hidden lg:pt-24 lg:pb-4 xl:pt-26 xl:pb-5"
+      >
+        <span className="sr-only">화면을 준비하고 있습니다.</span>
+        <section className="w-full lg:flex lg:h-full lg:flex-col">
+          <div className="mt-4 sm:mt-5 lg:mt-4">
+            <GameCardSkeletonList />
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default MainPageLoadingFallback;

--- a/src/features/auth/hooks/useLoginForm.ts
+++ b/src/features/auth/hooks/useLoginForm.ts
@@ -67,6 +67,7 @@ function useLoginForm() {
   const loginMutation = useLoginMutation();
   const [mockAccounts, setMockAccounts] = useState<DevMockLoginAccount[]>([]);
   const [isMockPanelOpen, setIsMockPanelOpen] = useState(false);
+  const [isLoginFlowLoading, setIsLoginFlowLoading] = useState(false);
   const mockPanelRef = useRef<HTMLDivElement | null>(null);
 
   const [formValues, setFormValues] = useState<LoginRequest>({
@@ -282,11 +283,13 @@ function useLoginForm() {
     };
 
     let accessToken: string;
+    setIsLoginFlowLoading(true);
 
     try {
       const response = await loginMutation.mutateAsync(payload);
       accessToken = response.access_token;
     } catch (error) {
+      setIsLoginFlowLoading(false);
       const resolvedError = resolveLoginApiError(error, payload);
 
       setApiFieldErrors(resolvedError.fieldErrors);
@@ -299,6 +302,7 @@ function useLoginForm() {
       await hydrateAuthSessionFromAccessToken(accessToken);
       navigate(ROUTES.HOME);
     } catch {
+      setIsLoginFlowLoading(false);
       setFormMessage(
         '로그인 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.',
       );
@@ -312,6 +316,7 @@ function useLoginForm() {
     noticeMessage,
     showNoticeMessage,
     showFormMessage: feedbackVisibility.showFormMessage,
+    isLoginFlowLoading,
     isSubmitting: loginMutation.isPending,
     visibleMockAccounts,
     showMockAccounts,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import App from './App';
+import MainPageLoadingFallback from './components/common/MainPageLoadingFallback';
 import LegacyRouteRedirect from './components/common/LegacyRouteRedirect';
 import { ROUTES } from './constants/routes';
 import { isMockServiceWorkerEnabled } from './lib/env';
@@ -23,20 +24,7 @@ const LazySignupPage = lazy(() => import('./pages/SignupPage'));
 // eslint-disable-next-line react-refresh/only-export-components
 const LazyMyPage = lazy(() => import('./pages/mypage/MyPage'));
 
-const authPageFallback = (
-  <div className="bg-login-page flex min-h-dvh flex-col text-white">
-    <div className="header-shell h-16 w-full lg:h-18" aria-hidden="true" />
-    <main className="auth-layout-main relative isolate flex flex-1 items-center justify-center overflow-hidden px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
-      <div aria-hidden="true" className="auth-layout-backdrop" />
-      <div aria-hidden="true" className="auth-layout-grid" />
-      <section className="auth-layout-panel w-full max-w-130 rounded-[28px] border px-4 py-5 backdrop-blur-sm sm:rounded-3xl sm:px-8 sm:py-8">
-        <div className="mx-auto w-full max-w-110 text-center text-white/68">
-          화면을 불러오는 중입니다...
-        </div>
-      </section>
-    </main>
-  </div>
-);
+const authPageFallback = <MainPageLoadingFallback />;
 
 const router = createBrowserRouter([
   {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -11,6 +11,7 @@ import {
   AUTH_SHARED_LAYOUT_CLASS_NAMES,
 } from '../components/auth/authSharedStyles';
 import DevApiModeToggle from '../components/common/DevApiModeToggle';
+import MainPageLoadingFallback from '../components/common/MainPageLoadingFallback';
 import AuthLayout from '../components/layout/AuthLayout';
 import { ROUTES } from '../constants/routes';
 import useLoginForm, {
@@ -32,6 +33,7 @@ function LoginPage() {
     noticeMessage,
     showNoticeMessage,
     showFormMessage,
+    isLoginFlowLoading,
     isSubmitting,
     visibleMockAccounts,
     showMockAccounts,
@@ -44,6 +46,10 @@ function LoginPage() {
     closeMockPanel,
     toggleMockPanel,
   } = useLoginForm();
+
+  if (isLoginFlowLoading) {
+    return <MainPageLoadingFallback />;
+  }
 
   return (
     <>


### PR DESCRIPTION
## 관련 이슈

- closes #365

## 변경 내용

- 메인 페이지에서 사용 중인 게임 카드 스켈레톤을 재사용하는 `MainPageLoadingFallback`를 추가해 인증 페이지 로딩 UI를 통일했습니다.
- 로그인/회원가입 페이지의 lazy fallback에서 기존 `"화면을 불러오는 중입니다..."` 텍스트를 제거하고 동일한 스켈레톤 로딩 화면으로 교체했습니다.
- 로그인 성공 후 세션 hydrate 및 메인 페이지 이동이 끝날 때까지 로그인 페이지에서 동일한 스켈레톤 로딩 화면을 보여주도록 전환 UX를 보완했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

https://github.com/user-attachments/assets/5dd0daa8-5774-4cb3-a34a-7c968a65c5ad

## 참고사항

