### PR TITLE
[Feat] 마이페이지 찜 목록 무한 스크롤 추가

### DIFF
--- a/src/features/auth/api/queryKeys.ts
+++ b/src/features/auth/api/queryKeys.ts
@@ -8,6 +8,8 @@ const resolveLikedGamesPage = (payload: LikedGamesRequest = {}) =>
   payload.page ?? 1;
 const resolveLikedGamesPageSize = (payload: LikedGamesRequest = {}) =>
   payload.page_size;
+const resolveLikedGamesInfinitePageSize = (payload: LikedGamesRequest = {}) =>
+  payload.page_size ?? 20;
 
 export const authKeys = {
   all: authRootKey,
@@ -22,6 +24,12 @@ export const authKeys = {
       ...authLikedGamesKey,
       resolveLikedGamesPage(payload),
       resolveLikedGamesPageSize(payload),
+    ] as const,
+  likedGamesInfiniteList: (payload: LikedGamesRequest = {}) =>
+    [
+      ...authLikedGamesKey,
+      'infinite',
+      resolveLikedGamesInfinitePageSize(payload),
     ] as const,
   unlikeLikedGame: () => [...authLikedGamesKey, 'unlike'] as const,
   profileImagePresignedUrl: () =>

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import {
   checkIdDuplicate,
@@ -30,6 +35,8 @@ import type {
 import { syncLikeMutationStateInQueryCache } from '../../games/queryCache';
 import { syncAuthAccount } from '../utils/sessionManager';
 import { useAuthStore } from '../../../store/useAuthStore';
+
+const LIKED_GAMES_PAGE_SIZE = 20;
 
 export const useLoginMutation = () =>
   useMutation({
@@ -67,6 +74,42 @@ export const useLikedGamesQuery = (
     enabled,
     staleTime: 60_000,
   });
+
+export const useInfiniteLikedGamesQuery = (
+  enabled = true,
+  payload: LikedGamesRequest = {},
+) => {
+  const pageSize = payload.page_size ?? LIKED_GAMES_PAGE_SIZE;
+  const initialPage = payload.page ?? 1;
+
+  return useInfiniteQuery({
+    queryKey: authKeys.likedGamesInfiniteList({
+      page_size: pageSize,
+    }),
+    queryFn: ({ pageParam }) =>
+      getLikedGames({
+        ...payload,
+        page: pageParam,
+        page_size: pageSize,
+      }),
+    initialPageParam: initialPage,
+    getNextPageParam: (lastPage, allPages) => {
+      const loadedCount = allPages.reduce(
+        (totalCount, page) =>
+          totalCount + (Array.isArray(page.results) ? page.results.length : 0),
+        0,
+      );
+      const totalCount =
+        typeof lastPage.count === 'number' ? lastPage.count : loadedCount;
+
+      return loadedCount < totalCount
+        ? initialPage + allPages.length
+        : undefined;
+    },
+    enabled,
+    staleTime: 60_000,
+  });
+};
 
 export const useUnlikeLikedGameMutation = () => {
   const queryClient = useQueryClient();

--- a/src/features/games/queryCache.ts
+++ b/src/features/games/queryCache.ts
@@ -93,6 +93,9 @@ const updateGameListItem = (
 const primaryLikedGamesQueryKey = authKeys.likedGamesList({
   page_size: PRIMARY_LIKED_GAMES_PAGE_SIZE,
 });
+const primaryInfiniteLikedGamesQueryKey = authKeys.likedGamesInfiniteList({
+  page_size: PRIMARY_LIKED_GAMES_PAGE_SIZE,
+});
 
 export const syncGameLikeStateInQueryCache = (
   queryClient: QueryClient,
@@ -184,6 +187,10 @@ export const syncLikedGamesStateInQueryCache = (
   queryClient: QueryClient,
   update: LikeMutationCacheUpdate,
 ) => {
+  const likedGameSeed = update.likedGame ?? {
+    gameId: update.gameId,
+  };
+
   queryClient.setQueryData<LikedGamesResponse>(
     primaryLikedGamesQueryKey,
     (currentLikedGames) => {
@@ -193,10 +200,57 @@ export const syncLikedGamesStateInQueryCache = (
 
       return applyLikeStateToLikedGamesResponse(currentLikedGames, {
         isLiked: update.isLiked,
-        seed: update.likedGame ?? {
-          gameId: update.gameId,
-        },
+        seed: likedGameSeed,
       });
+    },
+  );
+
+  queryClient.setQueryData<InfiniteData<LikedGamesResponse>>(
+    primaryInfiniteLikedGamesQueryKey,
+    (currentLikedGames) => {
+      if (!currentLikedGames || !Array.isArray(currentLikedGames.pages)) {
+        return currentLikedGames;
+      }
+
+      const hasLoadedGame = currentLikedGames.pages.some((page) =>
+        page.results.some((likedGame) => likedGame.game_id === update.gameId),
+      );
+
+      return {
+        ...currentLikedGames,
+        pages: currentLikedGames.pages.map((page, pageIndex) => {
+          if (!isLikedGamesResponse(page)) {
+            return page;
+          }
+
+          if (update.isLiked) {
+            const nextCount = hasLoadedGame ? page.count : page.count + 1;
+
+            if (pageIndex > 0 || hasLoadedGame) {
+              return {
+                ...page,
+                count: nextCount,
+              };
+            }
+
+            return {
+              ...applyLikeStateToLikedGamesResponse(page, {
+                isLiked: true,
+                seed: likedGameSeed,
+              }),
+              count: nextCount,
+            };
+          }
+
+          return {
+            ...page,
+            count: Math.max(0, page.count - 1),
+            results: page.results.filter(
+              (likedGame) => likedGame.game_id !== update.gameId,
+            ),
+          };
+        }),
+      };
     },
   );
 };

--- a/src/pages/mypage/components/MyPageLikedGamesSection.tsx
+++ b/src/pages/mypage/components/MyPageLikedGamesSection.tsx
@@ -1,4 +1,5 @@
 import { Heart } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 
 import AuthButton from '../../../components/auth/AuthButton';
 import ConfirmModal from '../../../components/mypage/ConfirmModal';
@@ -27,11 +28,15 @@ function MyPageLikedGamesSection({
     isFavoriteGamesLoading,
     isFavoriteGamesError,
     isFetchingFavoriteGames,
+    isFetchingMoreFavoriteGames,
+    hasMoreFavoriteGames,
+    loadedFavoriteGamesCount,
     selectedFavoriteGame,
     isUnlikePending,
     setSelectedFavoriteGame,
     handleFavoriteGameCardClick,
     handleFavoriteGameDeleteConfirm,
+    loadMoreFavoriteGames,
     refetchFavoriteGames,
   } = useMyPageLikedGames({
     enabled,
@@ -40,9 +45,52 @@ function MyPageLikedGamesSection({
   });
   const safeFavoriteGames = Array.isArray(favoriteGames) ? favoriteGames : [];
   const hasFavoriteGames = safeFavoriteGames.length > 0;
+  const listContainerRef = useRef<HTMLDivElement | null>(null);
+  const loadMoreTriggerRef = useRef<HTMLDivElement | null>(null);
   const listContainerClass = hasFavoriteGames
     ? 'mypage-scrollbar mt-5 max-w-full overflow-x-hidden overflow-y-auto pr-1 max-h-[38rem]'
     : 'mt-5 max-w-full';
+
+  useEffect(() => {
+    const triggerElement = loadMoreTriggerRef.current;
+
+    if (
+      !enabled ||
+      !hasFavoriteGames ||
+      !hasMoreFavoriteGames ||
+      isFavoriteGamesLoading ||
+      isFetchingMoreFavoriteGames ||
+      !triggerElement
+    ) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          void loadMoreFavoriteGames();
+        }
+      },
+      {
+        root: listContainerRef.current,
+        rootMargin: '160px 0px',
+        threshold: 0.1,
+      },
+    );
+
+    observer.observe(triggerElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    enabled,
+    hasFavoriteGames,
+    hasMoreFavoriteGames,
+    isFavoriteGamesLoading,
+    isFetchingMoreFavoriteGames,
+    loadMoreFavoriteGames,
+  ]);
 
   return (
     <>
@@ -68,20 +116,45 @@ function MyPageLikedGamesSection({
           ) : null}
         </div>
 
-        <div className={listContainerClass}>
+        <div ref={listContainerRef} className={listContainerClass}>
           {isFavoriteGamesLoading ? (
             <FavoriteGameCardSkeleton />
           ) : hasFavoriteGames ? (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              {safeFavoriteGames.map((game) => (
-                <FavoriteGameCard
-                  key={`${game.gameId}:${game.thumbnailUrl ?? 'none'}:${favoriteListRenderVersion}`}
-                  game={game}
-                  onClick={handleFavoriteGameCardClick}
-                  onFavoriteClick={setSelectedFavoriteGame}
-                />
-              ))}
-            </div>
+            <>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                {safeFavoriteGames.map((game) => (
+                  <FavoriteGameCard
+                    key={`${game.gameId}:${game.thumbnailUrl ?? 'none'}:${favoriteListRenderVersion}`}
+                    game={game}
+                    onClick={handleFavoriteGameCardClick}
+                    onFavoriteClick={setSelectedFavoriteGame}
+                  />
+                ))}
+              </div>
+
+              {hasMoreFavoriteGames ? (
+                <div className="mt-5 flex flex-col items-center gap-2">
+                  <div
+                    ref={loadMoreTriggerRef}
+                    className="flex min-h-12 items-center justify-center"
+                    aria-live="polite"
+                  >
+                    {isFetchingMoreFavoriteGames ? (
+                      <p className="text-mypage-muted text-sm">
+                        다음 찜 목록을 불러오는 중입니다.
+                      </p>
+                    ) : (
+                      <span className="sr-only">
+                        아래로 스크롤하면 다음 찜 목록을 불러옵니다.
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-mypage-muted text-xs">
+                    {loadedFavoriteGamesCount} / {favoriteCount}개 표시 중
+                  </p>
+                </div>
+              ) : null}
+            </>
           ) : isFavoriteGamesError ? (
             <div
               role="status"

--- a/src/pages/mypage/hooks/useMyPageLikedGames.ts
+++ b/src/pages/mypage/hooks/useMyPageLikedGames.ts
@@ -5,7 +5,7 @@ import { useMemo, useState } from 'react';
 import { extractAuthApiErrorMessage } from '../../../features/auth/api/auth';
 import { authKeys } from '../../../features/auth/api/queryKeys';
 import {
-  useLikedGamesQuery,
+  useInfiniteLikedGamesQuery,
   useUnlikeLikedGameMutation,
 } from '../../../features/auth/api/useAuthApi';
 import type { LikedGamesResponse } from '../../../features/auth/types/auth';
@@ -21,6 +21,8 @@ import {
   toStringList,
 } from '../utils';
 
+const LIKED_GAMES_PAGE_SIZE = 20;
+
 type UseMyPageLikedGamesOptions = {
   enabled: boolean;
   onOpenGameDetail: (game: GameListItem) => void;
@@ -33,8 +35,8 @@ function useMyPageLikedGames({
   onToast,
 }: UseMyPageLikedGamesOptions) {
   const queryClient = useQueryClient();
-  const likedGamesQuery = useLikedGamesQuery(enabled, {
-    page_size: 20,
+  const likedGamesQuery = useInfiniteLikedGamesQuery(enabled, {
+    page_size: LIKED_GAMES_PAGE_SIZE,
     page: 1,
   });
   const likedGamesData = likedGamesQuery.data;
@@ -42,21 +44,26 @@ function useMyPageLikedGames({
   const [selectedFavoriteGame, setSelectedFavoriteGame] =
     useState<FavoriteGamePreview | null>(null);
   const [favoriteListRenderVersion, setFavoriteListRenderVersion] = useState(0);
+  const likedGamesResults = useMemo(
+    () =>
+      likedGamesData?.pages.flatMap((page) =>
+        Array.isArray(page.results) ? page.results : [],
+      ) ?? [],
+    [likedGamesData],
+  );
   const serverFavoriteGames = useMemo(() => {
-    const safeLikedGamesResults = Array.isArray(likedGamesData?.results)
-      ? likedGamesData.results
-      : [];
-
-    return safeLikedGamesResults
+    return likedGamesResults
       .map(toFavoriteGamePreview)
       .filter((game) => game.gameId > 0);
-  }, [likedGamesData]);
+  }, [likedGamesResults]);
 
   const favoriteGames = serverFavoriteGames;
   const favoriteCount =
-    typeof likedGamesData?.count === 'number'
-      ? likedGamesData.count
-      : serverFavoriteGames.length;
+    likedGamesData?.pages.reduce(
+      (currentCount, page) =>
+        typeof page.count === 'number' ? page.count : currentCount,
+      serverFavoriteGames.length,
+    ) ?? serverFavoriteGames.length;
 
   const refetchFavoriteGames = likedGamesQuery.refetch;
   const isFavoriteGamesLoading =
@@ -81,48 +88,54 @@ function useMyPageLikedGames({
       const previousLikedGameMap = new Map(
         previousLikedGames.map((game) => [game.game_id, game]),
       );
-      const nextLikedGamesResults = Array.isArray(nextLikedGames.results)
-        ? nextLikedGames.results
-        : [];
-      const nextResults = nextLikedGamesResults.map((game) => {
-        const previousGame = previousLikedGameMap.get(game.game_id);
-        const normalizedGenres = toStringList(game.genres);
-        const previousGenres = toStringList(previousGame?.genres);
-
-        return {
-          ...game,
-          game_title: toDisplayText(
-            game.game_title,
-            toDisplayText(previousGame?.game_title),
-          ),
-          thumbnail_url:
-            normalizeThumbnailUrl(game.thumbnail_url) ??
-            normalizeThumbnailUrl(previousGame?.thumbnail_url) ??
-            null,
-          genres:
-            normalizedGenres.length > 0 ? normalizedGenres : previousGenres,
-        };
-      });
 
       queryClient.setQueryData(
-        authKeys.likedGamesList({
-          page_size: 20,
-          page: 1,
+        authKeys.likedGamesInfiniteList({
+          page_size: LIKED_GAMES_PAGE_SIZE,
         }),
         {
           ...nextLikedGames,
-          count:
-            typeof nextLikedGames.count === 'number'
-              ? nextLikedGames.count
-              : nextResults.length,
-          results: nextResults,
+          pages: nextLikedGames.pages.map((page) => {
+            const nextLikedGamesResults = Array.isArray(page.results)
+              ? page.results
+              : [];
+            const nextResults = nextLikedGamesResults.map((game) => {
+              const previousGame = previousLikedGameMap.get(game.game_id);
+              const normalizedGenres = toStringList(game.genres);
+              const previousGenres = toStringList(previousGame?.genres);
+
+              return {
+                ...game,
+                game_title: toDisplayText(
+                  game.game_title,
+                  toDisplayText(previousGame?.game_title),
+                ),
+                thumbnail_url:
+                  normalizeThumbnailUrl(game.thumbnail_url) ??
+                  normalizeThumbnailUrl(previousGame?.thumbnail_url) ??
+                  null,
+                genres:
+                  normalizedGenres.length > 0
+                    ? normalizedGenres
+                    : previousGenres,
+              };
+            });
+
+            return {
+              ...page,
+              count:
+                typeof page.count === 'number'
+                  ? page.count
+                  : nextResults.length,
+              results: nextResults,
+            };
+          }),
         },
       );
     } catch {
       void queryClient.invalidateQueries({
-        queryKey: authKeys.likedGamesList({
-          page_size: 20,
-          page: 1,
+        queryKey: authKeys.likedGamesInfiniteList({
+          page_size: LIKED_GAMES_PAGE_SIZE,
         }),
       });
     }
@@ -144,9 +157,7 @@ function useMyPageLikedGames({
       return;
     }
 
-    const previousLikedGames = Array.isArray(likedGamesData?.results)
-      ? likedGamesData.results
-      : [];
+    const previousLikedGames = likedGamesResults;
 
     try {
       await unlikeLikedGameMutation.mutateAsync(targetGameId);
@@ -187,11 +198,15 @@ function useMyPageLikedGames({
     isFavoriteGamesLoading,
     isFavoriteGamesError,
     isFetchingFavoriteGames: likedGamesQuery.isFetching,
+    isFetchingMoreFavoriteGames: likedGamesQuery.isFetchingNextPage,
+    hasMoreFavoriteGames: Boolean(likedGamesQuery.hasNextPage),
+    loadedFavoriteGamesCount: favoriteGames.length,
     selectedFavoriteGame,
     isUnlikePending: unlikeLikedGameMutation.isPending,
     setSelectedFavoriteGame,
     handleFavoriteGameCardClick,
     handleFavoriteGameDeleteConfirm,
+    loadMoreFavoriteGames: likedGamesQuery.fetchNextPage,
     refetchFavoriteGames,
   };
 }


### PR DESCRIPTION
## 관련 이슈

- closes #408

## 변경 내용

- API 명세의 `page`, `page_size`, `page_size max: 20` 기준에 맞춰 찜 목록을 페이지 단위로 추가 조회하도록 수정했습니다.
- 기존 첫 페이지만 조회하던 찜 목록을 TanStack Query `useInfiniteQuery` 기반으로 변경했습니다.
- 마이페이지 찜 목록 하단에 도달하면 다음 페이지를 자동 호출하는 무한 스크롤을 적용했습니다.
- 찜 해제 시 무한 페이지 캐시에서도 좋아요 상태와 찜 목록이 동기화되도록 보강했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="2480" height="1754" alt="image" src="https://github.com/user-attachments/assets/60fbf29a-356d-45f4-9bbc-7562792f2110" />

## 참고사항
