### PR TITLE
[Fix] 새로고침 시 인증 세션 유지 로직 복구

### DIFF
--- a/docs/ai/api-contract/auth.md
+++ b/docs/ai/api-contract/auth.md
@@ -18,10 +18,11 @@
 
 ## 1. 토큰 저장 및 관리 전략
 
-- **Access Token**: 클라이언트 메모리(Zustand State) 내에서 관리하여 XSS 공격 방어.
+- **Access Token**: 새로고침 안정성을 위해 `sessionStorage`와 클라이언트 메모리(Zustand State)에 함께 유지합니다. `localStorage`에는 저장하지 않습니다.
 - **Refresh Token**: 브라우저 **HttpOnly, Secure 쿠키** 기반으로 관리하여 보안 강화. 쿠키는 프론트 도메인이 아니라 **백엔드 API 도메인** 아래 저장되는 것을 기준으로 확인합니다.
-- **Startup Bootstrap**: 앱 최초 진입 시 `POST /api/v1/accounts/token/refresh`로 세션 복구를 시도하고, 성공 시 `/me` 조회로 사용자 정보를 hydrate함.
-- **Legacy Cleanup**: 기존 브라우저 저장소 인증 키(`auth-storage`, `access_token`, `refresh_token` 등)는 앱 시작 시 1회 정리함.
+- **Startup Bootstrap**: 앱 최초 진입 시 `sessionStorage`의 Access Token을 먼저 복구합니다. 저장된 Access Token이 없으면 바로 ready 처리하고, 저장된 토큰이 만료 임박한 경우에만 `POST /api/v1/accounts/token/refresh`를 호출합니다.
+- **Refresh 호출 조건**: 일반 새로고침(F5)에서는 불필요한 refresh를 피하고, Access Token 만료 임박 또는 API `401 Unauthorized` 응답 시에만 refresh를 시도합니다.
+- **Legacy Cleanup**: 기존 `localStorage` 인증 키(`auth-storage`, `access_token`, `refresh_token` 등)는 앱 시작 시 1회 정리합니다. 현재 세션의 `sessionStorage.access_token`은 유지합니다.
 
 ### 운영 Origin 기준
 
@@ -92,7 +93,8 @@
 
 ## 4. 인증 에러(401) 처리 로직
 
-- **Axios Interceptor**: 모든 API 요청에서 `401 Unauthorized` 발생 시 `/token/refresh`를 자동 호출하여 세션 연장 시도.
+- **Axios Interceptor**: 저장된 Access Token이 있는 요청에서 `401 Unauthorized` 발생 시 `/token/refresh`를 자동 호출하여 세션 연장 시도.
+- **Refresh 동시성 제어**: 여러 API가 동시에 401을 받아도 하나의 refresh만 실행하고, 나머지는 subscriber queue에서 대기합니다.
 - **세션 만료 처리**: 리프레시 토큰 만료로 갱신 실패 시, '세션 만료' 안내 후 강제 로그아웃 및 로그인 페이지로 유도.
 - **초기 진입 예외 처리**: 콜백 라우트(`/callback`, `/auth/callback`)에서는 중복 refresh를 피하기 위해 앱 시작 bootstrap을 건너뜀.
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -6,10 +6,10 @@ import axios, {
 
 import { logAxiosError } from './logApiError';
 import { apiBaseUrl } from '../lib/env';
-import { readMemoryAccessToken } from '../store/useAuthStore';
+import { readStoredAccessToken } from '../store/useAuthStore';
 import {
   expireAuthSession,
-  refreshMemoryAccessToken,
+  refreshStoredAccessToken,
 } from '../features/auth/utils/sessionManager';
 
 /**
@@ -91,7 +91,7 @@ const getRefreshedAccessToken = async () => {
   if (!isRefreshing) {
     isRefreshing = true;
     try {
-      const accessToken = await refreshMemoryAccessToken();
+      const accessToken = await refreshStoredAccessToken();
       onRefreshed(accessToken);
       return accessToken;
     } catch (refreshError) {
@@ -141,10 +141,10 @@ export const api = axios.create({
   },
 });
 
-// 요청 인터셉터: 메모리 상태의 최신 Access Token을 Authorization 헤더에 싣는다.
+// 요청 인터셉터: 항상 sessionStorage에서 최신 Access Token을 가져온다.
 api.interceptors.request.use(
   (config) => {
-    const token = readMemoryAccessToken();
+    const token = readStoredAccessToken();
 
     if (token) {
       setAuthorizationHeader(config as RetriableRequestConfig, token);
@@ -168,6 +168,7 @@ api.interceptors.response.use(
     if (
       originalRequest &&
       error.response?.status === 401 &&
+      readStoredAccessToken() &&
       !originalRequest._retry &&
       shouldResetAuthSession(originalRequest.url, originalRequest.baseURL)
     ) {

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -4,14 +4,17 @@ import { useLocation } from 'react-router';
 import { shouldSkipAuthBootstrapPath } from '../../../constants/routeResolver';
 import {
   clearLegacyAuthStorage,
+  syncAccessTokenFromStorage,
   useAuthStore,
 } from '../../../store/useAuthStore';
 import {
   clearAuthSession,
-  ensureAuthSessionRestored,
+  hydrateAuthSessionFromAccessToken,
+  refreshStoredAccessToken,
   setAuthBootstrapLoading,
   setAuthBootstrapReady,
 } from '../utils/sessionManager';
+import { isAccessTokenExpiringSoon } from '../utils/accessToken';
 
 function useAuthBootstrap() {
   const location = useLocation();
@@ -33,9 +36,22 @@ function useAuthBootstrap() {
       return;
     }
 
+    const storedAccessToken = syncAccessTokenFromStorage();
+
+    if (!storedAccessToken) {
+      setAuthBootstrapReady();
+      return;
+    }
+
     setAuthBootstrapLoading();
 
-    void ensureAuthSessionRestored()
+    const restorePromise = isAccessTokenExpiringSoon(storedAccessToken)
+      ? refreshStoredAccessToken().then((refreshedAccessToken) =>
+          hydrateAuthSessionFromAccessToken(refreshedAccessToken),
+        )
+      : hydrateAuthSessionFromAccessToken(storedAccessToken);
+
+    void restorePromise
       .catch(() => {
         clearAuthSession({ setReady: false });
       })

--- a/src/features/auth/utils/sessionManager.ts
+++ b/src/features/auth/utils/sessionManager.ts
@@ -146,7 +146,7 @@ export const hydrateAuthSessionFromAccessToken = async (
   };
 };
 
-export const refreshMemoryAccessToken = async (
+export const refreshStoredAccessToken = async (
   options: RestoreAuthSessionOptions = {},
 ) => {
   const { access_token: accessToken } = await refreshAccessToken(options);
@@ -159,7 +159,7 @@ export const restoreAuthSession = async (
   options: RestoreAuthSessionOptions = {},
 ) => {
   try {
-    const accessToken = await refreshMemoryAccessToken(options);
+    const accessToken = await refreshStoredAccessToken(options);
     return await hydrateAuthSessionFromAccessToken(accessToken);
   } catch (error) {
     const shouldNotifySessionRestoreFailure = hasSessionRestoreHint();

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -5,8 +5,8 @@ import type {
 } from '../features/auth/types/auth';
 
 /**
- * [Auth] 쿠키 기반 세션 복구
- * - Access Token: 클라이언트 메모리(Zustand State)에서만 유지합니다.
+ * [Auth] 쿠키 기반 세션 복구 업데이트
+ * - Access Token: sessionStorage 및 클라이언트 메모리(Zustand State)에서 유지합니다.
  * - Refresh Token: 브라우저 HttpOnly Cookie 기반 관리 (백엔드 주도)
  * - 레거시 localStorage 인증 키는 앱 시작 시 1회 정리합니다.
  */
@@ -14,8 +14,57 @@ import type {
 export type AuthBootstrapStatus = 'idle' | 'loading' | 'ready';
 export type AuthAccessStatus = 'loading' | 'authenticated' | 'unauthenticated';
 
+export const AUTH_ACCESS_TOKEN_STORAGE_KEY = 'access_token';
+const LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY = 'auth-access-token';
 const AUTH_PROFILE_PREVIEW_STORAGE_KEY = 'auth-profile-preview-image-url';
 const AUTH_SOCIAL_ACCOUNT_STORAGE_KEY = 'auth-social-account';
+
+export const readStoredAccessToken = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const persistedAccessToken =
+    window.sessionStorage.getItem(AUTH_ACCESS_TOKEN_STORAGE_KEY)?.trim() ?? '';
+
+  if (persistedAccessToken) {
+    return persistedAccessToken;
+  }
+
+  const legacyAccessToken =
+    window.sessionStorage
+      .getItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY)
+      ?.trim() ?? '';
+
+  if (!legacyAccessToken) {
+    return null;
+  }
+
+  window.sessionStorage.setItem(
+    AUTH_ACCESS_TOKEN_STORAGE_KEY,
+    legacyAccessToken,
+  );
+  window.sessionStorage.removeItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY);
+
+  return legacyAccessToken;
+};
+
+const persistAccessToken = (token: string | null) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const normalizedToken = token?.trim() ?? '';
+
+  if (!normalizedToken) {
+    window.sessionStorage.removeItem(AUTH_ACCESS_TOKEN_STORAGE_KEY);
+    window.sessionStorage.removeItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY);
+    return;
+  }
+
+  window.sessionStorage.setItem(AUTH_ACCESS_TOKEN_STORAGE_KEY, normalizedToken);
+  window.sessionStorage.removeItem(LEGACY_AUTH_ACCESS_TOKEN_STORAGE_KEY);
+};
 
 const readPersistedProfilePreviewImageUrl = () => {
   if (typeof window === 'undefined') {
@@ -120,16 +169,19 @@ export type AuthSessionStateSnapshot = {
 };
 
 export const useAuthStore = create<AuthState>((set) => {
+  const persistedAccessToken = readStoredAccessToken();
+
   return {
-    accessToken: null,
+    accessToken: persistedAccessToken,
     account: null,
     socialAccount: readPersistedSocialAccount(),
     profilePreviewImageUrl: readPersistedProfilePreviewImageUrl(),
-    isAuthenticated: false,
+    isAuthenticated: Boolean(persistedAccessToken),
     authBootstrapStatus: 'idle',
 
     setAccessToken: (token) => {
       const normalizedToken = token.trim();
+      persistAccessToken(normalizedToken);
       set({
         accessToken: normalizedToken,
         isAuthenticated: Boolean(normalizedToken),
@@ -153,6 +205,7 @@ export const useAuthStore = create<AuthState>((set) => {
 
     setAuth: (token, account, socialAccount) => {
       const normalizedToken = token.trim();
+      persistAccessToken(normalizedToken);
       persistProfilePreviewImageUrl(account?.profile_img_url);
       persistSocialAccount(socialAccount);
       set({
@@ -165,6 +218,7 @@ export const useAuthStore = create<AuthState>((set) => {
     },
 
     clearAuth: () => {
+      persistAccessToken(null);
       persistProfilePreviewImageUrl(null);
       persistSocialAccount(null);
       set({
@@ -184,11 +238,27 @@ export const useAuthStore = create<AuthState>((set) => {
   };
 });
 
-export const readMemoryAccessToken = () =>
-  useAuthStore.getState().accessToken?.trim() || null;
+export const syncAccessTokenFromStorage = () => {
+  const storedAccessToken = readStoredAccessToken();
+  const currentState = useAuthStore.getState();
+  const normalizedStoredAccessToken = storedAccessToken?.trim() ?? null;
+  const normalizedStateAccessToken = currentState.accessToken?.trim() ?? null;
+
+  if (normalizedStoredAccessToken === normalizedStateAccessToken) {
+    return normalizedStoredAccessToken;
+  }
+
+  if (normalizedStoredAccessToken) {
+    currentState.setAccessToken(normalizedStoredAccessToken);
+    return normalizedStoredAccessToken;
+  }
+
+  currentState.clearAuth();
+  return null;
+};
 
 /**
- * 기존 브라우저 저장소에 남아 있던 인증 관련 레거시 키를 삭제합니다.
+ * 기존 localStorage에 저장되던 모든 인증 관련 레거시 키를 삭제합니다.
  */
 export const clearLegacyAuthStorage = () => {
   if (typeof window === 'undefined') return;
@@ -204,6 +274,4 @@ export const clearLegacyAuthStorage = () => {
   ];
 
   LEGACY_KEYS.forEach((key) => window.localStorage.removeItem(key));
-  LEGACY_KEYS.forEach((key) => window.sessionStorage.removeItem(key));
-  window.sessionStorage.removeItem('auth-access-token');
 };


### PR DESCRIPTION
## 관련 이슈

- closes #410

## 변경 내용

- #404 이전의 새로고침 방어 로직을 복구했습니다.
- Access Token을 `sessionStorage`와 Zustand 메모리 상태에 함께 유지하도록 되돌렸습니다.
- 앱 시작 시 저장된 Access Token이 있으면 `/token/refresh` 대신 `/accounts/me` hydrate를 먼저 수행하도록 복구했습니다.
- Access Token이 없거나 만료 임박, 또는 API 401 발생 시에만 refresh를 호출하도록 정리했습니다.
- 내부 인증 계약 문서를 새로고침 안정성 기준 토큰 정책으로 업데이트했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- F5/RTR 레이스 컨디션 방지를 위해 백엔드 명세서 및 요구사항 정의서 수정 요청이 필요합니다.

