### PR TITLE
[Fix] access token 흐름을 명세에 맞게 정렬

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -6,10 +6,10 @@ import axios, {
 
 import { logAxiosError } from './logApiError';
 import { apiBaseUrl } from '../lib/env';
-import { readStoredAccessToken } from '../store/useAuthStore';
+import { readMemoryAccessToken } from '../store/useAuthStore';
 import {
   expireAuthSession,
-  refreshStoredAccessToken,
+  refreshMemoryAccessToken,
 } from '../features/auth/utils/sessionManager';
 
 /**
@@ -91,7 +91,7 @@ const getRefreshedAccessToken = async () => {
   if (!isRefreshing) {
     isRefreshing = true;
     try {
-      const accessToken = await refreshStoredAccessToken();
+      const accessToken = await refreshMemoryAccessToken();
       onRefreshed(accessToken);
       return accessToken;
     } catch (refreshError) {
@@ -141,10 +141,10 @@ export const api = axios.create({
   },
 });
 
-// 요청 인터셉터: 항상 sessionStorage에서 최신 Access Token을 가져온다.
+// 요청 인터셉터: 메모리 상태의 최신 Access Token을 Authorization 헤더에 싣는다.
 api.interceptors.request.use(
   (config) => {
-    const token = readStoredAccessToken();
+    const token = readMemoryAccessToken();
 
     if (token) {
       setAuthorizationHeader(config as RetriableRequestConfig, token);
@@ -168,7 +168,6 @@ api.interceptors.response.use(
     if (
       originalRequest &&
       error.response?.status === 401 &&
-      readStoredAccessToken() &&
       !originalRequest._retry &&
       shouldResetAuthSession(originalRequest.url, originalRequest.baseURL)
     ) {

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -4,17 +4,14 @@ import { useLocation } from 'react-router';
 import { shouldSkipAuthBootstrapPath } from '../../../constants/routeResolver';
 import {
   clearLegacyAuthStorage,
-  syncAccessTokenFromStorage,
   useAuthStore,
 } from '../../../store/useAuthStore';
 import {
   clearAuthSession,
-  hydrateAuthSessionFromAccessToken,
-  refreshStoredAccessToken,
+  ensureAuthSessionRestored,
   setAuthBootstrapLoading,
   setAuthBootstrapReady,
 } from '../utils/sessionManager';
-import { isAccessTokenExpiringSoon } from '../utils/accessToken';
 
 function useAuthBootstrap() {
   const location = useLocation();
@@ -36,22 +33,9 @@ function useAuthBootstrap() {
       return;
     }
 
-    const storedAccessToken = syncAccessTokenFromStorage();
-
-    if (!storedAccessToken) {
-      setAuthBootstrapReady();
-      return;
-    }
-
     setAuthBootstrapLoading();
 
-    const restorePromise = isAccessTokenExpiringSoon(storedAccessToken)
-      ? refreshStoredAccessToken().then((refreshedAccessToken) =>
-          hydrateAuthSessionFromAccessToken(refreshedAccessToken),
-        )
-      : hydrateAuthSessionFromAccessToken(storedAccessToken);
-
-    void restorePromise
+    void ensureAuthSessionRestored()
       .catch(() => {
         clearAuthSession({ setReady: false });
       })

--- a/src/features/auth/utils/sessionManager.ts
+++ b/src/features/auth/utils/sessionManager.ts
@@ -146,7 +146,7 @@ export const hydrateAuthSessionFromAccessToken = async (
   };
 };
 
-export const refreshStoredAccessToken = async (
+export const refreshMemoryAccessToken = async (
   options: RestoreAuthSessionOptions = {},
 ) => {
   const { access_token: accessToken } = await refreshAccessToken(options);
@@ -159,7 +159,7 @@ export const restoreAuthSession = async (
   options: RestoreAuthSessionOptions = {},
 ) => {
   try {
-    const accessToken = await refreshStoredAccessToken(options);
+    const accessToken = await refreshMemoryAccessToken(options);
     return await hydrateAuthSessionFromAccessToken(accessToken);
   } catch (error) {
     const shouldNotifySessionRestoreFailure = hasSessionRestoreHint();

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -5,8 +5,8 @@ import type {
 } from '../features/auth/types/auth';
 
 /**
- * [Auth] 쿠키 기반 세션 복구 업데이트
- * - Access Token: sessionStorage 및 클라이언트 메모리(Zustand State)에서 유지합니다.
+ * [Auth] 쿠키 기반 세션 복구
+ * - Access Token: 클라이언트 메모리(Zustand State)에서만 유지합니다.
  * - Refresh Token: 브라우저 HttpOnly Cookie 기반 관리 (백엔드 주도)
  * - 레거시 localStorage 인증 키는 앱 시작 시 1회 정리합니다.
  */
@@ -14,57 +14,8 @@ import type {
 export type AuthBootstrapStatus = 'idle' | 'loading' | 'ready';
 export type AuthAccessStatus = 'loading' | 'authenticated' | 'unauthenticated';
 
-export const AUTH_ACCESS_TOKEN_STORAGE_KEY = 'access_token';
-const LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY = 'auth-access-token';
 const AUTH_PROFILE_PREVIEW_STORAGE_KEY = 'auth-profile-preview-image-url';
 const AUTH_SOCIAL_ACCOUNT_STORAGE_KEY = 'auth-social-account';
-
-export const readStoredAccessToken = () => {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  const persistedAccessToken =
-    window.sessionStorage.getItem(AUTH_ACCESS_TOKEN_STORAGE_KEY)?.trim() ?? '';
-
-  if (persistedAccessToken) {
-    return persistedAccessToken;
-  }
-
-  const legacyAccessToken =
-    window.sessionStorage
-      .getItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY)
-      ?.trim() ?? '';
-
-  if (!legacyAccessToken) {
-    return null;
-  }
-
-  window.sessionStorage.setItem(
-    AUTH_ACCESS_TOKEN_STORAGE_KEY,
-    legacyAccessToken,
-  );
-  window.sessionStorage.removeItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY);
-
-  return legacyAccessToken;
-};
-
-const persistAccessToken = (token: string | null) => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  const normalizedToken = token?.trim() ?? '';
-
-  if (!normalizedToken) {
-    window.sessionStorage.removeItem(AUTH_ACCESS_TOKEN_STORAGE_KEY);
-    window.sessionStorage.removeItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY);
-    return;
-  }
-
-  window.sessionStorage.setItem(AUTH_ACCESS_TOKEN_STORAGE_KEY, normalizedToken);
-  window.sessionStorage.removeItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY);
-};
 
 const readPersistedProfilePreviewImageUrl = () => {
   if (typeof window === 'undefined') {
@@ -169,19 +120,16 @@ export type AuthSessionStateSnapshot = {
 };
 
 export const useAuthStore = create<AuthState>((set) => {
-  const persistedAccessToken = readStoredAccessToken();
-
   return {
-    accessToken: persistedAccessToken,
+    accessToken: null,
     account: null,
     socialAccount: readPersistedSocialAccount(),
     profilePreviewImageUrl: readPersistedProfilePreviewImageUrl(),
-    isAuthenticated: Boolean(persistedAccessToken),
+    isAuthenticated: false,
     authBootstrapStatus: 'idle',
 
     setAccessToken: (token) => {
       const normalizedToken = token.trim();
-      persistAccessToken(normalizedToken);
       set({
         accessToken: normalizedToken,
         isAuthenticated: Boolean(normalizedToken),
@@ -205,7 +153,6 @@ export const useAuthStore = create<AuthState>((set) => {
 
     setAuth: (token, account, socialAccount) => {
       const normalizedToken = token.trim();
-      persistAccessToken(normalizedToken);
       persistProfilePreviewImageUrl(account?.profile_img_url);
       persistSocialAccount(socialAccount);
       set({
@@ -218,7 +165,6 @@ export const useAuthStore = create<AuthState>((set) => {
     },
 
     clearAuth: () => {
-      persistAccessToken(null);
       persistProfilePreviewImageUrl(null);
       persistSocialAccount(null);
       set({
@@ -238,27 +184,11 @@ export const useAuthStore = create<AuthState>((set) => {
   };
 });
 
-export const syncAccessTokenFromStorage = () => {
-  const storedAccessToken = readStoredAccessToken();
-  const currentState = useAuthStore.getState();
-  const normalizedStoredAccessToken = storedAccessToken?.trim() ?? null;
-  const normalizedStateAccessToken = currentState.accessToken?.trim() ?? null;
-
-  if (normalizedStoredAccessToken === normalizedStateAccessToken) {
-    return normalizedStoredAccessToken;
-  }
-
-  if (normalizedStoredAccessToken) {
-    currentState.setAccessToken(normalizedStoredAccessToken);
-    return normalizedStoredAccessToken;
-  }
-
-  currentState.clearAuth();
-  return null;
-};
+export const readMemoryAccessToken = () =>
+  useAuthStore.getState().accessToken?.trim() || null;
 
 /**
- * 기존 localStorage에 저장되던 모든 인증 관련 레거시 키를 삭제합니다.
+ * 기존 브라우저 저장소에 남아 있던 인증 관련 레거시 키를 삭제합니다.
  */
 export const clearLegacyAuthStorage = () => {
   if (typeof window === 'undefined') return;
@@ -274,4 +204,6 @@ export const clearLegacyAuthStorage = () => {
   ];
 
   LEGACY_KEYS.forEach((key) => window.localStorage.removeItem(key));
+  LEGACY_KEYS.forEach((key) => window.sessionStorage.removeItem(key));
+  window.sessionStorage.removeItem('auth-access-token');
 };


### PR DESCRIPTION
## 관련 이슈

- closes #404

## 변경 내용

- Access Token을 `sessionStorage`에 저장하던 로직을 제거하고 In-Memory 상태에서만 관리하도록 정리했습니다.
- 앱 초기화/새로고침 시 Refresh Token(HttpOnly Cookie) 기반 `/api/v1/accounts/token/refresh` 복구를 시도하도록 인증 부트스트랩 흐름을 복구했습니다.
- 소셜 로그인 콜백 이후 refresh를 통해 Access Token을 발급받고 In-Memory에 반영하는 흐름을 명세 기준으로 정렬했습니다.
- Axios 요청 인터셉터가 In-Memory Access Token을 `Authorization: Bearer` 헤더에 사용하도록 수정했습니다.
- 401 응답 시 토큰 갱신 Queue/Lock 동시성 제어 로직은 유지했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- 브라우저 직접 검증은 Browser Use 보안 정책으로 완료하지 못했습니다.
- `npm run build` 시 기존과 동일하게 메인 chunk 500KB 초과 경고가 있습니다.
