### PR TITLE
[Feat] 프로필 메뉴 hover 인터랙션 추가 

### DIFF
--- a/src/components/common/HeaderProfileMenu.tsx
+++ b/src/components/common/HeaderProfileMenu.tsx
@@ -22,6 +22,11 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
   const trimmedProfileImageUrl = profileImageUrl?.trim() || null;
   const resolvedProfileImageUrl = trimmedProfileImageUrl || profileImg;
   const isOpen = isHoverOpen || isClickOpen;
+  const profileButtonClass = `h-10 w-10 cursor-pointer overflow-hidden rounded-full border-2 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none ${
+    isOpen
+      ? 'border-[#ff3b30] shadow-[0_0_0_4px_rgba(255,59,48,0.16)]'
+      : 'border-white/14 hover:border-[#ff3b30] hover:shadow-[0_0_0_4px_rgba(255,59,48,0.12)]'
+  }`;
   const closeMenu = () => {
     setIsHoverOpen(false);
     setIsClickOpen(false);
@@ -75,7 +80,7 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
         aria-expanded={isOpen}
         aria-controls={PROFILE_MENU_ID}
         onClick={() => setIsClickOpen((current) => !current)}
-        className="hover:border-header-accent h-10 w-10 cursor-pointer overflow-hidden rounded-full border-2 border-transparent transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
+        className={profileButtonClass}
       >
         <img
           src={resolvedProfileImageUrl}

--- a/src/components/common/HeaderProfileMenu.tsx
+++ b/src/components/common/HeaderProfileMenu.tsx
@@ -13,13 +13,19 @@ type HeaderProfileMenuProps = {
 };
 
 function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isHoverOpen, setIsHoverOpen] = useState(false);
+  const [isClickOpen, setIsClickOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const { logout, isPending } = useLogoutAction();
   const location = useLocation();
   const isMyPage = isMyPagePath(location.pathname);
   const trimmedProfileImageUrl = profileImageUrl?.trim() || null;
   const resolvedProfileImageUrl = trimmedProfileImageUrl || profileImg;
+  const isOpen = isHoverOpen || isClickOpen;
+  const closeMenu = () => {
+    setIsHoverOpen(false);
+    setIsClickOpen(false);
+  };
 
   useEffect(() => {
     if (!isOpen) {
@@ -31,13 +37,13 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
         containerRef.current &&
         !containerRef.current.contains(event.target as Node)
       ) {
-        setIsOpen(false);
+        closeMenu();
       }
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        setIsOpen(false);
+        closeMenu();
       }
     };
 
@@ -54,9 +60,11 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
     <div
       ref={containerRef}
       className="relative"
+      onMouseEnter={() => setIsHoverOpen(true)}
+      onMouseLeave={() => setIsHoverOpen(false)}
       onBlur={(event) => {
         if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
-          setIsOpen(false);
+          closeMenu();
         }
       }}
     >
@@ -66,7 +74,7 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
         aria-haspopup="menu"
         aria-expanded={isOpen}
         aria-controls={PROFILE_MENU_ID}
-        onClick={() => setIsOpen((current) => !current)}
+        onClick={() => setIsClickOpen((current) => !current)}
         className="hover:border-header-accent h-10 w-10 cursor-pointer overflow-hidden rounded-full border-2 border-transparent transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
       >
         <img
@@ -80,18 +88,26 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
         />
       </button>
 
-      {isOpen ? (
+      <div
+        className={`absolute top-full right-0 z-50 pt-3 transition-all duration-200 ease-out ${
+          isOpen
+            ? 'pointer-events-auto translate-y-0 opacity-100'
+            : 'pointer-events-none -translate-y-1 opacity-0'
+        }`}
+        aria-hidden={!isOpen}
+      >
         <div
           id={PROFILE_MENU_ID}
           role="menu"
           aria-label="프로필 메뉴"
-          className="bg-mypage-panel border-mypage-panel shadow-mypage-float absolute top-[calc(100%+0.85rem)] right-0 z-50 w-40 overflow-hidden rounded-2xl border p-2 backdrop-blur-xl"
+          className="bg-mypage-panel border-mypage-panel shadow-mypage-float w-40 overflow-hidden rounded-2xl border p-2 backdrop-blur-xl transition-[opacity,transform] duration-200 ease-out"
         >
           <Link
             to={ROUTE_PATHS.MY_PAGE}
             role="menuitem"
             aria-current={isMyPage ? 'page' : undefined}
-            onClick={() => setIsOpen(false)}
+            tabIndex={isOpen ? 0 : -1}
+            onClick={closeMenu}
             className={`flex min-h-12 items-center justify-center rounded-xl px-4 text-base font-medium transition focus-visible:outline-none ${
               isMyPage
                 ? 'text-login-primary bg-white/8'
@@ -104,9 +120,10 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
           <button
             type="button"
             role="menuitem"
+            tabIndex={isOpen ? 0 : -1}
             disabled={isPending}
             onClick={() => {
-              setIsOpen(false);
+              closeMenu();
               void logout();
             }}
             className="flex min-h-12 w-full items-center justify-center rounded-xl px-4 text-base font-medium text-white transition hover:bg-white/6 focus-visible:bg-white/6 focus-visible:outline-none disabled:opacity-60"
@@ -114,7 +131,7 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
             {isPending ? '로그아웃 중...' : '로그아웃'}
           </button>
         </div>
-      ) : null}
+      </div>
     </div>
   );
 }

--- a/src/components/common/HeaderProfileMenu.tsx
+++ b/src/components/common/HeaderProfileMenu.tsx
@@ -105,7 +105,7 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
           id={PROFILE_MENU_ID}
           role="menu"
           aria-label="프로필 메뉴"
-          className="bg-mypage-panel border-mypage-panel shadow-mypage-float w-40 overflow-hidden rounded-2xl border p-2 backdrop-blur-xl transition-[opacity,transform] duration-200 ease-out"
+          className="w-40 overflow-hidden rounded-2xl border border-white/10 bg-[#101013]/96 p-2 shadow-[0_24px_48px_rgba(0,0,0,0.42),0_0_0_1px_rgba(255,255,255,0.06)] ring-1 ring-white/5 backdrop-blur-xl transition-[opacity,transform] duration-200 ease-out"
         >
           <Link
             to={ROUTE_PATHS.MY_PAGE}
@@ -121,7 +121,7 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
           >
             마이페이지
           </Link>
-          <div className="border-mypage-divider mx-2 border-t" />
+          <div className="mx-2 border-t border-white/10" />
           <button
             type="button"
             role="menuitem"


### PR DESCRIPTION
## 관련 이슈

- closes #392

## 변경 내용

- 헤더 프로필 메뉴가 기존 클릭 방식뿐 아니라 마우스 hover 시에도 열리도록 인터랙션을 확장했습니다.
- 프로필 이미지와 드롭다운 메뉴를 같은 컨테이너 hover 영역 안에 두도록 구조를 정리해, 아바타에서 메뉴 항목으로 마우스를 이동할 때 메뉴가 중간에 닫히지 않도록 보완했습니다.
- 메뉴 노출 상태를 hover와 click 상태로 분리해 기존 클릭 토글 동작은 유지하면서도 hover 진입/이탈 시 자연스럽게 열리고 닫히도록 조정했습니다.
- 드롭다운 메뉴에 `opacity`와 `translateY` 기반 트랜지션을 추가하고, 닫힌 상태에서는 pointer-events와 tab 이동을 막아 상호작용 안정성을 높였습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="528" height="508" alt="image" src="https://github.com/user-attachments/assets/9d942d1a-d583-474a-9672-a2d0cae18aec" />

## 참고사항

- 이번 변경은 헤더 프로필 메뉴의 인터랙션과 표시 전환 UX 개선에 한정됩니다.
