### PR TITLE
[Fix] 로컬 소셜 로그인 세션 복구 및 소셜 계정 상태 유지

### DIFF
--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -47,8 +47,14 @@ const loginRequestPath = `${AUTH_BASE_PATH}/login`;
 const logoutRequestPath = `${AUTH_BASE_PATH}/logout`;
 const refreshRequestPath = `${AUTH_BASE_PATH}/token/refresh`;
 
-const resolveRefreshRequestUrl = () => {
-  if (import.meta.env.DEV) {
+type RefreshAccessTokenRequestOptions = {
+  preferDirectBackendOriginInDev?: boolean;
+};
+
+const resolveRefreshRequestUrl = (
+  options: RefreshAccessTokenRequestOptions = {},
+) => {
+  if (import.meta.env.DEV && !options.preferDirectBackendOriginInDev) {
     return refreshRequestPath;
   }
 
@@ -219,11 +225,12 @@ export const requestLogout = async () => {
 
 export const requestRefreshAccessToken = async (
   payload: { refresh_token?: string } = {},
+  options: RefreshAccessTokenRequestOptions = {},
 ) => {
   const waitedForPreviousRefresh = await waitForRefreshThrottleWindow();
   const requestConfig = createCredentialedAuthRequestConfig();
   const requestBody = payload.refresh_token?.trim() ? payload : undefined;
-  const refreshRequestUrl = resolveRefreshRequestUrl();
+  const refreshRequestUrl = resolveRefreshRequestUrl(options);
 
   logCredentialedAuthRequestDiagnostics({
     label: 'refresh',
@@ -234,8 +241,9 @@ export const requestRefreshAccessToken = async (
   const sendRefreshRequest = async () => {
     markRefreshThrottleTimestamp();
 
-    // Dev uses the Vite proxy via a relative path, while production must target
-    // the backend origin directly so the backend refresh cookie is included.
+    // Development usually uses the Vite proxy via a relative path, but the
+    // local social-login callback may need one direct backend refresh so the
+    // backend-domain cookie can be consumed before proxy-based API calls resume.
     const response = await axios.post<RefreshAccessTokenResponse>(
       refreshRequestUrl,
       requestBody,

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -46,6 +46,10 @@ export type {
 } from './auth.error.handler';
 export { hasMockRefreshToken } from './auth.session.helper';
 
+type RefreshAccessTokenOptions = {
+  preferDirectBackendOriginInDev?: boolean;
+};
+
 export const login = async (payload: LoginRequest) => {
   const response = await requestLogin(payload);
   const normalizedResponse = normalizeAuthTokenResponse(response, '로그인');
@@ -63,12 +67,15 @@ export const logout = async () => {
   }
 };
 
-export const refreshAccessToken = async () => {
+export const refreshAccessToken = async (
+  options: RefreshAccessTokenOptions = {},
+) => {
   logRefreshRequestStarted();
 
   try {
     const response = await requestRefreshAccessToken(
       createRefreshTokenFallbackRequestBody(),
+      options,
     );
     const normalizedResponse = normalizeAuthTokenResponse(
       response,

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../store/useAuthStore';
 import {
   clearAuthSession,
+  hydrateAuthSessionFromAccessToken,
   refreshStoredAccessToken,
   setAuthBootstrapLoading,
   setAuthBootstrapReady,
@@ -42,14 +43,15 @@ function useAuthBootstrap() {
       return;
     }
 
-    if (!isAccessTokenExpiringSoon(storedAccessToken)) {
-      setAuthBootstrapReady();
-      return;
-    }
-
     setAuthBootstrapLoading();
 
-    void refreshStoredAccessToken()
+    const restorePromise = isAccessTokenExpiringSoon(storedAccessToken)
+      ? refreshStoredAccessToken().then((refreshedAccessToken) =>
+          hydrateAuthSessionFromAccessToken(refreshedAccessToken),
+        )
+      : hydrateAuthSessionFromAccessToken(storedAccessToken);
+
+    void restorePromise
       .catch(() => {
         clearAuthSession({ setReady: false });
       })

--- a/src/features/auth/utils/sessionManager.ts
+++ b/src/features/auth/utils/sessionManager.ts
@@ -28,6 +28,10 @@ type ClearAuthSessionOptions = {
   setReady?: boolean;
 };
 
+type RestoreAuthSessionOptions = {
+  preferDirectBackendOriginInDev?: boolean;
+};
+
 let restoreAuthSessionPromise: Promise<RestoredAuthSession> | null = null;
 
 export const setAuthBootstrapLoading = () => {
@@ -142,16 +146,20 @@ export const hydrateAuthSessionFromAccessToken = async (
   };
 };
 
-export const refreshStoredAccessToken = async () => {
-  const { access_token: accessToken } = await refreshAccessToken();
+export const refreshStoredAccessToken = async (
+  options: RestoreAuthSessionOptions = {},
+) => {
+  const { access_token: accessToken } = await refreshAccessToken(options);
   applyAccessToken(accessToken);
   logRefreshStoreSync(accessToken);
   return accessToken;
 };
 
-export const restoreAuthSession = async () => {
+export const restoreAuthSession = async (
+  options: RestoreAuthSessionOptions = {},
+) => {
   try {
-    const accessToken = await refreshStoredAccessToken();
+    const accessToken = await refreshStoredAccessToken(options);
     return await hydrateAuthSessionFromAccessToken(accessToken);
   } catch (error) {
     const shouldNotifySessionRestoreFailure = hasSessionRestoreHint();
@@ -172,9 +180,11 @@ export const restoreAuthSession = async () => {
   }
 };
 
-export const ensureAuthSessionRestored = () => {
+export const ensureAuthSessionRestored = (
+  options: RestoreAuthSessionOptions = {},
+) => {
   if (!restoreAuthSessionPromise) {
-    restoreAuthSessionPromise = restoreAuthSession().finally(() => {
+    restoreAuthSessionPromise = restoreAuthSession(options).finally(() => {
       restoreAuthSessionPromise = null;
     });
   }

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -50,6 +50,9 @@ function AuthCallbackPage() {
         Boolean(authorizationCode) ||
         hasPendingSocialProvider ||
         searchParams.size === 0;
+      const shouldPreferDirectBackendRefreshInDev =
+        import.meta.env.DEV &&
+        (Boolean(authorizationCode) || hasPendingSocialProvider);
 
       if (callbackErrorMessage) {
         redirectToLogin(callbackErrorMessage);
@@ -62,7 +65,9 @@ function AuthCallbackPage() {
       }
 
       try {
-        await ensureAuthSessionRestored();
+        await ensureAuthSessionRestored({
+          preferDirectBackendOriginInDev: shouldPreferDirectBackendRefreshInDev,
+        });
 
         if (!isMounted) {
           return;

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -17,6 +17,7 @@ export type AuthAccessStatus = 'loading' | 'authenticated' | 'unauthenticated';
 export const AUTH_ACCESS_TOKEN_STORAGE_KEY = 'access_token';
 const LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY = 'auth-access-token';
 const AUTH_PROFILE_PREVIEW_STORAGE_KEY = 'auth-profile-preview-image-url';
+const AUTH_SOCIAL_ACCOUNT_STORAGE_KEY = 'auth-social-account';
 
 export const readStoredAccessToken = () => {
   if (typeof window === 'undefined') {
@@ -73,6 +74,37 @@ const readPersistedProfilePreviewImageUrl = () => {
   return window.sessionStorage.getItem(AUTH_PROFILE_PREVIEW_STORAGE_KEY);
 };
 
+const readPersistedSocialAccount = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const serializedSocialAccount = window.sessionStorage.getItem(
+    AUTH_SOCIAL_ACCOUNT_STORAGE_KEY,
+  );
+
+  if (!serializedSocialAccount) {
+    return null;
+  }
+
+  try {
+    const parsedSocialAccount = JSON.parse(
+      serializedSocialAccount,
+    ) as CurrentUserSocialResponse;
+
+    if (
+      typeof parsedSocialAccount?.is_social === 'boolean' &&
+      typeof parsedSocialAccount?.social_type === 'string'
+    ) {
+      return parsedSocialAccount;
+    }
+  } catch {
+    window.sessionStorage.removeItem(AUTH_SOCIAL_ACCOUNT_STORAGE_KEY);
+  }
+
+  return null;
+};
+
 const persistProfilePreviewImageUrl = (profileImageUrl?: string | null) => {
   if (typeof window === 'undefined') {
     return;
@@ -88,6 +120,24 @@ const persistProfilePreviewImageUrl = (profileImageUrl?: string | null) => {
   window.sessionStorage.setItem(
     AUTH_PROFILE_PREVIEW_STORAGE_KEY,
     normalizedProfileImageUrl,
+  );
+};
+
+const persistSocialAccount = (
+  socialAccount?: CurrentUserSocialResponse | null,
+) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (!socialAccount) {
+    window.sessionStorage.removeItem(AUTH_SOCIAL_ACCOUNT_STORAGE_KEY);
+    return;
+  }
+
+  window.sessionStorage.setItem(
+    AUTH_SOCIAL_ACCOUNT_STORAGE_KEY,
+    JSON.stringify(socialAccount),
   );
 };
 
@@ -124,7 +174,7 @@ export const useAuthStore = create<AuthState>((set) => {
   return {
     accessToken: persistedAccessToken,
     account: null,
-    socialAccount: null,
+    socialAccount: readPersistedSocialAccount(),
     profilePreviewImageUrl: readPersistedProfilePreviewImageUrl(),
     isAuthenticated: Boolean(persistedAccessToken),
     authBootstrapStatus: 'idle',
@@ -147,6 +197,7 @@ export const useAuthStore = create<AuthState>((set) => {
     },
 
     setSocialAccount: (socialAccount) => {
+      persistSocialAccount(socialAccount);
       set({
         socialAccount,
       });
@@ -156,6 +207,7 @@ export const useAuthStore = create<AuthState>((set) => {
       const normalizedToken = token.trim();
       persistAccessToken(normalizedToken);
       persistProfilePreviewImageUrl(account?.profile_img_url);
+      persistSocialAccount(socialAccount);
       set({
         accessToken: normalizedToken,
         account,
@@ -168,6 +220,7 @@ export const useAuthStore = create<AuthState>((set) => {
     clearAuth: () => {
       persistAccessToken(null);
       persistProfilePreviewImageUrl(null);
+      persistSocialAccount(null);
       set({
         accessToken: null,
         account: null,


### PR DESCRIPTION
## 관련 이슈

- closes #400

## 변경 내용

- 로컬 개발 환경의 소셜 로그인 콜백 복구 흐름에서 첫 `refresh` 요청만 백엔드 origin으로 직접 보내도록 조정해, callback 직후 `refresh` 403으로 세션 복구가 실패하던 문제를 완화했습니다.
- 일반 로그인 및 평소 인증 갱신 흐름은 그대로 유지하고, `DEV + 소셜 콜백 복구` 상황에만 예외 분기가 적용되도록 범위를 최소화했습니다.
- 새로고침 시 access token이 아직 유효하더라도 `/me` 및 `/me/social` 정보를 다시 동기화하도록 인증 부트스트랩 로직을 보강했습니다.
- `socialAccount` 상태를 `sessionStorage`에 함께 저장·복구하도록 수정해, 구글/카카오/네이버 소셜 계정 뱃지가 새로고침 후 일반 회원처럼 보이던 문제를 보완했습니다.
- 마이페이지의 소셜 뱃지 및 비밀번호 변경 노출 조건이 새로고침 이후 복구된 최신 `useAuthStore` 상태를 그대로 반영하도록 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

https://github.com/user-attachments/assets/1199cf32-2fef-43ff-89c4-bce6373a0d96

## 참고사항

- 이번 변경은 로컬 소셜 로그인 callback 이후 세션 복구와 새로고침 시 소셜 계정 상태 유지에 한정됩니다.

