### PR TITLE
[Fix] 프로필 이미지 확인 저장 API를 PUT 명세로 정렬

### DIFF
--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -244,9 +244,13 @@ export const uploadFileToS3 = async ({
 export const confirmProfileImage = async (
   payload: ConfirmProfileImageRequest,
 ) => {
-  const response = await api.patch<ConfirmProfileImageResponse>(
+  const requestBody: ConfirmProfileImageRequest = {
+    profile_img_url: payload.profile_img_url.trim(),
+  };
+
+  const response = await api.put<ConfirmProfileImageResponse>(
     `${AUTH_BASE_PATH}/me/profile-image`,
-    payload,
+    requestBody,
     createCredentialedAuthRequestConfig(),
   );
 

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -789,7 +789,7 @@ const accountHandlers = [
     },
   ),
 
-  http.patch(`${AUTH_BASE_PATH}/me/profile-image`, async ({ request }) => {
+  http.put(`${AUTH_BASE_PATH}/me/profile-image`, async ({ request }) => {
     const authorization = request.headers.get('Authorization');
     const user = getAuthorizedUser(authorization);
 


### PR DESCRIPTION
## 관련 이슈

- closes #367

## 변경 내용

- 프로필 이미지 확인 저장 API를 `PATCH /api/v1/accounts/me/profile-image`에서 `PUT /api/v1/accounts/me/profile-image`로 변경해 백엔드 명세와 맞췄습니다.
- 확인 저장 요청 바디를 `application/json` 형식의 `{ "profile_img_url": "..." }` 구조로 정리하고, 전송 전에 URL 문자열을 trim 하도록 보완했습니다.
- MSW mock 핸들러도 동일하게 `PUT /api/v1/accounts/me/profile-image`로 맞춰 실제 API 계약과 일치하도록 수정했습니다.
- 프론트 워크스페이스 전체를 확인한 결과 `https://picsum.photos/200` 하드코딩은 존재하지 않았고, 실제 업로드 후 받은 `profile_img_url` 상태값을 그대로 서버에 전달하는 흐름을 유지하고 있음을 확인했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 없습니다.

## 참고사항

- 프로필 이미지 업로드 흐름은 `presigned-url 발급(POST) -> S3 업로드(PUT) -> 프로필 이미지 확인 저장(PUT)` 구조입니다.
- 프로필 이미지 확인 저장 성공 시에는 기존처럼 query cache와 전역 사용자 상태를 함께 갱신해 화면에 즉시 반영되도록 유지했습니다.
