### PR TITLE
[Refactor] 메인 API 전환 도구 패널 통합

### DIFF
--- a/src/components/common/DevApiModeToggle.tsx
+++ b/src/components/common/DevApiModeToggle.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../lib/env';
 
 type DevApiModeToggleProps = {
-  variant?: 'floating' | 'compact' | 'fab';
+  variant?: 'floating' | 'compact' | 'fab' | 'dock';
   className?: string;
 };
 
@@ -36,19 +36,26 @@ function DevApiModeToggle({
   const isMockMode = currentMode === 'mock';
   const isCompact = variant === 'compact';
   const isFab = variant === 'fab';
+  const isDock = variant === 'dock';
 
-  if (isFab) {
+  if (isFab || isDock) {
     return (
       <div
-        className={`relative flex h-14 w-[12rem] items-center rounded-full border border-[#ff6b63]/36 bg-[#120b0b]/92 p-1 shadow-[0_22px_48px_rgba(0,0,0,0.42),0_0_28px_rgba(223,59,51,0.24)] backdrop-blur-xl ${className}`}
+        className={`relative flex items-center rounded-full border border-[#ff6b63]/36 bg-[#120b0b]/92 p-1 shadow-[0_22px_48px_rgba(0,0,0,0.42),0_0_28px_rgba(223,59,51,0.24)] backdrop-blur-xl ${
+          isDock ? 'h-12 w-[10.75rem]' : 'h-14 w-[12rem]'
+        } ${className}`}
         role="group"
         aria-label="개발 API 모드 전환"
       >
         <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.1),transparent_54%)]" />
         <span
-          className="pointer-events-none absolute top-1 left-1 h-12 w-[4.5rem] rounded-full border border-[#ff8d84]/42 bg-[linear-gradient(180deg,#ff6b5f_0%,#d92b22_100%)] shadow-[0_14px_30px_rgba(217,43,34,0.32),inset_0_1px_0_rgba(255,255,255,0.18)] transition-transform duration-300 ease-out motion-reduce:transition-none"
+          className={`pointer-events-none absolute top-1 left-1 rounded-full border border-[#ff8d84]/42 bg-[linear-gradient(180deg,#ff6b5f_0%,#d92b22_100%)] shadow-[0_14px_30px_rgba(217,43,34,0.32),inset_0_1px_0_rgba(255,255,255,0.18)] transition-transform duration-300 ease-out motion-reduce:transition-none ${
+            isDock ? 'h-10 w-[4rem]' : 'h-12 w-[4.5rem]'
+          }`}
           style={{
-            transform: `translateX(${isMockMode ? 0 : 112}px)`,
+            transform: `translateX(${
+              isDock ? (isMockMode ? 0 : 98) : isMockMode ? 0 : 112
+            }px)`,
           }}
           aria-hidden="true"
         />
@@ -60,9 +67,11 @@ function DevApiModeToggle({
               toggleDevApiMode('mock');
             }
           }}
-          className={`relative z-10 flex h-full w-[4.5rem] cursor-pointer items-center justify-center rounded-full text-sm font-extrabold tracking-[0.04em] transition-colors duration-300 focus-visible:outline-none motion-reduce:transition-none ${
-            isMockMode ? 'text-white' : 'text-white/58 hover:text-white/82'
-          }`}
+          className={`relative z-10 flex h-full cursor-pointer items-center justify-center rounded-full font-extrabold transition-colors duration-300 focus-visible:outline-none motion-reduce:transition-none ${
+            isDock
+              ? 'w-[4rem] text-[0.72rem] tracking-[0.08em]'
+              : 'w-[4.5rem] text-sm tracking-[0.04em]'
+          } ${isMockMode ? 'text-white' : 'text-white/58 hover:text-white/82'}`}
           aria-pressed={isMockMode}
           aria-label="MSW 모드로 전환"
           title="MSW 모드"
@@ -76,8 +85,12 @@ function DevApiModeToggle({
           </span>
         </button>
 
-        <span className="relative z-10 inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/8 bg-white/[0.04] text-white/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
-          <ArrowRightLeft size={15} />
+        <span
+          className={`relative z-10 inline-flex items-center justify-center rounded-full border border-white/8 bg-white/[0.04] text-white/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ${
+            isDock ? 'h-7 w-7' : 'h-8 w-8'
+          }`}
+        >
+          <ArrowRightLeft size={isDock ? 13 : 15} />
         </span>
 
         <button
@@ -87,7 +100,11 @@ function DevApiModeToggle({
               toggleDevApiMode('real');
             }
           }}
-          className={`relative z-10 flex h-full w-[4.5rem] cursor-pointer items-center justify-center rounded-full text-sm font-extrabold tracking-[0.02em] transition-colors duration-300 focus-visible:outline-none motion-reduce:transition-none ${
+          className={`relative z-10 flex h-full cursor-pointer items-center justify-center rounded-full font-extrabold transition-colors duration-300 focus-visible:outline-none motion-reduce:transition-none ${
+            isDock
+              ? 'w-[4rem] text-[0.72rem] tracking-[0.04em]'
+              : 'w-[4.5rem] text-sm tracking-[0.02em]'
+          } ${
             !isMockMode ? 'text-white' : 'text-white/58 hover:text-white/82'
           }`}
           aria-pressed={!isMockMode}

--- a/src/features/auth/hooks/useLoginForm.ts
+++ b/src/features/auth/hooks/useLoginForm.ts
@@ -206,8 +206,7 @@ function useLoginForm() {
       if (
         mockPanelRef.current &&
         !mockPanelRef.current.contains(event.target as Node) &&
-        !(event.target as HTMLElement)?.closest('.dev-login-fab') &&
-        !(event.target as HTMLElement)?.closest('.dev-api-mode-fab')
+        !(event.target as HTMLElement)?.closest('.dev-login-fab')
       ) {
         setIsMockPanelOpen(false);
       }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -101,8 +101,10 @@ export const toggleDevApiMode = (mode: DevApiMode) => {
     return;
   }
 
+  persistDevApiMode(mode);
+
   const currentUrl = new URL(window.location.href);
   currentUrl.searchParams.delete(DEV_API_MODE_QUERY_PARAM);
-  persistDevApiMode(mode);
-  window.location.replace(currentUrl.toString());
+  window.history.replaceState(window.history.state, '', currentUrl.toString());
+  window.location.reload();
 };

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -10,7 +10,6 @@ import {
   AUTH_SHARED_FORM_CLASS_NAMES,
   AUTH_SHARED_LAYOUT_CLASS_NAMES,
 } from '../components/auth/authSharedStyles';
-import DevApiModeToggle from '../components/common/DevApiModeToggle';
 import MainPageLoadingFallback from '../components/common/MainPageLoadingFallback';
 import AuthLayout from '../components/layout/AuthLayout';
 import { ROUTES } from '../constants/routes';
@@ -241,8 +240,6 @@ function LoginPage() {
             />
           </button>
         ) : null}
-
-        <DevApiModeToggle variant="fab" className="dev-api-mode-fab" />
       </div>
     </>
   );

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -4,6 +4,7 @@ import LazyHeader from '../../components/common/LazyHeader';
 import { ROUTES } from '../../constants/routes';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
 import type { GameListItem } from '../../features/games/types';
+import MainDevToolDock from './components/MainDevToolDock';
 import MainGamesSection from './components/MainGamesSection';
 import MainRecommendationCta from './components/MainRecommendationCta';
 import { useMainPageGames } from './hooks/useMainPageGames';
@@ -50,6 +51,8 @@ const MainPage = () => {
           onClose={() => setSelectedGame(null)}
         />
       ) : null}
+
+      <MainDevToolDock />
     </div>
   );
 };

--- a/src/pages/main/components/MainDevToolDock.tsx
+++ b/src/pages/main/components/MainDevToolDock.tsx
@@ -1,0 +1,119 @@
+import { ArrowRightLeft, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import DevApiModeToggle from '../../../components/common/DevApiModeToggle';
+import {
+  canToggleDevApiMode,
+  isMockServiceWorkerEnabled,
+} from '../../../lib/env';
+
+const DEV_TOOL_DOCK_CLASS_NAME =
+  'fixed left-4 bottom-4 z-[95] sm:left-6 sm:bottom-6';
+const DEV_API_BUTTON_CLASS_NAME =
+  'support-chat-fab group relative flex h-14 w-14 items-center justify-center rounded-full border border-[#ff7068]/48 bg-[linear-gradient(180deg,#ff6e66_0%,#d92b22_100%)] text-white shadow-[0_22px_48px_rgba(0,0,0,0.45),0_0_28px_rgba(223,59,51,0.28)] transition-transform hover:-translate-y-0.5 focus-visible:outline-none';
+const DEV_API_PANEL_CLASS_NAME =
+  'support-chat-panel absolute bottom-[calc(100%+0.75rem)] left-0 flex w-[min(92vw,19rem)] origin-bottom-left flex-col overflow-hidden rounded-[1.6rem] border border-[#ff6b63]/20 bg-[linear-gradient(180deg,rgba(20,13,13,0.98)_0%,rgba(10,8,8,0.96)_100%)] shadow-[0_28px_60px_rgba(0,0,0,0.48),0_0_36px_rgba(223,59,51,0.16)] backdrop-blur-xl transition-all duration-300 ease-out';
+
+function MainDevToolDock() {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+  const isMockMode = isMockServiceWorkerEnabled();
+
+  useEffect(() => {
+    if (!isPanelOpen) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsPanelOpen(false);
+      }
+    };
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(event.target as Node) &&
+        !(event.target as HTMLElement)?.closest('.main-dev-api-fab')
+      ) {
+        setIsPanelOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    window.addEventListener('mousedown', handleOutsideClick);
+
+    return () => {
+      window.removeEventListener('keydown', handleEscape);
+      window.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [isPanelOpen]);
+
+  if (!canToggleDevApiMode) {
+    return null;
+  }
+
+  return (
+    <div className={DEV_TOOL_DOCK_CLASS_NAME}>
+      <div className="relative">
+        <div
+          ref={panelRef}
+          className={`${DEV_API_PANEL_CLASS_NAME} ${
+            isPanelOpen
+              ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
+              : 'pointer-events-none translate-y-4 scale-95 opacity-0'
+          }`}
+          role="dialog"
+          aria-modal="false"
+          aria-label="개발용 API 전환 패널"
+        >
+          <div className="border-b border-white/8 px-4 py-3.5">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-white">API 전환</p>
+                <p className="mt-1 text-xs/5 text-white/55">
+                  {isMockMode
+                    ? '현재 MSW 모드예요. 전환하면 바로 새로고침됩니다.'
+                    : '현재 실 API 모드예요. 전환하면 바로 새로고침됩니다.'}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsPanelOpen(false)}
+                className="support-chat-icon-btn"
+                aria-label="개발용 API 전환 패널 닫기"
+              >
+                <X size={16} />
+              </button>
+            </div>
+          </div>
+
+          <div className="px-4 py-4">
+            <DevApiModeToggle variant="dock" />
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setIsPanelOpen((previous) => !previous)}
+          className={`${DEV_API_BUTTON_CLASS_NAME} main-dev-api-fab`}
+          aria-label={
+            isPanelOpen
+              ? '개발용 API 전환 패널 닫기'
+              : '개발용 API 전환 패널 열기'
+          }
+        >
+          <span className="support-chat-fab-glow" />
+          <ArrowRightLeft
+            size={21}
+            className={`relative z-10 transition-transform ${
+              isPanelOpen ? 'scale-95 -rotate-6' : 'scale-100'
+            }`}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default MainDevToolDock;


### PR DESCRIPTION
## 관련 이슈

- closes #389

## 변경 내용

- 메인 페이지 하단 고정 개발 도구 영역에 `API 전환` 버튼을 추가하고, 버튼 클릭 시에만 `MSW / 실 API` 전환 패널이 열리도록 개발용 UI를 통합했습니다.
- 기존 `DevApiModeToggle`에 메인 패널용 `dock` 변형을 추가해 로그인 페이지 계정 패널과 어울리는 알약형 토글 스타일로 재사용할 수 있도록 정리했습니다.
- 로그인 페이지에 중복 노출되던 API 전환 토글을 제거하고, 개발용 패널 바깥 클릭 처리도 현재 구조에 맞게 정리했습니다.
- API 전환 시 개발 모드를 `localStorage`에 저장한 뒤 `window.location.reload()`를 호출하도록 변경해 MSW 서비스 워커 반영이 즉시 적용되도록 맞췄습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3386" height="1834" alt="image" src="https://github.com/user-attachments/assets/67b7d518-88b5-4155-a85c-1d99f137ceff" />

## 참고사항

