### PR TITLE
[Fix] 연속 새로고침 시 강제로 로그아웃되는 현상 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
   type AuthSessionExpiredDetail,
 } from './features/auth/constants/session';
 import useAuthBootstrap from './features/auth/hooks/useAuthBootstrap';
+import { useAuthStore } from './store/useAuthStore';
 import SupportChatWidget from './components/support-chat/SupportChatWidget';
 
 function App() {
@@ -18,6 +19,10 @@ function App() {
 
   useEffect(() => {
     const handleSessionExpired = (event: Event) => {
+      if (useAuthStore.getState().authBootstrapStatus === 'loading') {
+        return;
+      }
+
       const customEvent = event as CustomEvent<AuthSessionExpiredDetail>;
       const noticeMessage =
         customEvent.detail?.noticeMessage ||

--- a/src/components/auth/AuthWrapper.tsx
+++ b/src/components/auth/AuthWrapper.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import MainPageLoadingFallback from '../common/MainPageLoadingFallback';
 import useAuthGate, {
   type UseAuthGateResult,
 } from '../../features/auth/hooks/useAuthGate';
@@ -16,7 +17,7 @@ function AuthWrapper({
   children,
   gate,
   allowMockBypass = false,
-  loadingFallback = null,
+  loadingFallback = <MainPageLoadingFallback />,
   unauthorizedFallback = null,
 }: AuthWrapperProps) {
   const fallbackGate = useAuthGate({ allowMockBypass });

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import { ROUTES } from '../../../constants/routes';
@@ -15,26 +15,12 @@ import {
   hasPendingSocialAuthProvider,
 } from '../utils/socialAuth';
 import {
-  restoreAuthSession,
+  ensureAuthSessionRestored,
   setAuthBootstrapLoading,
   setAuthBootstrapReady,
 } from '../utils/sessionManager';
-
-let authBootstrapPromise: Promise<void> | null = null;
 const DEFAULT_SOCIAL_AUTH_ERROR_MESSAGE =
   '세션을 확인하지 못했습니다. 다시 로그인해 주세요.';
-
-const ensureAuthBootstrap = (): Promise<void> => {
-  if (!authBootstrapPromise) {
-    authBootstrapPromise = restoreAuthSession()
-      .then(() => undefined)
-      .finally(() => {
-        authBootstrapPromise = null;
-      });
-  }
-
-  return authBootstrapPromise;
-};
 
 function useAuthBootstrap() {
   const location = useLocation();
@@ -42,18 +28,15 @@ function useAuthBootstrap() {
   const authBootstrapStatus = useAuthStore(
     (state) => state.authBootstrapStatus,
   );
-  const hasBootstrappedRef = useRef(false);
 
   useEffect(() => {
     clearLegacyAuthStorage();
   }, []);
 
   useEffect(() => {
-    if (hasBootstrappedRef.current) {
+    if (authBootstrapStatus !== 'idle') {
       return;
     }
-
-    hasBootstrappedRef.current = true;
 
     const store = useAuthStore.getState();
 
@@ -81,7 +64,7 @@ function useAuthBootstrap() {
     let isMounted = true;
     setAuthBootstrapLoading();
 
-    void ensureAuthBootstrap()
+    void ensureAuthSessionRestored()
       .catch((error) => {
         if (!hasPendingSocialProvider || !isMounted) {
           return;
@@ -101,7 +84,10 @@ function useAuthBootstrap() {
           clearPendingSocialAuthProvider();
         }
 
-        if (isMounted) {
+        if (
+          isMounted &&
+          useAuthStore.getState().authBootstrapStatus === 'loading'
+        ) {
           setAuthBootstrapReady();
         }
       });
@@ -109,7 +95,7 @@ function useAuthBootstrap() {
     return () => {
       isMounted = false;
     };
-  }, [location.pathname, navigate]);
+  }, [authBootstrapStatus, location.pathname, navigate]);
 
   return {
     authBootstrapStatus,

--- a/src/features/auth/hooks/useAuthGate.ts
+++ b/src/features/auth/hooks/useAuthGate.ts
@@ -7,6 +7,7 @@ type UseAuthGateOptions = {
 
 export type UseAuthGateResult = {
   isAuthenticated: boolean;
+  isAuthLoading: boolean;
   isAuthReady: boolean;
   authBootstrapStatus: 'idle' | 'loading' | 'ready';
   isMockMode: boolean;
@@ -19,8 +20,13 @@ export type UseAuthGateResult = {
 
 function useAuthGate(options: UseAuthGateOptions = {}): UseAuthGateResult {
   const { allowMockBypass = false } = options;
-  const { isAuthenticated, authBootstrapStatus, isAuthReady, accessStatus } =
-    useAuthSessionState();
+  const {
+    isAuthenticated,
+    isAuthLoading,
+    authBootstrapStatus,
+    isAuthReady,
+    accessStatus,
+  } = useAuthSessionState();
   const isMockMode = isMockServiceWorkerEnabled();
   const canBypassAuth = allowMockBypass && isMockMode;
   const canAccessAuthenticatedRoute =
@@ -36,6 +42,7 @@ function useAuthGate(options: UseAuthGateOptions = {}): UseAuthGateResult {
 
   return {
     isAuthenticated,
+    isAuthLoading,
     isAuthReady,
     authBootstrapStatus,
     isMockMode,

--- a/src/features/auth/hooks/useAuthSessionState.ts
+++ b/src/features/auth/hooks/useAuthSessionState.ts
@@ -9,6 +9,7 @@ function useAuthSessionState() {
   const authBootstrapStatus = useAuthStore(
     (state) => state.authBootstrapStatus,
   );
+  const isAuthLoading = authBootstrapStatus === 'loading';
   const isAuthReady = authBootstrapStatus === 'ready';
   const accessStatus: AuthAccessStatus = !isAuthReady
     ? 'loading'
@@ -18,6 +19,7 @@ function useAuthSessionState() {
 
   const authSessionState: AuthSessionStateSnapshot = {
     isAuthenticated,
+    isAuthLoading,
     isAuthReady,
     authBootstrapStatus,
     accessStatus,

--- a/src/features/auth/utils/sessionManager.ts
+++ b/src/features/auth/utils/sessionManager.ts
@@ -16,6 +16,14 @@ import type {
   CurrentUserSocialResponse,
 } from '../types/auth';
 
+type RestoredAuthSession = {
+  accessToken: string;
+  profile: CurrentUserProfileResponse;
+  socialAccount: CurrentUserSocialResponse;
+};
+
+let restoreAuthSessionPromise: Promise<RestoredAuthSession> | null = null;
+
 export const setAuthBootstrapLoading = () => {
   useAuthStore.getState().setAuthBootstrapStatus('loading');
 };
@@ -110,6 +118,16 @@ export const restoreAuthSession = async () => {
 
     throw error;
   }
+};
+
+export const ensureAuthSessionRestored = () => {
+  if (!restoreAuthSessionPromise) {
+    restoreAuthSessionPromise = restoreAuthSession().finally(() => {
+      restoreAuthSessionPromise = null;
+    });
+  }
+
+  return restoreAuthSessionPromise;
 };
 
 export const notifyAuthSessionExpired = (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -82,16 +82,7 @@ const router = createBrowserRouter([
       {
         path: ROUTES.MY_PAGE,
         element: (
-          <Suspense
-            fallback={
-              <div className="relative min-h-screen overflow-hidden bg-[#050505] text-white">
-                <div className="app-aurora pointer-events-none absolute inset-0 opacity-70" />
-                <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-310 items-center justify-center px-4 text-center text-white/70 sm:px-6 md:px-8">
-                  마이페이지를 불러오는 중입니다...
-                </main>
-              </div>
-            }
-          >
+          <Suspense fallback={authPageFallback}>
             <LazyMyPage />
           </Suspense>
         ),

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import AuthLayout from '../components/layout/AuthLayout';
@@ -10,7 +10,7 @@ import {
 } from '../features/auth/utils/socialAuth';
 import {
   clearAuthSession,
-  restoreAuthSession,
+  ensureAuthSessionRestored,
 } from '../features/auth/utils/sessionManager';
 
 const DEFAULT_REFRESH_ERROR_MESSAGE =
@@ -19,25 +19,12 @@ const DEFAULT_REFRESH_ERROR_MESSAGE =
 function AuthCallbackPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const restorePromiseRef = useRef<Promise<void> | null>(null);
   const [statusMessage, setStatusMessage] = useState(
     '소셜 로그인 세션을 확인하는 중입니다.',
   );
 
   useEffect(() => {
     let isMounted = true;
-
-    const ensureRestorePromise = () => {
-      if (!restorePromiseRef.current) {
-        restorePromiseRef.current = restoreAuthSession()
-          .then(() => undefined)
-          .finally(() => {
-            restorePromiseRef.current = null;
-          });
-      }
-
-      return restorePromiseRef.current;
-    };
 
     const handleAuthCallback = async () => {
       const searchParams = new URLSearchParams(location.search);
@@ -54,7 +41,7 @@ function AuthCallbackPage() {
       }
 
       try {
-        await ensureRestorePromise();
+        await ensureAuthSessionRestored();
 
         if (!isMounted) {
           return;

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -12,6 +12,7 @@ import {
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import LazyHeader from '../../components/common/LazyHeader';
+import MainPageLoadingFallback from '../../components/common/MainPageLoadingFallback';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import { likeGame, unlikeGame } from '../../features/games/gameApi';
@@ -262,6 +263,10 @@ function MatchingGenreDetailPage() {
     );
   }
 
+  if (authGate.needsAuthCheck) {
+    return <MainPageLoadingFallback />;
+  }
+
   const handleSubmit = async () => {
     if (!genre || !allCandidatesRated || displayCandidates.length === 0) {
       return;
@@ -316,8 +321,6 @@ function MatchingGenreDetailPage() {
               장르 선택으로 돌아가기
             </Link>
           </section>
-        ) : authGate.accessStatus === 'loading' ? (
-          <MatchingDetailSkeleton />
         ) : !canAccessPage ? (
           <AuthGateStatusPanel
             title="로그인 후 매칭을 진행할 수 있어요."

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -5,6 +5,7 @@ import { Link, Navigate, useLocation } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import LazyHeader from '../../components/common/LazyHeader';
+import MainPageLoadingFallback from '../../components/common/MainPageLoadingFallback';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import { getMatchCandidates } from '../../features/matching/api/matching';
@@ -84,28 +85,17 @@ function MatchingListPage() {
     );
   }
 
+  if (authGate.needsAuthCheck) {
+    return <MainPageLoadingFallback />;
+  }
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.18),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
       <LazyHeader fixed />
 
       <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-22 pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-25 md:pb-14">
-        {authGate.accessStatus === 'loading' ? (
-          <section className="mx-auto max-w-240 animate-pulse">
-            <div className="mb-7 text-center sm:mb-8">
-              <div className="mx-auto h-4 w-24 rounded-full bg-[#792222]/35" />
-              <div className="mx-auto mt-3 h-10 w-72 rounded-full bg-white/9" />
-              <div className="mx-auto mt-3 h-4 w-full max-w-130 rounded-full bg-white/7" />
-              <div className="mx-auto mt-2 h-4 w-4/5 max-w-110 rounded-full bg-white/7" />
-            </div>
-
-            <div className="grid gap-4 md:grid-cols-2">
-              {MATCHING_GENRES.map((genre) => (
-                <MatchingGenreCardSkeleton key={genre.slug} />
-              ))}
-            </div>
-          </section>
-        ) : !canAccessPage ? (
+        {!canAccessPage ? (
           <AuthGateStatusPanel
             title="로그인 후 매칭을 시작할 수 있어요."
             description="로그인하면 장르를 고르고 트레일러를 보며 별점을 남긴 뒤, 취향에 맞는 추천 결과까지 바로 이어서 확인할 수 있어요."

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -3,6 +3,7 @@ import { Navigate } from 'react-router';
 
 import AuthWrapper from '../../components/auth/AuthWrapper';
 import LazyHeader from '../../components/common/LazyHeader';
+import MainPageLoadingFallback from '../../components/common/MainPageLoadingFallback';
 import { ROUTE_PATHS } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
@@ -17,16 +18,7 @@ import useMyPagePasswordChange from './hooks/useMyPagePasswordChange';
 import useMyPageProfile from './hooks/useMyPageProfile';
 import type { MyPageToast } from './types';
 
-const loadingFallback = (
-  <div className="relative min-h-screen overflow-hidden bg-[#050505]">
-    <LazyHeader fixed />
-    <main className="mx-auto flex min-h-[calc(100dvh-6.1rem)] w-full max-w-[1240px] px-4 pt-[6.1rem] pb-10 sm:px-6 md:px-8 md:pt-[6.4rem]">
-      <section className="survey-panel mx-auto w-full max-w-[920px] px-8 py-12 text-center text-white/68">
-        인증 상태를 확인하는 중입니다...
-      </section>
-    </main>
-  </div>
-);
+const loadingFallback = <MainPageLoadingFallback />;
 
 const unauthorizedFallback = (
   <Navigate

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -11,6 +11,7 @@ import { Link } from 'react-router';
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import ActionButton from '../../components/common/ActionButton';
 import LazyHeader from '../../components/common/LazyHeader';
+import MainPageLoadingFallback from '../../components/common/MainPageLoadingFallback';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
@@ -258,6 +259,10 @@ function RecommendationListPage() {
     setFeedbackMessage,
   });
 
+  if (authGate.needsAuthCheck) {
+    return <MainPageLoadingFallback />;
+  }
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <RecommendationBackdrop items={recommendationItems} />
@@ -300,9 +305,7 @@ function RecommendationListPage() {
             </div>
           </div>
 
-          {authGate.accessStatus === 'loading' ? (
-            <RecommendationListSkeleton />
-          ) : !canAccessPage ? (
+          {!canAccessPage ? (
             <AuthGateStatusPanel
               title="로그인 후 추천 결과를 볼 수 있어요."
               description="실제 API 모드에서는 인증 토큰이 필요합니다. 개발 중에는 MSW를 켜두면 추천 결과 흐름을 확인할 수 있습니다."

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -3,11 +3,10 @@ import { Navigate, useLocation, useSearchParams } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import LazyHeader from '../../components/common/LazyHeader';
+import MainPageLoadingFallback from '../../components/common/MainPageLoadingFallback';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
-import SurveyChatPanel, {
-  SurveyChatLoadingState,
-} from '../../features/survey/components/SurveyChatPanel';
+import SurveyChatPanel from '../../features/survey/components/SurveyChatPanel';
 import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
 import { mockTopGames } from '../../features/games/mockGames';
 import { useAuthStore } from '../../store/useAuthStore';
@@ -115,6 +114,10 @@ function SurveyPage() {
     );
   }
 
+  if (authGate.needsAuthCheck) {
+    return <MainPageLoadingFallback />;
+  }
+
   if (shouldRedirectCompletedEntry) {
     const recommendationQuery = surveySessionId
       ? `?source=survey&session_id=${encodeURIComponent(surveySessionId)}`
@@ -134,9 +137,7 @@ function SurveyPage() {
       <LazyHeader fixed />
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
-        {authGate.accessStatus === 'loading' ? (
-          <SurveyChatLoadingState />
-        ) : canAccessSurvey ? (
+        {canAccessSurvey ? (
           <SurveyChatPanel isHistoryView={isHistoryMode} />
         ) : (
           <AuthGateStatusPanel

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -63,6 +63,7 @@ interface AuthState {
 
 export type AuthSessionStateSnapshot = {
   isAuthenticated: boolean;
+  isAuthLoading: boolean;
   isAuthReady: boolean;
   authBootstrapStatus: AuthBootstrapStatus;
   accessStatus: AuthAccessStatus;


### PR DESCRIPTION
## 관련 이슈

- closes #369

## 변경 내용

- 인증 세션 복구 안정화: 앱 시작 시 인증 부트스트랩이 `idle -> loading -> ready` 흐름으로 한 번만 진행되도록 정리하고, 세션 복구 Promise를 공유해 빠른 새로고침이나 React Strict Mode 재마운트 상황에서도 중복 복구 요청이 겹치지 않도록 수정했습니다.
- 성급한 로그아웃/리다이렉트 방어: 인증 검증이 끝나기 전에는 비로그인 상태로 확정하지 않도록 `needsAuthCheck` 분기를 정리하고, 세션 만료 이벤트도 부트스트랩 로딩 중에는 바로 로그인 페이지로 보내지 않도록 보완했습니다.
- 공통 로딩 UI 통일: 인증 확인 중에는 로그인/회원가입 작업에서 이미 사용하던 메인 페이지 공통 스피너(`MainPageLoadingFallback`)를 마이페이지, 설문, 매칭, 추천, 라우트 lazy fallback에 동일하게 적용해 흰 화면이나 텍스트 기반 로딩이 보이지 않도록 정리했습니다.
- 소셜 콜백 복구 흐름 정렬: 소셜 로그인 콜백 페이지도 일반 인증 부트스트랩과 같은 세션 복구 Promise를 재사용하도록 맞춰 인증 확인 경합 가능성을 줄였습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 로컬 브라우저에서 MSW 모드 로그인 후 `https://localhost:5173/my-page` 기준으로 연속 새로고침 시 로그인 페이지로 리다이렉트되지 않고 세션이 유지되는 것을 확인했습니다.

