### PR TITLE
[Refactor] 추천리스트 결과 조회 흐름 단순화

### DIFF
--- a/src/features/recommendation/hooks/useRecommendationResultsSource.ts
+++ b/src/features/recommendation/hooks/useRecommendationResultsSource.ts
@@ -1,166 +1,127 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { useLayoutEffect, useRef } from 'react';
+import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 
 import { getPaginatedResults } from '../../../utils/paginatedResults';
 import { useMatchResultsInfinite } from '../../matching/api/useMatchingApi';
 import { useMatchingStore } from '../../matching/store/useMatchingStore';
-import type { MatchResultResponse } from '../../matching/types';
-import { useSurveyStore } from '../../survey/store/useSurveyStore';
 import { useSurveyResultsInfinite } from '../../survey/api/useSurveyApi';
 import { extractApiErrorMessage } from '../../survey/api/survey';
-import type { SurveyResultResponse } from '../../survey/types/survey';
-import { getRecommendationHighlights } from '../utils/normalizeRecommendationItem';
+import { useSurveyStore } from '../../survey/store/useSurveyStore';
+import type { RecommendationDisplayItem } from '../types';
 
 type UseRecommendationResultsSourceParams = {
   canAccessPage: boolean;
+};
+
+const isRecommendationUnavailableError = (
+  error: unknown,
+  isSurveySource: boolean,
+) => {
+  if (!(error instanceof AxiosError)) {
+    return false;
+  }
+
+  const status = error.response?.status;
+
+  return isSurveySource ? status === 404 || status === 409 : status === 404;
+};
+
+const getRecommendationEmptyStateMessage = ({
+  isMatchSource,
+  isSurveySource,
+  isResultNotFound,
+}: {
+  isMatchSource: boolean;
+  isSurveySource: boolean;
+  isResultNotFound: boolean;
+}) => {
+  if (isMatchSource && isResultNotFound) {
+    return '매칭 추천 결과가 아직 없습니다. 먼저 매칭 평가를 완료해 주세요.';
+  }
+
+  if (isSurveySource && isResultNotFound) {
+    return '설문 추천 결과가 아직 준비되지 않았습니다. 설문을 먼저 완료해 주세요.';
+  }
+
+  return isMatchSource
+    ? '매칭 추천 결과가 아직 없습니다.'
+    : '추천 결과가 아직 없습니다.';
 };
 
 export const useRecommendationResultsSource = ({
   canAccessPage,
 }: UseRecommendationResultsSourceParams) => {
   const [searchParams] = useSearchParams();
-  const queryClient = useQueryClient();
-  const source = searchParams.get('source');
-  const matchGenreIdFromUrlValue = searchParams.get('genre_id');
-  const surveySessionIdFromUrl = searchParams.get('session_id');
   const storedSurveySessionId = useSurveyStore((state) => state.sessionId);
   const selectedGenreId = useMatchingStore((state) => state.selectedGenreId);
+  const source = searchParams.get('source');
+  const matchGenreIdParam = searchParams.get('genre_id');
+  const surveySessionIdParam = searchParams.get('session_id');
   const isMatchSource = source === 'match';
   const isSurveySource =
-    source === 'survey' || (!source && Boolean(surveySessionIdFromUrl));
-  const matchGenreIdFromUrl =
-    matchGenreIdFromUrlValue !== null ? Number(matchGenreIdFromUrlValue) : null;
+    source === 'survey' || (!source && Boolean(surveySessionIdParam));
+  const matchGenreId = matchGenreIdParam ? Number(matchGenreIdParam) : null;
   const resolvedMatchGenreId =
-    typeof matchGenreIdFromUrl === 'number' &&
-    !Number.isNaN(matchGenreIdFromUrl) &&
-    matchGenreIdFromUrl >= 1
-      ? matchGenreIdFromUrl
+    typeof matchGenreId === 'number' &&
+    !Number.isNaN(matchGenreId) &&
+    matchGenreId >= 1
+      ? matchGenreId
       : selectedGenreId;
-  const resolvedSurveySessionId =
-    surveySessionIdFromUrl ?? storedSurveySessionId;
-  const hasTrimmedOnEntryRef = useRef<string | null>(null);
-  const activeTrimKey = isMatchSource
-    ? `match:${resolvedMatchGenreId ?? 'none'}`
-    : isSurveySource
-      ? `survey:${resolvedSurveySessionId ?? 'current'}`
-      : null;
+  const resolvedSurveySessionId = surveySessionIdParam ?? storedSurveySessionId;
 
   const surveyResultsQuery = useSurveyResultsInfinite(
-    !isMatchSource && isSurveySource && canAccessPage,
+    canAccessPage && isSurveySource && !isMatchSource,
     resolvedSurveySessionId,
   );
   const matchResultsQuery = useMatchResultsInfinite(
     resolvedMatchGenreId,
-    isMatchSource && canAccessPage,
+    canAccessPage && isMatchSource,
   );
   const activeQuery = isMatchSource ? matchResultsQuery : surveyResultsQuery;
-  const { error, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
-    activeQuery;
+  const recommendationItems = useMemo<RecommendationDisplayItem[]>(() => {
+    const pages = isMatchSource
+      ? matchResultsQuery.data?.pages
+      : surveyResultsQuery.data?.pages;
 
-  const surveyItems =
-    surveyResultsQuery.data?.pages.flatMap((page) =>
-      getPaginatedResults(page),
-    ) ?? [];
-  const matchItems =
-    matchResultsQuery.data?.pages.flatMap((page) =>
-      getPaginatedResults(page),
-    ) ?? [];
-  const recommendationItems = isMatchSource ? matchItems : surveyItems;
-  const recommendationHighlights =
-    getRecommendationHighlights(recommendationItems);
-  const isResultNotFound =
-    error instanceof AxiosError && error.response?.status === 404;
-  const errorMessage =
-    error && !isResultNotFound
-      ? extractApiErrorMessage(
-          error,
-          isSurveySource ? 'recommendations' : 'generic',
-        )
-      : null;
-  const emptyStateMessage =
-    isResultNotFound && isMatchSource
-      ? '매칭 추천 결과가 아직 없습니다. 먼저 매칭 평가를 완료해 주세요.'
-      : isResultNotFound && isSurveySource
-        ? '설문 추천 결과가 아직 준비되지 않았습니다. 설문을 먼저 완료해 주세요.'
-        : isMatchSource
-          ? '매칭 추천 결과가 아직 없습니다.'
-          : '추천 결과가 아직 없습니다.';
-  const shouldShowMatchEntryCta =
-    isMatchSource &&
-    !isLoading &&
-    (isResultNotFound || recommendationItems.length === 0);
-
-  useLayoutEffect(() => {
-    if (!canAccessPage || !activeTrimKey) {
-      return;
-    }
-
-    if (hasTrimmedOnEntryRef.current === activeTrimKey) {
-      return;
-    }
-
-    hasTrimmedOnEntryRef.current = activeTrimKey;
-
-    if (isMatchSource && resolvedMatchGenreId !== null) {
-      queryClient.setQueriesData<{
-        pages: MatchResultResponse[];
-        pageParams: unknown[];
-      }>(
-        { queryKey: ['match-results', resolvedMatchGenreId] },
-        (currentData) =>
-          currentData
-            ? {
-                ...currentData,
-                pages: currentData.pages.slice(0, 1),
-                pageParams: currentData.pageParams.slice(0, 1),
-              }
-            : currentData,
-      );
-
-      return;
-    }
-
-    if (isSurveySource) {
-      queryClient.setQueriesData<{
-        pages: SurveyResultResponse[];
-        pageParams: unknown[];
-      }>(
-        { queryKey: ['survey-results', resolvedSurveySessionId ?? 'current'] },
-        (currentData) =>
-          currentData
-            ? {
-                ...currentData,
-                pages: currentData.pages.slice(0, 1),
-                pageParams: currentData.pageParams.slice(0, 1),
-              }
-            : currentData,
-      );
-    }
+    return pages?.flatMap((page) => getPaginatedResults(page)) ?? [];
   }, [
-    activeTrimKey,
-    canAccessPage,
+    isMatchSource,
+    matchResultsQuery.data?.pages,
+    surveyResultsQuery.data?.pages,
+  ]);
+  const isResultNotFound = isRecommendationUnavailableError(
+    activeQuery.error,
+    isSurveySource,
+  );
+  const hasBlockingError = Boolean(activeQuery.error && !isResultNotFound);
+  const errorMessage = hasBlockingError
+    ? extractApiErrorMessage(
+        activeQuery.error,
+        isSurveySource ? 'recommendations' : 'generic',
+      )
+    : null;
+  const emptyStateMessage = getRecommendationEmptyStateMessage({
     isMatchSource,
     isSurveySource,
-    queryClient,
-    resolvedMatchGenreId,
-    resolvedSurveySessionId,
-  ]);
+    isResultNotFound,
+  });
 
   return {
     isMatchSource,
     isSurveySource,
     recommendationItems,
-    recommendationHighlights,
     errorMessage,
     emptyStateMessage,
     isResultNotFound,
-    shouldShowMatchEntryCta,
-    error,
-    isLoading,
-    isFetchingNextPage,
-    fetchNextPage,
-    hasNextPage,
+    hasBlockingError,
+    shouldShowMatchEntryCta:
+      isMatchSource &&
+      !activeQuery.isLoading &&
+      (isResultNotFound || recommendationItems.length === 0),
+    isLoading: activeQuery.isLoading,
+    isFetchingNextPage: activeQuery.isFetchingNextPage,
+    fetchNextPage: activeQuery.fetchNextPage,
+    hasNextPage: Boolean(activeQuery.hasNextPage),
   };
 };

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -135,6 +135,13 @@ type RecommendationBackdropProps = {
   items: RecommendationDisplayItem[];
 };
 
+type RecommendationPromptCardProps = {
+  title: string;
+  description: string;
+  ctaLabel: string;
+  to: string;
+};
+
 function RecommendationRowSkeleton() {
   return (
     <div className="grid animate-pulse gap-4 px-4 py-5 sm:grid-cols-[118px_minmax(0,1fr)] sm:items-center sm:px-6 sm:py-6 lg:grid-cols-[118px_minmax(0,1fr)_auto] lg:gap-6 lg:px-7">
@@ -207,6 +214,28 @@ function RecommendationBackdrop({ items }: RecommendationBackdropProps) {
   );
 }
 
+function RecommendationPromptCard({
+  title,
+  description,
+  ctaLabel,
+  to,
+}: RecommendationPromptCardProps) {
+  return (
+    <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
+      <h2 className="text-2xl font-bold text-white">{title}</h2>
+      <p className="mt-4 text-base leading-7 break-keep text-white/60">
+        {description}
+      </p>
+      <Link
+        to={to}
+        className="mt-6 inline-flex rounded-2xl bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3 text-sm font-semibold text-white transition hover:brightness-105"
+      >
+        {ctaLabel}
+      </Link>
+    </section>
+  );
+}
+
 function RecommendationListPage() {
   const [selectedGame, setSelectedGame] = useState<GameListItem | null>(null);
   const authGate = useAuthGate({ allowMockBypass: true });
@@ -217,9 +246,8 @@ function RecommendationListPage() {
     recommendationItems,
     errorMessage,
     emptyStateMessage,
-    isResultNotFound,
+    hasBlockingError,
     shouldShowMatchEntryCta,
-    error,
     isLoading,
     isFetchingNextPage,
     fetchNextPage,
@@ -293,7 +321,7 @@ function RecommendationListPage() {
                     type="button"
                     onClick={() => void handleResetSurvey()}
                     disabled={isResettingSurvey}
-                    className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/3 px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/3 px-4 py-3 text-sm font-semibold text-white/88 transition hover:border-white/20 hover:bg-white/6 disabled:opacity-60"
                   >
                     <RotateCcw size={16} />
                     {isResettingSurvey ? '설문 초기화 중...' : '설문 초기화'}
@@ -311,36 +339,19 @@ function RecommendationListPage() {
               description="실제 API 모드에서는 인증 토큰이 필요합니다. 개발 중에는 MSW를 켜두면 추천 결과 흐름을 확인할 수 있습니다."
             />
           ) : !isMatchSource && !isSurveySource ? (
-            <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
-              <h2 className="text-2xl font-bold text-white">
-                먼저 설문을 완료해 주세요.
-              </h2>
-              <p className="mt-4 text-base leading-7 break-keep text-white/60">
-                설문이 끝나면 추천 결과를 이 페이지에서 바로 확인할 수 있어요.
-              </p>
-              <Link
-                to={`/${ROUTES.SURVEY}`}
-                className="mt-6 inline-flex rounded-2xl bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3 text-sm font-semibold text-white transition hover:brightness-105"
-              >
-                설문 페이지로 이동
-              </Link>
-            </section>
+            <RecommendationPromptCard
+              title="먼저 설문을 완료해 주세요."
+              description="설문이 끝나면 추천 결과를 이 페이지에서 바로 확인할 수 있어요."
+              ctaLabel="설문 페이지로 이동"
+              to={`/${ROUTES.SURVEY}`}
+            />
           ) : shouldShowMatchEntryCta ? (
-            <section className="survey-panel max-w-2xl px-6 py-8 sm:px-8 sm:py-10">
-              <h2 className="text-2xl font-bold text-white">
-                먼저 매칭 평가를 완료해 주세요.
-              </h2>
-              <p className="mt-4 text-base leading-7 break-keep text-white/60">
-                좋아하는 장르를 고르고 최대 5개 게임의 트레일러를 보며 별점을
-                남기면 추천 결과가 바로 준비돼요.
-              </p>
-              <Link
-                to={`/${ROUTES.MATCHING_LIST}`}
-                className="mt-6 inline-flex rounded-2xl bg-[linear-gradient(135deg,#ff3535,#9f1212)] px-5 py-3 text-sm font-semibold text-white transition hover:brightness-105"
-              >
-                매칭 페이지로 이동
-              </Link>
-            </section>
+            <RecommendationPromptCard
+              title="먼저 매칭 평가를 완료해 주세요."
+              description="좋아하는 장르를 고르고 최대 5개 게임의 트레일러를 보며 별점을 남기면 추천 결과가 바로 준비돼요."
+              ctaLabel="매칭 페이지로 이동"
+              to={`/${ROUTES.MATCHING_LIST}`}
+            />
           ) : (
             <section className="flex min-h-0 flex-col overflow-hidden rounded-4xl border border-white/8 bg-[linear-gradient(180deg,rgba(16,16,18,0.92),rgba(9,9,10,0.98))] shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-2xl">
               {feedbackMessage ? (
@@ -353,7 +364,7 @@ function RecommendationListPage() {
 
               {isLoading ? (
                 <RecommendationListSkeleton />
-              ) : error && !isResultNotFound ? (
+              ) : hasBlockingError ? (
                 <div className="px-4 py-12 text-[#ffc2c2] sm:px-6 lg:px-7">
                   {errorMessage}
                 </div>
@@ -385,7 +396,7 @@ function RecommendationListPage() {
                       type="button"
                       onClick={handleLoadMore}
                       disabled={isFetchingNextPage}
-                      className="flex w-full items-center justify-center gap-2 border-t border-white/8 bg-[linear-gradient(180deg,rgba(255,255,255,0.01),rgba(255,255,255,0.03))] px-4 py-2.5 text-sm font-medium text-white/82 transition hover:bg-white/4 hover:text-white disabled:cursor-not-allowed disabled:opacity-45 sm:px-6 lg:px-7"
+                      className="flex w-full items-center justify-center gap-2 border-t border-white/8 bg-[linear-gradient(180deg,rgba(255,255,255,0.01),rgba(255,255,255,0.03))] px-4 py-2.5 text-sm font-medium text-white/82 transition hover:bg-white/4 hover:text-white disabled:opacity-45 sm:px-6 lg:px-7"
                     >
                       {!isFetchingNextPage ? (
                         <ChevronDown


### PR DESCRIPTION
## 관련 이슈

- closes #386 

## 변경 내용

- 추천 결과 source 판별과 결과 query 선택 흐름을 단순화해, match/survey 결과 조회 구조가 더 직접적으로 읽히도록 정리했습니다.
- 추천 결과 진입 시 사용하던 과한 cache trim 로직과 관련 보조 타입/헬퍼를 제거했습니다.
- survey recommendations는 `404`뿐 아니라 `409`도 결과 준비 전 상태로 해석하도록 정리했습니다.
- 추천리스트 페이지에서 과하게 분리했던 보조 컴포넌트는 다시 줄이고, header / 진입 안내 / 결과 패널 흐름이 한 파일 안에서 자연스럽게 읽히도록 정리했습니다.
- 기능 변경 없이 추천리스트의 가독성과 유지보수성을 높이고, 필요 없는 로직과 추상화를 줄이는 방향에 집중했습니다.

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 “더 나누는 리팩토링”보다, 실제로 사용하지 않거나 과했던 로직/분기/추상화를 덜어내는 방향에 초점을 맞췄습니다.
- 추천 결과 조회 흐름은 유지하되, 코드량과 진입 복잡도를 줄이는 것이 목적입니다.
