### PR TITLE
[Fix] 설문 챗봇 실서버 정합성 및 로딩 UX 개선

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -132,6 +132,7 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
   const progress = useSurveyStore((state) => state.progress);
   const hasBootstrapped = useSurveyStore((state) => state.hasBootstrapped);
   const isSubmitting = useSurveyStore((state) => state.isSubmitting);
+  const pendingAction = useSurveyStore((state) => state.pendingAction);
   const error = useSurveyStore((state) => state.error);
   const recommendationReady = useSurveyStore(
     (state) => state.recommendationReady,
@@ -191,11 +192,10 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
       : moderationHeuristicEnabled
         ? `${nonGameStrikeCount}/${NON_GAME_CHAT_MAX_STRIKES} 누적`
         : '실서버 기준';
-  const pendingAssistantMessage = recommendationReady
-    ? null
-    : messages.length === 0
-      ? null
-      : 'AI가 답변을 정리하고 있습니다.';
+  const pendingAssistantMessage =
+    pendingAction === 'continue' && !recommendationReady
+      ? 'AI가 답변을 정리하고 있습니다.'
+      : null;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -253,7 +253,10 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
     }
   };
 
-  if (!messages.length && isSubmitting) {
+  if (
+    isSubmitting &&
+    (pendingAction === 'start' || pendingAction === 'reset')
+  ) {
     return <SurveyChatLoadingState />;
   }
 

--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react';
 import { useNavigate } from 'react-router';
 import {
+  LoaderCircle,
   ChevronRight,
   RotateCcw,
   SendHorizontal,
@@ -105,6 +106,22 @@ export function SurveyChatLoadingState() {
   );
 }
 
+function SurveyPendingAssistantBubble({ message }: { message: string }) {
+  return (
+    <div className="flex w-full justify-start">
+      <div className="flex max-w-[92%] items-start gap-[0.7rem] md:max-w-[78%]">
+        <div className="mt-1 h-[38px] w-[38px] shrink-0 rounded-2xl bg-white/8" />
+        <div className="rounded-[24px] rounded-tl-md border border-white/8 bg-white/4 px-4 py-3.5 text-left shadow-[0_18px_40px_rgba(0,0,0,0.22)]">
+          <div className="flex items-center gap-2.5 text-white/78">
+            <LoaderCircle size={16} className="animate-spin text-[#ff8d8d]" />
+            <p className="text-[15px] leading-6 break-keep">{message}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
   const navigate = useNavigate();
   const [inputValue, setInputValue] = useState('');
@@ -124,6 +141,7 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
   );
 
   const {
+    moderationHeuristicEnabled,
     nonGameStrikeCount,
     remainingBlockTimeMs,
     isChatTemporarilyBlocked,
@@ -170,7 +188,14 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
     ? `${formatRemainingBlockTime(remainingBlockTimeMs)} 남음`
     : hasExpiredChatBlock
       ? '제한 종료'
-      : `${nonGameStrikeCount}/${NON_GAME_CHAT_MAX_STRIKES} 누적`;
+      : moderationHeuristicEnabled
+        ? `${nonGameStrikeCount}/${NON_GAME_CHAT_MAX_STRIKES} 누적`
+        : '실서버 기준';
+  const pendingAssistantMessage = recommendationReady
+    ? null
+    : messages.length === 0
+      ? null
+      : 'AI가 답변을 정리하고 있습니다.';
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -268,6 +293,10 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
             {messages.map((message) => (
               <SurveyMessageBubble key={message.id} message={message} />
             ))}
+
+            {isSubmitting && pendingAssistantMessage ? (
+              <SurveyPendingAssistantBubble message={pendingAssistantMessage} />
+            ) : null}
 
             {error ? (
               <div className="rounded-3xl border border-[#7d2424] bg-[#220a0a] px-5 py-4 text-[#ffb4b4]">

--- a/src/features/survey/hooks/useSurveyModerationGuard.ts
+++ b/src/features/survey/hooks/useSurveyModerationGuard.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { isMockServiceWorkerEnabled } from '../../../lib/env';
 import { useSurveyStore } from '../store/useSurveyStore';
 
 export const NON_GAME_CHAT_MAX_STRIKES = 3;
@@ -69,6 +70,7 @@ export const useSurveyModerationGuard = ({
   isSubmitting,
   recommendationReady,
 }: UseSurveyModerationGuardOptions) => {
+  const moderationHeuristicEnabled = isMockServiceWorkerEnabled();
   const nonGameStrikeCount = useSurveyStore(
     (state) => state.nonGameStrikeCount,
   );
@@ -80,18 +82,42 @@ export const useSurveyModerationGuard = ({
     (state) => state.setChatBlockedUntil,
   );
   const [currentTime, setCurrentTime] = useState(() => Date.now());
+  const didResetLocalModerationRef = useRef(false);
+
+  useEffect(() => {
+    if (moderationHeuristicEnabled || didResetLocalModerationRef.current) {
+      return;
+    }
+
+    didResetLocalModerationRef.current = true;
+
+    if (nonGameStrikeCount !== 0) {
+      setNonGameStrikeCount(0);
+    }
+
+    if (chatBlockedUntil !== null) {
+      setChatBlockedUntil(null);
+    }
+  }, [
+    chatBlockedUntil,
+    moderationHeuristicEnabled,
+    nonGameStrikeCount,
+    setChatBlockedUntil,
+    setNonGameStrikeCount,
+  ]);
 
   const remainingBlockTimeMs = chatBlockedUntil
     ? Math.max(chatBlockedUntil - currentTime, 0)
     : 0;
-  const hasReachedNonGameChatLimit =
-    nonGameStrikeCount >= NON_GAME_CHAT_MAX_STRIKES;
-  const isChatTemporarilyBlocked = Boolean(
-    chatBlockedUntil && remainingBlockTimeMs > 0,
-  );
-  const hasExpiredChatBlock = Boolean(
-    chatBlockedUntil && remainingBlockTimeMs <= 0,
-  );
+  const hasReachedNonGameChatLimit = moderationHeuristicEnabled
+    ? nonGameStrikeCount >= NON_GAME_CHAT_MAX_STRIKES
+    : false;
+  const isChatTemporarilyBlocked = moderationHeuristicEnabled
+    ? Boolean(chatBlockedUntil && remainingBlockTimeMs > 0)
+    : false;
+  const hasExpiredChatBlock = moderationHeuristicEnabled
+    ? Boolean(chatBlockedUntil && remainingBlockTimeMs <= 0)
+    : false;
   const isTextareaDisabled =
     isSubmitting ||
     recommendationReady ||
@@ -149,6 +175,10 @@ export const useSurveyModerationGuard = ({
         onBlocked?: () => void;
       },
     ) => {
+      if (!moderationHeuristicEnabled) {
+        return;
+      }
+
       const isGameRelatedMessage = isLikelyGameRelatedMessage(content);
       const nextStrikeCount = isGameRelatedMessage
         ? nonGameStrikeCount
@@ -167,13 +197,18 @@ export const useSurveyModerationGuard = ({
         options?.onBlocked?.();
       }
     },
-    [nonGameStrikeCount, setChatBlockedUntil, setNonGameStrikeCount],
+    [
+      moderationHeuristicEnabled,
+      nonGameStrikeCount,
+      setChatBlockedUntil,
+      setNonGameStrikeCount,
+    ],
   );
 
   return {
+    moderationHeuristicEnabled,
     nonGameStrikeCount,
     remainingBlockTimeMs,
-    hasReachedNonGameChatLimit,
     isChatTemporarilyBlocked,
     hasExpiredChatBlock,
     isTextareaDisabled,

--- a/src/features/survey/hooks/useSurveySessionFlow.ts
+++ b/src/features/survey/hooks/useSurveySessionFlow.ts
@@ -61,6 +61,32 @@ export const useSurveySessionFlow = ({
   const continueSurveyMutation = useContinueSurveyMutation();
   const resetSurveyMutation = useResetSurveyMutation();
 
+  const requestSessionStart = useCallback(
+    async (isReset: boolean) => {
+      const response = await startSessionMutation.mutateAsync({
+        is_reset: isReset,
+      });
+      hydrateInitialSession(response);
+
+      return response;
+    },
+    [hydrateInitialSession, startSessionMutation],
+  );
+
+  const requestSurveyMessage = useCallback(
+    async (activeSessionId: string, content: string) => {
+      const response = await continueSurveyMutation.mutateAsync({
+        session_id: activeSessionId,
+        user_answer: content,
+      });
+
+      applyChatResponse(response);
+
+      return response;
+    },
+    [applyChatResponse, continueSurveyMutation],
+  );
+
   const bootstrapSurvey = useCallback(
     async (force = false) => {
       if ((hasBootstrapped && !force) || (isSubmitting && !force)) {
@@ -73,10 +99,7 @@ export const useSurveySessionFlow = ({
       setSubmitting(true);
 
       try {
-        const response = await startSessionMutation.mutateAsync({
-          is_reset: false,
-        });
-        hydrateInitialSession(response);
+        await requestSessionStart(false);
       } catch (requestError) {
         setError(extractApiErrorMessage(requestError, 'start'));
       } finally {
@@ -86,13 +109,12 @@ export const useSurveySessionFlow = ({
     [
       clearError,
       hasBootstrapped,
-      hydrateInitialSession,
       isSubmitting,
+      requestSessionStart,
       resetSurveyState,
       setError,
       setHasBootstrapped,
       setSubmitting,
-      startSessionMutation,
     ],
   );
 
@@ -107,13 +129,10 @@ export const useSurveySessionFlow = ({
       return sessionId;
     }
 
-    const sessionResponse = await startSessionMutation.mutateAsync({
-      is_reset: false,
-    });
-    hydrateInitialSession(sessionResponse);
+    const sessionResponse = await requestSessionStart(false);
 
     return sessionResponse.session_id;
-  }, [hydrateInitialSession, sessionId, startSessionMutation]);
+  }, [requestSessionStart, sessionId]);
 
   const applyServerSideChatBlock = useCallback(
     (requestError: unknown) => {
@@ -153,12 +172,7 @@ export const useSurveySessionFlow = ({
           addUserMessage(trimmed);
         }
 
-        const response = await continueSurveyMutation.mutateAsync({
-          session_id: activeSessionId,
-          user_answer: trimmed,
-        });
-
-        applyChatResponse(response);
+        await requestSurveyMessage(activeSessionId, trimmed);
 
         return true;
       } catch (requestError) {
@@ -172,11 +186,10 @@ export const useSurveySessionFlow = ({
     [
       addUserMessage,
       applyServerSideChatBlock,
-      applyChatResponse,
       clearError,
-      continueSurveyMutation,
       ensureSessionId,
       isSubmitting,
+      requestSurveyMessage,
       setError,
       setLastSubmittedMessage,
       setSubmitting,
@@ -192,18 +205,9 @@ export const useSurveySessionFlow = ({
       setSubmitting(true);
 
       try {
-        const sessionResponse = await startSessionMutation.mutateAsync({
-          is_reset: true,
-        });
-        hydrateInitialSession(sessionResponse);
+        const sessionResponse = await requestSessionStart(true);
         addUserMessage(content);
-
-        const response = await continueSurveyMutation.mutateAsync({
-          session_id: sessionResponse.session_id,
-          user_answer: content,
-        });
-
-        applyChatResponse(response);
+        await requestSurveyMessage(sessionResponse.session_id, content);
       } catch (requestError) {
         applyServerSideChatBlock(requestError);
         setError(extractApiErrorMessage(requestError, 'continue'));
@@ -214,16 +218,14 @@ export const useSurveySessionFlow = ({
     [
       addUserMessage,
       applyServerSideChatBlock,
-      applyChatResponse,
       clearError,
-      continueSurveyMutation,
-      hydrateInitialSession,
+      requestSessionStart,
+      requestSurveyMessage,
       resetSurveyState,
       setError,
       setHasBootstrapped,
       setLastSubmittedMessage,
       setSubmitting,
-      startSessionMutation,
     ],
   );
 

--- a/src/features/survey/hooks/useSurveySessionFlow.ts
+++ b/src/features/survey/hooks/useSurveySessionFlow.ts
@@ -36,6 +36,7 @@ export const useSurveySessionFlow = ({
     (state) => state.lastSubmittedMessage,
   );
   const clearError = useSurveyStore((state) => state.clearError);
+  const setPendingAction = useSurveyStore((state) => state.setPendingAction);
   const setHasBootstrapped = useSurveyStore(
     (state) => state.setHasBootstrapped,
   );
@@ -95,6 +96,7 @@ export const useSurveySessionFlow = ({
 
       clearError();
       resetSurveyState();
+      setPendingAction('start');
       setHasBootstrapped(true);
       setSubmitting(true);
 
@@ -103,6 +105,7 @@ export const useSurveySessionFlow = ({
       } catch (requestError) {
         setError(extractApiErrorMessage(requestError, 'start'));
       } finally {
+        setPendingAction(null);
         setSubmitting(false);
       }
     },
@@ -114,6 +117,7 @@ export const useSurveySessionFlow = ({
       resetSurveyState,
       setError,
       setHasBootstrapped,
+      setPendingAction,
       setSubmitting,
     ],
   );
@@ -163,6 +167,7 @@ export const useSurveySessionFlow = ({
 
       clearError();
       setLastSubmittedMessage(trimmed);
+      setPendingAction('continue');
       setSubmitting(true);
 
       try {
@@ -180,6 +185,7 @@ export const useSurveySessionFlow = ({
         setError(extractApiErrorMessage(requestError, 'continue'));
         return false;
       } finally {
+        setPendingAction(null);
         setSubmitting(false);
       }
     },
@@ -192,6 +198,7 @@ export const useSurveySessionFlow = ({
       requestSurveyMessage,
       setError,
       setLastSubmittedMessage,
+      setPendingAction,
       setSubmitting,
     ],
   );
@@ -200,6 +207,7 @@ export const useSurveySessionFlow = ({
     async (content: string) => {
       clearError();
       resetSurveyState();
+      setPendingAction('continue');
       setHasBootstrapped(true);
       setLastSubmittedMessage(content);
       setSubmitting(true);
@@ -212,6 +220,7 @@ export const useSurveySessionFlow = ({
         applyServerSideChatBlock(requestError);
         setError(extractApiErrorMessage(requestError, 'continue'));
       } finally {
+        setPendingAction(null);
         setSubmitting(false);
       }
     },
@@ -225,6 +234,7 @@ export const useSurveySessionFlow = ({
       setError,
       setHasBootstrapped,
       setLastSubmittedMessage,
+      setPendingAction,
       setSubmitting,
     ],
   );
@@ -271,6 +281,7 @@ export const useSurveySessionFlow = ({
     }
 
     queueFocusRestore();
+    setPendingAction('reset');
     setSubmitting(true);
 
     try {
@@ -290,6 +301,7 @@ export const useSurveySessionFlow = ({
 
       setError(errorMessage);
     } finally {
+      setPendingAction(null);
       setSubmitting(false);
     }
   }, [
@@ -304,6 +316,7 @@ export const useSurveySessionFlow = ({
     sessionId,
     setError,
     setHasBootstrapped,
+    setPendingAction,
     setSubmitting,
   ]);
 

--- a/src/features/survey/store/useSurveyStore.ts
+++ b/src/features/survey/store/useSurveyStore.ts
@@ -12,6 +12,7 @@ import {
 } from '../types/survey';
 
 interface SurveyStoreState {
+  pendingAction: 'start' | 'continue' | 'reset' | null;
   ownerKey: string | null;
   sessionId: string | null;
   messages: SurveyMessage[];
@@ -25,6 +26,7 @@ interface SurveyStoreState {
   nonGameStrikeCount: number;
   chatBlockedUntil: number | null;
   syncOwnerKey: (ownerKey: string) => void;
+  setPendingAction: (pendingAction: SurveyStoreState['pendingAction']) => void;
   setHasBootstrapped: (hasBootstrapped: boolean) => void;
   setSubmitting: (isSubmitting: boolean) => void;
   setError: (error: string | null) => void;
@@ -117,6 +119,7 @@ const getSessionStatePatch = (
 });
 
 const createInitialState = (ownerKey: string | null = null) => ({
+  pendingAction: null as SurveyStoreState['pendingAction'],
   ownerKey,
   sessionId: null,
   messages: [] as SurveyMessage[],
@@ -143,6 +146,7 @@ export const useSurveyStore = create<SurveyStoreState>()(
                 ...createInitialState(ownerKey),
               },
         ),
+      setPendingAction: (pendingAction) => set({ pendingAction }),
       setHasBootstrapped: (hasBootstrapped) => set({ hasBootstrapped }),
       setSubmitting: (isSubmitting) => set({ isSubmitting }),
       setError: (error) => set({ error }),

--- a/src/features/survey/store/useSurveyStore.ts
+++ b/src/features/survey/store/useSurveyStore.ts
@@ -87,6 +87,35 @@ const appendAssistantMessageIfNeeded = (
   return [...messages, createMessage('assistant', content)];
 };
 
+const getFollowUpAssistantMessage = (payload: SurveyChatResponse) => {
+  if (payload.assistant_message) {
+    return payload.assistant_message;
+  }
+
+  if (payload.recommendation_ready) {
+    return COMPLETION_GUIDE_MESSAGE;
+  }
+
+  return null;
+};
+
+const getSessionStatePatch = (
+  payload: SurveySessionStartResponse,
+  ownerKey: string | null,
+) => ({
+  ownerKey,
+  sessionId: payload.session_id,
+  status: payload.status,
+  progress: payload.progress ?? { ...DEFAULT_SURVEY_PROGRESS },
+  hasBootstrapped: true,
+  isSubmitting: false,
+  error: null,
+  recommendationReady: payload.recommendation_ready,
+  lastSubmittedMessage: null,
+  nonGameStrikeCount: 0,
+  chatBlockedUntil: null,
+});
+
 const createInitialState = (ownerKey: string | null = null) => ({
   ownerKey,
   sessionId: null,
@@ -133,18 +162,8 @@ export const useSurveyStore = create<SurveyStoreState>()(
         })),
       hydrateInitialSession: (payload) =>
         set((state) => ({
-          sessionId: payload.session_id,
-          status: payload.status,
-          progress: payload.progress ?? { ...DEFAULT_SURVEY_PROGRESS },
-          isSubmitting: false,
-          hasBootstrapped: true,
-          error: null,
-          recommendationReady: payload.recommendation_ready,
-          lastSubmittedMessage: null,
-          nonGameStrikeCount: 0,
-          chatBlockedUntil: null,
+          ...getSessionStatePatch(payload, state.ownerKey),
           messages: getInitialMessages(payload),
-          ownerKey: state.ownerKey,
         })),
       applyChatResponse: (payload) =>
         set((state) => ({
@@ -153,23 +172,10 @@ export const useSurveyStore = create<SurveyStoreState>()(
           recommendationReady: payload.recommendation_ready,
           isSubmitting: false,
           error: null,
-          messages: (() => {
-            if (payload.assistant_message) {
-              return appendAssistantMessageIfNeeded(
-                state.messages,
-                payload.assistant_message,
-              );
-            }
-
-            if (payload.recommendation_ready) {
-              return appendAssistantMessageIfNeeded(
-                state.messages,
-                COMPLETION_GUIDE_MESSAGE,
-              );
-            }
-
-            return state.messages;
-          })(),
+          messages: appendAssistantMessageIfNeeded(
+            state.messages,
+            getFollowUpAssistantMessage(payload),
+          ),
         })),
       resetSurveyState: () =>
         set((state) => ({


### PR DESCRIPTION
## 관련 이슈

- closes #373 

## 변경 내용

- 실서버 사용 시 프론트의 로컬 키워드 기반 설문 차단 로직이 정상 답변까지 막지 않도록 조정했습니다.
- mock/dev 보조용으로만 사용하던 설문 휴리스틱 차단 로직은 실 API 환경에서는 비활성화되도록 정리했습니다.
- 설문 첫 진입 시에는 기존 설문 화면 구조에 맞춘 스켈레톤 로딩을 유지하도록 정리했습니다.
- 설문 진행 중 AI가 다음 질문을 생성하는 동안에는 채팅 내부에 assistant pending bubble 형태의 인라인 로딩 UI가 보이도록 추가했습니다.
- 설문 초기화 시에는 대화 진행 중 로딩과 구분되도록, 답변 생성 로딩이 아닌 전체 설문 쉘 로딩이 보이도록 분리했습니다.
- 설문 시작 / 진행 / 초기화 상태를 `pendingAction` 기준으로 구분해, 로딩 표현이 각 상황의 의미에 맞게 보이도록 정리했습니다.
- survey session flow/store의 공통 로직을 일부 정리해, 세션 시작과 메시지 전송 흐름의 중복을 줄였습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 survey 챗봇의 실서버 동작 정합성과 로딩 상태 표현 개선에 집중했습니다.
- 설문 API 계약은 현재 실서버 Swagger 기준을 우선 참고하는 방향으로 유지했습니다.
- 설문 첫 질문 준비, 설문 초기화, 다음 질문 생성이 서로 다른 사용자 맥락을 가지는 만큼 로딩 UI도 구분되도록 정리했습니다.