### PR TITLE
[Fix] 설문 세션 시작 계약 정리 및 매칭 로딩 fallback 수정

### DIFF
--- a/src/features/survey/api/survey.ts
+++ b/src/features/survey/api/survey.ts
@@ -19,7 +19,6 @@ import type {
   SurveyResetResponse,
   SurveyResultQuery,
   SurveyResultResponse,
-  SurveySessionStartRequest,
   SurveySessionStartResponse,
   SurveyProgress,
   SurveyResultItem,
@@ -184,27 +183,26 @@ export const normalizeSurveyResultResponse = (
     : [],
 });
 
-export const startSurveySession = async (
-  payload: SurveySessionStartRequest,
-): Promise<SurveySessionStartResponse> => {
-  try {
-    const response = await api.post<SurveyApiSessionResponse>(
-      `${SURVEY_CHATBOT_BASE_PATH}/sessions/`,
-      payload,
-      {
-        timeout: SURVEY_CHATBOT_REQUEST_TIMEOUT_MS,
-      },
-    );
+export const startSurveySession =
+  async (): Promise<SurveySessionStartResponse> => {
+    try {
+      const response = await api.post<SurveyApiSessionResponse>(
+        `${SURVEY_CHATBOT_BASE_PATH}/sessions/`,
+        undefined,
+        {
+          timeout: SURVEY_CHATBOT_REQUEST_TIMEOUT_MS,
+        },
+      );
 
-    return normalizeSurveySessionResponse(response.data);
-  } catch (error) {
-    if (!isMockServiceWorkerEnabled()) {
-      throw error;
+      return normalizeSurveySessionResponse(response.data);
+    } catch (error) {
+      if (!isMockServiceWorkerEnabled()) {
+        throw error;
+      }
+
+      return normalizeSurveySessionResponse(startMockSurveySession());
     }
-
-    return normalizeSurveySessionResponse(startMockSurveySession());
-  }
-};
+  };
 
 export const continueSurveyChat = async (
   payload: SurveyChatRequest,

--- a/src/features/survey/hooks/useSurveySessionFlow.ts
+++ b/src/features/survey/hooks/useSurveySessionFlow.ts
@@ -62,17 +62,19 @@ export const useSurveySessionFlow = ({
   const continueSurveyMutation = useContinueSurveyMutation();
   const resetSurveyMutation = useResetSurveyMutation();
 
-  const requestSessionStart = useCallback(
-    async (isReset: boolean) => {
-      const response = await startSessionMutation.mutateAsync({
-        is_reset: isReset,
-      });
-      hydrateInitialSession(response);
+  const requestSessionStart = useCallback(async () => {
+    const response = await startSessionMutation.mutateAsync();
+    hydrateInitialSession(response);
 
-      return response;
-    },
-    [hydrateInitialSession, startSessionMutation],
-  );
+    return response;
+  }, [hydrateInitialSession, startSessionMutation]);
+
+  const requestSessionReset = useCallback(async () => {
+    const response = await resetSurveyMutation.mutateAsync();
+    hydrateInitialSession(response);
+
+    return response;
+  }, [hydrateInitialSession, resetSurveyMutation]);
 
   const requestSurveyMessage = useCallback(
     async (activeSessionId: string, content: string) => {
@@ -101,7 +103,7 @@ export const useSurveySessionFlow = ({
       setSubmitting(true);
 
       try {
-        await requestSessionStart(false);
+        await requestSessionStart();
       } catch (requestError) {
         setError(extractApiErrorMessage(requestError, 'start'));
       } finally {
@@ -133,7 +135,7 @@ export const useSurveySessionFlow = ({
       return sessionId;
     }
 
-    const sessionResponse = await requestSessionStart(false);
+    const sessionResponse = await requestSessionStart();
 
     return sessionResponse.session_id;
   }, [requestSessionStart, sessionId]);
@@ -213,7 +215,7 @@ export const useSurveySessionFlow = ({
       setSubmitting(true);
 
       try {
-        const sessionResponse = await requestSessionStart(true);
+        const sessionResponse = await requestSessionReset();
         addUserMessage(content);
         await requestSurveyMessage(sessionResponse.session_id, content);
       } catch (requestError) {
@@ -228,7 +230,7 @@ export const useSurveySessionFlow = ({
       addUserMessage,
       applyServerSideChatBlock,
       clearError,
-      requestSessionStart,
+      requestSessionReset,
       requestSurveyMessage,
       resetSurveyState,
       setError,
@@ -285,10 +287,8 @@ export const useSurveySessionFlow = ({
     setSubmitting(true);
 
     try {
-      const response = await resetSurveyMutation.mutateAsync();
-
       clearModerationState();
-      hydrateInitialSession(response);
+      await requestSessionReset();
     } catch (requestError) {
       const errorMessage = extractApiErrorMessage(requestError, 'reset');
 
@@ -308,10 +308,9 @@ export const useSurveySessionFlow = ({
     bootstrapSurvey,
     clearError,
     clearModerationState,
-    hydrateInitialSession,
     isSubmitting,
     queueFocusRestore,
-    resetSurveyMutation,
+    requestSessionReset,
     resetSurveyState,
     sessionId,
     setError,

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -106,8 +106,7 @@ const getQuestionCountFromAnswer = (answer: string) => {
 };
 
 export const surveyHandlers = [
-  http.post('/api/v1/survey/chatbot/sessions/', async ({ request }) => {
-    await request.json().catch(() => ({}));
+  http.post('/api/v1/survey/chatbot/sessions/', async () => {
     const sessionId = createSessionId();
     const totalQuestions = SURVEY_MAX_STEPS;
 

--- a/src/features/survey/types/survey.ts
+++ b/src/features/survey/types/survey.ts
@@ -21,10 +21,6 @@ export interface SurveyProgress {
   completion_rate: number;
 }
 
-export interface SurveySessionStartRequest {
-  is_reset?: boolean;
-}
-
 export interface SurveyApiChatRequest {
   message: string;
 }

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -12,7 +12,6 @@ import {
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import LazyHeader from '../../components/common/LazyHeader';
-import MainPageLoadingFallback from '../../components/common/MainPageLoadingFallback';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import { likeGame, unlikeGame } from '../../features/games/gameApi';
@@ -128,6 +127,19 @@ function MatchingDetailSkeleton() {
         </div>
       </div>
     </section>
+  );
+}
+
+function MatchingDetailLoadingState() {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.18),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
+      <LazyHeader fixed />
+
+      <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-22 pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-25 md:pb-14">
+        <MatchingDetailSkeleton />
+      </main>
+    </div>
   );
 }
 
@@ -273,7 +285,7 @@ function MatchingGenreDetailPage() {
   }
 
   if (authGate.needsAuthCheck) {
-    return <MainPageLoadingFallback />;
+    return <MatchingDetailLoadingState />;
   }
 
   const handleSubmit = async () => {

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -5,7 +5,6 @@ import { Link, Navigate, useLocation } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import LazyHeader from '../../components/common/LazyHeader';
-import MainPageLoadingFallback from '../../components/common/MainPageLoadingFallback';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import { getMatchCandidates } from '../../features/matching/api/matching';
@@ -24,6 +23,32 @@ function MatchingGenreCardSkeleton() {
           <div className="h-4 w-4/5 rounded-full bg-white/7" />
         </div>
       </div>
+    </div>
+  );
+}
+
+function MatchingListLoadingState() {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.18),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
+      <LazyHeader fixed />
+
+      <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-22 pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-25 md:pb-14">
+        <section className="mx-auto max-w-240">
+          <div className="mb-7 text-center sm:mb-8">
+            <div className="mx-auto h-4 w-24 animate-pulse rounded-full bg-[#792222]/35" />
+            <div className="mx-auto mt-3 h-11 w-62 animate-pulse rounded-full bg-white/9" />
+            <div className="mx-auto mt-3 h-4 w-full max-w-125 animate-pulse rounded-full bg-white/7" />
+            <div className="mx-auto mt-2 h-4 w-full max-w-98 animate-pulse rounded-full bg-white/7" />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {MATCHING_GENRES.map((genre) => (
+              <MatchingGenreCardSkeleton key={genre.slug} />
+            ))}
+          </div>
+        </section>
+      </main>
     </div>
   );
 }
@@ -86,7 +111,7 @@ function MatchingListPage() {
   }
 
   if (authGate.needsAuthCheck) {
-    return <MainPageLoadingFallback />;
+    return <MatchingListLoadingState />;
   }
 
   return (


### PR DESCRIPTION
## 관련 이슈

- closes #384 

## 변경 내용

- 설문 시작 API(`POST /api/v1/survey/chatbot/sessions/`)는 Swagger 기준에 맞춰 request body 없이 호출하도록 수정했습니다.
- 기존에 프론트에서 보내던 `is_reset` payload는 제거했습니다.
- 세션 복구/초기화 흐름은 시작 API가 아닌 reset API(`POST /api/v1/survey/chatbot/sessions/reset/`)만 사용하도록 정리했습니다.
- survey session flow에서 `requestSessionStart(true)` 기반 우회 흐름을 제거하고, retry/reset 동작이 reset API를 기준으로 움직이도록 정리했습니다.
- survey mock handler도 같은 계약을 따르도록 body 없는 세션 시작 흐름으로 맞췄습니다.
- 장르별 매칭 목록/상세 페이지는 auth 확인 중 메인페이지용 loading fallback이 노출되던 문제를 수정하고, matching 전용 스켈레톤이 바로 보이도록 정리했습니다.

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 실서버 Swagger 기준 survey 세션 계약 정합성과 matching 로딩 경험 일관성 개선에 집중했습니다.
- survey는 `start = 세션 시작`, `reset = 세션 초기화/복구` 책임이 분리되도록 정리했습니다.