### PR TITLE
[Fix] 마이페이지 렌더링 크래시 방어 처리

### DIFF
--- a/src/components/mypage/FavoriteGameCard.tsx
+++ b/src/components/mypage/FavoriteGameCard.tsx
@@ -6,6 +6,7 @@ import {
   isIgdbImageId,
   normalizeThumbnailUrl,
 } from '../../lib/normalizeThumbnailUrl';
+import { toDisplayText } from '../../pages/mypage/utils';
 import ActionButton from '../common/ActionButton';
 
 type FavoriteGameCardProps = {
@@ -19,6 +20,8 @@ function FavoriteGameCard({
   onClick,
   onFavoriteClick,
 }: FavoriteGameCardProps) {
+  const displayTitle = toDisplayText(game?.title, '알 수 없는 게임');
+  const displaySummary = toDisplayText(game?.summary);
   const [igdbExtension, setIgdbExtension] = useState<'jpg' | 'png'>('jpg');
   const normalizedThumbnailUrl =
     normalizeThumbnailUrl(game.thumbnailUrl, {
@@ -48,7 +51,7 @@ function FavoriteGameCard({
             <img
               key={currentThumbnailKey ?? `thumbnail-fallback-${game.gameId}`}
               src={normalizedThumbnailUrl || undefined}
-              alt={`${game.title} 썸네일`}
+              alt={`${displayTitle} 썸네일`}
               onLoad={() => setFailedThumbnailKey(null)}
               onError={() => {
                 if (canRetryWithPng) {
@@ -72,7 +75,7 @@ function FavoriteGameCard({
           <ActionButton
             type="button"
             variant="icon"
-            aria-label={`${game.title} 찜 해제`}
+            aria-label={`${displayTitle} 찜 해제`}
             onClick={() => onFavoriteClick?.(game)}
             className="border-[#ff7a8c]/28! bg-[linear-gradient(145deg,rgba(169,38,60,0.96)_0%,rgba(112,19,37,0.98)_100%)] text-white! shadow-[0_12px_28px_rgba(53,7,18,0.46),inset_0_1px_0_rgba(255,255,255,0.12)] hover:border-[#ff9baa]/46! hover:bg-[linear-gradient(145deg,rgba(195,57,81,0.98)_0%,rgba(130,26,46,0.99)_100%)] hover:text-white! focus-visible:ring-[#ff96a5]/45"
           >
@@ -87,10 +90,10 @@ function FavoriteGameCard({
         className="flex min-h-[5.75rem] min-w-0 flex-1 cursor-pointer flex-col justify-center gap-1 px-3 pt-3 pb-2.5 text-left sm:min-h-[6.2rem] sm:px-4 sm:pt-3.5 sm:pb-3"
       >
         <h3 className="line-clamp-1 text-sm/5 font-semibold text-white sm:text-base/6 lg:text-lg/7">
-          {game.title}
+          {displayTitle}
         </h3>
         <p className="text-mypage-muted line-clamp-1 text-[11px]/4 sm:text-xs/5">
-          {game.summary}
+          {displaySummary}
         </p>
       </button>
     </article>

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -1,8 +1,10 @@
 import { Camera, CircleUserRound, LoaderCircle } from 'lucide-react';
 import { useState, type ReactNode } from 'react';
 
+import defaultProfileImage from '../../assets/프로필 이미지.png';
 import type { CurrentUserSocialResponse } from '../../features/auth/types/auth';
 import type { MyPageToast } from '../../pages/mypage/types';
+import { toDisplayText } from '../../pages/mypage/utils';
 import AuthButton from '../auth/AuthButton';
 import InputControl from '../common/InputControl';
 import ToastMessage from './ToastMessage';
@@ -27,6 +29,57 @@ type MyPageProfileSectionProps = {
   children?: ReactNode;
 };
 
+type ProfileAvatarImageProps = {
+  displayNickname: string;
+  profileImageUrl: string;
+  isProfileImageUploading: boolean;
+};
+
+function ProfileAvatarImage({
+  displayNickname,
+  profileImageUrl,
+  isProfileImageUploading,
+}: ProfileAvatarImageProps) {
+  const [hasCustomProfileImageFailed, setHasCustomProfileImageFailed] =
+    useState(false);
+  const [hasDefaultProfileImageFailed, setHasDefaultProfileImageFailed] =
+    useState(false);
+  const hasCustomProfileImage =
+    Boolean(profileImageUrl) && !hasCustomProfileImageFailed;
+  const resolvedProfileImageUrl = hasCustomProfileImage
+    ? profileImageUrl
+    : defaultProfileImage;
+
+  if (hasDefaultProfileImageFailed) {
+    return (
+      <CircleUserRound
+        size={56}
+        className="text-white transition duration-200 group-hover:opacity-75"
+      />
+    );
+  }
+
+  return (
+    <img
+      src={resolvedProfileImageUrl}
+      alt={`${displayNickname} 프로필 이미지`}
+      onError={() => {
+        if (hasCustomProfileImage) {
+          setHasCustomProfileImageFailed(true);
+          return;
+        }
+
+        setHasDefaultProfileImageFailed(true);
+      }}
+      className={`h-full w-full object-cover transition duration-200 ${
+        isProfileImageUploading
+          ? 'blur-[1.8px] brightness-[0.58]'
+          : 'group-hover:blur-[1.8px] group-hover:brightness-[0.58]'
+      }`}
+    />
+  );
+}
+
 function MyPageProfileSection({
   nickname,
   name,
@@ -46,17 +99,15 @@ function MyPageProfileSection({
   onProfileImageSelect,
   children,
 }: MyPageProfileSectionProps) {
+  const displayNickname = toDisplayText(nickname, '회원');
+  const displayName = toDisplayText(name);
+  const displayGenderLabel = toDisplayText(genderLabel);
   const normalizedProfileImageUrl = profileImageUrl?.trim() ?? '';
-  const [failedProfileImageUrl, setFailedProfileImageUrl] = useState<
-    string | null
-  >(null);
-  const hasProfileImage =
-    Boolean(normalizedProfileImageUrl) &&
-    failedProfileImageUrl !== normalizedProfileImageUrl;
   const [isNicknameEditMode, setIsNicknameEditMode] = useState(false);
-  const [nextNickname, setNextNickname] = useState(nickname);
+  const [nextNickname, setNextNickname] = useState(displayNickname);
   const [nicknameFieldError, setNicknameFieldError] = useState('');
-  const normalizedSocialType = socialAccount?.social_type?.trim().toLowerCase();
+  const normalizedSocialType =
+    socialAccount?.social_type?.trim()?.toLowerCase() ?? '';
   const accountBadge =
     socialAccount?.is_social === true
       ? normalizedSocialType === 'google'
@@ -96,7 +147,7 @@ function MyPageProfileSection({
       return;
     }
 
-    if (trimmedNickname === nickname.trim()) {
+    if (trimmedNickname === displayNickname.trim()) {
       setIsNicknameEditMode(false);
       setNicknameFieldError('');
       return;
@@ -156,25 +207,14 @@ function MyPageProfileSection({
                         : '프로필 변경'}
                     </span>
                     <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border-[0.72rem] border-[#111114] bg-[linear-gradient(145deg,#8a4d55_0%,#78424a_100%)] shadow-[0_18px_44px_rgba(0,0,0,0.45)]">
-                      {hasProfileImage ? (
-                        <img
-                          src={normalizedProfileImageUrl}
-                          alt={`${nickname} 프로필 이미지`}
-                          onError={() =>
-                            setFailedProfileImageUrl(normalizedProfileImageUrl)
-                          }
-                          className={`h-full w-full object-cover transition duration-200 ${
-                            isProfileImageUploading
-                              ? 'blur-[1.8px] brightness-[0.58]'
-                              : 'group-hover:blur-[1.8px] group-hover:brightness-[0.58]'
-                          }`}
-                        />
-                      ) : (
-                        <CircleUserRound
-                          size={56}
-                          className="text-white transition duration-200 group-hover:opacity-75"
-                        />
-                      )}
+                      <ProfileAvatarImage
+                        key={
+                          normalizedProfileImageUrl || 'default-profile-image'
+                        }
+                        displayNickname={displayNickname}
+                        profileImageUrl={normalizedProfileImageUrl}
+                        isProfileImageUploading={isProfileImageUploading}
+                      />
                       <span
                         className={`pointer-events-none absolute inset-0 flex items-center justify-center rounded-full transition ${
                           isProfileImageUploading
@@ -208,7 +248,7 @@ function MyPageProfileSection({
                 <div className="min-w-0 pt-2">
                   <div className="flex flex-wrap items-center gap-3">
                     <p className="max-w-full truncate text-[clamp(2rem,3.6vw,2.8rem)] font-semibold tracking-[-0.04em] text-white">
-                      {nickname}
+                      {displayNickname}
                     </p>
                     <span
                       className={`inline-flex shrink-0 items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-[-0.01em] ${accountBadge.className}`}
@@ -249,7 +289,7 @@ function MyPageProfileSection({
                     <p className="text-sm font-semibold text-white/76">별명</p>
                     {!isNicknameEditMode ? (
                       <p className="mt-2 truncate text-[1.05rem] font-medium text-white">
-                        {nickname}
+                        {displayNickname}
                       </p>
                     ) : (
                       <>
@@ -291,7 +331,7 @@ function MyPageProfileSection({
                         className="inline-flex cursor-pointer items-center rounded-2xl border border-white/8 bg-white/[0.04] px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/12 hover:bg-white/[0.08]"
                         onClick={() => {
                           setIsNicknameEditMode(true);
-                          setNextNickname(nickname);
+                          setNextNickname(displayNickname);
                           setNicknameFieldError('');
                         }}
                       >
@@ -304,7 +344,7 @@ function MyPageProfileSection({
                           className="inline-flex cursor-pointer items-center justify-center rounded-2xl border border-white/8 bg-white/[0.04] px-4 py-3 text-sm font-semibold text-white/72 transition hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-50"
                           onClick={() => {
                             setIsNicknameEditMode(false);
-                            setNextNickname(nickname);
+                            setNextNickname(displayNickname);
                             setNicknameFieldError('');
                           }}
                           disabled={isProfileUpdating}
@@ -330,14 +370,14 @@ function MyPageProfileSection({
               <div className="py-5">
                 <p className="text-sm font-semibold text-white/76">사용자명</p>
                 <p className="mt-2 truncate text-[1.05rem] font-medium text-white">
-                  {name}
+                  {displayName}
                 </p>
               </div>
 
               <div className="py-5 pb-1">
                 <p className="text-sm font-semibold text-white/76">성별</p>
                 <p className="mt-2 truncate text-[1.05rem] font-medium text-white">
-                  {genderLabel}
+                  {displayGenderLabel}
                 </p>
               </div>
             </div>

--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -18,6 +18,7 @@ import type {
   CurrentUserSocialResponse,
   DeleteLikedGameResponse,
   DuplicateCheckResponse,
+  LikedGameItemResponse,
   LikedGamesRequest,
   LikedGamesResponse,
   LoginRequest,
@@ -59,25 +60,59 @@ const createCredentialedAuthRequestConfig = <T = unknown>(
   };
 };
 
+const normalizeLikedGameText = (
+  value: string | null | undefined,
+  fallback = 'N/A',
+) => {
+  const trimmedValue = typeof value === 'string' ? value.trim() : '';
+
+  return trimmedValue || fallback;
+};
+
 const normalizeLikedGameGenres = (
-  genres: RawLikedGameItemResponse['genres'],
-) =>
-  Array.isArray(genres)
-    ? genres.map((genre) => genre.trim()).filter((genre) => genre.length > 0)
-    : genres
-        .split(',')
-        .map((genre) => genre.trim())
-        .filter((genre) => genre.length > 0);
+  genres: RawLikedGameItemResponse['genres'] | null | undefined,
+) => {
+  if (Array.isArray(genres)) {
+    return genres
+      .map((genre) => (typeof genre === 'string' ? genre.trim() : ''))
+      .filter((genre) => genre.length > 0);
+  }
+
+  if (typeof genres === 'string') {
+    return genres
+      .split(',')
+      .map((genre) => genre.trim())
+      .filter((genre) => genre.length > 0);
+  }
+
+  return [];
+};
+
+const normalizeLikedGameItem = (
+  item: RawLikedGameItemResponse | null | undefined,
+): LikedGameItemResponse => ({
+  game_id:
+    typeof item?.game_id === 'number' && Number.isInteger(item.game_id)
+      ? item.game_id
+      : 0,
+  game_title: normalizeLikedGameText(item?.game_title),
+  thumbnail_url: normalizeThumbnailUrl(item?.thumbnail_url),
+  genres: normalizeLikedGameGenres(item?.genres),
+  liked_at: typeof item?.liked_at === 'string' ? item.liked_at : '',
+});
 
 const normalizeLikedGamesResponse = (
-  response: RawLikedGamesResponse,
+  response: RawLikedGamesResponse | null | undefined,
 ): LikedGamesResponse => ({
-  count: response.count,
-  results: response.results.map((item) => ({
-    ...item,
-    thumbnail_url: normalizeThumbnailUrl(item.thumbnail_url),
-    genres: normalizeLikedGameGenres(item.genres),
-  })),
+  count:
+    typeof response?.count === 'number'
+      ? response.count
+      : Array.isArray(response?.results)
+        ? response.results.length
+        : 0,
+  results: Array.isArray(response?.results)
+    ? response.results.map(normalizeLikedGameItem)
+    : [],
 });
 
 export const requestLogin = async (payload: LoginRequest) => {

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -38,7 +38,8 @@ function MyPageLikedGamesSection({
     onOpenGameDetail,
     onToast,
   });
-  const hasFavoriteGames = favoriteGames.length > 0;
+  const safeFavoriteGames = Array.isArray(favoriteGames) ? favoriteGames : [];
+  const hasFavoriteGames = safeFavoriteGames.length > 0;
   const listContainerClass = hasFavoriteGames
     ? 'mypage-scrollbar mt-5 max-w-full overflow-x-hidden overflow-y-auto pr-1 max-h-[38rem]'
     : 'mt-5 max-w-full';
@@ -72,7 +73,7 @@ function MyPageLikedGamesSection({
             <FavoriteGameCardSkeleton />
           ) : hasFavoriteGames ? (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              {favoriteGames.map((game) => (
+              {safeFavoriteGames.map((game) => (
                 <FavoriteGameCard
                   key={`${game.gameId}:${game.thumbnailUrl ?? 'none'}:${favoriteListRenderVersion}`}
                   game={game}

--- a/src/pages/mypage/hooks/useMyPageLikedGames.ts
+++ b/src/pages/mypage/hooks/useMyPageLikedGames.ts
@@ -14,7 +14,12 @@ import { syncLikedGamesStateInQueryCache } from '../../../features/games/queryCa
 import type { FavoriteGamePreview } from '../../../features/mypage/types';
 import { normalizeThumbnailUrl } from '../../../lib/normalizeThumbnailUrl';
 import type { MyPageToastPayload } from '../types';
-import { toFavoriteGameListItem, toFavoriteGamePreview } from '../utils';
+import {
+  toDisplayText,
+  toFavoriteGameListItem,
+  toFavoriteGamePreview,
+  toStringList,
+} from '../utils';
 
 type UseMyPageLikedGamesOptions = {
   enabled: boolean;
@@ -38,11 +43,20 @@ function useMyPageLikedGames({
     useState<FavoriteGamePreview | null>(null);
   const [favoriteListRenderVersion, setFavoriteListRenderVersion] = useState(0);
   const serverFavoriteGames = useMemo(() => {
-    return (likedGamesData?.results ?? []).map(toFavoriteGamePreview);
-  }, [likedGamesData?.results]);
+    const safeLikedGamesResults = Array.isArray(likedGamesData?.results)
+      ? likedGamesData.results
+      : [];
+
+    return safeLikedGamesResults
+      .map(toFavoriteGamePreview)
+      .filter((game) => game.gameId > 0);
+  }, [likedGamesData]);
 
   const favoriteGames = serverFavoriteGames;
-  const favoriteCount = likedGamesData?.count ?? serverFavoriteGames.length;
+  const favoriteCount =
+    typeof likedGamesData?.count === 'number'
+      ? likedGamesData.count
+      : serverFavoriteGames.length;
 
   const refetchFavoriteGames = likedGamesQuery.refetch;
   const isFavoriteGamesLoading =
@@ -56,42 +70,62 @@ function useMyPageLikedGames({
   const refetchFavoriteGamesWithPreservedThumbnails = async (
     previousLikedGames: LikedGamesResponse['results'],
   ) => {
-    const refetchResult = await refetchFavoriteGames();
-    const nextLikedGames = refetchResult.data;
+    try {
+      const refetchResult = await refetchFavoriteGames();
+      const nextLikedGames = refetchResult.data;
 
-    if (!nextLikedGames) {
-      return;
+      if (!nextLikedGames) {
+        return;
+      }
+
+      const previousLikedGameMap = new Map(
+        previousLikedGames.map((game) => [game.game_id, game]),
+      );
+      const nextLikedGamesResults = Array.isArray(nextLikedGames.results)
+        ? nextLikedGames.results
+        : [];
+      const nextResults = nextLikedGamesResults.map((game) => {
+        const previousGame = previousLikedGameMap.get(game.game_id);
+        const normalizedGenres = toStringList(game.genres);
+        const previousGenres = toStringList(previousGame?.genres);
+
+        return {
+          ...game,
+          game_title: toDisplayText(
+            game.game_title,
+            toDisplayText(previousGame?.game_title),
+          ),
+          thumbnail_url:
+            normalizeThumbnailUrl(game.thumbnail_url) ??
+            normalizeThumbnailUrl(previousGame?.thumbnail_url) ??
+            null,
+          genres:
+            normalizedGenres.length > 0 ? normalizedGenres : previousGenres,
+        };
+      });
+
+      queryClient.setQueryData(
+        authKeys.likedGamesList({
+          page_size: 20,
+          page: 1,
+        }),
+        {
+          ...nextLikedGames,
+          count:
+            typeof nextLikedGames.count === 'number'
+              ? nextLikedGames.count
+              : nextResults.length,
+          results: nextResults,
+        },
+      );
+    } catch {
+      void queryClient.invalidateQueries({
+        queryKey: authKeys.likedGamesList({
+          page_size: 20,
+          page: 1,
+        }),
+      });
     }
-
-    const previousLikedGameMap = new Map(
-      previousLikedGames.map((game) => [game.game_id, game]),
-    );
-    const nextResults = nextLikedGames.results.map((game) => {
-      const previousGame = previousLikedGameMap.get(game.game_id);
-
-      return {
-        ...game,
-        game_title:
-          game.game_title.trim() || previousGame?.game_title?.trim() || 'N/A',
-        thumbnail_url:
-          normalizeThumbnailUrl(game.thumbnail_url) ??
-          normalizeThumbnailUrl(previousGame?.thumbnail_url) ??
-          null,
-        genres:
-          game.genres.length > 0 ? game.genres : (previousGame?.genres ?? []),
-      };
-    });
-
-    queryClient.setQueryData(
-      authKeys.likedGamesList({
-        page_size: 20,
-        page: 1,
-      }),
-      {
-        ...nextLikedGames,
-        results: nextResults,
-      },
-    );
   };
 
   const handleFavoriteGameDeleteConfirm = async () => {
@@ -110,7 +144,9 @@ function useMyPageLikedGames({
       return;
     }
 
-    const previousLikedGames = likedGamesData?.results ?? [];
+    const previousLikedGames = Array.isArray(likedGamesData?.results)
+      ? likedGamesData.results
+      : [];
 
     try {
       await unlikeLikedGameMutation.mutateAsync(targetGameId);

--- a/src/pages/mypage/hooks/useMyPageProfile.ts
+++ b/src/pages/mypage/hooks/useMyPageProfile.ts
@@ -17,7 +17,7 @@ import type { CurrentUserProfileResponse } from '../../../features/auth/types/au
 import { useAuthStore } from '../../../store/useAuthStore';
 import { syncAuthAccount } from '../../../features/auth/utils/sessionManager';
 import type { MyPageToastPayload } from '../types';
-import { toGenderLabel } from '../utils';
+import { toDisplayText, toGenderLabel, toOptionalDisplayText } from '../utils';
 
 type UseMyPageProfileOptions = {
   enabled: boolean;
@@ -74,8 +74,14 @@ function useMyPageProfile({ enabled, onToast }: UseMyPageProfileOptions) {
           file_name: file.name,
           content_type: file.type || 'application/octet-stream',
         });
-      const presignedUrl = presignedResponse.presigned_url.trim();
-      const profileImageUrl = presignedResponse.img_url.trim();
+      const presignedUrl =
+        typeof presignedResponse?.presigned_url === 'string'
+          ? presignedResponse.presigned_url.trim()
+          : '';
+      const profileImageUrl =
+        typeof presignedResponse?.img_url === 'string'
+          ? presignedResponse.img_url.trim()
+          : '';
 
       if (!presignedUrl || !profileImageUrl) {
         throw new Error(
@@ -181,11 +187,11 @@ function useMyPageProfile({ enabled, onToast }: UseMyPageProfileOptions) {
 
   return {
     resolvedProfile,
-    profileName: resolvedProfile?.name || 'N/A',
-    profileEmail: resolvedProfile?.email || null,
+    profileName: toDisplayText(resolvedProfile?.name),
+    profileEmail: toOptionalDisplayText(resolvedProfile?.email),
     profileGenderLabel: toGenderLabel(resolvedProfile?.gender),
-    profileImageUrl: resolvedProfile?.profile_img_url ?? null,
-    profileNickname: resolvedProfile?.nickname ?? '회원',
+    profileImageUrl: toOptionalDisplayText(resolvedProfile?.profile_img_url),
+    profileNickname: toDisplayText(resolvedProfile?.nickname, '회원'),
     isProfileLoading,
     isProfileImageUploading,
     isProfileUpdating: updateUserInfoMutation.isPending,

--- a/src/pages/mypage/utils.ts
+++ b/src/pages/mypage/utils.ts
@@ -5,6 +5,30 @@ import type {
 import type { GameListItem } from '../../features/games/types';
 import type { FavoriteGamePreview } from '../../features/mypage/types';
 
+const DEFAULT_DISPLAY_TEXT = 'N/A';
+
+export const toDisplayText = (
+  value: string | null | undefined,
+  fallback = DEFAULT_DISPLAY_TEXT,
+) => {
+  const trimmedValue = typeof value === 'string' ? value.trim() : '';
+
+  return trimmedValue || fallback;
+};
+
+export const toOptionalDisplayText = (value: string | null | undefined) => {
+  const trimmedValue = typeof value === 'string' ? value.trim() : '';
+
+  return trimmedValue || null;
+};
+
+export const toStringList = (value: string[] | null | undefined) =>
+  Array.isArray(value)
+    ? value
+        .map((item) => (typeof item === 'string' ? item.trim() : ''))
+        .filter((item) => item.length > 0)
+    : [];
+
 export const toGenderLabel = (gender?: AuthGender) => {
   if (gender === 'M') {
     return '남성';
@@ -18,26 +42,36 @@ export const toGenderLabel = (gender?: AuthGender) => {
 };
 
 export const toFavoriteGamePreview = (
-  game: LikedGameItemResponse,
+  game: Partial<LikedGameItemResponse> | null | undefined,
 ): FavoriteGamePreview => {
-  const normalizedGenres = game.genres.filter((genre) => genre.trim());
+  const normalizedGenres = toStringList(game?.genres);
 
   return {
-    gameId: game.game_id,
-    title: game.game_title.trim() || 'N/A',
+    gameId:
+      typeof game?.game_id === 'number' && Number.isInteger(game.game_id)
+        ? game.game_id
+        : 0,
+    title: toDisplayText(game?.game_title),
     summary: normalizedGenres.length > 0 ? normalizedGenres.join(', ') : 'N/A',
-    thumbnailUrl: game.thumbnail_url,
+    thumbnailUrl: toOptionalDisplayText(game?.thumbnail_url),
     genres: normalizedGenres,
   };
 };
 
 export const toFavoriteGameListItem = (
-  game: FavoriteGamePreview,
-): GameListItem => ({
-  gameId: game.gameId,
-  name: game.title,
-  genres: game.genres.length > 0 ? game.genres : ['N/A'],
-  thumbnailUrl: game.thumbnailUrl,
-  rating: null,
-  isLiked: true,
-});
+  game: Partial<FavoriteGamePreview> | null | undefined,
+): GameListItem => {
+  const normalizedGenres = toStringList(game?.genres);
+
+  return {
+    gameId:
+      typeof game?.gameId === 'number' && Number.isInteger(game.gameId)
+        ? game.gameId
+        : 0,
+    name: toDisplayText(game?.title),
+    genres: normalizedGenres.length > 0 ? normalizedGenres : ['N/A'],
+    thumbnailUrl: toOptionalDisplayText(game?.thumbnailUrl),
+    rating: null,
+    isLiked: true,
+  };
+};


### PR DESCRIPTION
## 관련 이슈

- closes #377

## 변경 내용

- 마이페이지 프로필 영역에서 `null`/`undefined` 응답값에 안전하게 대응하도록 사용자 정보 표시값을 정규화하고, 소셜 계정 정보 접근에 옵셔널 체이닝과 기본값 처리를 보강했습니다.
- 프로필 이미지가 없거나 로드에 실패할 때 프로젝트 기본 프로필 이미지를 우선 사용하고, 그마저 실패하면 아이콘으로 대체되도록 fallback 렌더링을 안정화했습니다.
- 찜한 목록 API 응답 정규화와 마이페이지 리스트 렌더링 로직을 보강해 `results`, `genres`, `game_title`, `thumbnail_url`가 비어 있거나 예상과 다를 때도 `map()`/`trim()`에서 크래시가 나지 않도록 처리했습니다.
- 찜 목록 재조회 후 썸네일 보존 처리 흐름에 `try-catch`를 추가해 비동기 후속 요청 실패가 앱 전체 렌더링 크래시로 이어지지 않도록 보완했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 변경은 마이페이지 렌더링 안정성과 fallback 처리 보강에 한정됩니다.
