### PR TITLE
[Fix] 새로고침 시 세션 초기화 레이스 컨디션 및 로그인 풀림 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,8 @@ npm run dev
 ```
 
 기본 개발 서버는 `https://localhost:5173` 기준으로 실행합니다.
-
-처음 한 번은 로컬 인증서를 생성합니다.
-
-```bash
-brew install mkcert
-mkcert -install
-mkdir -p certs
-mkcert -key-file certs/localhost-key.pem -cert-file certs/localhost.pem localhost 127.0.0.1 ::1
-```
-
-이후 아래 명령으로 개발 서버를 실행합니다.
+아래 명령으로 개발 서버를 실행하면 `vite-plugin-mkcert`가 로컬 HTTPS 인증서를 자동으로 준비합니다.
+처음 한 번은 운영체제에서 로컬 인증서 신뢰 관련 안내가 뜰 수 있습니다.
 
 ```bash
 npm run dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "tailwindcss": "^4.2.2",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
-        "vite": "^8.0.4"
+        "vite": "^8.0.4",
+        "vite-plugin-mkcert": "^2.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -76,6 +77,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -586,27 +588,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1341,6 +1322,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
@@ -1749,6 +1751,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
       "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.99.0"
       },
@@ -1807,6 +1810,7 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1817,6 +1821,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1883,6 +1888,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -2152,6 +2158,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2313,6 +2320,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2648,6 +2656,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -2913,6 +2922,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2973,6 +2983,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4659,6 +4670,7 @@
       "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4785,6 +4797,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4794,6 +4807,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5290,6 +5304,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5320,6 +5335,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.2.0.tgz",
+      "integrity": "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -5385,6 +5410,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5455,6 +5481,37 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-mkcert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-2.0.0.tgz",
+      "integrity": "sha512-+5roXeOT91WRO3NKFRcDZKEHhze/1uahSSKOIq3vz2w19mJojBcyOo0JyLRHbME31Ym5qPRNJ8CwKO0mu4RJ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "supports-color": "^10.2.2",
+        "undici": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "peerDependencies": {
+        "vite": ">=3"
+      }
+    },
+    "node_modules/vite-plugin-mkcert/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/which": {
@@ -5681,6 +5738,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",
-    "vite": "^8.0.4"
+    "vite": "^8.0.4",
+    "vite-plugin-mkcert": "^2.0.0"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
 
   useEffect(() => {
     const handleSessionExpired = (event: Event) => {
-      if (useAuthStore.getState().authBootstrapStatus === 'loading') {
+      if (useAuthStore.getState().authBootstrapStatus !== 'ready') {
         return;
       }
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -6,7 +6,7 @@ import axios, {
 
 import { logAxiosError } from './logApiError';
 import { apiBaseUrl } from '../lib/env';
-import { useAuthStore } from '../store/useAuthStore';
+import { readStoredAccessToken } from '../store/useAuthStore';
 import {
   expireAuthSession,
   refreshStoredAccessToken,
@@ -26,37 +26,99 @@ const AUTH_EXCLUDED_PATHS = [
   '/api/v1/accounts/token/refresh', // 무한 루프 방지
 ];
 
-const shouldResetAuthSession = (requestUrl?: string) => {
-  if (!requestUrl) return true;
-  return !AUTH_EXCLUDED_PATHS.some((path) => requestUrl.includes(path));
+const resolveRequestPath = (requestUrl?: string, baseURL?: string) => {
+  if (!requestUrl) {
+    return '';
+  }
+
+  try {
+    if (requestUrl.startsWith('http://') || requestUrl.startsWith('https://')) {
+      return new URL(requestUrl).pathname;
+    }
+
+    if (baseURL) {
+      return new URL(requestUrl, baseURL).pathname;
+    }
+  } catch {
+    return requestUrl;
+  }
+
+  return requestUrl;
 };
 
 type RetriableRequestConfig = InternalAxiosRequestConfig & {
   _retry?: boolean;
 };
 
-let refreshAccessTokenPromise: Promise<string> | null = null;
+type RefreshSubscriber = {
+  resolve: (token: string) => void;
+  reject: (error: unknown) => void;
+};
 
-const getRefreshedAccessToken = async () => {
-  if (!refreshAccessTokenPromise) {
-    refreshAccessTokenPromise = refreshStoredAccessToken()
-      .catch((refreshError) => {
-        expireAuthSession();
+// 같은 런타임에서 동시에 터진 401 응답은 하나의 refresh 호출로 직렬화한다.
+let isRefreshing = false;
+let refreshSubscribers: RefreshSubscriber[] = [];
 
-        if (refreshError instanceof AxiosError) {
-          logAxiosError(refreshError, 'auth-refresh');
-        } else {
-          console.error('[auth-refresh] unexpected error');
-        }
+const shouldResetAuthSession = (requestUrl?: string, baseURL?: string) => {
+  const requestPath = resolveRequestPath(requestUrl, baseURL);
 
-        throw refreshError;
-      })
-      .finally(() => {
-        refreshAccessTokenPromise = null;
-      });
+  if (!requestPath) {
+    return true;
   }
 
-  return refreshAccessTokenPromise;
+  return !AUTH_EXCLUDED_PATHS.some((path) => requestPath.includes(path));
+};
+
+const onRefreshed = (token: string) => {
+  refreshSubscribers.forEach(({ resolve }) => resolve(token));
+  refreshSubscribers = [];
+};
+
+const onRefreshFailed = (error: unknown) => {
+  refreshSubscribers.forEach(({ reject }) => reject(error));
+  refreshSubscribers = [];
+};
+
+const addRefreshSubscriber = (subscriber: RefreshSubscriber) => {
+  refreshSubscribers.push(subscriber);
+};
+
+const isRefreshSessionInvalidationError = (error: unknown) =>
+  error instanceof AxiosError &&
+  (error.response?.status === 401 || error.response?.status === 403);
+
+const getRefreshedAccessToken = async () => {
+  if (!isRefreshing) {
+    isRefreshing = true;
+    try {
+      const accessToken = await refreshStoredAccessToken();
+      onRefreshed(accessToken);
+      return accessToken;
+    } catch (refreshError) {
+      onRefreshFailed(refreshError);
+
+      if (isRefreshSessionInvalidationError(refreshError)) {
+        expireAuthSession();
+      }
+
+      if (refreshError instanceof AxiosError) {
+        logAxiosError(refreshError, 'auth-refresh');
+      } else {
+        console.error('[auth-refresh] unexpected error');
+      }
+
+      throw refreshError;
+    } finally {
+      isRefreshing = false;
+    }
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    addRefreshSubscriber({
+      resolve,
+      reject,
+    });
+  });
 };
 
 const setAuthorizationHeader = (
@@ -79,10 +141,10 @@ export const api = axios.create({
   },
 });
 
-// 요청 인터셉터: 메모리에 있는 Access Token을 Authorization 헤더에 삽입
+// 요청 인터셉터: 항상 sessionStorage에서 최신 Access Token을 가져온다.
 api.interceptors.request.use(
   (config) => {
-    const token = useAuthStore.getState().accessToken;
+    const token = readStoredAccessToken();
 
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
@@ -103,19 +165,18 @@ api.interceptors.response.use(
 
     const originalRequest = error.config as RetriableRequestConfig | undefined;
 
-    // 401 에러이고, 재시도한 적이 없으며, 인증 제외 경로가 아닐 때
     if (
       originalRequest &&
       error.response?.status === 401 &&
+      readStoredAccessToken() &&
       !originalRequest._retry &&
-      shouldResetAuthSession(originalRequest.url)
+      shouldResetAuthSession(originalRequest.url, originalRequest.baseURL)
     ) {
       originalRequest._retry = true;
 
       try {
         const accessToken = await getRefreshedAccessToken();
 
-        // 원래 요청 재시도
         setAuthorizationHeader(originalRequest, accessToken);
         return api(originalRequest);
       } catch (refreshError) {

--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -1,11 +1,9 @@
-import axios, { type AxiosRequestConfig } from 'axios';
+import axios, { AxiosError, type AxiosRequestConfig } from 'axios';
 
 import { api } from '@/api/axios';
-import { apiBaseUrl, configuredApiBaseUrl } from '@/lib/env';
 import { normalizeThumbnailUrl } from '@/lib/normalizeThumbnailUrl';
 import { AUTH_BASE_PATH } from '../constants/auth';
 import { logCredentialedAuthRequestDiagnostics } from './auth.diagnostics';
-import { hasPendingSocialAuthProvider } from '../utils/socialAuth';
 import type {
   CheckIdDuplicateRequest,
   CheckNicknameDuplicateRequest,
@@ -38,35 +36,67 @@ import type {
 } from '../types/auth';
 
 const AUTH_REFRESH_TIMEOUT_MS = 7000;
-
-const normalizeApiBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
-const normalizedApiBaseUrl = normalizeApiBaseUrl(apiBaseUrl);
-const normalizedConfiguredApiBaseUrl =
-  normalizeApiBaseUrl(configuredApiBaseUrl);
-
-const buildAuthRequestUrl = (
-  path: string,
-  options: {
-    preferConfiguredOrigin?: boolean;
-  } = {},
-) => {
-  const { preferConfiguredOrigin = false } = options;
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-
-  if (preferConfiguredOrigin && normalizedConfiguredApiBaseUrl) {
-    return `${normalizedConfiguredApiBaseUrl}${normalizedPath}`;
-  }
-
-  if (normalizedApiBaseUrl) {
-    return `${normalizedApiBaseUrl}${normalizedPath}`;
-  }
-
-  return normalizedPath;
-};
+const REFRESH_REQUEST_THROTTLE_MS = 1500;
+const REFRESH_RETRY_AFTER_THROTTLED_FAILURE_MS = 900;
+const REFRESH_REQUEST_THROTTLE_STORAGE_KEY =
+  'auth-refresh-request-last-started-at';
 
 const loginRequestPath = `${AUTH_BASE_PATH}/login`;
 const logoutRequestPath = `${AUTH_BASE_PATH}/logout`;
 const refreshRequestPath = `${AUTH_BASE_PATH}/token/refresh`;
+
+const readRefreshThrottleTimestamp = () => {
+  if (typeof window === 'undefined') {
+    return 0;
+  }
+
+  const rawValue = window.sessionStorage.getItem(
+    REFRESH_REQUEST_THROTTLE_STORAGE_KEY,
+  );
+  const parsedValue = Number(rawValue);
+
+  return Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : 0;
+};
+
+const markRefreshThrottleTimestamp = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.sessionStorage.setItem(
+    REFRESH_REQUEST_THROTTLE_STORAGE_KEY,
+    String(Date.now()),
+  );
+};
+
+const waitForRefreshThrottleWindow = async () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const lastStartedAt = readRefreshThrottleTimestamp();
+
+  if (!lastStartedAt) {
+    return false;
+  }
+
+  const elapsed = Date.now() - lastStartedAt;
+  const remaining = REFRESH_REQUEST_THROTTLE_MS - elapsed;
+
+  if (remaining <= 0) {
+    return false;
+  }
+
+  await new Promise<void>((resolve) => {
+    window.setTimeout(resolve, remaining);
+  });
+
+  return true;
+};
+
+const isRetryableRefreshThrottleFailure = (error: unknown) =>
+  error instanceof AxiosError &&
+  (error.response?.status === 401 || error.response?.status === 403);
 
 const createCredentialedAuthRequestConfig = <T = unknown>(
   config: AxiosRequestConfig<T> = {},
@@ -141,11 +171,10 @@ const normalizeLikedGamesResponse = (
 
 export const requestLogin = async (payload: LoginRequest) => {
   const requestConfig = createCredentialedAuthRequestConfig();
-  const loginRequestUrl = buildAuthRequestUrl(loginRequestPath);
 
   logCredentialedAuthRequestDiagnostics({
     label: 'login',
-    requestUrl: loginRequestUrl,
+    requestUrl: loginRequestPath,
     withCredentials: true,
   });
 
@@ -160,11 +189,10 @@ export const requestLogin = async (payload: LoginRequest) => {
 
 export const requestLogout = async () => {
   const requestConfig = createCredentialedAuthRequestConfig();
-  const logoutRequestUrl = buildAuthRequestUrl(logoutRequestPath);
 
   logCredentialedAuthRequestDiagnostics({
     label: 'logout',
-    requestUrl: logoutRequestUrl,
+    requestUrl: logoutRequestPath,
     withCredentials: true,
   });
 
@@ -180,29 +208,46 @@ export const requestLogout = async () => {
 export const requestRefreshAccessToken = async (
   payload: { refresh_token?: string } = {},
 ) => {
+  const waitedForPreviousRefresh = await waitForRefreshThrottleWindow();
   const requestConfig = createCredentialedAuthRequestConfig();
   const requestBody = payload.refresh_token?.trim() ? payload : undefined;
-  const shouldUseConfiguredOriginForRefresh =
-    import.meta.env.DEV &&
-    hasPendingSocialAuthProvider() &&
-    Boolean(normalizedConfiguredApiBaseUrl);
-  const refreshRequestUrl = buildAuthRequestUrl(refreshRequestPath, {
-    preferConfiguredOrigin: shouldUseConfiguredOriginForRefresh,
-  });
 
   logCredentialedAuthRequestDiagnostics({
     label: 'refresh',
-    requestUrl: refreshRequestUrl,
+    requestUrl: refreshRequestPath,
     withCredentials: true,
   });
 
-  const response = await axios.post<RefreshAccessTokenResponse>(
-    refreshRequestUrl,
-    requestBody,
-    requestConfig,
-  );
+  const sendRefreshRequest = async () => {
+    markRefreshThrottleTimestamp();
 
-  return response.data;
+    // Use relative path directly with axios to ensure it goes through Vite Proxy
+    const response = await axios.post<RefreshAccessTokenResponse>(
+      refreshRequestPath,
+      requestBody,
+      requestConfig,
+    );
+
+    return response.data;
+  };
+
+  try {
+    return await sendRefreshRequest();
+  } catch (error) {
+    if (
+      waitedForPreviousRefresh &&
+      isRetryableRefreshThrottleFailure(error) &&
+      typeof window !== 'undefined'
+    ) {
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, REFRESH_RETRY_AFTER_THROTTLED_FAILURE_MS);
+      });
+
+      return sendRefreshRequest();
+    }
+
+    throw error;
+  }
 };
 
 export const getCurrentUserProfile = async () => {

--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -1,10 +1,11 @@
 import axios, { type AxiosRequestConfig } from 'axios';
 
 import { api } from '@/api/axios';
-import { apiBaseUrl } from '@/lib/env';
+import { apiBaseUrl, configuredApiBaseUrl } from '@/lib/env';
 import { normalizeThumbnailUrl } from '@/lib/normalizeThumbnailUrl';
 import { AUTH_BASE_PATH } from '../constants/auth';
 import { logCredentialedAuthRequestDiagnostics } from './auth.diagnostics';
+import { hasPendingSocialAuthProvider } from '../utils/socialAuth';
 import type {
   CheckIdDuplicateRequest,
   CheckNicknameDuplicateRequest,
@@ -39,10 +40,33 @@ import type {
 const AUTH_REFRESH_TIMEOUT_MS = 7000;
 
 const normalizeApiBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
-const authApiUrl = `${normalizeApiBaseUrl(apiBaseUrl)}${AUTH_BASE_PATH}`;
-const loginRequestUrl = `${authApiUrl}/login`;
-const logoutRequestUrl = `${authApiUrl}/logout`;
-const refreshRequestUrl = `${authApiUrl}/token/refresh`;
+const normalizedApiBaseUrl = normalizeApiBaseUrl(apiBaseUrl);
+const normalizedConfiguredApiBaseUrl =
+  normalizeApiBaseUrl(configuredApiBaseUrl);
+
+const buildAuthRequestUrl = (
+  path: string,
+  options: {
+    preferConfiguredOrigin?: boolean;
+  } = {},
+) => {
+  const { preferConfiguredOrigin = false } = options;
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  if (preferConfiguredOrigin && normalizedConfiguredApiBaseUrl) {
+    return `${normalizedConfiguredApiBaseUrl}${normalizedPath}`;
+  }
+
+  if (normalizedApiBaseUrl) {
+    return `${normalizedApiBaseUrl}${normalizedPath}`;
+  }
+
+  return normalizedPath;
+};
+
+const loginRequestPath = `${AUTH_BASE_PATH}/login`;
+const logoutRequestPath = `${AUTH_BASE_PATH}/logout`;
+const refreshRequestPath = `${AUTH_BASE_PATH}/token/refresh`;
 
 const createCredentialedAuthRequestConfig = <T = unknown>(
   config: AxiosRequestConfig<T> = {},
@@ -117,6 +141,7 @@ const normalizeLikedGamesResponse = (
 
 export const requestLogin = async (payload: LoginRequest) => {
   const requestConfig = createCredentialedAuthRequestConfig();
+  const loginRequestUrl = buildAuthRequestUrl(loginRequestPath);
 
   logCredentialedAuthRequestDiagnostics({
     label: 'login',
@@ -125,7 +150,7 @@ export const requestLogin = async (payload: LoginRequest) => {
   });
 
   const response = await api.post<LoginResponse>(
-    `${AUTH_BASE_PATH}/login`,
+    loginRequestPath,
     payload,
     requestConfig,
   );
@@ -135,6 +160,7 @@ export const requestLogin = async (payload: LoginRequest) => {
 
 export const requestLogout = async () => {
   const requestConfig = createCredentialedAuthRequestConfig();
+  const logoutRequestUrl = buildAuthRequestUrl(logoutRequestPath);
 
   logCredentialedAuthRequestDiagnostics({
     label: 'logout',
@@ -143,7 +169,7 @@ export const requestLogout = async () => {
   });
 
   const response = await api.post<LogoutResponse>(
-    `${AUTH_BASE_PATH}/logout`,
+    logoutRequestPath,
     undefined,
     requestConfig,
   );
@@ -156,6 +182,13 @@ export const requestRefreshAccessToken = async (
 ) => {
   const requestConfig = createCredentialedAuthRequestConfig();
   const requestBody = payload.refresh_token?.trim() ? payload : undefined;
+  const shouldUseConfiguredOriginForRefresh =
+    import.meta.env.DEV &&
+    hasPendingSocialAuthProvider() &&
+    Boolean(normalizedConfiguredApiBaseUrl);
+  const refreshRequestUrl = buildAuthRequestUrl(refreshRequestPath, {
+    preferConfiguredOrigin: shouldUseConfiguredOriginForRefresh,
+  });
 
   logCredentialedAuthRequestDiagnostics({
     label: 'refresh',

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -34,7 +34,10 @@ function useAuthBootstrap() {
   }, []);
 
   useEffect(() => {
-    if (authBootstrapStatus !== 'idle') {
+    const currentAuthBootstrapStatus =
+      useAuthStore.getState().authBootstrapStatus;
+
+    if (currentAuthBootstrapStatus !== 'idle') {
       return;
     }
 
@@ -61,12 +64,11 @@ function useAuthBootstrap() {
       return;
     }
 
-    let isMounted = true;
     setAuthBootstrapLoading();
 
     void ensureAuthSessionRestored()
       .catch((error) => {
-        if (!hasPendingSocialProvider || !isMounted) {
+        if (!hasPendingSocialProvider) {
           return;
         }
 
@@ -80,22 +82,17 @@ function useAuthBootstrap() {
         });
       })
       .finally(() => {
+        // React StrictMode in development replays effects once, so this
+        // completion path must not depend on component-local mount flags.
         if (hasPendingSocialProvider) {
           clearPendingSocialAuthProvider();
         }
 
-        if (
-          isMounted &&
-          useAuthStore.getState().authBootstrapStatus === 'loading'
-        ) {
+        if (useAuthStore.getState().authBootstrapStatus === 'loading') {
           setAuthBootstrapReady();
         }
       });
-
-    return () => {
-      isMounted = false;
-    };
-  }, [authBootstrapStatus, location.pathname, navigate]);
+  }, [location.pathname, navigate]);
 
   return {
     authBootstrapStatus,

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -1,30 +1,22 @@
 import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router';
+import { useLocation } from 'react-router';
 
-import { ROUTES } from '../../../constants/routes';
 import { shouldSkipAuthBootstrapPath } from '../../../constants/routeResolver';
-import { isMockServiceWorkerEnabled } from '../../../lib/env';
 import {
   clearLegacyAuthStorage,
+  syncAccessTokenFromStorage,
   useAuthStore,
 } from '../../../store/useAuthStore';
-import { hasMockRefreshToken } from '../api/auth.session.helper';
-import { extractAuthApiErrorMessage } from '../api/auth';
 import {
-  clearPendingSocialAuthProvider,
-  hasPendingSocialAuthProvider,
-} from '../utils/socialAuth';
-import {
-  ensureAuthSessionRestored,
+  clearAuthSession,
+  refreshStoredAccessToken,
   setAuthBootstrapLoading,
   setAuthBootstrapReady,
 } from '../utils/sessionManager';
-const DEFAULT_SOCIAL_AUTH_ERROR_MESSAGE =
-  '세션을 확인하지 못했습니다. 다시 로그인해 주세요.';
+import { isAccessTokenExpiringSoon } from '../utils/accessToken';
 
 function useAuthBootstrap() {
   const location = useLocation();
-  const navigate = useNavigate();
   const authBootstrapStatus = useAuthStore(
     (state) => state.authBootstrapStatus,
   );
@@ -41,58 +33,35 @@ function useAuthBootstrap() {
       return;
     }
 
-    const store = useAuthStore.getState();
-
-    if (store.accessToken) {
-      setAuthBootstrapReady();
-      return;
-    }
-
     if (shouldSkipAuthBootstrapPath(location.pathname)) {
       setAuthBootstrapReady();
       return;
     }
 
-    const hasPendingSocialProvider = hasPendingSocialAuthProvider();
+    const storedAccessToken = syncAccessTokenFromStorage();
 
-    if (
-      isMockServiceWorkerEnabled() &&
-      !hasMockRefreshToken() &&
-      !hasPendingSocialProvider
-    ) {
+    if (!storedAccessToken) {
+      setAuthBootstrapReady();
+      return;
+    }
+
+    if (!isAccessTokenExpiringSoon(storedAccessToken)) {
       setAuthBootstrapReady();
       return;
     }
 
     setAuthBootstrapLoading();
 
-    void ensureAuthSessionRestored()
-      .catch((error) => {
-        if (!hasPendingSocialProvider) {
-          return;
-        }
-
-        navigate(`/${ROUTES.LOGIN}`, {
-          replace: true,
-          state: {
-            errorMessage:
-              extractAuthApiErrorMessage(error) ||
-              DEFAULT_SOCIAL_AUTH_ERROR_MESSAGE,
-          },
-        });
+    void refreshStoredAccessToken()
+      .catch(() => {
+        clearAuthSession({ setReady: false });
       })
       .finally(() => {
-        // React StrictMode in development replays effects once, so this
-        // completion path must not depend on component-local mount flags.
-        if (hasPendingSocialProvider) {
-          clearPendingSocialAuthProvider();
-        }
-
         if (useAuthStore.getState().authBootstrapStatus === 'loading') {
           setAuthBootstrapReady();
         }
       });
-  }, [location.pathname, navigate]);
+  }, [location.pathname]);
 
   return {
     authBootstrapStatus,

--- a/src/features/auth/hooks/useAuthSessionState.ts
+++ b/src/features/auth/hooks/useAuthSessionState.ts
@@ -9,7 +9,7 @@ function useAuthSessionState() {
   const authBootstrapStatus = useAuthStore(
     (state) => state.authBootstrapStatus,
   );
-  const isAuthLoading = authBootstrapStatus === 'loading';
+  const isAuthLoading = authBootstrapStatus !== 'ready';
   const isAuthReady = authBootstrapStatus === 'ready';
   const accessStatus: AuthAccessStatus = !isAuthReady
     ? 'loading'

--- a/src/features/auth/hooks/useLoginForm.ts
+++ b/src/features/auth/hooks/useLoginForm.ts
@@ -117,7 +117,26 @@ function useLoginForm() {
     setFormMessage(
       locationState?.errorMessage ?? locationSearchErrorMessage ?? '',
     );
-  }, [locationState?.errorMessage, locationSearchErrorMessage]);
+
+    // Clear location state to prevent message from persisting on reload
+    if (locationState?.errorMessage || locationState?.noticeMessage) {
+      navigate(location.pathname + location.search, {
+        replace: true,
+        state: {
+          ...locationState,
+          errorMessage: undefined,
+          noticeMessage: undefined,
+        },
+      });
+    }
+  }, [
+    locationState,
+    locationState?.errorMessage,
+    locationSearchErrorMessage,
+    location.pathname,
+    location.search,
+    navigate,
+  ]);
 
   useEffect(() => {
     setNoticeMessage(

--- a/src/features/auth/utils/accessToken.ts
+++ b/src/features/auth/utils/accessToken.ts
@@ -1,0 +1,67 @@
+const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 30_000;
+
+type AccessTokenPayload = {
+  exp?: number;
+};
+
+const decodeBase64Url = (value: string) => {
+  const normalizedValue = value.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingLength = (4 - (normalizedValue.length % 4)) % 4;
+  const paddedValue = `${normalizedValue}${'='.repeat(paddingLength)}`;
+
+  if (typeof window === 'undefined' || typeof window.atob !== 'function') {
+    throw new Error('Access token decoding is only available in the browser.');
+  }
+
+  return window.atob(paddedValue);
+};
+
+const decodeAccessTokenPayload = (
+  accessToken: string,
+): AccessTokenPayload | null => {
+  const normalizedAccessToken = accessToken.trim();
+
+  if (!normalizedAccessToken) {
+    return null;
+  }
+
+  const tokenSegments = normalizedAccessToken.split('.');
+
+  if (tokenSegments.length < 2) {
+    return null;
+  }
+
+  try {
+    const decodedPayload = decodeBase64Url(tokenSegments[1]);
+    return JSON.parse(decodedPayload) as AccessTokenPayload;
+  } catch {
+    return null;
+  }
+};
+
+export const getAccessTokenExpiryEpochMs = (accessToken: string) => {
+  const decodedPayload = decodeAccessTokenPayload(accessToken);
+
+  if (
+    !decodedPayload ||
+    typeof decodedPayload.exp !== 'number' ||
+    !Number.isFinite(decodedPayload.exp)
+  ) {
+    return null;
+  }
+
+  return decodedPayload.exp * 1000;
+};
+
+export const isAccessTokenExpiringSoon = (
+  accessToken: string,
+  bufferMs = ACCESS_TOKEN_EXPIRY_BUFFER_MS,
+) => {
+  const expiryEpochMs = getAccessTokenExpiryEpochMs(accessToken);
+
+  if (!expiryEpochMs) {
+    return true;
+  }
+
+  return expiryEpochMs - Date.now() < bufferMs;
+};

--- a/src/features/auth/utils/sessionManager.ts
+++ b/src/features/auth/utils/sessionManager.ts
@@ -1,3 +1,5 @@
+import { AxiosError } from 'axios';
+
 import { useAuthStore } from '../../../store/useAuthStore';
 import {
   AUTH_SESSION_EXPIRED_NOTICE_MESSAGE,
@@ -18,8 +20,12 @@ import type {
 
 type RestoredAuthSession = {
   accessToken: string;
-  profile: CurrentUserProfileResponse;
-  socialAccount: CurrentUserSocialResponse;
+  profile: CurrentUserProfileResponse | null;
+  socialAccount: CurrentUserSocialResponse | null;
+};
+
+type ClearAuthSessionOptions = {
+  setReady?: boolean;
 };
 
 let restoreAuthSessionPromise: Promise<RestoredAuthSession> | null = null;
@@ -55,9 +61,14 @@ export const applyAuthenticatedSession = (
   setAuthBootstrapReady();
 };
 
-export const clearAuthSession = () => {
+export const clearAuthSession = ({
+  setReady = true,
+}: ClearAuthSessionOptions = {}) => {
   useAuthStore.getState().clearAuth();
-  setAuthBootstrapReady();
+
+  if (setReady) {
+    setAuthBootstrapReady();
+  }
 };
 
 const hasSessionRestoreHint = () => {
@@ -70,16 +81,47 @@ const hasSessionRestoreHint = () => {
   );
 };
 
+const isAuthBootstrapPending = () =>
+  useAuthStore.getState().authBootstrapStatus !== 'ready';
+
+const isAuthSessionInvalidationError = (error: unknown) =>
+  error instanceof AxiosError &&
+  (error.response?.status === 401 || error.response?.status === 403);
+
 export const hydrateAuthSessionFromAccessToken = async (
   accessToken: string,
 ) => {
   applyAccessToken(accessToken);
 
-  try {
-    const [profile, socialAccount] = await Promise.all([
-      getCurrentUserProfile(),
-      getCurrentUserSocialProfile(),
-    ]);
+  const [profileResult, socialAccountResult] = await Promise.allSettled([
+    getCurrentUserProfile(),
+    getCurrentUserSocialProfile(),
+  ]);
+  const failedResults = [profileResult, socialAccountResult].filter(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+  const invalidationError = failedResults.find((result) =>
+    isAuthSessionInvalidationError(result.reason),
+  );
+
+  if (invalidationError) {
+    clearAuthSession({
+      setReady: !isAuthBootstrapPending(),
+    });
+    throw invalidationError.reason;
+  }
+
+  const currentStore = useAuthStore.getState();
+  const profile =
+    profileResult.status === 'fulfilled'
+      ? profileResult.value
+      : currentStore.account;
+  const socialAccount =
+    socialAccountResult.status === 'fulfilled'
+      ? socialAccountResult.value
+      : currentStore.socialAccount;
+
+  if (profile && socialAccount) {
     applyAuthenticatedSession(accessToken, profile, socialAccount);
 
     return {
@@ -87,10 +129,17 @@ export const hydrateAuthSessionFromAccessToken = async (
       profile,
       socialAccount,
     };
-  } catch (error) {
-    clearAuthSession();
-    throw error;
   }
+
+  syncAuthAccount(profile ?? null);
+  syncAuthSocialAccount(socialAccount ?? null);
+  setAuthBootstrapReady();
+
+  return {
+    accessToken,
+    profile: profile ?? null,
+    socialAccount: socialAccount ?? null,
+  };
 };
 
 export const refreshStoredAccessToken = async () => {
@@ -106,10 +155,13 @@ export const restoreAuthSession = async () => {
     return await hydrateAuthSessionFromAccessToken(accessToken);
   } catch (error) {
     const shouldNotifySessionRestoreFailure = hasSessionRestoreHint();
+    const shouldDeferSessionReset = isAuthBootstrapPending();
 
-    clearAuthSession();
+    clearAuthSession({
+      setReady: !shouldDeferSessionReset,
+    });
 
-    if (shouldNotifySessionRestoreFailure) {
+    if (shouldNotifySessionRestoreFailure && !shouldDeferSessionReset) {
       notifyAuthSessionExpired({
         noticeMessage: AUTH_SESSION_RESTORE_FAILED_NOTICE_MESSAGE,
         source: 'refresh',
@@ -149,6 +201,15 @@ export const expireAuthSession = (
     source: 'refresh',
   },
 ) => {
-  clearAuthSession();
+  const shouldDeferSessionExpiration = isAuthBootstrapPending();
+
+  clearAuthSession({
+    setReady: !shouldDeferSessionExpiration,
+  });
+
+  if (shouldDeferSessionExpiration) {
+    return;
+  }
+
   notifyAuthSessionExpired(detail);
 };

--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -1,4 +1,8 @@
-import { apiBaseUrl, mockServiceWorkerEnabled } from '@/lib/env';
+import {
+  apiBaseUrl,
+  configuredApiBaseUrl,
+  mockServiceWorkerEnabled,
+} from '@/lib/env';
 import { AUTH_BASE_PATH } from '../constants/auth';
 import type { SocialAuthProvider } from '../types/auth';
 
@@ -28,6 +32,8 @@ const isLocalFrontendRuntime = () => {
   return LOCAL_FRONTEND_HOSTNAMES.has(window.location.hostname);
 };
 
+const normalizeBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
+
 export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
   const socialLoginStartPath = isLocalFrontendRuntime()
     ? SOCIAL_AUTH_LOCAL_START_PATHS[provider]
@@ -37,7 +43,14 @@ export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
     return socialLoginStartPath;
   }
 
-  const normalizedApiBaseUrl = apiBaseUrl.trim().replace(/\/$/, '');
+  const normalizedConfiguredApiBaseUrl = normalizeBaseUrl(configuredApiBaseUrl);
+  const normalizedApiBaseUrl = normalizeBaseUrl(apiBaseUrl);
+
+  // 로컬 소셜 로그인 시작은 backend origin에서 직접 시작해야
+  // OAuth용 state/PKCE 쿠키가 backend 도메인 기준으로 유지된다.
+  if (isLocalFrontendRuntime() && normalizedConfiguredApiBaseUrl) {
+    return `${normalizedConfiguredApiBaseUrl}${socialLoginStartPath}`;
+  }
 
   if (normalizedApiBaseUrl) {
     return `${normalizedApiBaseUrl}${socialLoginStartPath}`;

--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -1,8 +1,4 @@
-import {
-  apiBaseUrl,
-  configuredApiBaseUrl,
-  mockServiceWorkerEnabled,
-} from '@/lib/env';
+import { mockServiceWorkerEnabled } from '@/lib/env';
 import { AUTH_BASE_PATH } from '../constants/auth';
 import type { SocialAuthProvider } from '../types/auth';
 
@@ -16,46 +12,14 @@ const SOCIAL_AUTH_START_PATHS: Record<SocialAuthProvider, string> = {
   naver: `${AUTH_BASE_PATH}/social-login/naver`,
 };
 
-const SOCIAL_AUTH_LOCAL_START_PATHS: Record<SocialAuthProvider, string> = {
-  google: `${AUTH_BASE_PATH}/social-login/google/local`,
-  kakao: `${AUTH_BASE_PATH}/social-login/kakao/local`,
-  naver: `${AUTH_BASE_PATH}/social-login/naver/local`,
-};
-
-const LOCAL_FRONTEND_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
-
-const isLocalFrontendRuntime = () => {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  return LOCAL_FRONTEND_HOSTNAMES.has(window.location.hostname);
-};
-
-const normalizeBaseUrl = (value: string) => value.trim().replace(/\/$/, '');
-
 export const getSocialLoginStartUrl = (provider: SocialAuthProvider) => {
-  const socialLoginStartPath = isLocalFrontendRuntime()
-    ? SOCIAL_AUTH_LOCAL_START_PATHS[provider]
-    : SOCIAL_AUTH_START_PATHS[provider];
+  const socialLoginStartPath = SOCIAL_AUTH_START_PATHS[provider];
 
   if (mockServiceWorkerEnabled) {
     return socialLoginStartPath;
   }
 
-  const normalizedConfiguredApiBaseUrl = normalizeBaseUrl(configuredApiBaseUrl);
-  const normalizedApiBaseUrl = normalizeBaseUrl(apiBaseUrl);
-
-  // 로컬 소셜 로그인 시작은 backend origin에서 직접 시작해야
-  // OAuth용 state/PKCE 쿠키가 backend 도메인 기준으로 유지된다.
-  if (isLocalFrontendRuntime() && normalizedConfiguredApiBaseUrl) {
-    return `${normalizedConfiguredApiBaseUrl}${socialLoginStartPath}`;
-  }
-
-  if (normalizedApiBaseUrl) {
-    return `${normalizedApiBaseUrl}${socialLoginStartPath}`;
-  }
-
+  // Always use relative path to go through Vite Proxy in development
   return socialLoginStartPath;
 };
 

--- a/src/features/games/components/GameDetailModal.tsx
+++ b/src/features/games/components/GameDetailModal.tsx
@@ -162,7 +162,7 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
     detailQuery,
     handleToggleLike,
     hasResolvedDetail,
-    isLikePending,
+    isLikeInteractionDisabled,
     isLiked,
     likeCount,
     likeLabel,
@@ -404,9 +404,9 @@ const GameDetailModal = ({ game, onClose }: GameDetailModalProps) => {
                     type="button"
                     aria-label={likeLabel}
                     aria-pressed={isLiked}
-                    aria-disabled={isLikePending}
+                    aria-disabled={isLikeInteractionDisabled}
                     title={likeLabel}
-                    disabled={isLikePending}
+                    disabled={isLikeInteractionDisabled}
                     onClick={handleToggleLike}
                     className={`inline-flex h-10 shrink-0 cursor-pointer items-center gap-2 rounded-md border px-3 text-sm font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d20b12] disabled:cursor-wait disabled:opacity-70 ${
                       isLiked

--- a/src/features/games/hooks/useGameDetailModal.ts
+++ b/src/features/games/hooks/useGameDetailModal.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 
 import { useAuthStore } from '../../../store/useAuthStore';
 import { shouldRetryApiQuery } from '../../../api/queryRetry';
+import useAuthSessionState from '../../auth/hooks/useAuthSessionState';
 import {
   GAME_DETAIL_GC_TIME,
   GAME_DETAIL_STALE_TIME,
@@ -14,6 +15,8 @@ import { gamesKeys, syncLikeMutationStateInQueryCache } from '../queryCache';
 import type { GameDetail, GameListItem } from '../types';
 
 const LOGIN_REQUIRED_MESSAGE = '로그인 후 찜하기를 사용할 수 있어요.';
+const AUTH_CHECK_PENDING_MESSAGE =
+  '로그인 상태를 확인하고 있어요. 잠시만 기다려 주세요.';
 const LIKE_ERROR_MESSAGE =
   '찜하기 상태를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.';
 const DETAIL_NOT_FOUND_MESSAGE = '해당 게임 상세 정보를 찾을 수 없습니다.';
@@ -54,6 +57,7 @@ const getDetailErrorKind = (error: unknown): DetailErrorKind => {
 
 export const useGameDetailModal = (game: GameListItem) => {
   const accessToken = useAuthStore((state) => state.accessToken);
+  const { isAuthLoading } = useAuthSessionState();
   const queryClient = useQueryClient();
   const [likeState, setLikeState] = useState<{
     gameId: number;
@@ -126,8 +130,17 @@ export const useGameDetailModal = (game: GameListItem) => {
       });
     },
   });
+  const isLikeInteractionDisabled = isAuthLoading || likeMutation.isPending;
 
   const handleToggleLike = () => {
+    if (isAuthLoading) {
+      setToast({
+        message: AUTH_CHECK_PENDING_MESSAGE,
+        tone: 'error',
+      });
+      return;
+    }
+
     if (!accessToken) {
       setToast({
         message: LOGIN_REQUIRED_MESSAGE,
@@ -161,7 +174,7 @@ export const useGameDetailModal = (game: GameListItem) => {
     detailQuery,
     handleToggleLike,
     hasResolvedDetail: Boolean(detail),
-    isLikePending: likeMutation.isPending,
+    isLikeInteractionDisabled,
     isLiked,
     likeCount: Math.max(
       0,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -77,8 +77,13 @@ export const canToggleDevApiMode = import.meta.env.DEV;
 export const mockServiceWorkerEnabled =
   import.meta.env.DEV && devApiMode === 'mock';
 
-// MSW 모드에서는 절대 API 호스트를 비워, 상대 경로 요청이 핸들러에 안정적으로 매칭되게 한다.
-export const apiBaseUrl = mockServiceWorkerEnabled ? '' : configuredApiBaseUrl;
+const shouldUseRelativeApiBaseUrl = import.meta.env.DEV;
+
+// 개발 환경에서는 항상 상대 경로(`/api/...`)를 사용해 Vite 프록시나
+// MSW가 요청을 동일한 진입점에서 가로챌 수 있게 맞춘다.
+export const apiBaseUrl = shouldUseRelativeApiBaseUrl
+  ? ''
+  : configuredApiBaseUrl;
 
 export const isMockServiceWorkerEnabled = () => mockServiceWorkerEnabled;
 export const getCurrentDevApiMode = () => devApiMode;

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -6,7 +6,7 @@ import type {
 
 /**
  * [Auth] 쿠키 기반 세션 복구 업데이트
- * - Access Token: 클라이언트 메모리(Zustand State)에서만 유지합니다.
+ * - Access Token: sessionStorage 및 클라이언트 메모리(Zustand State)에서 유지합니다.
  * - Refresh Token: 브라우저 HttpOnly Cookie 기반 관리 (백엔드 주도)
  * - 레거시 localStorage 인증 키는 앱 시작 시 1회 정리합니다.
  */
@@ -14,7 +14,56 @@ import type {
 export type AuthBootstrapStatus = 'idle' | 'loading' | 'ready';
 export type AuthAccessStatus = 'loading' | 'authenticated' | 'unauthenticated';
 
+export const AUTH_ACCESS_TOKEN_STORAGE_KEY = 'access_token';
+const LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY = 'auth-access-token';
 const AUTH_PROFILE_PREVIEW_STORAGE_KEY = 'auth-profile-preview-image-url';
+
+export const readStoredAccessToken = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const persistedAccessToken =
+    window.sessionStorage.getItem(AUTH_ACCESS_TOKEN_STORAGE_KEY)?.trim() ?? '';
+
+  if (persistedAccessToken) {
+    return persistedAccessToken;
+  }
+
+  const legacyAccessToken =
+    window.sessionStorage
+      .getItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY)
+      ?.trim() ?? '';
+
+  if (!legacyAccessToken) {
+    return null;
+  }
+
+  window.sessionStorage.setItem(
+    AUTH_ACCESS_TOKEN_STORAGE_KEY,
+    legacyAccessToken,
+  );
+  window.sessionStorage.removeItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY);
+
+  return legacyAccessToken;
+};
+
+const persistAccessToken = (token: string | null) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const normalizedToken = token?.trim() ?? '';
+
+  if (!normalizedToken) {
+    window.sessionStorage.removeItem(AUTH_ACCESS_TOKEN_STORAGE_KEY);
+    window.sessionStorage.removeItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY);
+    return;
+  }
+
+  window.sessionStorage.setItem(AUTH_ACCESS_TOKEN_STORAGE_KEY, normalizedToken);
+  window.sessionStorage.removeItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY);
+};
 
 const readPersistedProfilePreviewImageUrl = () => {
   if (typeof window === 'undefined') {
@@ -69,62 +118,91 @@ export type AuthSessionStateSnapshot = {
   accessStatus: AuthAccessStatus;
 };
 
-export const useAuthStore = create<AuthState>((set) => ({
-  accessToken: null,
-  account: null,
-  socialAccount: null,
-  profilePreviewImageUrl: readPersistedProfilePreviewImageUrl(),
-  isAuthenticated: false,
-  authBootstrapStatus: 'idle',
+export const useAuthStore = create<AuthState>((set) => {
+  const persistedAccessToken = readStoredAccessToken();
 
-  setAccessToken: (token) =>
-    set({
-      accessToken: token,
-      isAuthenticated: !!token,
-    }),
+  return {
+    accessToken: persistedAccessToken,
+    account: null,
+    socialAccount: null,
+    profilePreviewImageUrl: readPersistedProfilePreviewImageUrl(),
+    isAuthenticated: Boolean(persistedAccessToken),
+    authBootstrapStatus: 'idle',
 
-  setAccount: (account) => {
-    persistProfilePreviewImageUrl(account?.profile_img_url);
-    set({
-      account,
-      profilePreviewImageUrl: account?.profile_img_url?.trim() ?? null,
-    });
-  },
+    setAccessToken: (token) => {
+      const normalizedToken = token.trim();
+      persistAccessToken(normalizedToken);
+      set({
+        accessToken: normalizedToken,
+        isAuthenticated: Boolean(normalizedToken),
+      });
+    },
 
-  setSocialAccount: (socialAccount) => {
-    set({
-      socialAccount,
-    });
-  },
+    setAccount: (account) => {
+      persistProfilePreviewImageUrl(account?.profile_img_url);
+      set({
+        account,
+        profilePreviewImageUrl: account?.profile_img_url?.trim() ?? null,
+      });
+    },
 
-  setAuth: (token, account, socialAccount) => {
-    persistProfilePreviewImageUrl(account?.profile_img_url);
-    set({
-      accessToken: token,
-      account: account,
-      socialAccount,
-      profilePreviewImageUrl: account?.profile_img_url?.trim() ?? null,
-      isAuthenticated: true,
-    });
-  },
+    setSocialAccount: (socialAccount) => {
+      set({
+        socialAccount,
+      });
+    },
 
-  clearAuth: () => {
-    persistProfilePreviewImageUrl(null);
-    set({
-      accessToken: null,
-      account: null,
-      socialAccount: null,
-      profilePreviewImageUrl: null,
-      isAuthenticated: false,
-    });
-  },
+    setAuth: (token, account, socialAccount) => {
+      const normalizedToken = token.trim();
+      persistAccessToken(normalizedToken);
+      persistProfilePreviewImageUrl(account?.profile_img_url);
+      set({
+        accessToken: normalizedToken,
+        account,
+        socialAccount,
+        profilePreviewImageUrl: account?.profile_img_url?.trim() ?? null,
+        isAuthenticated: true,
+      });
+    },
 
-  setAuthBootstrapStatus: (status) => {
-    set({
-      authBootstrapStatus: status,
-    });
-  },
-}));
+    clearAuth: () => {
+      persistAccessToken(null);
+      persistProfilePreviewImageUrl(null);
+      set({
+        accessToken: null,
+        account: null,
+        socialAccount: null,
+        profilePreviewImageUrl: null,
+        isAuthenticated: false,
+      });
+    },
+
+    setAuthBootstrapStatus: (status) => {
+      set({
+        authBootstrapStatus: status,
+      });
+    },
+  };
+});
+
+export const syncAccessTokenFromStorage = () => {
+  const storedAccessToken = readStoredAccessToken();
+  const currentState = useAuthStore.getState();
+  const normalizedStoredAccessToken = storedAccessToken?.trim() ?? null;
+  const normalizedStateAccessToken = currentState.accessToken?.trim() ?? null;
+
+  if (normalizedStoredAccessToken === normalizedStateAccessToken) {
+    return normalizedStoredAccessToken;
+  }
+
+  if (normalizedStoredAccessToken) {
+    currentState.setAccessToken(normalizedStoredAccessToken);
+    return normalizedStoredAccessToken;
+  }
+
+  currentState.clearAuth();
+  return null;
+};
 
 /**
  * 기존 localStorage에 저장되던 모든 인증 관련 레거시 키를 삭제합니다.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,13 +2,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, URL } from 'node:url';
 
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 
 const LOCAL_HTTPS_KEY_PATH = path.resolve('certs/localhost-key.pem');
 const LOCAL_HTTPS_CERT_PATH = path.resolve('certs/localhost.pem');
-const isLocalHttpsEnabled = process.env.VITE_DEV_HTTPS === 'true';
+const DEFAULT_API_PROXY_TARGET = 'https://oz-pgti.duckdns.org';
 
 const readLocalHttpsConfig = () => {
   if (
@@ -32,19 +32,38 @@ const readLocalHttpsConfig = () => {
   };
 };
 
+const normalizeProxyTarget = (value: string | undefined) =>
+  value?.trim().replace(/\/$/, '') || DEFAULT_API_PROXY_TARGET;
+
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const isLocalHttpsEnabled = env.VITE_DEV_HTTPS === 'true';
+  const apiProxyTarget = normalizeProxyTarget(
+    env.VITE_API_PROXY_TARGET || env.VITE_API_BASE_URL,
+  );
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
     },
-  },
-  server: isLocalHttpsEnabled
-    ? {
-        host: 'localhost',
-        port: 5173,
-        https: readLocalHttpsConfig(),
-      }
-    : undefined,
+    server: {
+      host: 'localhost',
+      port: 5173,
+      proxy: {
+        '/api': {
+          target: apiProxyTarget,
+          changeOrigin: true,
+          secure: false,
+          // Strip the backend cookie domain in dev so refresh cookies bind to
+          // localhost and survive same-origin reloads through the Vite proxy.
+          cookieDomainRewrite: '',
+        },
+      },
+      ...(isLocalHttpsEnabled ? { https: readLocalHttpsConfig() } : {}),
+    },
+  };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,36 +1,11 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import { fileURLToPath, URL } from 'node:url';
 
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import mkcert from 'vite-plugin-mkcert';
 
-const LOCAL_HTTPS_KEY_PATH = path.resolve('certs/localhost-key.pem');
-const LOCAL_HTTPS_CERT_PATH = path.resolve('certs/localhost.pem');
 const DEFAULT_API_PROXY_TARGET = 'https://oz-pgti.duckdns.org';
-
-const readLocalHttpsConfig = () => {
-  if (
-    !fs.existsSync(LOCAL_HTTPS_KEY_PATH) ||
-    !fs.existsSync(LOCAL_HTTPS_CERT_PATH)
-  ) {
-    throw new Error(
-      [
-        '로컬 HTTPS 인증서를 찾을 수 없습니다.',
-        '`npm run dev` 전에 아래 명령을 먼저 실행해주세요.',
-        'mkcert -install',
-        'mkdir -p certs',
-        'mkcert -key-file certs/localhost-key.pem -cert-file certs/localhost.pem localhost 127.0.0.1 ::1',
-      ].join('\n'),
-    );
-  }
-
-  return {
-    key: fs.readFileSync(LOCAL_HTTPS_KEY_PATH),
-    cert: fs.readFileSync(LOCAL_HTTPS_CERT_PATH),
-  };
-};
 
 const normalizeProxyTarget = (value: string | undefined) =>
   value?.trim().replace(/\/$/, '') || DEFAULT_API_PROXY_TARGET;
@@ -38,13 +13,17 @@ const normalizeProxyTarget = (value: string | undefined) =>
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
-  const isLocalHttpsEnabled = env.VITE_DEV_HTTPS === 'true';
+  const isLocalHttpsEnabled = true; // Always enable HTTPS for local development to support Secure cookies
   const apiProxyTarget = normalizeProxyTarget(
     env.VITE_API_PROXY_TARGET || env.VITE_API_BASE_URL,
   );
 
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [
+      react(),
+      tailwindcss(),
+      ...(isLocalHttpsEnabled ? [mkcert()] : []),
+    ],
     resolve: {
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),
@@ -53,17 +32,20 @@ export default defineConfig(({ mode }) => {
     server: {
       host: 'localhost',
       port: 5173,
+      ...(isLocalHttpsEnabled ? { https: {} } : {}),
       proxy: {
         '/api': {
           target: apiProxyTarget,
           changeOrigin: true,
           secure: false,
-          // Strip the backend cookie domain in dev so refresh cookies bind to
-          // localhost and survive same-origin reloads through the Vite proxy.
-          cookieDomainRewrite: '',
+          // Rewrite backend cookie domain to localhost so the browser accepts
+          // rotated refresh cookies during local development.
+          cookieDomainRewrite: {
+            'oz-pgti.duckdns.org': 'localhost',
+            '*': '',
+          },
         },
       },
-      ...(isLocalHttpsEnabled ? { https: readLocalHttpsConfig() } : {}),
     },
   };
 });


### PR DESCRIPTION
## 관련 이슈

- closes #381

## 변경 내용

- 액세스 토큰을 `sessionStorage`의 `access_token` 기준으로 저장·복구하도록 인증 상태 관리 로직을 정리하고, 앱 부트스트랩 시 저장된 토큰이 있으면 무조건 `/refresh`를 호출하지 않도록 변경했습니다.
- 저장된 액세스 토큰의 만료 시각(`exp`)을 파싱하는 유틸을 추가하고, 만료까지 30초 미만으로 남은 경우에만 앱 시작 시 선제적으로 refresh를 수행하도록 인증 초기화 흐름을 보강했습니다.
- Axios 요청 인터셉터가 항상 `sessionStorage` 기준 최신 액세스 토큰을 Authorization 헤더에 반영하도록 수정하고, refresh 실패 시 대기 중인 요청 reject 처리와 `401/403` 세션 만료 처리 흐름을 강화했습니다.
- 로컬 개발 환경에서 Secure 쿠키 검증이 가능하도록 `vite-plugin-mkcert`를 도입하고, Vite dev server HTTPS 및 프록시 관련 안내를 README에 반영했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 변경은 프론트 인증 부트스트랩/refresh 처리 안정화와 로컬 HTTPS 개발 환경 정리에 초점이 있습니다.
- 백엔드 RTR(Refresh Token Rotation) 정책에 Reuse Gap(Grace Period) 도입 여부와 `/refresh` 403 원인 로그 확인이 추가로 필요합니다.
- 브라우저에서 실제 토큰 만료 임박 상태 및 새로고침 연타 시나리오는 별도 실동작 확인이 필요합니다.
