### PR TITLE
[Refactor] 소셜 로그인 콜백 리다이렉트 로딩 흐름 정리 (#375)

### DIFF
--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -81,6 +81,19 @@ export const getPendingSocialAuthProvider = (): SocialAuthProvider | null => {
 export const hasPendingSocialAuthProvider = () =>
   Boolean(getPendingSocialAuthProvider());
 
+const getNormalizedSocialCallbackParam = (
+  searchParams: URLSearchParams,
+  key: string,
+) => {
+  const value = searchParams.get(key)?.trim();
+
+  return value ? value : null;
+};
+
+export const getSocialCallbackAuthorizationCode = (
+  searchParams: URLSearchParams,
+) => getNormalizedSocialCallbackParam(searchParams, 'code');
+
 const getSocialCallbackErrorMessageFromCode = (errorCode: string | null) => {
   if (!errorCode) {
     return null;
@@ -94,7 +107,9 @@ const getSocialCallbackErrorMessageFromCode = (errorCode: string | null) => {
 };
 
 export const getSocialCallbackErrorMessage = (searchParams: URLSearchParams) =>
-  searchParams.get('error_description') ||
-  searchParams.get('error_detail') ||
-  searchParams.get('detail') ||
-  getSocialCallbackErrorMessageFromCode(searchParams.get('error'));
+  getNormalizedSocialCallbackParam(searchParams, 'error_description') ||
+  getNormalizedSocialCallbackParam(searchParams, 'error_detail') ||
+  getNormalizedSocialCallbackParam(searchParams, 'detail') ||
+  getSocialCallbackErrorMessageFromCode(
+    getNormalizedSocialCallbackParam(searchParams, 'error'),
+  );

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -1,42 +1,63 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
-import AuthLayout from '../components/layout/AuthLayout';
+import MainPageLoadingFallback from '../components/common/MainPageLoadingFallback';
 import { ROUTES } from '../constants/routes';
 import { extractAuthApiErrorMessage } from '../features/auth/api/auth';
 import {
   clearPendingSocialAuthProvider,
+  getSocialCallbackAuthorizationCode,
   getSocialCallbackErrorMessage,
+  hasPendingSocialAuthProvider,
 } from '../features/auth/utils/socialAuth';
 import {
   clearAuthSession,
   ensureAuthSessionRestored,
 } from '../features/auth/utils/sessionManager';
 
+const DEFAULT_CALLBACK_ERROR_MESSAGE =
+  '소셜 로그인 정보를 확인하지 못했습니다. 다시 시도해 주세요.';
 const DEFAULT_REFRESH_ERROR_MESSAGE =
   '세션을 확인하지 못했습니다. 다시 로그인해 주세요.';
 
 function AuthCallbackPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const [statusMessage, setStatusMessage] = useState(
-    '소셜 로그인 세션을 확인하는 중입니다.',
-  );
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let isMounted = true;
 
+    const redirectToLogin = (errorMessage: string) => {
+      clearAuthSession();
+      clearPendingSocialAuthProvider();
+
+      navigate(`/${ROUTES.LOGIN}`, {
+        replace: true,
+        state: { errorMessage },
+      });
+    };
+
     const handleAuthCallback = async () => {
+      setIsLoading(true);
+
       const searchParams = new URLSearchParams(location.search);
+      const authorizationCode =
+        getSocialCallbackAuthorizationCode(searchParams);
       const callbackErrorMessage = getSocialCallbackErrorMessage(searchParams);
+      const hasPendingSocialProvider = hasPendingSocialAuthProvider();
+      const shouldRestoreSession =
+        Boolean(authorizationCode) ||
+        hasPendingSocialProvider ||
+        searchParams.size === 0;
 
       if (callbackErrorMessage) {
-        clearAuthSession();
-        clearPendingSocialAuthProvider();
-        navigate(`/${ROUTES.LOGIN}`, {
-          replace: true,
-          state: { errorMessage: callbackErrorMessage },
-        });
+        redirectToLogin(callbackErrorMessage);
+        return;
+      }
+
+      if (!shouldRestoreSession) {
+        redirectToLogin(DEFAULT_CALLBACK_ERROR_MESSAGE);
         return;
       }
 
@@ -48,29 +69,15 @@ function AuthCallbackPage() {
         }
 
         clearPendingSocialAuthProvider();
-
-        if (typeof window !== 'undefined') {
-          window.location.replace(ROUTES.HOME);
-          return;
-        }
-
         navigate(ROUTES.HOME, { replace: true });
       } catch (error) {
         if (!isMounted) {
           return;
         }
 
-        clearPendingSocialAuthProvider();
-        setStatusMessage(DEFAULT_REFRESH_ERROR_MESSAGE);
-
-        navigate(`/${ROUTES.LOGIN}`, {
-          replace: true,
-          state: {
-            errorMessage:
-              extractAuthApiErrorMessage(error) ||
-              DEFAULT_REFRESH_ERROR_MESSAGE,
-          },
-        });
+        redirectToLogin(
+          extractAuthApiErrorMessage(error) || DEFAULT_REFRESH_ERROR_MESSAGE,
+        );
       }
     };
 
@@ -81,18 +88,7 @@ function AuthCallbackPage() {
     };
   }, [location.search, navigate]);
 
-  return (
-    <AuthLayout
-      title="로그인 확인"
-      subtitle="소셜 로그인 세션을 확인하고 있습니다."
-      withPanel
-      panelClassName="max-w-[500px]"
-    >
-      <div className="mt-8 rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-center text-sm/6 text-white/75">
-        {statusMessage}
-      </div>
-    </AuthLayout>
-  );
+  return isLoading ? <MainPageLoadingFallback /> : null;
 }
 
 export default AuthCallbackPage;


### PR DESCRIPTION
## 관련 이슈

- closes #375

## 변경 내용

- 소셜 로그인 콜백 페이지에서 기존 전용 안내 박스/불필요한 성공 안내 흐름을 제거하고, 메인 페이지에서 사용하는 공통 로딩 UI(`MainPageLoadingFallback`)로 통일했습니다.
- 콜백 URL의 `code` 및 에러 파라미터 해석 로직을 정리해 `socialAuth` 유틸에서 일관되게 처리하도록 리팩토링했습니다.
- 콜백 진입 후 세션 복구와 전역 Auth 상태 갱신이 끝날 때까지 `isLoading` 상태를 유지하고, 완료 시 메인 페이지(`/`)로 `replace` 라우팅되도록 흐름을 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 변경은 소셜 로그인 콜백 처리 흐름과 로딩 UX 정리에 한정됩니다.

