### PR TITLE
[Feat] 인기 게임 목록 스크롤 초기화 버튼 추가

### DIFF
--- a/src/components/common/ScrollResetButton.tsx
+++ b/src/components/common/ScrollResetButton.tsx
@@ -1,0 +1,32 @@
+import { ArrowLeftToLine } from 'lucide-react';
+
+type ScrollResetButtonProps = {
+  isVisible: boolean;
+  onClick: () => void;
+  label?: string;
+};
+
+const ScrollResetButton = ({
+  isVisible,
+  onClick,
+  label = '처음으로',
+}: ScrollResetButtonProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-label={label}
+    className={`absolute right-3 bottom-[5.8rem] z-30 inline-flex h-10 items-center gap-1.5 rounded-full border border-white/12 bg-black/72 px-3 text-xs font-semibold text-white shadow-[0_16px_40px_rgba(0,0,0,0.42)] backdrop-blur-xl transition-all duration-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#d20b12] sm:right-4 sm:bottom-[6.2rem] sm:text-sm ${
+      isVisible
+        ? 'translate-y-0 opacity-100'
+        : 'pointer-events-none translate-y-2 opacity-0'
+    }`}
+  >
+    <ArrowLeftToLine
+      aria-hidden="true"
+      className="h-3.5 w-3.5 text-[#ff5a5f] sm:h-4 sm:w-4"
+    />
+    <span className="hidden sm:inline">{label}</span>
+  </button>
+);
+
+export default ScrollResetButton;

--- a/src/pages/main/components/MainGameCarousel.tsx
+++ b/src/pages/main/components/MainGameCarousel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import type { Swiper as SwiperInstance } from 'swiper';
 
+import ScrollResetButton from '../../../components/common/ScrollResetButton';
 import GameCard from '../../../features/games/components/GameCard';
 import {
   GAME_CARD_BODY_CLASS,
@@ -41,6 +42,8 @@ const GAME_CARD_SWIPER_BREAKPOINTS = {
 } as const;
 const GAME_CARD_SKELETON_COUNT = 6;
 const SEARCH_RESULT_PREFETCH_GROUP_COUNT = 2;
+const SCROLL_RESET_VISIBILITY_THRESHOLD_PX = 300;
+const SCROLL_RESET_VISIBILITY_THROTTLE_MS = 120;
 
 type MainGameCarouselProps = {
   games: GameListItem[];
@@ -144,36 +147,106 @@ const GameCardSwiperFrame = ({
   onNext,
   onSlideChange,
   onSwiper,
-}: GameCardSwiperFrameProps) => (
-  <div className="group/carousel relative left-1/2 w-screen -translate-x-1/2">
-    {showNavigation && onPrevious ? (
-      <SlideButton direction="previous" onClick={onPrevious} />
-    ) : null}
+}: GameCardSwiperFrameProps) => {
+  const swiperRef = useRef<SwiperInstance | null>(null);
+  const throttledSwiperRef = useRef<SwiperInstance | null>(null);
+  const throttleTimeoutRef = useRef<number | null>(null);
+  const [shouldShowScrollReset, setShouldShowScrollReset] = useState(false);
 
-    <div className="px-[clamp(1rem,5vw,20rem)] py-2">
-      <div className="relative">
-        <Swiper
-          onSwiper={onSwiper}
-          onSlideChange={onSlideChange}
-          slidesPerView={1}
-          slidesPerGroup={1}
-          spaceBetween={20}
-          speed={450}
-          watchOverflow
-          breakpoints={GAME_CARD_SWIPER_BREAKPOINTS}
-          className="overflow-visible!"
-        >
-          {children}
-        </Swiper>
-        {showUpdatingOverlay ? <GameListUpdatingOverlay /> : null}
+  useEffect(
+    () => () => {
+      if (throttleTimeoutRef.current !== null) {
+        window.clearTimeout(throttleTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const syncScrollResetVisibility = (swiper: SwiperInstance) => {
+    const scrolledDistance = Math.abs(swiper.translate ?? 0);
+    const nextVisibility =
+      scrolledDistance >= SCROLL_RESET_VISIBILITY_THRESHOLD_PX &&
+      !swiper.isBeginning;
+
+    setShouldShowScrollReset((currentVisibility) =>
+      currentVisibility === nextVisibility ? currentVisibility : nextVisibility,
+    );
+  };
+
+  const scheduleScrollResetVisibilitySync = (swiper: SwiperInstance) => {
+    throttledSwiperRef.current = swiper;
+
+    if (throttleTimeoutRef.current !== null) {
+      return;
+    }
+
+    throttleTimeoutRef.current = window.setTimeout(() => {
+      throttleTimeoutRef.current = null;
+
+      if (throttledSwiperRef.current) {
+        syncScrollResetVisibility(throttledSwiperRef.current);
+      }
+    }, SCROLL_RESET_VISIBILITY_THROTTLE_MS);
+  };
+
+  const handleSwiper = (swiper: SwiperInstance) => {
+    swiperRef.current = swiper;
+    syncScrollResetVisibility(swiper);
+    onSwiper?.(swiper);
+  };
+
+  const handleSlideChange = (swiper: SwiperInstance) => {
+    scheduleScrollResetVisibilitySync(swiper);
+    onSlideChange?.(swiper);
+  };
+
+  const handleResetScroll = () => {
+    const swiper = swiperRef.current;
+
+    if (!swiper) {
+      return;
+    }
+
+    setShouldShowScrollReset(false);
+    swiper.slideTo(0, 450);
+  };
+
+  return (
+    <div className="group/carousel relative left-1/2 w-screen -translate-x-1/2">
+      {showNavigation && onPrevious ? (
+        <SlideButton direction="previous" onClick={onPrevious} />
+      ) : null}
+
+      <div className="px-[clamp(1rem,5vw,20rem)] py-2">
+        <div className="relative">
+          <Swiper
+            onSwiper={handleSwiper}
+            onSlideChange={handleSlideChange}
+            onSetTranslate={handleSlideChange}
+            slidesPerView={1}
+            slidesPerGroup={1}
+            spaceBetween={20}
+            speed={450}
+            watchOverflow
+            breakpoints={GAME_CARD_SWIPER_BREAKPOINTS}
+            className="overflow-visible!"
+          >
+            {children}
+          </Swiper>
+          <ScrollResetButton
+            isVisible={shouldShowScrollReset}
+            onClick={handleResetScroll}
+          />
+          {showUpdatingOverlay ? <GameListUpdatingOverlay /> : null}
+        </div>
       </div>
-    </div>
 
-    {showNavigation && onNext ? (
-      <SlideButton direction="next" onClick={onNext} />
-    ) : null}
-  </div>
-);
+      {showNavigation && onNext ? (
+        <SlideButton direction="next" onClick={onNext} />
+      ) : null}
+    </div>
+  );
+};
 
 type SlideButtonProps = {
   direction: 'previous' | 'next';


### PR DESCRIPTION
## 관련 이슈

- closes #402

## 변경 내용

- 메인 페이지 `인기 TOP 100` 가로 게임 목록에 스크롤 위치 기반 `처음으로` 초기화 버튼을 추가했습니다.
- 목록이 일정 거리 이상 이동했을 때만 버튼이 나타나고, 버튼 클릭 시 목록이 맨 앞으로 부드럽게 이동하도록 캐러셀 동작을 보강했습니다.
- 스크롤이 다시 시작점으로 돌아오면 버튼이 자동으로 숨겨지도록 상태를 정리했습니다.
- 스크롤 감지 로직은 throttle 처리해 불필요한 상태 업데이트를 줄였고, 향후 다른 가로 목록에서도 재사용할 수 있도록 `ScrollResetButton` 컴포넌트로 분리했습니다.
- 버튼이 게임 제목이나 별점을 가리지 않도록 크기와 위치를 조정해, 카드 이미지 하단 우측 오버레이 영역에 자연스럽게 배치했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="888" height="1092" alt="image" src="https://github.com/user-attachments/assets/c141c591-b8cf-4a1b-af77-d73b480c4d71" />

## 참고사항

- 이번 변경은 메인 페이지 인기 게임 캐러셀의 스크롤 복귀 UX 개선에 한정됩니다.
- 현재 목록은 네이티브 `scrollLeft`가 아닌 `Swiper` 기반이라, 동일한 사용자 경험을 `Swiper translate` 기준으로 구현했습니다.
