### PR TITLE
[Fix] 고객센터 챗봇 세션 유지 및 모바일 접근성 개선

### DIFF
--- a/docs/ai/api-contract/support-chat.md
+++ b/docs/ai/api-contract/support-chat.md
@@ -22,6 +22,22 @@ POST   /api/v1/chatbot/messages     # 메시지 전송 (세션 생성/재사용)
 GET    /api/v1/chatbot/stream       # AI 응답 스트리밍 (SSE, query: session_id)
 ```
 
+## Message Session Contract
+
+- `POST /api/v1/chatbot/messages`는 인증 없이 호출하며 `Authorization` 헤더를 사용하지 않습니다.
+- Request body는 `message`를 필수로 보내고, 최초 요청이 아닌 경우 직전 응답에서 받은 `session_id`를 함께 보냅니다.
+- 최초 요청은 `session_id`를 생략할 수 있으며, 응답의 `session_id`는 이후 메시지 요청과 스트리밍 요청에 재사용합니다.
+- `GET /api/v1/chatbot/stream`은 `session_id` query가 필수입니다.
+- 세션은 생성 또는 마지막 유효 요청 기준 30분 동안 유지됩니다.
+- 챗봇 대화는 현재 화면 한정 임시 상태입니다. 챗봇 종료, 패널 바깥 클릭, `Esc`, 화면 이탈, 새로고침 시 세션과 메시지 내역을 초기화합니다.
+
+```json
+{
+  "message": "아이디는 어디서 찾나요?",
+  "session_id": "1ae7032f-1051-441c-ae9d-07b7eb6d2b7d"
+}
+```
+
 ## Integration Details
 
 - **Widget**: `SupportChatWidget`을 통해 전역 레이아웃(`App.tsx`)에 배치.

--- a/src/components/support-chat/SupportChatLauncherButton.tsx
+++ b/src/components/support-chat/SupportChatLauncherButton.tsx
@@ -14,7 +14,9 @@ function SupportChatLauncherButton({
       type="button"
       onClick={onClick}
       aria-label={isOpen ? '고객센터 챗봇 닫기' : '고객센터 챗봇 열기'}
-      className="support-chat-fab group fixed right-4 bottom-4 z-95 flex h-16 w-16 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none motion-reduce:transition-none motion-reduce:hover:translate-y-0 sm:right-6 sm:bottom-6"
+      aria-controls={isOpen ? 'support-chat-panel' : undefined}
+      aria-expanded={isOpen}
+      className="support-chat-fab group fixed right-4 bottom-[calc(env(safe-area-inset-bottom,0px)+5.5rem)] z-95 flex h-16 w-16 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none motion-reduce:transition-none motion-reduce:hover:translate-y-0 sm:right-6 sm:bottom-6"
     >
       <span className="support-chat-fab-glow" />
       <Bot

--- a/src/components/support-chat/SupportChatPanel.tsx
+++ b/src/components/support-chat/SupportChatPanel.tsx
@@ -58,14 +58,15 @@ function SupportChatPanel({
   onInputChange,
   onSubmit,
 }: SupportChatPanelProps) {
+  if (!isOpen) {
+    return null;
+  }
+
   return (
     <div
+      id="support-chat-panel"
       ref={panelRef}
-      className={`support-chat-panel fixed right-4 bottom-24 z-90 flex h-[min(78vh,46rem)] w-[min(94vw,27rem)] origin-bottom-right flex-col overflow-hidden transition-all duration-300 ease-out motion-reduce:transition-none sm:right-6 sm:bottom-26 ${
-        isOpen
-          ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
-          : 'pointer-events-none translate-y-4 scale-95 opacity-0'
-      }`}
+      className="support-chat-panel support-chat-widget-panel pointer-events-auto fixed right-4 bottom-24 z-90 flex h-[min(78vh,46rem)] w-[min(94vw,27rem)] origin-bottom-right translate-y-0 scale-100 flex-col overflow-hidden opacity-100 transition-all duration-300 ease-out motion-reduce:transition-none sm:right-6 sm:bottom-26"
       role="dialog"
       aria-modal="false"
       aria-label="고객센터 챗봇"

--- a/src/features/support-chat/hooks/useSupportChatConversation.ts
+++ b/src/features/support-chat/hooks/useSupportChatConversation.ts
@@ -250,9 +250,11 @@ function useSupportChatConversation({
       setSubmitting(true);
 
       try {
+        const activeSessionId = useSupportChatStore.getState().sessionId;
+
         const response = await sendMessageMutation.mutateAsync({
           message: trimmedMessage,
-          session_id: sessionId ?? undefined,
+          session_id: activeSessionId ?? undefined,
         });
 
         if (requestGeneration !== requestGenerationRef.current) {
@@ -350,7 +352,6 @@ function useSupportChatConversation({
       finalizeAssistantMessage,
       hideQuickActions,
       isSubmitting,
-      sessionId,
       removeMessage,
       sendMessageMutation,
       setSubmitting,

--- a/src/index.css
+++ b/src/index.css
@@ -629,11 +629,15 @@
 }
 
 @media (max-width: 640px) {
-  .support-chat-panel {
+  .support-chat-widget-panel {
     right: 0.5rem;
-    bottom: 5rem;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 10.5rem);
     width: calc(100vw - 1rem);
-    height: min(76vh, 40rem);
+    height: min(
+      64vh,
+      calc(100dvh - env(safe-area-inset-bottom, 0px) - 12rem),
+      38rem
+    );
     border-radius: 24px;
   }
 }


### PR DESCRIPTION
## 관련 이슈

- closes #412

## 변경 내용

- 고객센터 챗봇 메시지 요청 시 직전 응답의 `session_id`를 다음 요청 payload에 재사용하도록 보강했습니다.
- 닫힌 챗봇 패널이 접근성 DOM 트리에 남지 않도록 조건부 렌더링으로 변경했습니다.
- 모바일 환경에서 챗봇 FAB가 하단 UI와 겹치지 않도록 safe-area 기반 bottom offset을 조정했습니다.
- `docs/ai` 고객센터 챗봇 API 문서를 최신 명세 기준으로 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="918" height="1484" alt="image" src="https://github.com/user-attachments/assets/8f691cfb-a3bb-47ad-aea1-234b9c415d99" />

## 참고사항

- 고객센터 챗봇 세션은 요구사항 정의서 기준에 따라 챗봇 닫기, 패널 바깥 클릭, `Esc`, 화면 이탈, 새로고침 시 초기화됩니다.
