### PR TITLE
[Fix] 설문/매칭 인터랙션 커서 일관성 및 버튼 스타일 정리

### DIFF
--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -31,6 +31,15 @@ type SurveyChatPanelProps = {
   isHistoryView?: boolean;
 };
 
+const SURVEY_CONTROL_BUTTON_CLASS =
+  'inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/3 px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/6 disabled:opacity-60';
+
+const SURVEY_RETRY_BUTTON_CLASS =
+  'mt-4 inline-flex items-center gap-2 rounded-xl border border-[#944141] px-3 py-2 text-sm font-semibold text-white transition hover:bg-white/5 disabled:opacity-60';
+
+const SURVEY_SEND_BUTTON_CLASS =
+  'inline-flex h-11.5 w-11.5 items-center justify-center rounded-full bg-[linear-gradient(135deg,#ff3535,#9f1212)] text-white shadow-[0_14px_30px_rgba(139,0,0,0.28)] transition hover:brightness-105 disabled:opacity-45';
+
 export function SurveyChatLoadingState() {
   return (
     <section className="survey-panel relative flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -278,7 +287,7 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
               type="button"
               onClick={handleResetClick}
               disabled={isSubmitting}
-              className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/3 px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-60"
+              className={SURVEY_CONTROL_BUTTON_CLASS}
             >
               <RotateCcw size={16} />
               설문 초기화
@@ -319,7 +328,7 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
                       type="button"
                       onClick={handleRetry}
                       disabled={!lastSubmittedMessage || isSubmitting}
-                      className="mt-4 inline-flex items-center gap-2 rounded-xl border border-[#944141] px-3 py-2 text-sm font-semibold text-white transition hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-60"
+                      className={SURVEY_RETRY_BUTTON_CLASS}
                     >
                       다시 시도
                     </button>
@@ -380,7 +389,7 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
                             ? '응답 생성 중'
                             : '메시지 보내기'
                       }
-                      className="inline-flex h-11.5 w-11.5 items-center justify-center rounded-full bg-[linear-gradient(135deg,#ff3535,#9f1212)] text-white shadow-[0_14px_30px_rgba(139,0,0,0.28)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-45"
+                      className={SURVEY_SEND_BUTTON_CLASS}
                     >
                       <SendHorizontal size={16} />
                     </button>

--- a/src/index.css
+++ b/src/index.css
@@ -85,6 +85,18 @@
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
   }
+
+  a[href],
+  button:not(:disabled),
+  summary,
+  [role='button']:not([aria-disabled='true']) {
+    cursor: pointer;
+  }
+
+  button:disabled,
+  [role='button'][aria-disabled='true'] {
+    cursor: not-allowed;
+  }
 }
 
 @layer components {

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -38,6 +38,15 @@ const MATCHING_LIKE_ERROR_MESSAGE =
 const MATCHING_CANDIDATES_NETWORK_ERROR_MESSAGE =
   '매칭 후보 서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.';
 
+const MATCHING_ICON_ACTION_BUTTON_BASE_CLASS =
+  'mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center self-start rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] disabled:opacity-60';
+
+const MATCHING_SECONDARY_ACTION_BUTTON_CLASS =
+  'inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:border-white/8 disabled:bg-white/2 disabled:text-white/28';
+
+const MATCHING_PRIMARY_ACTION_BUTTON_CLASS =
+  'inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212] disabled:bg-[#5c1a1a] disabled:text-white/44';
+
 const formatMatchingCandidateRating = (rating: number | null) => {
   if (typeof rating !== 'number') {
     return 'N/A';
@@ -448,7 +457,7 @@ function MatchingGenreDetailPage() {
                             : '좋아요 추가'
                         }
                         disabled={likeMutation.isPending}
-                        className={`mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center self-start rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[#d93737] disabled:cursor-not-allowed disabled:opacity-60 ${
+                        className={`${MATCHING_ICON_ACTION_BUTTON_BASE_CLASS} ${
                           currentCandidate.is_liked
                             ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
                             : 'border-white/10 bg-white/3 text-white/54 hover:border-white/20 hover:text-white/80'
@@ -502,7 +511,7 @@ function MatchingGenreDetailPage() {
                             type="button"
                             onClick={goPrevious}
                             disabled={!canGoPrevious}
-                            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/2 disabled:text-white/28"
+                            className={MATCHING_SECONDARY_ACTION_BUTTON_CLASS}
                           >
                             <ChevronLeft size={16} />
                             이전
@@ -516,7 +525,7 @@ function MatchingGenreDetailPage() {
                               submitMatchResponsesMutation.isPending ||
                               likeMutation.isPending
                             }
-                            className="inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212] disabled:cursor-not-allowed disabled:bg-[#5c1a1a] disabled:text-white/44"
+                            className={MATCHING_PRIMARY_ACTION_BUTTON_CLASS}
                           >
                             {submitMatchResponsesMutation.isPending
                               ? '제출 중...'
@@ -533,7 +542,7 @@ function MatchingGenreDetailPage() {
                           type="button"
                           onClick={goPrevious}
                           disabled={!canGoPrevious}
-                          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-5 py-3 text-sm font-medium text-white transition hover:border-[#a31c1c]/60 hover:bg-[#160909] disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/2 disabled:text-white/28"
+                          className={MATCHING_SECONDARY_ACTION_BUTTON_CLASS}
                         >
                           <ChevronLeft size={16} />
                           이전
@@ -543,7 +552,7 @@ function MatchingGenreDetailPage() {
                           type="button"
                           onClick={goNext}
                           disabled={!hasSelectedRating}
-                          className="inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212] disabled:cursor-not-allowed disabled:bg-[#5c1a1a] disabled:text-white/44"
+                          className={MATCHING_PRIMARY_ACTION_BUTTON_CLASS}
                         >
                           다음
                           <ChevronRight size={16} />


### PR DESCRIPTION
## 관련 이슈

- closes #382 

## 변경 내용

- 전역 base 스타일에 인터랙션 커서 규칙을 추가해, `a[href]`, `button:not(:disabled)`, `summary`, `[role="button"]` 요소에 공통으로 `cursor: pointer`가 적용되도록 정리했습니다.
- 비활성화된 버튼과 `aria-disabled="true"` 상태에는 `cursor: not-allowed`가 적용되도록 맞췄습니다.
- 설문 페이지와 매칭 상세 페이지에서 개별적으로 반복되던 `disabled:cursor-not-allowed` 스타일을 제거하고, 전역 규칙을 따르도록 정리했습니다.
- survey/matching 버튼 클래스도 상수로 일부 정리해, 동일한 스타일이 반복되던 부분의 가독성을 보강했습니다.

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 기능 변경 없이 인터랙션 피드백의 일관성과 버튼 스타일 가독성 개선에 집중한 UI fix입니다.
- 개별 컴포넌트에 커서 스타일을 반복해서 넣기보다, 전역 스타일에서 공통 규칙으로 관리하도록 정리했습니다.
