### PR TITLE
[Fix]설문 실서버 정합성 및 매칭/추천 UX 개선

### DIFF
--- a/src/features/survey/api/survey.ts
+++ b/src/features/survey/api/survey.ts
@@ -145,6 +145,7 @@ export const normalizeSurveySessionResponse = (
       payload.ai_message ??
       payload.chatbot_reply ??
       null,
+    warning_message: payload.warning_message ?? null,
     progress: normalizeSurveyProgress(payload.progress, payload.progress_rate),
     status: normalizeSurveyStatus(payload.status, isCompleted),
     recommendation_ready: recommendationReady,
@@ -154,6 +155,23 @@ export const normalizeSurveySessionResponse = (
 export const normalizeSurveyResetResponse = (
   payload: SurveyApiResetResponse,
 ): SurveyResetResponse => normalizeSurveySessionResponse(payload);
+
+const ensureSurveyPromptResponse = <
+  T extends SurveySessionStartResponse | SurveyResetResponse,
+>(
+  payload: T,
+  context: 'start' | 'reset',
+) => {
+  if (payload.assistant_message || payload.recommendation_ready) {
+    return payload;
+  }
+
+  throw new Error(
+    context === 'start'
+      ? '설문 시작 응답에 첫 질문이 없습니다.'
+      : '설문 초기화 응답에 첫 질문이 없습니다.',
+  );
+};
 
 const normalizeSurveyResultItem = (
   item: SurveyApiResultItem,
@@ -187,20 +205,26 @@ export const startSurveySession =
   async (): Promise<SurveySessionStartResponse> => {
     try {
       const response = await api.post<SurveyApiSessionResponse>(
-        `${SURVEY_CHATBOT_BASE_PATH}/sessions/`,
+        `${SURVEY_CHATBOT_BASE_PATH}/sessions`,
         undefined,
         {
           timeout: SURVEY_CHATBOT_REQUEST_TIMEOUT_MS,
         },
       );
 
-      return normalizeSurveySessionResponse(response.data);
+      return ensureSurveyPromptResponse(
+        normalizeSurveySessionResponse(response.data),
+        'start',
+      );
     } catch (error) {
       if (!isMockServiceWorkerEnabled()) {
         throw error;
       }
 
-      return normalizeSurveySessionResponse(startMockSurveySession());
+      return ensureSurveyPromptResponse(
+        normalizeSurveySessionResponse(startMockSurveySession()),
+        'start',
+      );
     }
   };
 
@@ -209,7 +233,7 @@ export const continueSurveyChat = async (
 ): Promise<SurveyChatResponse> => {
   try {
     const response = await api.post<SurveyApiSessionResponse>(
-      `${SURVEY_CHATBOT_BASE_PATH}/sessions/${payload.session_id}/messages/`,
+      `${SURVEY_CHATBOT_BASE_PATH}/sessions/${payload.session_id}/messages`,
       {
         message: payload.user_answer,
       } satisfies SurveyApiChatRequest,
@@ -236,27 +260,33 @@ export const continueSurveyChat = async (
 export const resetSurveySession = async () => {
   try {
     const response = await api.post<SurveyApiResetResponse>(
-      `${SURVEY_CHATBOT_BASE_PATH}/sessions/reset/`,
+      `${SURVEY_CHATBOT_BASE_PATH}/sessions/reset`,
       undefined,
       {
         timeout: SURVEY_CHATBOT_REQUEST_TIMEOUT_MS,
       },
     );
 
-    return normalizeSurveyResetResponse(response.data);
+    return ensureSurveyPromptResponse(
+      normalizeSurveyResetResponse(response.data),
+      'reset',
+    );
   } catch (error) {
     if (!isMockServiceWorkerEnabled()) {
       throw error;
     }
 
-    return normalizeSurveyResetResponse(resetMockSurveySession());
+    return ensureSurveyPromptResponse(
+      normalizeSurveyResetResponse(resetMockSurveySession()),
+      'reset',
+    );
   }
 };
 
 export const getSurveyResults = async (query: SurveyResultQuery) => {
   try {
     const response = await api.get<SurveyApiResultResponse>(
-      `${SURVEY_CHATBOT_BASE_PATH}/sessions/${query.session_id}/recommendations/`,
+      `${SURVEY_CHATBOT_BASE_PATH}/sessions/${query.session_id}/recommendations`,
       {
         params: {
           cursor: query.cursor,

--- a/src/features/survey/components/SurveyChatPanel.tsx
+++ b/src/features/survey/components/SurveyChatPanel.tsx
@@ -201,6 +201,7 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
       : moderationHeuristicEnabled
         ? `${nonGameStrikeCount}/${NON_GAME_CHAT_MAX_STRIKES} 누적`
         : '실서버 기준';
+  const isResetTemporarilyDisabled = isSubmitting || isChatTemporarilyBlocked;
   const pendingAssistantMessage =
     pendingAction === 'continue' && !recommendationReady
       ? 'AI가 답변을 정리하고 있습니다.'
@@ -286,7 +287,7 @@ function SurveyChatPanel({ isHistoryView = false }: SurveyChatPanelProps) {
             <button
               type="button"
               onClick={handleResetClick}
-              disabled={isSubmitting}
+              disabled={isResetTemporarilyDisabled}
               className={SURVEY_CONTROL_BUTTON_CLASS}
             >
               <RotateCcw size={16} />

--- a/src/features/survey/hooks/useSurveyModerationGuard.ts
+++ b/src/features/survey/hooks/useSurveyModerationGuard.ts
@@ -94,17 +94,7 @@ export const useSurveyModerationGuard = ({
     if (nonGameStrikeCount !== 0) {
       setNonGameStrikeCount(0);
     }
-
-    if (chatBlockedUntil !== null) {
-      setChatBlockedUntil(null);
-    }
-  }, [
-    chatBlockedUntil,
-    moderationHeuristicEnabled,
-    nonGameStrikeCount,
-    setChatBlockedUntil,
-    setNonGameStrikeCount,
-  ]);
+  }, [moderationHeuristicEnabled, nonGameStrikeCount, setNonGameStrikeCount]);
 
   const remainingBlockTimeMs = chatBlockedUntil
     ? Math.max(chatBlockedUntil - currentTime, 0)
@@ -112,12 +102,12 @@ export const useSurveyModerationGuard = ({
   const hasReachedNonGameChatLimit = moderationHeuristicEnabled
     ? nonGameStrikeCount >= NON_GAME_CHAT_MAX_STRIKES
     : false;
-  const isChatTemporarilyBlocked = moderationHeuristicEnabled
-    ? Boolean(chatBlockedUntil && remainingBlockTimeMs > 0)
-    : false;
-  const hasExpiredChatBlock = moderationHeuristicEnabled
-    ? Boolean(chatBlockedUntil && remainingBlockTimeMs <= 0)
-    : false;
+  const isChatTemporarilyBlocked = Boolean(
+    chatBlockedUntil && remainingBlockTimeMs > 0,
+  );
+  const hasExpiredChatBlock = Boolean(
+    chatBlockedUntil && remainingBlockTimeMs <= 0,
+  );
   const isTextareaDisabled =
     isSubmitting ||
     recommendationReady ||

--- a/src/features/survey/mocks/handlers.ts
+++ b/src/features/survey/mocks/handlers.ts
@@ -106,7 +106,7 @@ const getQuestionCountFromAnswer = (answer: string) => {
 };
 
 export const surveyHandlers = [
-  http.post('/api/v1/survey/chatbot/sessions/', async () => {
+  http.post('/api/v1/survey/chatbot/sessions', async () => {
     const sessionId = createSessionId();
     const totalQuestions = SURVEY_MAX_STEPS;
 
@@ -127,7 +127,7 @@ export const surveyHandlers = [
   }),
 
   http.post(
-    '/api/v1/survey/chatbot/sessions/:sessionId/messages/',
+    '/api/v1/survey/chatbot/sessions/:sessionId/messages',
     async ({ request, params }) => {
       const body = (await request.json()) as SurveyApiChatRequest;
       const sessionId = String(params.sessionId ?? '');
@@ -181,7 +181,7 @@ export const surveyHandlers = [
   ),
 
   http.get(
-    '/api/v1/survey/chatbot/sessions/:sessionId/recommendations/',
+    '/api/v1/survey/chatbot/sessions/:sessionId/recommendations',
     async ({ request, params }) => {
       const url = new URL(request.url);
       const cursor = Number(url.searchParams.get('cursor') ?? '0');
@@ -217,7 +217,7 @@ export const surveyHandlers = [
     },
   ),
 
-  http.post('/api/v1/survey/chatbot/sessions/reset/', async () => {
+  http.post('/api/v1/survey/chatbot/sessions/reset', async () => {
     surveySessions.clear();
     latestCompletedSurveySessionId = null;
 

--- a/src/features/survey/store/useSurveyStore.ts
+++ b/src/features/survey/store/useSurveyStore.ts
@@ -57,16 +57,31 @@ const SURVEY_INTRO_MESSAGE =
 const COMPLETION_GUIDE_MESSAGE =
   "추천 결과가 준비되었어요. 아래의 '추천 결과 바로 보기' 버튼을 눌러 확인해 보세요.";
 
-const getInitialMessages = (payload: SurveySessionStartResponse) => {
+const getInitialAssistantMessages = (payload: SurveySessionStartResponse) => {
+  const messages: SurveyMessage[] = [
+    createMessage('assistant', SURVEY_INTRO_MESSAGE),
+  ];
+
+  if (payload.warning_message) {
+    messages.push(createMessage('assistant', payload.warning_message));
+  }
+
   if (payload.assistant_message) {
-    return [
-      createMessage('assistant', SURVEY_INTRO_MESSAGE),
-      createMessage('assistant', payload.assistant_message),
-    ];
+    messages.push(createMessage('assistant', payload.assistant_message));
+  } else if (payload.recommendation_ready) {
+    messages.push(createMessage('assistant', COMPLETION_GUIDE_MESSAGE));
+  }
+
+  return messages;
+};
+
+const getInitialMessages = (payload: SurveySessionStartResponse) => {
+  if (payload.assistant_message || payload.warning_message) {
+    return getInitialAssistantMessages(payload);
   }
 
   if (payload.recommendation_ready) {
-    return [createMessage('assistant', COMPLETION_GUIDE_MESSAGE)];
+    return getInitialAssistantMessages(payload);
   }
 
   return [];
@@ -89,16 +104,33 @@ const appendAssistantMessageIfNeeded = (
   return [...messages, createMessage('assistant', content)];
 };
 
-const getFollowUpAssistantMessage = (payload: SurveyChatResponse) => {
+const appendAssistantMessagesIfNeeded = (
+  messages: SurveyMessage[],
+  contents: Array<string | null>,
+) =>
+  contents.reduce(
+    (nextMessages, content) =>
+      appendAssistantMessageIfNeeded(nextMessages, content),
+    messages,
+  );
+
+const getFollowUpAssistantMessages = (payload: SurveyChatResponse) => {
+  const messages: Array<string | null> = [];
+
+  if (payload.warning_message) {
+    messages.push(payload.warning_message);
+  }
+
   if (payload.assistant_message) {
-    return payload.assistant_message;
+    messages.push(payload.assistant_message);
+    return messages;
   }
 
   if (payload.recommendation_ready) {
-    return COMPLETION_GUIDE_MESSAGE;
+    messages.push(COMPLETION_GUIDE_MESSAGE);
   }
 
-  return null;
+  return messages;
 };
 
 const getSessionStatePatch = (
@@ -176,9 +208,9 @@ export const useSurveyStore = create<SurveyStoreState>()(
           recommendationReady: payload.recommendation_ready,
           isSubmitting: false,
           error: null,
-          messages: appendAssistantMessageIfNeeded(
+          messages: appendAssistantMessagesIfNeeded(
             state.messages,
-            getFollowUpAssistantMessage(payload),
+            getFollowUpAssistantMessages(payload),
           ),
         })),
       resetSurveyState: () =>

--- a/src/features/survey/types/survey.ts
+++ b/src/features/survey/types/survey.ts
@@ -59,6 +59,7 @@ export interface SurveyChatRequest {
 export interface SurveySessionResponse {
   session_id: string;
   assistant_message: string | null;
+  warning_message: string | null;
   progress: SurveyProgress;
   status: SurveySessionStatus;
   recommendation_ready: boolean;

--- a/src/pages/matching/MatchingGenreDetailPage.tsx
+++ b/src/pages/matching/MatchingGenreDetailPage.tsx
@@ -45,6 +45,8 @@ const MATCHING_SECONDARY_ACTION_BUTTON_CLASS =
 
 const MATCHING_PRIMARY_ACTION_BUTTON_CLASS =
   'inline-flex items-center gap-2 rounded-full bg-[#c91818] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#b11212] disabled:bg-[#5c1a1a] disabled:text-white/44';
+const MATCHING_TITLE_COLLAPSED_HEIGHT_REM = 4.8;
+const MATCHING_SUMMARY_COLLAPSED_HEIGHT_REM = 6;
 
 const formatMatchingCandidateRating = (rating: number | null) => {
   if (typeof rating !== 'number') {
@@ -87,21 +89,30 @@ function MatchingDetailSkeleton() {
     <section className="mx-auto mt-9 max-w-255 animate-pulse sm:mt-10 md:mt-12">
       <div className="text-center">
         <div className="mx-auto h-4 w-20 rounded-full bg-[#792222]/35" />
-        <div className="mx-auto mt-3 h-10 w-72 rounded-full bg-white/9" />
+        <div className="relative mt-3">
+          <h1 className="text-3xl font-semibold tracking-[-0.03em] text-transparent sm:text-4xl md:text-[40px]">
+            매칭 과정을 따라가세요
+          </h1>
+          <div className="absolute top-1/2 left-1/2 h-10 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/9" />
+        </div>
       </div>
 
       <div className="mt-8 grid gap-4 lg:grid-cols-[1.32fr_0.92fr] lg:gap-5 xl:mt-9">
-        <div className="overflow-hidden rounded-[28px] border border-white/8 bg-[#0c0c0d] p-3">
-          <div className="aspect-video rounded-[22px] bg-white/[0.05]" />
-          <div className="mt-4 h-4 w-28 rounded-full bg-white/8" />
-          <div className="mt-3 h-4 w-full rounded-full bg-white/7" />
-          <div className="mt-2 h-4 w-5/6 rounded-full bg-white/7" />
+        <div className="overflow-hidden rounded-[26px] border border-white/8 bg-[#0d0d0f] shadow-[0_24px_48px_rgba(0,0,0,0.28)]">
+          <div className="aspect-video h-full min-h-[360px] rounded-[26px] bg-white/[0.05] sm:min-h-[420px]" />
         </div>
 
         <div className="survey-panel flex flex-col px-5 py-5 sm:px-6 sm:py-6">
-          <div className="h-9 w-2/3 rounded-full bg-white/9" />
+          <div className="relative max-w-[72%]">
+            <h2 className="text-2xl leading-[1.28] font-semibold tracking-[-0.02em] text-transparent sm:text-[30px]">
+              플레이스홀더 제목 제목
+            </h2>
+            <div className="absolute top-1/2 left-0 h-9 w-full -translate-y-1/2 rounded-full bg-white/9" />
+          </div>
           <div className="mt-4 h-4 w-full rounded-full bg-white/7" />
-          <div className="mt-2 h-4 w-4/5 rounded-full bg-white/7" />
+          <div className="mt-2 h-4 w-[88%] rounded-full bg-white/7" />
+          <div className="mt-2 h-4 w-[82%] rounded-full bg-white/7" />
+          <div className="mt-2 h-4 w-[64%] rounded-full bg-white/7" />
 
           <div className="mt-5 grid gap-1.5 sm:grid-cols-2">
             <div className="h-16 rounded-[14px] border border-white/8 bg-white/3" />
@@ -118,10 +129,10 @@ function MatchingDetailSkeleton() {
             ))}
           </div>
 
-          <div className="mt-auto pt-8">
-            <div className="flex gap-3">
-              <div className="h-12 flex-1 rounded-full bg-white/[0.05]" />
-              <div className="h-12 flex-1 rounded-full bg-white/[0.08]" />
+          <div className="mt-auto pt-5">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div className="h-[48px] w-[92px] rounded-full bg-white/[0.05]" />
+              <div className="h-[48px] w-[104px] rounded-full bg-white/[0.08]" />
             </div>
           </div>
         </div>
@@ -184,9 +195,19 @@ function MatchingGenreDetailPage() {
   const goPrevious = useMatchingStore((state) => state.goPrevious);
   const resetFlow = useMatchingStore((state) => state.resetFlow);
   const hasInitializedFlowRef = useRef(false);
+  const titleRef = useRef<HTMLHeadingElement | null>(null);
+  const summaryRef = useRef<HTMLParagraphElement | null>(null);
   const [likeFeedbackMessage, setLikeFeedbackMessage] = useState<string | null>(
     null,
   );
+  const [previewTitleGameId, setPreviewTitleGameId] = useState<number | null>(
+    null,
+  );
+  const [openSummaryOverlayGameId, setOpenSummaryOverlayGameId] = useState<
+    number | null
+  >(null);
+  const [isTitleOverflowing, setIsTitleOverflowing] = useState(false);
+  const [isSummaryOverflowing, setIsSummaryOverflowing] = useState(false);
 
   useLayoutEffect(() => {
     resetFlow();
@@ -223,6 +244,12 @@ function MatchingGenreDetailPage() {
         rating: null,
       })
     : null;
+  const isTitlePreviewOpen =
+    currentCandidate !== undefined &&
+    previewTitleGameId === currentCandidate.game_id;
+  const isSummaryOverlayOpen =
+    currentCandidate !== undefined &&
+    openSummaryOverlayGameId === currentCandidate.game_id;
   const isLastCard = totalSteps > 0 && safeIndex === totalSteps - 1;
   const hasSelectedRating = currentEvaluation?.rating !== null;
   const canGoPrevious = safeIndex > 0;
@@ -241,6 +268,37 @@ function MatchingGenreDetailPage() {
         ' · ',
       )} 감각을 대표하는 후보예요. 트레일러를 보고 취향에 얼마나 맞는지 편하게 판단해보세요.`
     : '';
+  useEffect(() => {
+    const measureOverflow = () => {
+      const titleElement = titleRef.current;
+      const summaryElement = summaryRef.current;
+
+      if (titleElement) {
+        setIsTitleOverflowing(
+          titleElement.scrollHeight >
+            MATCHING_TITLE_COLLAPSED_HEIGHT_REM * 16 + 1,
+        );
+      }
+
+      if (summaryElement) {
+        setIsSummaryOverflowing(
+          summaryElement.scrollHeight >
+            MATCHING_SUMMARY_COLLAPSED_HEIGHT_REM * 16 + 1,
+        );
+      }
+    };
+
+    measureOverflow();
+    window.addEventListener('resize', measureOverflow);
+
+    return () => {
+      window.removeEventListener('resize', measureOverflow);
+    };
+  }, [currentCandidate?.game_id, currentCandidateSummary]);
+
+  const shouldShowTitleToggle = Boolean(currentCandidate) && isTitleOverflowing;
+  const shouldShowSummaryToggle = isSummaryOverflowing;
+
   const likeMutation = useMutation({
     mutationFn: ({
       candidate,
@@ -423,22 +481,94 @@ function MatchingGenreDetailPage() {
                 ) : null}
 
                 {currentCandidate && currentEvaluation ? (
-                  <article className="survey-panel flex flex-col px-5 py-5 sm:px-6 sm:py-6">
+                  <article className="survey-panel relative flex flex-col px-5 py-5 sm:px-6 sm:py-6">
                     <div className="flex items-start justify-between gap-4">
                       <div className="min-w-0 flex-1">
-                        <h2 className="text-2xl font-semibold tracking-[-0.02em] break-keep text-white sm:text-[30px]">
-                          {currentCandidate.title}
-                        </h2>
-                        <p className="mt-3 text-sm leading-6 break-keep text-white/62">
+                        <div
+                          className="relative"
+                          onMouseEnter={() =>
+                            shouldShowTitleToggle
+                              ? setPreviewTitleGameId(currentCandidate.game_id)
+                              : undefined
+                          }
+                          onMouseLeave={() => setPreviewTitleGameId(null)}
+                        >
+                          <h2
+                            ref={titleRef}
+                            tabIndex={shouldShowTitleToggle ? 0 : undefined}
+                            className={`text-2xl leading-[1.28] font-semibold tracking-[-0.02em] break-keep text-white sm:text-[30px] ${
+                              shouldShowTitleToggle ? 'cursor-help' : ''
+                            }`}
+                            title={currentCandidate.title}
+                            style={{
+                              maxHeight: `${MATCHING_TITLE_COLLAPSED_HEIGHT_REM}rem`,
+                              overflow: 'hidden',
+                            }}
+                            onFocus={() =>
+                              shouldShowTitleToggle
+                                ? setPreviewTitleGameId(
+                                    currentCandidate.game_id,
+                                  )
+                                : undefined
+                            }
+                            onBlur={() => setPreviewTitleGameId(null)}
+                          >
+                            {currentCandidate.title}
+                          </h2>
+                          {shouldShowTitleToggle && isTitlePreviewOpen ? (
+                            <div className="pointer-events-none absolute top-full left-0 z-20 mt-3 w-full max-w-[34rem] rounded-2xl border border-white/10 bg-[#0f0f11]/96 px-4 py-3 shadow-[0_20px_48px_rgba(0,0,0,0.38)] backdrop-blur-xl">
+                              <p className="text-[15px] leading-6 break-keep text-white/92">
+                                {currentCandidate.title}
+                              </p>
+                            </div>
+                          ) : null}
+                        </div>
+                        <p
+                          ref={summaryRef}
+                          className="mt-3 text-sm leading-6 break-keep text-white/62"
+                          style={
+                            isSummaryOverlayOpen
+                              ? undefined
+                              : {
+                                  maxHeight: `${MATCHING_SUMMARY_COLLAPSED_HEIGHT_REM}rem`,
+                                  overflow: 'hidden',
+                                }
+                          }
+                        >
                           {currentCandidateSummary}
                         </p>
+                        {shouldShowSummaryToggle ? (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setOpenSummaryOverlayGameId((current) =>
+                                current === currentCandidate.game_id
+                                  ? null
+                                  : currentCandidate.game_id,
+                              )
+                            }
+                            className="mt-2.5 text-sm font-semibold text-[#ff8d8d] transition hover:text-[#ffb1b1]"
+                          >
+                            줄거리 전체 보기
+                          </button>
+                        ) : null}
                         <div className="mt-4 grid gap-1.5 border-t border-white/8 pt-2.5 sm:grid-cols-2">
                           <div className="flex h-full flex-col rounded-[14px] border border-white/8 bg-white/3 px-2.5 py-2">
                             <p className="text-[10px] font-medium text-white/38">
                               장르
                             </p>
-                            <p className="mt-1 text-[13px] leading-5 font-medium break-keep text-white/78">
-                              {currentCandidate.genres.join(' · ') ||
+                            <p
+                              className="mt-1 text-[13px] leading-5 font-medium text-white/78"
+                              style={{
+                                maxHeight: '1.25rem',
+                                overflow: 'hidden',
+                              }}
+                              title={
+                                currentCandidate.genres.join(' / ') ||
+                                genreTitle
+                              }
+                            >
+                              {currentCandidate.genres.join(' / ') ||
                                 genreTitle}
                             </p>
                           </div>
@@ -571,6 +701,33 @@ function MatchingGenreDetailPage() {
                         </button>
                       </div>
                     )}
+                    {isSummaryOverlayOpen ? (
+                      <div className="absolute inset-0 z-10 rounded-[32px] border border-white/10 bg-[#09090b]/96 p-5 shadow-[0_24px_60px_rgba(0,0,0,0.44)] backdrop-blur-xl sm:p-6">
+                        <div className="flex h-full flex-col">
+                          <div className="flex items-start justify-between gap-4">
+                            <div className="min-w-0">
+                              <p className="text-xs font-semibold tracking-[0.18em] text-[#ff8d8d] uppercase">
+                                Summary
+                              </p>
+                              <h3 className="mt-2 text-xl font-semibold break-keep text-white sm:text-2xl">
+                                {currentCandidate.title}
+                              </h3>
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => setOpenSummaryOverlayGameId(null)}
+                              className="inline-flex shrink-0 items-center gap-2 self-start rounded-full border border-white/10 bg-white/4 px-3 py-2 text-sm font-medium text-white/86 transition hover:border-white/20 hover:bg-white/7"
+                            >
+                              닫기
+                            </button>
+                          </div>
+
+                          <div className="mt-5 min-h-0 flex-1 overflow-y-auto pr-1 text-sm leading-7 break-keep text-white/72">
+                            {currentCandidateSummary}
+                          </div>
+                        </div>
+                      </div>
+                    ) : null}
                   </article>
                 ) : null}
               </div>

--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -15,12 +15,26 @@ import { useMatchingStore } from '../../features/matching/store/useMatchingStore
 function MatchingGenreCardSkeleton() {
   return (
     <div className="overflow-hidden rounded-3xl border border-white/8 bg-[#0c0c0d] p-2.5 shadow-[0_18px_36px_rgba(0,0,0,0.26)]">
-      <div className="animate-pulse overflow-hidden rounded-[18px] border border-white/5 bg-white/[0.02]">
+      <div className="relative animate-pulse overflow-hidden rounded-[18px]">
         <div className="aspect-[16/8.4] w-full bg-[linear-gradient(90deg,rgba(255,255,255,0.03),rgba(255,255,255,0.08),rgba(255,255,255,0.03))]" />
-        <div className="space-y-3 px-4 py-4">
-          <div className="h-6 w-36 rounded-full bg-white/10" />
-          <div className="h-4 w-full rounded-full bg-white/7" />
-          <div className="h-4 w-4/5 rounded-full bg-white/7" />
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(6,6,8,0.1),rgba(6,6,8,0.28)_34%,rgba(6,6,8,0.86))]" />
+        <div className="absolute right-3.5 bottom-3.5 left-3.5 flex items-end justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="relative w-fit">
+              <p className="text-[22px] font-semibold tracking-[-0.02em] text-transparent">
+                장르별 게임 매칭
+              </p>
+              <div className="absolute top-1/2 left-0 h-7 w-34 -translate-y-1/2 rounded-full bg-white/11" />
+            </div>
+            <div className="relative mt-1.5 max-w-[24ch]">
+              <p className="text-[13px] leading-5 font-medium text-transparent">
+                좋아하는 장르를 고르고 트레일러를 보며 별점을 남깁니다.
+              </p>
+              <div className="absolute top-0 left-0 h-4 w-full max-w-60 rounded-full bg-white/9" />
+              <div className="absolute top-5 left-0 h-4 w-full max-w-44 rounded-full bg-white/9" />
+            </div>
+          </div>
+          <div className="h-9 w-9 shrink-0 rounded-full border border-white/10 bg-black/28" />
         </div>
       </div>
     </div>
@@ -37,9 +51,19 @@ function MatchingListLoadingState() {
         <section className="mx-auto max-w-240">
           <div className="mb-7 text-center sm:mb-8">
             <div className="mx-auto h-4 w-24 animate-pulse rounded-full bg-[#792222]/35" />
-            <div className="mx-auto mt-3 h-11 w-62 animate-pulse rounded-full bg-white/9" />
-            <div className="mx-auto mt-3 h-4 w-full max-w-125 animate-pulse rounded-full bg-white/7" />
-            <div className="mx-auto mt-2 h-4 w-full max-w-98 animate-pulse rounded-full bg-white/7" />
+            <div className="relative mt-3">
+              <h1 className="text-3xl font-semibold tracking-[-0.03em] text-transparent sm:text-4xl md:text-[42px]">
+                장르별 게임 매칭
+              </h1>
+              <div className="absolute top-1/2 left-1/2 h-11 w-62 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-full bg-white/9" />
+            </div>
+            <div className="relative mt-3">
+              <p className="truncate text-sm leading-6 text-transparent sm:text-[15px]">
+                좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에
+                맞는 게임을 빠르게 추천해드려요.
+              </p>
+              <div className="absolute top-1/2 left-1/2 h-4 w-full max-w-124 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-full bg-white/7" />
+            </div>
           </div>
 
           <div className="grid gap-4 md:grid-cols-2">
@@ -136,7 +160,10 @@ function MatchingListPage() {
               <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[42px]">
                 장르별 게임 매칭
               </h1>
-              <p className="mt-3 text-sm leading-6 break-keep text-white/58 sm:text-[15px]">
+              <p
+                className="mt-3 truncate text-sm leading-6 text-white/58 sm:text-[15px]"
+                title="좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에 맞는 게임을 빠르게 추천해드려요."
+              >
                 좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에
                 맞는 게임을 빠르게 추천해드려요.
               </p>

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -11,7 +11,6 @@ import { Link } from 'react-router';
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import ActionButton from '../../components/common/ActionButton';
 import LazyHeader from '../../components/common/LazyHeader';
-import MainPageLoadingFallback from '../../components/common/MainPageLoadingFallback';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
@@ -109,7 +108,7 @@ function RecommendationRow({
           disabled={isLikePending}
           className={`${
             item.is_liked
-              ? 'border-[#6f2525] bg-[#170b0b] text-[#f07373]'
+              ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
               : 'border-white/10 bg-white/2 text-white/60 hover:border-white/18 hover:text-white/86'
           } ${isLikePending ? 'cursor-not-allowed opacity-55' : ''}`}
           aria-label={item.is_liked ? '좋아요 해제' : '좋아요 추가'}
@@ -236,6 +235,41 @@ function RecommendationPromptCard({
   );
 }
 
+function RecommendationPageLoadingState() {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+      <RecommendationBackdrop items={[]} />
+      <LazyHeader fixed />
+
+      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-300 flex-col px-3 pt-24 pb-8 sm:px-4 sm:pt-28 sm:pb-10 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
+        <section className="mx-auto flex min-h-0 w-full max-w-245 flex-1 flex-col">
+          <div className="mb-8">
+            <div className="grid gap-4 md:grid-cols-[1fr_auto_1fr] md:items-end">
+              <div className="hidden md:block" />
+
+              <div className="text-center">
+                <div className="relative">
+                  <h1 className="text-3xl font-semibold tracking-[-0.04em] text-transparent sm:text-4xl md:text-[52px]">
+                    게임 추천 리스트
+                  </h1>
+                  <div className="absolute top-1/2 left-1/2 h-12 w-72 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-full bg-white/10" />
+                </div>
+              </div>
+
+              <div className="flex justify-center gap-2.5 md:justify-end">
+                <div className="h-[50px] w-31 animate-pulse rounded-2xl border border-white/10 bg-white/4" />
+                <div className="h-[50px] w-31 animate-pulse rounded-2xl border border-white/10 bg-white/4" />
+              </div>
+            </div>
+          </div>
+
+          <RecommendationListSkeleton />
+        </section>
+      </main>
+    </div>
+  );
+}
+
 function RecommendationListPage() {
   const [selectedGame, setSelectedGame] = useState<GameListItem | null>(null);
   const authGate = useAuthGate({ allowMockBypass: true });
@@ -288,7 +322,7 @@ function RecommendationListPage() {
   });
 
   if (authGate.needsAuthCheck) {
-    return <MainPageLoadingFallback />;
+    return <RecommendationPageLoadingState />;
   }
 
   return (

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -108,7 +108,7 @@ function RecommendationRow({
           disabled={isLikePending}
           className={`${
             item.is_liked
-              ? 'border-[#c12626]/70 bg-[#220b0b] text-[#f25a5a]'
+              ? '!border-[#c12626]/70 !bg-[#220b0b] !text-[#f25a5a] hover:!border-[#d43a3a]/80 hover:!bg-[#2b0d0d] hover:!text-[#ff6666]'
               : 'border-white/10 bg-white/2 text-white/60 hover:border-white/18 hover:text-white/86'
           } ${isLikePending ? 'cursor-not-allowed opacity-55' : ''}`}
           aria-label={item.is_liked ? '좋아요 해제' : '좋아요 추가'}

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -3,10 +3,11 @@ import { Navigate, useLocation, useSearchParams } from 'react-router';
 
 import AuthGateStatusPanel from '../../components/auth/AuthGateStatusPanel';
 import LazyHeader from '../../components/common/LazyHeader';
-import MainPageLoadingFallback from '../../components/common/MainPageLoadingFallback';
 import { ROUTES } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
-import SurveyChatPanel from '../../features/survey/components/SurveyChatPanel';
+import SurveyChatPanel, {
+  SurveyChatLoadingState,
+} from '../../features/survey/components/SurveyChatPanel';
 import { useSurveyStore } from '../../features/survey/store/useSurveyStore';
 import { mockTopGames } from '../../features/games/mockGames';
 import { useAuthStore } from '../../store/useAuthStore';
@@ -31,6 +32,20 @@ function SurveyBackdrop() {
         ))}
       </div>
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(170,25,25,0.16),transparent_24%),linear-gradient(180deg,rgba(5,5,5,0.46),rgba(5,5,5,0.92))]" />
+    </div>
+  );
+}
+
+function SurveyPageLoadingState() {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
+      <SurveyBackdrop />
+      <div className="app-aurora pointer-events-none absolute inset-0 opacity-90" />
+      <LazyHeader fixed />
+
+      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
+        <SurveyChatLoadingState />
+      </main>
     </div>
   );
 }
@@ -115,7 +130,7 @@ function SurveyPage() {
   }
 
   if (authGate.needsAuthCheck) {
-    return <MainPageLoadingFallback />;
+    return <SurveyPageLoadingState />;
   }
 
   if (shouldRedirectCompletedEntry) {


### PR DESCRIPTION
## 관련 이슈

- closes #393 

## 변경 내용

- survey API 경로를 최신 Swagger 기준에 맞춰 trailing slash 없이 정리했습니다.
- survey 세션 시작/초기화 응답에 첫 질문이 없는 경우를 조용히 통과시키지 않고, 명확한 오류 흐름으로 처리하도록 보강했습니다.
- survey 응답의 `warning_message`가 있을 경우 질문보다 먼저 노출되도록 정리했습니다.
- 실서버 차단 상태(`chatBlockedUntil`)는 재진입/새로고침 후에도 유지되도록 정리했습니다.
- 차단 시간이 남아 있는 동안에는 설문 초기화 버튼도 비활성화되도록 수정했습니다.
- survey auth 확인 단계에서 메인페이지 fallback 대신 설문 전용 loading shell이 보이도록 정리했습니다.
- survey mock handler도 동일한 API 계약을 따르도록 함께 수정했습니다.

- 장르별 게임 매칭 페이지의 헤더/카드 스켈레톤 위치와 크기를 실제 UI 기준으로 다시 맞췄습니다.
- 매칭 상세 스켈레톤도 실제 트레일러/정보 패널/하단 버튼 구조에 맞게 정리했습니다.
- 매칭 상세 페이지에서 긴 제목은 hover/focus로 전체 제목을 볼 수 있도록 보강했습니다.
- 긴 줄거리는 우측 정보 패널 안에서 별도 오버레이로 전체 보기 할 수 있도록 정리했습니다.
- 장르 표시와 텍스트 클램프도 실제 UI 흐름에 맞게 보정했습니다.

- 추천 리스트는 auth 확인 단계에서 추천 페이지 전용 스켈레톤을 보여주도록 수정했습니다.
- 추천 리스트 좋아요 하트 활성 색상을 다른 페이지와 같은 계열의 빨간색으로 통일했습니다.


## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 survey 실서버 연동 과정에서 확인된 계약 불일치와 상태 처리 문제를 정리하면서, matching/recommendation 페이지의 로딩/상세 UI 이질감도 함께 개선한 후속 수정입니다.
- survey는 최신 Swagger 기준을 우선 따르도록 정리했습니다.
