### PR TITLE
[Feat] 줄거리 더보기 UX 개선

### DIFF
--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -1,5 +1,12 @@
-import { ExternalLink, Heart, PlayCircle, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import {
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+  Heart,
+  PlayCircle,
+  X,
+} from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import ToastMessage from '../../../components/mypage/ToastMessage';
 import {
   DETAIL_LOADING_TEXT,
@@ -33,8 +40,6 @@ const DETAIL_NOT_FOUND_TITLE = '게임 상세 정보 없음';
 const DETAIL_NOT_FOUND_MESSAGE = '해당 게임 상세 정보를 찾을 수 없습니다.';
 const DETAIL_FETCH_ERROR_MESSAGE =
   '상세 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.';
-const DESCRIPTION_TOGGLE_MIN_LENGTH = 140;
-
 const GameDetailModalSkeleton = ({ game }: { game: GameListItem }) => {
   const title = normalizeMeaningfulText(game.name) ?? 'N/A';
   const listGenres = normalizeMeaningfulTextList(game.genres);
@@ -147,6 +152,8 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
     Record<number, string[]>
   >({});
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
+  const [isDescriptionTruncated, setIsDescriptionTruncated] = useState(false);
+  const descriptionRef = useRef<HTMLParagraphElement | null>(null);
   const {
     canRenderFallbackSummary,
     clearToast,
@@ -195,11 +202,15 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
     descriptionField === DETAIL_LOADING_TEXT
       ? '상세 정보를 불러오는 중입니다.'
       : formatNullableText(descriptionField);
-  const canToggleDescription =
-    descriptionField !== DETAIL_LOADING_TEXT &&
-    descriptionText !== 'N/A' &&
-    (descriptionText.length >= DESCRIPTION_TOGGLE_MIN_LENGTH ||
-      descriptionText.includes('\n'));
+  const canMeasureDescription =
+    descriptionField !== DETAIL_LOADING_TEXT && descriptionText !== 'N/A';
+  const shouldMeasureDescription =
+    canMeasureDescription && !isDescriptionExpanded;
+  const shouldShowDescriptionToggle =
+    isDescriptionExpanded || isDescriptionTruncated;
+  const collapsedDescriptionClampClass = shouldShowDescriptionToggle
+    ? 'line-clamp-4 sm:line-clamp-5'
+    : 'line-clamp-5 sm:line-clamp-6';
   const detailRows = [
     {
       label: '게임 출시일',
@@ -263,6 +274,40 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
       window.removeEventListener('keydown', closeOnEscape);
     };
   }, [onClose]);
+
+  useEffect(() => {
+    if (!shouldMeasureDescription) {
+      return;
+    }
+
+    const element = descriptionRef.current;
+
+    if (!element) {
+      return;
+    }
+
+    const measure = () => {
+      setIsDescriptionTruncated(
+        element.scrollHeight - element.clientHeight > 1,
+      );
+    };
+
+    const frameId = window.requestAnimationFrame(measure);
+
+    if (typeof ResizeObserver === 'undefined') {
+      return () => {
+        window.cancelAnimationFrame(frameId);
+      };
+    }
+
+    const resizeObserver = new ResizeObserver(measure);
+    resizeObserver.observe(element);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      resizeObserver.disconnect();
+    };
+  }, [descriptionText, shouldMeasureDescription]);
 
   return (
     <div
@@ -392,35 +437,32 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                     {likeCount.toLocaleString('ko-KR')}
                   </span>
                 </p>
-                <div
-                  className={`mt-5 sm:flex sm:flex-1 sm:flex-col ${canToggleDescription && !isDescriptionExpanded ? 'sm:relative' : ''}`}
-                >
-                  <div
-                    className={`relative ${canToggleDescription && !isDescriptionExpanded ? 'sm:pr-0 sm:pb-7' : ''}`}
-                  >
+                <div className="mt-5 sm:flex sm:flex-1 sm:flex-col">
+                  <div className="sm:flex-1">
                     <p
-                      className={`text-sm leading-6 text-white/60 transition-[max-height] duration-200 ease-out ${isDescriptionExpanded ? '' : 'line-clamp-5 sm:line-clamp-6'}`}
+                      ref={descriptionRef}
+                      className={`text-sm leading-6 text-white/60 transition-[max-height] duration-200 ease-out ${isDescriptionExpanded ? '' : collapsedDescriptionClampClass}`}
                     >
                       {descriptionText}
                     </p>
-                    {canToggleDescription && !isDescriptionExpanded ? (
-                      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-[linear-gradient(180deg,rgba(12,12,14,0),rgba(12,12,14,0.92)_72%,rgba(12,12,14,1))]" />
-                    ) : null}
                   </div>
-                  {canToggleDescription ? (
+                  {shouldShowDescriptionToggle ? (
                     <button
                       type="button"
+                      aria-label={
+                        isDescriptionExpanded ? '줄거리 접기' : '줄거리 펼치기'
+                      }
                       aria-expanded={isDescriptionExpanded}
                       onClick={() =>
                         setIsDescriptionExpanded((current) => !current)
                       }
-                      className={`mt-1 inline-flex cursor-pointer items-center text-sm font-semibold text-white/78 underline-offset-4 transition hover:text-white hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12] ${
-                        !isDescriptionExpanded
-                          ? 'sm:absolute sm:bottom-0 sm:left-0'
-                          : ''
-                      }`}
+                      className="mt-1 flex h-6 w-full cursor-pointer items-center justify-center text-white/70 transition hover:text-white focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12] sm:mt-auto"
                     >
-                      {isDescriptionExpanded ? '줄거리 접기' : '줄거리 더보기'}
+                      {isDescriptionExpanded ? (
+                        <ChevronUp aria-hidden="true" className="h-5 w-5" />
+                      ) : (
+                        <ChevronDown aria-hidden="true" className="h-5 w-5" />
+                      )}
                     </button>
                   ) : null}
                 </div>


### PR DESCRIPTION
## 관련 이슈

- closes #378

## 변경 내용

- 게임 상세 모달 줄거리 영역에 더보기/접기 인터랙션을 추가했습니다.
- 토글 노출 기준을 문자열 길이 대신 실제 말줄임 발생 여부로 변경했습니다.
- 긴 줄거리는 기본 노출 줄 수를 1줄 줄이고, 마지막 1줄 높이를 CTA 슬롯으로 사용하도록 조정했습니다.
- 줄거리 CTA를 텍스트 링크 대신 중앙 정렬 화살표로 변경했습니다.
- 화살표 아이콘만이 아니라 가로 한 줄 전체가 클릭 가능하도록 클릭 영역을 확장했습니다.
- CTA 유무와 관계없이 상단 요약 영역과 하단 트레일러 사이 간격이 안정적으로 유지되도록 레이아웃을 조정했습니다.
- 줄거리 하단 페이드 오버레이를 제거해 마지막 줄 가독성을 높였습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷


https://github.com/user-attachments/assets/4e1f2f68-63b6-4159-9399-13075b0c8198



## 참고사항

- 변경 파일: `src/features/games/components/GameDetailModal.tsx`
- 공개 props, 타입, API 계약 변경은 없습니다.
- 확인 포인트:
  - 실제 말줄임이 생길 때만 CTA가 노출되는지
  - 긴 줄거리/짧은 줄거리 모두에서 상단 영역과 트레일러 간격이 안정적인지
  - 중앙 화살표 CTA와 확장된 클릭 영역이 자연스럽게 동작하는지
