### PR TITLE
[Fix] ConfirmModal 키보드 포커스 제어 개선

### DIFF
--- a/src/components/mypage/ConfirmModal.tsx
+++ b/src/components/mypage/ConfirmModal.tsx
@@ -1,6 +1,36 @@
+import { useEffect, useId, useRef } from 'react';
 import type { ReactNode } from 'react';
 
 import AuthButton from '../auth/AuthButton';
+
+const FOCUSABLE_ELEMENT_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+const getFocusableElements = (container: HTMLElement) =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_ELEMENT_SELECTOR),
+  ).filter((element) => {
+    if (element.getAttribute('aria-hidden') === 'true') {
+      return false;
+    }
+
+    return (
+      element.offsetWidth > 0 ||
+      element.offsetHeight > 0 ||
+      element.getClientRects().length > 0
+    );
+  });
 
 type ConfirmModalProps = {
   open: boolean;
@@ -25,26 +55,140 @@ function ConfirmModal({
   onConfirm,
   onClose,
 }: ConfirmModalProps) {
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const previousFocusedElementRef = useRef<HTMLElement | null>(null);
+  const onCloseRef = useRef(onClose);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    previousFocusedElementRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    const focusInitialElement = () => {
+      const modalElement = modalRef.current;
+
+      if (!modalElement) {
+        return;
+      }
+
+      const [firstFocusableElement] = getFocusableElements(modalElement);
+      (firstFocusableElement ?? modalElement).focus({ preventScroll: true });
+    };
+
+    const animationFrameId = window.requestAnimationFrame(focusInitialElement);
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const modalElement = modalRef.current;
+
+      if (!modalElement) {
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusableElements = getFocusableElements(modalElement);
+
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        modalElement.focus({ preventScroll: true });
+        return;
+      }
+
+      const firstFocusableElement = focusableElements[0];
+      const activeElement = document.activeElement;
+
+      if (!modalElement.contains(activeElement)) {
+        event.preventDefault();
+        firstFocusableElement.focus({ preventScroll: true });
+        return;
+      }
+
+      const activeElementIndex = focusableElements.findIndex(
+        (element) => element === activeElement,
+      );
+
+      if (activeElementIndex === -1) {
+        event.preventDefault();
+        firstFocusableElement.focus({ preventScroll: true });
+        return;
+      }
+
+      const nextElementIndex = event.shiftKey
+        ? activeElementIndex - 1
+        : activeElementIndex + 1;
+      const nextElement =
+        focusableElements[
+          (nextElementIndex + focusableElements.length) %
+            focusableElements.length
+        ];
+
+      if (!nextElement) {
+        return;
+      }
+
+      event.preventDefault();
+      nextElement.focus({ preventScroll: true });
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+      document.removeEventListener('keydown', handleKeyDown);
+
+      previousFocusedElementRef.current?.focus({ preventScroll: true });
+      previousFocusedElementRef.current = null;
+    };
+  }, [open]);
+
   if (!open) {
     return null;
   }
 
   return (
-    <div className="fixed inset-0 z-80 flex items-center justify-center px-4">
-      <button
-        type="button"
-        aria-label="모달 닫기"
+    <div
+      ref={modalRef}
+      className="fixed inset-0 z-80 flex items-center justify-center px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      tabIndex={-1}
+    >
+      <div
+        aria-hidden="true"
         onClick={onClose}
         className="bg-mypage-overlay absolute inset-0 cursor-pointer backdrop-blur-[3px]"
       />
 
       <div className="bg-mypage-panel relative z-10 w-full max-w-md rounded-[28px] border border-white/12 px-5 py-6 shadow-[0_38px_100px_rgba(0,0,0,0.58)] ring-1 ring-white/6 backdrop-blur-xl sm:px-6">
         <h2
+          id={titleId}
           className={`text-2xl font-semibold text-white ${align === 'center' ? 'text-center' : ''}`}
         >
           {title}
         </h2>
         <div
+          id={descriptionId}
           className={`text-mypage-muted mt-3 text-sm/6 sm:text-base/7 ${align === 'center' ? 'text-center' : ''}`}
         >
           {description}


### PR DESCRIPTION
## 관련 이슈

- closes #414

## 변경 내용

- `ConfirmModal`에 `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, `aria-describedby`를 추가했습니다.
- 모달 오픈 시 내부 첫 포커스 가능 요소로 초기 포커스가 이동하도록 개선했습니다.
- `Tab` / `Shift + Tab` 포커스 트랩을 추가해 키보드 포커스가 모달 밖으로 빠지지 않도록 했습니다.
- `Escape` 키로 모달을 닫을 수 있도록 지원했습니다.
- 모달 닫힘 후 기존에 포커스되어 있던 버튼으로 포커스가 복귀하도록 개선했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="1382" height="792" alt="image" src="https://github.com/user-attachments/assets/539b5688-86f2-47d0-9aad-6a4ea0c3b625" />

<img width="1172" height="646" alt="image" src="https://github.com/user-attachments/assets/c328af1e-3c90-4356-90fc-989ca6033990" />

## 참고사항

- UI 레이아웃 변경은 없고, 모달 접근성 및 키보드 조작 개선만 포함됩니다.
