### PR TITLE
[Fix] 회원가입 접근 가드 및 비밀번호 변경 UX 개선

### DIFF
--- a/src/components/auth/AuthInputField.tsx
+++ b/src/components/auth/AuthInputField.tsx
@@ -1,4 +1,4 @@
-import type { InputHTMLAttributes, ReactNode } from 'react';
+import type { InputHTMLAttributes, ReactNode, Ref } from 'react';
 import InputControl from '../common/InputControl';
 
 type AuthInputFieldMessageTone = 'success' | 'muted';
@@ -14,6 +14,7 @@ type AuthInputFieldProps = {
   action?: ReactNode;
   toast?: ReactNode;
   containerClassName?: string;
+  inputRef?: Ref<HTMLInputElement>;
 } & InputHTMLAttributes<HTMLInputElement>;
 
 function AuthInputField({
@@ -28,6 +29,7 @@ function AuthInputField({
   toast,
   containerClassName = '',
   className = '',
+  inputRef,
   ...inputProps
 }: AuthInputFieldProps) {
   const resolvedMessage = errorMessage ?? helperMessage;
@@ -54,6 +56,7 @@ function AuthInputField({
       <div className="relative flex w-full max-w-none min-w-0 flex-col items-stretch gap-3.5 sm:flex-row sm:items-stretch sm:gap-3">
         <InputControl
           id={id}
+          inputRef={inputRef}
           {...inputProps}
           hasError={Boolean(errorMessage)}
           className={`w-full max-w-none min-w-0 flex-1 ${className}`}

--- a/src/components/auth/GuestOnlyRoute.tsx
+++ b/src/components/auth/GuestOnlyRoute.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { Navigate } from 'react-router';
+
+import { ROUTE_PATHS } from '../../constants/routes';
+import useAuthGate from '../../features/auth/hooks/useAuthGate';
+import MainPageLoadingFallback from '../common/MainPageLoadingFallback';
+
+type GuestOnlyRouteProps = {
+  children: ReactNode;
+  loadingFallback?: ReactNode;
+};
+
+function GuestOnlyRoute({
+  children,
+  loadingFallback = <MainPageLoadingFallback />,
+}: GuestOnlyRouteProps) {
+  const authGate = useAuthGate();
+
+  if (authGate.needsAuthCheck) {
+    return <>{loadingFallback}</>;
+  }
+
+  if (authGate.canAccessAuthenticatedRoute) {
+    return <Navigate to={ROUTE_PATHS.HOME} replace />;
+  }
+
+  return <>{children}</>;
+}
+
+export default GuestOnlyRoute;

--- a/src/components/common/InputControl.tsx
+++ b/src/components/common/InputControl.tsx
@@ -1,8 +1,9 @@
-import type { InputHTMLAttributes } from 'react';
+import type { InputHTMLAttributes, Ref } from 'react';
 
 type InputControlProps = {
   hasError?: boolean;
   className?: string;
+  inputRef?: Ref<HTMLInputElement>;
 } & InputHTMLAttributes<HTMLInputElement>;
 
 const inputBaseClassName =
@@ -11,11 +12,13 @@ const inputBaseClassName =
 function InputControl({
   hasError = false,
   className = '',
+  inputRef,
   'aria-invalid': ariaInvalid,
   ...props
 }: InputControlProps) {
   return (
     <input
+      ref={inputRef}
       aria-invalid={ariaInvalid ?? hasError}
       className={`${inputBaseClassName} ${hasError ? 'border-red-500/90 hover:border-red-400 focus-visible:border-red-400 focus-visible:ring-red-500/30' : 'border-login-field hover:border-white/24 focus-visible:border-[#ff5d61] focus-visible:ring-[#ff5d61]/28'} ${className}`}
       {...props}

--- a/src/components/mypage/MyPageProfileSection.tsx
+++ b/src/components/mypage/MyPageProfileSection.tsx
@@ -3,6 +3,10 @@ import { useState, type ReactNode } from 'react';
 
 import defaultProfileImage from '../../assets/프로필 이미지.png';
 import type { CurrentUserSocialResponse } from '../../features/auth/types/auth';
+import {
+  isSocialLoginAccount,
+  normalizeSocialType,
+} from '../../features/auth/utils/socialAccount';
 import type { MyPageToast } from '../../pages/mypage/types';
 import { toDisplayText } from '../../pages/mypage/utils';
 import AuthButton from '../auth/AuthButton';
@@ -108,38 +112,36 @@ function MyPageProfileSection({
   const [isNicknameEditMode, setIsNicknameEditMode] = useState(false);
   const [nextNickname, setNextNickname] = useState(displayNickname);
   const [nicknameFieldError, setNicknameFieldError] = useState('');
-  const normalizedSocialType =
-    socialAccount?.social_type?.trim()?.toLowerCase() ?? '';
-  const accountBadge =
-    socialAccount?.is_social === true
-      ? normalizedSocialType === 'google'
-        ? {
-            label: '구글',
-            className:
-              'border-[#4285F4]/30 bg-[#4285F4]/14 text-[#8ab4ff] shadow-[0_8px_20px_rgba(66,133,244,0.14)]',
-          }
-        : normalizedSocialType === 'naver'
-          ? {
-              label: '네이버',
-              className:
-                'border-[#03C75A]/30 bg-[#03C75A]/14 text-[#68e6a5] shadow-[0_8px_20px_rgba(3,199,90,0.14)]',
-            }
-          : normalizedSocialType === 'kakao'
-            ? {
-                label: '카카오',
-                className:
-                  'border-[#FEE500]/24 bg-[#FEE500]/14 text-[#ffe768] shadow-[0_8px_20px_rgba(254,229,0,0.12)]',
-              }
-            : {
-                label: '소셜회원',
-                className:
-                  'border-white/10 bg-white/[0.05] text-white/78 shadow-[0_8px_20px_rgba(255,255,255,0.05)]',
-              }
-      : {
-          label: '일반회원',
+  const normalizedSocialType = normalizeSocialType(socialAccount);
+  const accountBadge = isSocialLoginAccount(socialAccount)
+    ? normalizedSocialType === 'google'
+      ? {
+          label: '구글',
           className:
-            'border-white/10 bg-white/[0.05] text-white/78 shadow-[0_8px_20px_rgba(255,255,255,0.05)]',
-        };
+            'border-[#4285F4]/30 bg-[#4285F4]/14 text-[#8ab4ff] shadow-[0_8px_20px_rgba(66,133,244,0.14)]',
+        }
+      : normalizedSocialType === 'naver'
+        ? {
+            label: '네이버',
+            className:
+              'border-[#03C75A]/30 bg-[#03C75A]/14 text-[#68e6a5] shadow-[0_8px_20px_rgba(3,199,90,0.14)]',
+          }
+        : normalizedSocialType === 'kakao'
+          ? {
+              label: '카카오',
+              className:
+                'border-[#FEE500]/24 bg-[#FEE500]/14 text-[#ffe768] shadow-[0_8px_20px_rgba(254,229,0,0.12)]',
+            }
+          : {
+              label: '소셜회원',
+              className:
+                'border-white/10 bg-white/[0.05] text-white/78 shadow-[0_8px_20px_rgba(255,255,255,0.05)]',
+            }
+    : {
+        label: '일반회원',
+        className:
+          'border-white/10 bg-white/[0.05] text-white/78 shadow-[0_8px_20px_rgba(255,255,255,0.05)]',
+      };
 
   const handleNicknameSave = async () => {
     const trimmedNickname = nextNickname.trim();

--- a/src/components/mypage/PasswordChangePanel.tsx
+++ b/src/components/mypage/PasswordChangePanel.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent } from 'react';
+import type { FormEvent, RefObject } from 'react';
 
 import AuthButton from '../auth/AuthButton';
 import AuthFormMessage from '../auth/AuthFormMessage';
@@ -15,6 +15,10 @@ export type PasswordChangeFieldName = keyof PasswordChangeValues;
 type PasswordChangePanelProps = {
   values: PasswordChangeValues;
   errors: Partial<Record<PasswordChangeFieldName, string>>;
+  fieldRefs: Record<
+    PasswordChangeFieldName,
+    RefObject<HTMLInputElement | null>
+  >;
   message?: string;
   messageTone?: 'success' | 'error';
   isPending: boolean;
@@ -27,6 +31,7 @@ type PasswordChangePanelProps = {
 function PasswordChangePanel({
   values,
   errors,
+  fieldRefs,
   message,
   messageTone = 'error',
   isPending,
@@ -55,6 +60,7 @@ function PasswordChangePanel({
           label="현재 비밀번호"
           placeholder="현재 비밀번호를 입력하세요"
           value={values.currentPassword}
+          inputRef={fieldRefs.currentPassword}
           onChange={(event) =>
             onValueChange('currentPassword', event.target.value)
           }
@@ -72,6 +78,7 @@ function PasswordChangePanel({
           label="새 비밀번호"
           placeholder="새 비밀번호를 입력하세요"
           value={values.newPassword}
+          inputRef={fieldRefs.newPassword}
           onChange={(event) => onValueChange('newPassword', event.target.value)}
           onBlur={() => onFieldBlur('newPassword')}
           errorMessage={errors.newPassword}
@@ -87,6 +94,7 @@ function PasswordChangePanel({
           label="새 비밀번호 확인"
           placeholder="새 비밀번호를 한번 더 입력하세요"
           value={values.newPasswordConfirm}
+          inputRef={fieldRefs.newPasswordConfirm}
           onChange={(event) =>
             onValueChange('newPasswordConfirm', event.target.value)
           }

--- a/src/features/auth/utils/socialAccount.ts
+++ b/src/features/auth/utils/socialAccount.ts
@@ -1,0 +1,13 @@
+import type { CurrentUserSocialResponse } from '../types/auth';
+
+const SOCIAL_LOGIN_PROVIDER_TYPES = new Set(['google', 'kakao', 'naver']);
+
+export const normalizeSocialType = (
+  socialAccount?: CurrentUserSocialResponse | null,
+) => socialAccount?.social_type?.trim().toLowerCase() ?? '';
+
+export const isSocialLoginAccount = (
+  socialAccount?: CurrentUserSocialResponse | null,
+) =>
+  socialAccount?.is_social === true &&
+  SOCIAL_LOGIN_PROVIDER_TYPES.has(normalizeSocialType(socialAccount));

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import App from './App';
+import GuestOnlyRoute from './components/auth/GuestOnlyRoute';
 import MainPageLoadingFallback from './components/common/MainPageLoadingFallback';
 import LegacyRouteRedirect from './components/common/LegacyRouteRedirect';
 import { ROUTE_PATHS, ROUTES } from './constants/routes';
@@ -72,9 +73,11 @@ const router = createBrowserRouter([
       {
         path: ROUTES.SIGNUP,
         element: (
-          <Suspense fallback={authPageFallback}>
-            <LazySignupPage />
-          </Suspense>
+          <GuestOnlyRoute loadingFallback={authPageFallback}>
+            <Suspense fallback={authPageFallback}>
+              <LazySignupPage />
+            </Suspense>
+          </GuestOnlyRoute>
         ),
       },
       {

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -7,6 +7,7 @@ import MainPageLoadingFallback from '../../components/common/MainPageLoadingFall
 import { ROUTE_PATHS } from '../../constants/routes';
 import useAuthGate from '../../features/auth/hooks/useAuthGate';
 import useLogoutAction from '../../features/auth/hooks/useLogoutAction';
+import { isSocialLoginAccount } from '../../features/auth/utils/socialAccount';
 import GameDetailModal from '../../features/games/components/GameDetailModal';
 import type { GameListItem } from '../../features/games/types';
 import { useAuthStore } from '../../store/useAuthStore';
@@ -33,7 +34,7 @@ function MyPage() {
   const { logout, isPending: isLogoutPending } = useLogoutAction();
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const socialAccount = useAuthStore((state) => state.socialAccount);
-  const isSocialAccount = socialAccount?.is_social === true;
+  const isSocialAccount = isSocialLoginAccount(socialAccount);
   const canShowPasswordChange = isAuthenticated && !isSocialAccount;
   const [toast, setToast] = useState<MyPageToast>(null);
   const [selectedDetailGame, setSelectedDetailGame] =
@@ -91,6 +92,7 @@ function MyPage() {
             isPasswordPanelOpen={myPagePasswordChange.isPasswordPanelOpen}
             onPasswordToggle={myPagePasswordChange.togglePasswordPanel}
             passwordValues={myPagePasswordChange.passwordValues}
+            passwordFieldRefs={myPagePasswordChange.passwordFieldRefs}
             passwordErrors={myPagePasswordChange.resolvedPasswordErrors}
             passwordPanelMessage={
               myPagePasswordChange.passwordPanelMessage?.message

--- a/src/pages/mypage/components/MyPageProfileContainer.tsx
+++ b/src/pages/mypage/components/MyPageProfileContainer.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent } from 'react';
+import type { FormEvent, RefObject } from 'react';
 
 import MyPageProfileSection from '../../../components/mypage/MyPageProfileSection';
 import PasswordChangePanel, {
@@ -25,6 +25,10 @@ type MyPageProfileContainerProps = {
   isPasswordPanelOpen: boolean;
   onPasswordToggle: () => void;
   passwordValues: PasswordChangeValues;
+  passwordFieldRefs: Record<
+    PasswordChangeFieldName,
+    RefObject<HTMLInputElement | null>
+  >;
   passwordErrors: Partial<Record<PasswordChangeFieldName, string>>;
   passwordPanelMessage?: string;
   passwordPanelMessageTone?: 'success' | 'error';
@@ -57,6 +61,7 @@ function MyPageProfileContainer({
   isPasswordPanelOpen,
   onPasswordToggle,
   passwordValues,
+  passwordFieldRefs,
   passwordErrors,
   passwordPanelMessage,
   passwordPanelMessageTone = 'error',
@@ -93,6 +98,7 @@ function MyPageProfileContainer({
       {canShowPasswordChange && isPasswordPanelOpen ? (
         <PasswordChangePanel
           values={passwordValues}
+          fieldRefs={passwordFieldRefs}
           errors={passwordErrors}
           message={passwordPanelMessage}
           messageTone={passwordPanelMessageTone}

--- a/src/pages/mypage/hooks/useMyPageDeleteAccount.ts
+++ b/src/pages/mypage/hooks/useMyPageDeleteAccount.ts
@@ -11,6 +11,7 @@ import {
   useDeleteAccountMutation,
 } from '../../../features/auth/api/useAuthApi';
 import { clearAuthSession } from '../../../features/auth/utils/sessionManager';
+import { isSocialLoginAccount } from '../../../features/auth/utils/socialAccount';
 import { useAuthStore } from '../../../store/useAuthStore';
 import type { MyPageToastPayload } from '../types';
 
@@ -26,7 +27,7 @@ function useMyPageDeleteAccount({ onToast }: UseMyPageDeleteAccountOptions) {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [deletePassword, setDeletePassword] = useState('');
   const [deletePasswordError, setDeletePasswordError] = useState('');
-  const isSocialAccount = socialAccount?.is_social === true;
+  const isSocialAccount = isSocialLoginAccount(socialAccount);
 
   const openDeleteModal = () => {
     setDeletePassword('');

--- a/src/pages/mypage/hooks/useMyPagePasswordChange.ts
+++ b/src/pages/mypage/hooks/useMyPagePasswordChange.ts
@@ -1,5 +1,5 @@
 import type { FormEvent } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   extractAuthApiErrorMessage,
@@ -18,6 +18,12 @@ type PasswordPanelMessage = {
   tone: 'success' | 'error';
   message: string;
 } | null;
+
+const PASSWORD_CHANGE_FIELD_ORDER = [
+  'currentPassword',
+  'newPassword',
+  'newPasswordConfirm',
+] as const satisfies readonly PasswordChangeFieldName[];
 
 const initialPasswordValues: PasswordChangeValues = {
   currentPassword: '',
@@ -72,8 +78,19 @@ const mapPasswordApiFieldErrors = (
   newPasswordConfirm: fieldErrors.new_password_check,
 });
 
+const getFirstInvalidPasswordFieldName = (
+  values: PasswordChangeValues,
+  fieldErrors: Partial<Record<PasswordChangeFieldName, string>>,
+) =>
+  PASSWORD_CHANGE_FIELD_ORDER.find(
+    (fieldName) => Boolean(fieldErrors[fieldName]) || !values[fieldName].trim(),
+  ) ?? null;
+
 function useMyPagePasswordChange() {
   const changePasswordMutation = useChangePasswordMutation();
+  const currentPasswordInputRef = useRef<HTMLInputElement | null>(null);
+  const newPasswordInputRef = useRef<HTMLInputElement | null>(null);
+  const newPasswordConfirmInputRef = useRef<HTMLInputElement | null>(null);
   const [isPasswordPanelOpen, setIsPasswordPanelOpen] = useState(false);
   const [passwordValues, setPasswordValues] = useState<PasswordChangeValues>(
     initialPasswordValues,
@@ -94,6 +111,34 @@ function useMyPagePasswordChange() {
     newPassword: apiFieldErrors.newPassword ?? localFieldErrors.newPassword,
     newPasswordConfirm:
       apiFieldErrors.newPasswordConfirm ?? localFieldErrors.newPasswordConfirm,
+  };
+  const passwordFieldRefs = useMemo(
+    () => ({
+      currentPassword: currentPasswordInputRef,
+      newPassword: newPasswordInputRef,
+      newPasswordConfirm: newPasswordConfirmInputRef,
+    }),
+    [],
+  );
+
+  const focusPasswordField = (fieldName: PasswordChangeFieldName | null) => {
+    if (!fieldName) {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      const targetElement = passwordFieldRefs[fieldName].current;
+
+      if (!targetElement) {
+        return;
+      }
+
+      targetElement.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+      targetElement.focus({ preventScroll: true });
+    });
   };
 
   useEffect(() => {
@@ -186,6 +231,9 @@ function useMyPagePasswordChange() {
     const hasLocalError = Object.values(nextFieldErrors).some(Boolean);
 
     if (hasLocalError) {
+      focusPasswordField(
+        getFirstInvalidPasswordFieldName(passwordValues, nextFieldErrors),
+      );
       return;
     }
 
@@ -210,6 +258,9 @@ function useMyPagePasswordChange() {
 
       if (Object.values(nextApiFieldErrors).some(Boolean)) {
         setApiFieldErrors(nextApiFieldErrors);
+        focusPasswordField(
+          getFirstInvalidPasswordFieldName(passwordValues, nextApiFieldErrors),
+        );
         return;
       }
 
@@ -224,6 +275,7 @@ function useMyPagePasswordChange() {
     isPasswordPanelOpen,
     togglePasswordPanel,
     closePasswordPanel,
+    passwordFieldRefs,
     passwordValues,
     resolvedPasswordErrors,
     passwordPanelMessage,


### PR DESCRIPTION
## 관련 이슈

- closes #416

## 변경 내용

- 로그인된 사용자가 `/join`에 접근하면 회원가입 폼을 렌더링하지 않고 메인 페이지(`/`)로 즉시 이동하도록 guest-only 라우트 가드를 추가했습니다.
- 비밀번호 변경 폼 제출 시 첫 번째 빈 값 또는 유효성 오류 input으로 부드럽게 스크롤되고 포커스가 이동하도록 개선했습니다.
- 일반/관리자 계정이 소셜 계정으로 오판되지 않도록 소셜 계정 판정 기준을 `google/kakao/naver` provider 기반으로 보강했습니다.
- 일반/관리자 계정은 비밀번호 변경 버튼이 보이고, 실제 소셜 로그인 계정만 비밀번호 변경을 숨기도록 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="3176" height="1822" alt="image" src="https://github.com/user-attachments/assets/598860b6-8544-47e9-b8f6-d1b78be3400f" />

## 참고사항

- API 호출 로직 변경은 없습니다.
- 소셜 로그인 계정은 기존 정책대로 비밀번호 변경 버튼이 노출되지 않습니다.
