### PR TITLE
[Refactor] 인증 UI 구조 정리 및 패널 렌더링 최적화

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -9,16 +9,7 @@ type HeaderProps = {
 };
 
 const Header = ({ fixed = true }: HeaderProps) => {
-  const {
-    resolvedProfileImageUrl,
-    shouldHideGuestActions,
-    shouldShowGuestActions,
-    shouldShowDeferredGuestPreview,
-    shouldShowGuestPlaceholder,
-    shouldShowProfileMenu,
-    shouldShowProfilePreview,
-    shouldShowProfilePlaceholder,
-  } = useHeaderAuthState();
+  const { resolvedProfileImageUrl, authPresentation } = useHeaderAuthState();
   const profilePreview = resolvedProfileImageUrl ? (
     <div
       aria-hidden="true"
@@ -40,6 +31,45 @@ const Header = ({ fixed = true }: HeaderProps) => {
   const guestActionsPlaceholder = (
     <div className="h-9 w-44" aria-hidden="true" />
   );
+  const authContent = (() => {
+    switch (authPresentation.kind) {
+      case 'hidden':
+        return null;
+      case 'guestActions':
+        return (
+          <>
+            <Link
+              to={`/${ROUTES.LOGIN}`}
+              className="header-btn-outline flex h-9 w-20 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
+            >
+              <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
+                로그인
+              </span>
+            </Link>
+            <Link
+              to={`/${ROUTES.SIGNUP}`}
+              className="header-btn-solid flex h-9 w-22 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
+            >
+              <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
+                회원가입
+              </span>
+            </Link>
+          </>
+        );
+      case 'guestProfilePreview':
+        return profilePreview;
+      case 'profileMenu':
+        return <HeaderProfileMenu profileImageUrl={resolvedProfileImageUrl} />;
+      case 'profilePreview':
+        return profilePreview ?? profilePlaceholder;
+      case 'guestPlaceholder':
+        return guestActionsPlaceholder;
+      case 'profilePlaceholder':
+        return profilePlaceholder;
+      default:
+        return guestActionsPlaceholder;
+    }
+  })();
 
   return (
     <header
@@ -63,40 +93,7 @@ const Header = ({ fixed = true }: HeaderProps) => {
           />
         </Link>
 
-        <div className="flex items-center gap-2 sm:gap-3">
-          {shouldHideGuestActions ? null : shouldShowGuestActions ? (
-            <>
-              <Link
-                to={`/${ROUTES.LOGIN}`}
-                className="header-btn-outline flex h-9 w-20 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
-              >
-                <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
-                  로그인
-                </span>
-              </Link>
-              <Link
-                to={`/${ROUTES.SIGNUP}`}
-                className="header-btn-solid flex h-9 w-22 cursor-pointer items-center justify-center rounded-md border px-4 py-1.5 transition-all focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none"
-              >
-                <span className="text-[13px] leading-[150%] font-normal sm:text-sm">
-                  회원가입
-                </span>
-              </Link>
-            </>
-          ) : shouldShowDeferredGuestPreview ? (
-            profilePreview
-          ) : shouldShowGuestPlaceholder ? (
-            guestActionsPlaceholder
-          ) : shouldShowProfileMenu ? (
-            <HeaderProfileMenu profileImageUrl={resolvedProfileImageUrl} />
-          ) : shouldShowProfilePreview ? (
-            (profilePreview ?? profilePlaceholder)
-          ) : shouldShowProfilePlaceholder ? (
-            profilePlaceholder
-          ) : (
-            guestActionsPlaceholder
-          )}
-        </div>
+        <div className="flex items-center gap-2 sm:gap-3">{authContent}</div>
       </div>
     </header>
   );

--- a/src/components/common/HeaderProfileMenu.tsx
+++ b/src/components/common/HeaderProfileMenu.tsx
@@ -12,24 +12,34 @@ type HeaderProfileMenuProps = {
   profileImageUrl?: string | null;
 };
 
+type ProfileMenuOpenState = {
+  hover: boolean;
+  click: boolean;
+};
+
+const closedProfileMenuState: ProfileMenuOpenState = {
+  hover: false,
+  click: false,
+};
+
 function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
-  const [isHoverOpen, setIsHoverOpen] = useState(false);
-  const [isClickOpen, setIsClickOpen] = useState(false);
+  const [openState, setOpenState] = useState<ProfileMenuOpenState>(
+    closedProfileMenuState,
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const { logout, isPending } = useLogoutAction();
   const location = useLocation();
   const isMyPage = isMyPagePath(location.pathname);
   const trimmedProfileImageUrl = profileImageUrl?.trim() || null;
   const resolvedProfileImageUrl = trimmedProfileImageUrl || profileImg;
-  const isOpen = isHoverOpen || isClickOpen;
+  const isOpen = openState.hover || openState.click;
   const profileButtonClass = `h-10 w-10 cursor-pointer overflow-hidden rounded-full border-2 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:outline-none ${
     isOpen
       ? 'border-[#ff3b30] shadow-[0_0_0_4px_rgba(255,59,48,0.16)]'
       : 'border-white/14 hover:border-[#ff3b30] hover:shadow-[0_0_0_4px_rgba(255,59,48,0.12)]'
   }`;
   const closeMenu = () => {
-    setIsHoverOpen(false);
-    setIsClickOpen(false);
+    setOpenState(closedProfileMenuState);
   };
 
   useEffect(() => {
@@ -65,8 +75,12 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
     <div
       ref={containerRef}
       className="relative"
-      onMouseEnter={() => setIsHoverOpen(true)}
-      onMouseLeave={() => setIsHoverOpen(false)}
+      onMouseEnter={() =>
+        setOpenState((current) => ({ ...current, hover: true }))
+      }
+      onMouseLeave={() =>
+        setOpenState((current) => ({ ...current, hover: false }))
+      }
       onBlur={(event) => {
         if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
           closeMenu();
@@ -79,7 +93,9 @@ function HeaderProfileMenu({ profileImageUrl = null }: HeaderProfileMenuProps) {
         aria-haspopup="menu"
         aria-expanded={isOpen}
         aria-controls={PROFILE_MENU_ID}
-        onClick={() => setIsClickOpen((current) => !current)}
+        onClick={() =>
+          setOpenState((current) => ({ ...current, click: !current.click }))
+        }
         className={profileButtonClass}
       >
         <img

--- a/src/components/support-chat/SupportChatLauncherButton.tsx
+++ b/src/components/support-chat/SupportChatLauncherButton.tsx
@@ -1,17 +1,21 @@
 import { Bot } from 'lucide-react';
+import type { RefObject } from 'react';
 
 type SupportChatLauncherButtonProps = {
   isOpen: boolean;
+  buttonRef: RefObject<HTMLButtonElement | null>;
   onClick: () => void;
 };
 
 function SupportChatLauncherButton({
   isOpen,
+  buttonRef,
   onClick,
 }: SupportChatLauncherButtonProps) {
   return (
     <button
       type="button"
+      ref={buttonRef}
       onClick={onClick}
       aria-label={isOpen ? '고객센터 챗봇 닫기' : '고객센터 챗봇 열기'}
       aria-controls={isOpen ? 'support-chat-panel' : undefined}

--- a/src/features/auth/hooks/useHeaderAuthState.ts
+++ b/src/features/auth/hooks/useHeaderAuthState.ts
@@ -7,6 +7,51 @@ import { useAuthStore } from '../../../store/useAuthStore';
 import { syncAuthAccount } from '../utils/sessionManager';
 import useAuthSessionState from './useAuthSessionState';
 
+export type HeaderAuthPresentation =
+  | { kind: 'hidden' }
+  | { kind: 'guestActions' }
+  | { kind: 'guestProfilePreview' }
+  | { kind: 'guestPlaceholder' }
+  | { kind: 'profileMenu' }
+  | { kind: 'profilePreview' }
+  | { kind: 'profilePlaceholder' };
+
+type ResolveHeaderAuthPresentationParams = {
+  accessStatus: 'loading' | 'authenticated' | 'unauthenticated';
+  shouldHideGuestActions: boolean;
+  isProfileHydrating: boolean;
+  hasProfileImage: boolean;
+};
+
+const resolveHeaderAuthPresentation = ({
+  accessStatus,
+  shouldHideGuestActions,
+  isProfileHydrating,
+  hasProfileImage,
+}: ResolveHeaderAuthPresentationParams): HeaderAuthPresentation => {
+  if (shouldHideGuestActions) {
+    return { kind: 'hidden' };
+  }
+
+  if (accessStatus === 'unauthenticated') {
+    return { kind: 'guestActions' };
+  }
+
+  if (accessStatus === 'loading') {
+    return hasProfileImage
+      ? { kind: 'guestProfilePreview' }
+      : { kind: 'guestPlaceholder' };
+  }
+
+  if (!isProfileHydrating) {
+    return { kind: 'profileMenu' };
+  }
+
+  return hasProfileImage
+    ? { kind: 'profilePreview' }
+    : { kind: 'profilePlaceholder' };
+};
+
 function useHeaderAuthState() {
   const location = useLocation();
   const { accessStatus } = useAuthSessionState();
@@ -35,30 +80,16 @@ function useHeaderAuthState() {
     }
   }, [profileHydrationQuery.data]);
 
-  return {
+  const authPresentation = resolveHeaderAuthPresentation({
     accessStatus,
-    resolvedProfileImageUrl,
     shouldHideGuestActions,
-    shouldShowGuestActions:
-      accessStatus === 'unauthenticated' && !shouldHideGuestActions,
-    shouldShowDeferredGuestPreview:
-      accessStatus === 'loading' &&
-      !shouldHideGuestActions &&
-      Boolean(resolvedProfileImageUrl),
-    shouldShowGuestPlaceholder:
-      accessStatus === 'loading' &&
-      !shouldHideGuestActions &&
-      !resolvedProfileImageUrl,
-    shouldShowProfileMenu:
-      accessStatus === 'authenticated' && !isProfileHydrating,
-    shouldShowProfilePreview:
-      accessStatus === 'authenticated' &&
-      isProfileHydrating &&
-      Boolean(resolvedProfileImageUrl),
-    shouldShowProfilePlaceholder:
-      accessStatus === 'authenticated' &&
-      isProfileHydrating &&
-      !resolvedProfileImageUrl,
+    isProfileHydrating,
+    hasProfileImage: Boolean(resolvedProfileImageUrl),
+  });
+
+  return {
+    resolvedProfileImageUrl,
+    authPresentation,
   };
 }
 

--- a/src/features/auth/hooks/useLoginForm.ts
+++ b/src/features/auth/hooks/useLoginForm.ts
@@ -69,6 +69,7 @@ function useLoginForm() {
   const [isMockPanelOpen, setIsMockPanelOpen] = useState(false);
   const [isLoginFlowLoading, setIsLoginFlowLoading] = useState(false);
   const mockPanelRef = useRef<HTMLDivElement | null>(null);
+  const mockFabRef = useRef<HTMLButtonElement | null>(null);
 
   const [formValues, setFormValues] = useState<LoginRequest>({
     login_id: '',
@@ -204,7 +205,7 @@ function useLoginForm() {
       if (
         mockPanelRef.current &&
         !mockPanelRef.current.contains(event.target as Node) &&
-        !(event.target as HTMLElement)?.closest('.dev-login-fab')
+        !mockFabRef.current?.contains(event.target as Node)
       ) {
         setIsMockPanelOpen(false);
       }
@@ -340,6 +341,7 @@ function useLoginForm() {
     showMockAccounts,
     isMockPanelOpen: showMockAccounts && isMockPanelOpen,
     mockPanelRef,
+    mockFabRef,
     handleChange,
     handleBlur,
     handleSubmit,

--- a/src/features/auth/hooks/useSignupForm.ts
+++ b/src/features/auth/hooks/useSignupForm.ts
@@ -13,116 +13,34 @@ import {
   useLoginMutation,
   useSignupMutation,
 } from '../api/useAuthApi';
-import type { AuthGender, SignupRequest } from '../types/auth';
+import type { SignupRequest } from '../types/auth';
 import { resolveAuthFeedbackVisibility } from '../utils/feedbackPriority';
 import { focusFieldByName, getFirstErrorFieldName } from '../utils/focusField';
 import { hydrateAuthSessionFromAccessToken } from '../utils/sessionManager';
+import {
+  initialDuplicateCheckState,
+  initialSignupFormValues,
+  initialSignupTouchedState,
+  NICKNAME_WHITESPACE_MESSAGE,
+  SIGNUP_FIELD_ORDER,
+  SIGNUP_FORM_FIELD_IDS,
+  SIGNUP_FORM_FIELD_MAX_LENGTHS,
+  touchedAllSignupFields,
+  getSignupFieldErrors,
+  type DuplicateCheckState,
+  type DuplicateCheckToastState,
+  type SignupFieldErrors,
+  type SignupFieldName,
+  type SignupFormValues,
+  type SignupTouchedState,
+} from '../utils/signupForm';
 
-type SignupFormValues = Omit<SignupRequest, 'gender'> & {
-  gender: AuthGender | '';
-};
-
-type SignupFieldName = keyof SignupFormValues;
-type SignupFieldErrors = Partial<Record<SignupFieldName, string>>;
-type SignupTouchedState = Record<SignupFieldName, boolean>;
-
-type DuplicateCheckState = {
-  verifiedValue: string | null;
-  message: string;
-  tone: 'success' | 'error' | null;
-};
-
-type DuplicateCheckToastState = {
-  message: string;
-  tone: 'success' | 'error';
-  anchor: 'login_id' | 'nickname';
-} | null;
-
-export const SIGNUP_FORM_GENDER_OPTIONS = [
-  { label: '남성', value: 'M' },
-  { label: '여성', value: 'W' },
-] as const;
-
-export const SIGNUP_FORM_FIELD_MAX_LENGTHS = {
-  name: 30,
-  login_id: 15,
-  nickname: 10,
-} as const;
-
-export const SIGNUP_FORM_GENDER_ID_PREFIX = 'signup-gender';
-
-export const SIGNUP_FORM_FIELD_IDS: Record<SignupFieldName, string> = {
-  name: 'signup-name',
-  login_id: 'signup-id',
-  nickname: 'signup-nickname',
-  password: 'signup-password',
-  password_check: 'signup-password-confirm',
-  gender: `${SIGNUP_FORM_GENDER_ID_PREFIX}-M`,
-};
-
-const NICKNAME_WHITESPACE_MESSAGE = '닉네임에는 띄어쓰기를 사용할 수 없습니다.';
-
-const initialDuplicateCheckState: DuplicateCheckState = {
-  verifiedValue: null,
-  message: '',
-  tone: null,
-};
-
-const SIGNUP_FIELD_ORDER = [
-  'name',
-  'login_id',
-  'nickname',
-  'password',
-  'password_check',
-  'gender',
-] as const satisfies readonly SignupFieldName[];
-
-const getSignupFieldErrors = (
-  values: SignupFormValues,
-  touchedState: SignupTouchedState,
-  loginIdVerified: boolean,
-  nicknameVerified: boolean,
-) => {
-  const trimmedName = values.name.trim();
-  const trimmedLoginId = values.login_id.trim();
-  const trimmedNickname = values.nickname.trim();
-  const trimmedPassword = values.password.trim();
-  const trimmedPasswordCheck = values.password_check.trim();
-
-  return {
-    name: touchedState.name && !trimmedName ? '이름을 입력해주세요.' : '',
-    login_id:
-      touchedState.login_id && !trimmedLoginId
-        ? '아이디를 입력해주세요.'
-        : touchedState.login_id && trimmedLoginId && !loginIdVerified
-          ? '아이디 중복확인을 해주세요.'
-          : '',
-    nickname:
-      touchedState.nickname && !trimmedNickname
-        ? '닉네임을 입력해주세요.'
-        : touchedState.nickname && trimmedNickname && !nicknameVerified
-          ? '닉네임 중복확인을 해주세요.'
-          : '',
-    password:
-      touchedState.password && !trimmedPassword
-        ? '비밀번호를 입력해주세요.'
-        : touchedState.password &&
-            trimmedPassword.length > 0 &&
-            trimmedPassword.length < 8
-          ? '비밀번호는 8자 이상이어야 합니다.'
-          : '',
-    password_check:
-      touchedState.password_check && !trimmedPasswordCheck
-        ? '비밀번호를 한번 더 입력해주세요.'
-        : touchedState.password_check &&
-            trimmedPassword.length > 0 &&
-            trimmedPasswordCheck.length > 0 &&
-            trimmedPassword !== trimmedPasswordCheck
-          ? '비밀번호와 일치하지 않습니다.'
-          : '',
-    gender: touchedState.gender && !values.gender ? '성별을 선택해주세요.' : '',
-  } satisfies Record<SignupFieldName, string>;
-};
+export {
+  SIGNUP_FORM_FIELD_IDS,
+  SIGNUP_FORM_FIELD_MAX_LENGTHS,
+  SIGNUP_FORM_GENDER_ID_PREFIX,
+  SIGNUP_FORM_GENDER_OPTIONS,
+} from '../utils/signupForm';
 
 function useSignupForm() {
   const navigate = useNavigate();
@@ -130,22 +48,12 @@ function useSignupForm() {
   const loginMutation = useLoginMutation();
   const checkIdDuplicateMutation = useCheckIdDuplicateMutation();
   const checkNicknameDuplicateMutation = useCheckNicknameDuplicateMutation();
-  const [formValues, setFormValues] = useState<SignupFormValues>({
-    name: '',
-    login_id: '',
-    nickname: '',
-    password: '',
-    password_check: '',
-    gender: '',
-  });
-  const [touchedState, setTouchedState] = useState<SignupTouchedState>({
-    name: false,
-    login_id: false,
-    nickname: false,
-    password: false,
-    password_check: false,
-    gender: false,
-  });
+  const [formValues, setFormValues] = useState<SignupFormValues>(
+    initialSignupFormValues,
+  );
+  const [touchedState, setTouchedState] = useState<SignupTouchedState>(
+    initialSignupTouchedState,
+  );
   const [apiFieldErrors, setApiFieldErrors] = useState<SignupFieldErrors>({});
   const [formMessage, setFormMessage] = useState('');
   const [nicknameWhitespaceMessage, setNicknameWhitespaceMessage] =
@@ -389,22 +297,13 @@ function useSignupForm() {
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    const nextTouchedState = {
-      name: true,
-      login_id: true,
-      nickname: true,
-      password: true,
-      password_check: true,
-      gender: true,
-    } satisfies SignupTouchedState;
-
-    setTouchedState(nextTouchedState);
+    setTouchedState(touchedAllSignupFields);
     setApiFieldErrors({});
     setFormMessage('');
 
     const nextFieldErrors = getSignupFieldErrors(
       formValues,
-      nextTouchedState,
+      touchedAllSignupFields,
       isLoginIdVerified,
       isNicknameVerified,
     );

--- a/src/features/auth/utils/signupForm.ts
+++ b/src/features/auth/utils/signupForm.ts
@@ -1,0 +1,135 @@
+import type { AuthGender, SignupRequest } from '../types/auth';
+
+export type SignupFormValues = Omit<SignupRequest, 'gender'> & {
+  gender: AuthGender | '';
+};
+
+export type SignupFieldName = keyof SignupFormValues;
+export type SignupFieldErrors = Partial<Record<SignupFieldName, string>>;
+export type SignupTouchedState = Record<SignupFieldName, boolean>;
+
+export type DuplicateCheckState = {
+  verifiedValue: string | null;
+  message: string;
+  tone: 'success' | 'error' | null;
+};
+
+export type DuplicateCheckToastState = {
+  message: string;
+  tone: 'success' | 'error';
+  anchor: 'login_id' | 'nickname';
+} | null;
+
+export const SIGNUP_FORM_GENDER_OPTIONS = [
+  { label: '남성', value: 'M' },
+  { label: '여성', value: 'W' },
+] as const satisfies readonly { label: string; value: AuthGender }[];
+
+export const SIGNUP_FORM_FIELD_MAX_LENGTHS = {
+  name: 30,
+  login_id: 15,
+  nickname: 10,
+} as const;
+
+export const SIGNUP_FORM_GENDER_ID_PREFIX = 'signup-gender';
+
+export const SIGNUP_FORM_FIELD_IDS: Record<SignupFieldName, string> = {
+  name: 'signup-name',
+  login_id: 'signup-id',
+  nickname: 'signup-nickname',
+  password: 'signup-password',
+  password_check: 'signup-password-confirm',
+  gender: `${SIGNUP_FORM_GENDER_ID_PREFIX}-M`,
+};
+
+export const NICKNAME_WHITESPACE_MESSAGE =
+  '닉네임에는 띄어쓰기를 사용할 수 없습니다.';
+
+export const initialSignupFormValues: SignupFormValues = {
+  name: '',
+  login_id: '',
+  nickname: '',
+  password: '',
+  password_check: '',
+  gender: '',
+};
+
+export const initialSignupTouchedState: SignupTouchedState = {
+  name: false,
+  login_id: false,
+  nickname: false,
+  password: false,
+  password_check: false,
+  gender: false,
+};
+
+export const touchedAllSignupFields: SignupTouchedState = {
+  name: true,
+  login_id: true,
+  nickname: true,
+  password: true,
+  password_check: true,
+  gender: true,
+};
+
+export const initialDuplicateCheckState: DuplicateCheckState = {
+  verifiedValue: null,
+  message: '',
+  tone: null,
+};
+
+export const SIGNUP_FIELD_ORDER = [
+  'name',
+  'login_id',
+  'nickname',
+  'password',
+  'password_check',
+  'gender',
+] as const satisfies readonly SignupFieldName[];
+
+export const getSignupFieldErrors = (
+  values: SignupFormValues,
+  touchedState: SignupTouchedState,
+  loginIdVerified: boolean,
+  nicknameVerified: boolean,
+) => {
+  const trimmedName = values.name.trim();
+  const trimmedLoginId = values.login_id.trim();
+  const trimmedNickname = values.nickname.trim();
+  const trimmedPassword = values.password.trim();
+  const trimmedPasswordCheck = values.password_check.trim();
+
+  return {
+    name: touchedState.name && !trimmedName ? '이름을 입력해주세요.' : '',
+    login_id:
+      touchedState.login_id && !trimmedLoginId
+        ? '아이디를 입력해주세요.'
+        : touchedState.login_id && trimmedLoginId && !loginIdVerified
+          ? '아이디 중복확인을 해주세요.'
+          : '',
+    nickname:
+      touchedState.nickname && !trimmedNickname
+        ? '닉네임을 입력해주세요.'
+        : touchedState.nickname && trimmedNickname && !nicknameVerified
+          ? '닉네임 중복확인을 해주세요.'
+          : '',
+    password:
+      touchedState.password && !trimmedPassword
+        ? '비밀번호를 입력해주세요.'
+        : touchedState.password &&
+            trimmedPassword.length > 0 &&
+            trimmedPassword.length < 8
+          ? '비밀번호는 8자 이상이어야 합니다.'
+          : '',
+    password_check:
+      touchedState.password_check && !trimmedPasswordCheck
+        ? '비밀번호를 한번 더 입력해주세요.'
+        : touchedState.password_check &&
+            trimmedPassword.length > 0 &&
+            trimmedPasswordCheck.length > 0 &&
+            trimmedPassword !== trimmedPasswordCheck
+          ? '비밀번호와 일치하지 않습니다.'
+          : '',
+    gender: touchedState.gender && !values.gender ? '성별을 선택해주세요.' : '',
+  } satisfies Record<SignupFieldName, string>;
+};

--- a/src/features/support-chat/hooks/useSupportChat.ts
+++ b/src/features/support-chat/hooks/useSupportChat.ts
@@ -1,3 +1,4 @@
+import type { RefObject } from 'react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useLocation } from 'react-router';
 
@@ -12,6 +13,7 @@ type UseSupportChatResult = {
   panelProps: SupportChatPanelProps;
   launcherProps: {
     isOpen: boolean;
+    buttonRef: RefObject<HTMLButtonElement | null>;
     onClick: () => void;
   };
 };
@@ -54,6 +56,7 @@ export const useSupportChat = (): UseSupportChatResult => {
     isOpen,
     isPinnedToBottom,
     panelRef,
+    launcherRef,
     viewportRef,
     handleClosePanel,
     handleTogglePanel,
@@ -141,6 +144,7 @@ export const useSupportChat = (): UseSupportChatResult => {
     },
     launcherProps: {
       isOpen,
+      buttonRef: launcherRef,
       onClick: handleTogglePanel,
     },
   };

--- a/src/features/support-chat/hooks/useSupportChatPanel.ts
+++ b/src/features/support-chat/hooks/useSupportChatPanel.ts
@@ -22,6 +22,7 @@ const toMessageUpdateCursor = (
 function useSupportChatPanel({ onRequestClose }: UseSupportChatPanelParams) {
   const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const launcherRef = useRef<HTMLButtonElement | null>(null);
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const lastHandledMessageCursorRef = useRef<string | null>(null);
 
@@ -98,7 +99,7 @@ function useSupportChatPanel({ onRequestClose }: UseSupportChatPanelParams) {
       if (
         panelRef.current &&
         !panelRef.current.contains(event.target as Node) &&
-        !(event.target as HTMLElement)?.closest('.support-chat-fab')
+        !launcherRef.current?.contains(event.target as Node)
       ) {
         handleClosePanel();
       }
@@ -210,6 +211,7 @@ function useSupportChatPanel({ onRequestClose }: UseSupportChatPanelParams) {
     isOpen,
     isPinnedToBottom,
     panelRef,
+    launcherRef,
     viewportRef,
     handleClosePanel,
     handleTogglePanel,

--- a/src/index.css
+++ b/src/index.css
@@ -358,7 +358,8 @@
     border-radius: 28px;
   }
 
-  .support-chat-fab {
+  .support-chat-fab,
+  .dev-floating-fab {
     background:
       radial-gradient(
         circle at 30% 20%,
@@ -371,7 +372,8 @@
       0 0 28px rgba(223, 59, 51, 0.4);
   }
 
-  .support-chat-fab-glow {
+  .support-chat-fab-glow,
+  .dev-floating-fab-glow {
     position: absolute;
     inset: 0;
     border-radius: inherit;
@@ -586,7 +588,9 @@
   @media (prefers-reduced-motion: reduce) {
     .support-chat-panel,
     .support-chat-fab,
+    .dev-floating-fab,
     .support-chat-fab *,
+    .dev-floating-fab *,
     .support-chat-icon-btn,
     .support-chat-quick-action,
     .support-chat-input,

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -18,7 +18,7 @@ import useLoginForm, {
 } from '../features/auth/hooks/useLoginForm';
 
 const LOGIN_MOCK_FAB_CLASS_NAME =
-  'support-chat-fab group relative flex h-14 w-14 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none';
+  'dev-floating-fab group relative flex h-14 w-14 items-center justify-center rounded-full text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none';
 const LOGIN_DEV_FABS_CLASS_NAME =
   'fixed left-4 bottom-4 z-[95] flex items-center gap-3 sm:left-6 sm:bottom-6';
 const LOGIN_MOCK_PANEL_CLASS_NAME =
@@ -38,6 +38,7 @@ function LoginPage() {
     showMockAccounts,
     isMockPanelOpen,
     mockPanelRef,
+    mockFabRef,
     handleChange,
     handleBlur,
     handleSubmit,
@@ -138,84 +139,80 @@ function LoginPage() {
 
       {showMockAccounts ? (
         <>
-          <div
-            className={`${LOGIN_MOCK_PANEL_CLASS_NAME} ${
-              isMockPanelOpen
-                ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
-                : 'pointer-events-none translate-y-4 scale-95 opacity-0'
-            }`}
-          >
+          {isMockPanelOpen ? (
             <div
               ref={mockPanelRef}
-              className="flex w-full flex-col"
+              className={`${LOGIN_MOCK_PANEL_CLASS_NAME} pointer-events-auto translate-y-0 scale-100 opacity-100`}
               role="dialog"
               aria-modal="false"
               aria-label="개발용 로그인 계정"
             >
-              <div className="border-login-outline flex items-center justify-between border-b px-4 py-3">
-                <div>
-                  <p className="text-sm font-semibold text-white">
-                    개발용 로그인 계정
-                  </p>
-                  <p className="text-login-helper mt-1 text-xs/5">
-                    dev + MSW에서만 표시됩니다.
-                  </p>
+              <div className="flex w-full flex-col">
+                <div className="border-login-outline flex items-center justify-between border-b px-4 py-3">
+                  <div>
+                    <p className="text-sm font-semibold text-white">
+                      개발용 로그인 계정
+                    </p>
+                    <p className="text-login-helper mt-1 text-xs/5">
+                      dev + MSW에서만 표시됩니다.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={closeMockPanel}
+                    className="support-chat-icon-btn"
+                    aria-label="개발용 로그인 계정 패널 닫기"
+                  >
+                    <X size={16} />
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  onClick={closeMockPanel}
-                  className="support-chat-icon-btn"
-                  aria-label="개발용 로그인 계정 패널 닫기"
-                >
-                  <X size={16} />
-                </button>
-              </div>
 
-              <div className="support-chat-scrollbar max-h-[min(60vh,28rem)] overflow-y-auto px-4 py-4">
-                <ul className="space-y-2.5">
-                  {visibleMockAccounts.map((account) => (
-                    <li
-                      key={account.loginId}
-                      className="border-login-outline rounded-2xl border bg-black/20 p-3"
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <p className="text-sm font-semibold text-white">
-                            {account.name}
-                          </p>
+                <div className="support-chat-scrollbar max-h-[min(60vh,28rem)] overflow-y-auto px-4 py-4">
+                  <ul className="space-y-2.5">
+                    {visibleMockAccounts.map((account) => (
+                      <li
+                        key={account.loginId}
+                        className="border-login-outline rounded-2xl border bg-black/20 p-3"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="text-sm font-semibold text-white">
+                              {account.name}
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => handleApplyMockAccount(account)}
+                            className="border-login-outline shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:border-white/25 hover:bg-white/5"
+                          >
+                            입력하기
+                          </button>
                         </div>
-                        <button
-                          type="button"
-                          onClick={() => handleApplyMockAccount(account)}
-                          className="border-login-outline shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:border-white/25 hover:bg-white/5"
-                        >
-                          입력하기
-                        </button>
-                      </div>
-                      <dl className="mt-3 space-y-1.5 text-xs/5">
-                        <div className="flex items-center justify-between gap-3">
-                          <dt className="text-login-helper">아이디</dt>
-                          <dd className="font-mono text-white">
-                            {account.loginId}
-                          </dd>
-                        </div>
-                        <div className="flex items-center justify-between gap-3">
-                          <dt className="text-login-helper">비밀번호</dt>
-                          <dd className="font-mono text-white">
-                            {account.password}
-                          </dd>
-                        </div>
-                        <div className="flex items-center justify-between gap-3">
-                          <dt className="text-login-helper">닉네임</dt>
-                          <dd className="text-white">{account.nickname}</dd>
-                        </div>
-                      </dl>
-                    </li>
-                  ))}
-                </ul>
+                        <dl className="mt-3 space-y-1.5 text-xs/5">
+                          <div className="flex items-center justify-between gap-3">
+                            <dt className="text-login-helper">아이디</dt>
+                            <dd className="font-mono text-white">
+                              {account.loginId}
+                            </dd>
+                          </div>
+                          <div className="flex items-center justify-between gap-3">
+                            <dt className="text-login-helper">비밀번호</dt>
+                            <dd className="font-mono text-white">
+                              {account.password}
+                            </dd>
+                          </div>
+                          <div className="flex items-center justify-between gap-3">
+                            <dt className="text-login-helper">닉네임</dt>
+                            <dd className="text-white">{account.nickname}</dd>
+                          </div>
+                        </dl>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </div>
             </div>
-          </div>
+          ) : null}
         </>
       ) : null}
 
@@ -223,15 +220,16 @@ function LoginPage() {
         {showMockAccounts ? (
           <button
             type="button"
+            ref={mockFabRef}
             onClick={toggleMockPanel}
-            className={`${LOGIN_MOCK_FAB_CLASS_NAME} dev-login-fab`}
+            className={LOGIN_MOCK_FAB_CLASS_NAME}
             aria-label={
               isMockPanelOpen
                 ? '개발용 로그인 계정 패널 닫기'
                 : '개발용 로그인 계정 패널 열기'
             }
           >
-            <span className="support-chat-fab-glow" />
+            <span className="dev-floating-fab-glow" />
             <KeyRound
               size={22}
               className={`relative z-10 transition-transform ${

--- a/src/pages/main/components/MainDevToolDock.tsx
+++ b/src/pages/main/components/MainDevToolDock.tsx
@@ -10,12 +10,13 @@ import {
 const DEV_TOOL_DOCK_CLASS_NAME =
   'fixed left-4 bottom-4 z-[95] sm:left-6 sm:bottom-6';
 const DEV_API_BUTTON_CLASS_NAME =
-  'support-chat-fab group relative flex h-14 w-14 items-center justify-center rounded-full border border-[#ff7068]/48 bg-[linear-gradient(180deg,#ff6e66_0%,#d92b22_100%)] text-white shadow-[0_22px_48px_rgba(0,0,0,0.45),0_0_28px_rgba(223,59,51,0.28)] transition-transform hover:-translate-y-0.5 focus-visible:outline-none';
+  'dev-floating-fab group relative flex h-14 w-14 items-center justify-center rounded-full border border-[#ff7068]/48 bg-[linear-gradient(180deg,#ff6e66_0%,#d92b22_100%)] text-white shadow-[0_22px_48px_rgba(0,0,0,0.45),0_0_28px_rgba(223,59,51,0.28)] transition-transform hover:-translate-y-0.5 focus-visible:outline-none';
 const DEV_API_PANEL_CLASS_NAME =
   'support-chat-panel absolute bottom-[calc(100%+0.75rem)] left-0 flex w-[min(92vw,19rem)] origin-bottom-left flex-col overflow-hidden rounded-[1.6rem] border border-[#ff6b63]/20 bg-[linear-gradient(180deg,rgba(20,13,13,0.98)_0%,rgba(10,8,8,0.96)_100%)] shadow-[0_28px_60px_rgba(0,0,0,0.48),0_0_36px_rgba(223,59,51,0.16)] backdrop-blur-xl transition-all duration-300 ease-out';
 
 function MainDevToolDock() {
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const isMockMode = isMockServiceWorkerEnabled();
 
@@ -34,7 +35,7 @@ function MainDevToolDock() {
       if (
         panelRef.current &&
         !panelRef.current.contains(event.target as Node) &&
-        !(event.target as HTMLElement)?.closest('.main-dev-api-fab')
+        !buttonRef.current?.contains(event.target as Node)
       ) {
         setIsPanelOpen(false);
       }
@@ -56,54 +57,53 @@ function MainDevToolDock() {
   return (
     <div className={DEV_TOOL_DOCK_CLASS_NAME}>
       <div className="relative">
-        <div
-          ref={panelRef}
-          className={`${DEV_API_PANEL_CLASS_NAME} ${
-            isPanelOpen
-              ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
-              : 'pointer-events-none translate-y-4 scale-95 opacity-0'
-          }`}
-          role="dialog"
-          aria-modal="false"
-          aria-label="개발용 API 전환 패널"
-        >
-          <div className="border-b border-white/8 px-4 py-3.5">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <p className="text-sm font-semibold text-white">API 전환</p>
-                <p className="mt-1 text-xs/5 text-white/55">
-                  {isMockMode
-                    ? '현재 MSW 모드예요. 전환하면 바로 새로고침됩니다.'
-                    : '현재 실 API 모드예요. 전환하면 바로 새로고침됩니다.'}
-                </p>
+        {isPanelOpen ? (
+          <div
+            ref={panelRef}
+            className={`${DEV_API_PANEL_CLASS_NAME} pointer-events-auto translate-y-0 scale-100 opacity-100`}
+            role="dialog"
+            aria-modal="false"
+            aria-label="개발용 API 전환 패널"
+          >
+            <div className="border-b border-white/8 px-4 py-3.5">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-white">API 전환</p>
+                  <p className="mt-1 text-xs/5 text-white/55">
+                    {isMockMode
+                      ? '현재 MSW 모드예요. 전환하면 바로 새로고침됩니다.'
+                      : '현재 실 API 모드예요. 전환하면 바로 새로고침됩니다.'}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setIsPanelOpen(false)}
+                  className="support-chat-icon-btn"
+                  aria-label="개발용 API 전환 패널 닫기"
+                >
+                  <X size={16} />
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={() => setIsPanelOpen(false)}
-                className="support-chat-icon-btn"
-                aria-label="개발용 API 전환 패널 닫기"
-              >
-                <X size={16} />
-              </button>
+            </div>
+
+            <div className="px-4 py-4">
+              <DevApiModeToggle variant="dock" />
             </div>
           </div>
-
-          <div className="px-4 py-4">
-            <DevApiModeToggle variant="dock" />
-          </div>
-        </div>
+        ) : null}
 
         <button
           type="button"
+          ref={buttonRef}
           onClick={() => setIsPanelOpen((previous) => !previous)}
-          className={`${DEV_API_BUTTON_CLASS_NAME} main-dev-api-fab`}
+          className={DEV_API_BUTTON_CLASS_NAME}
           aria-label={
             isPanelOpen
               ? '개발용 API 전환 패널 닫기'
               : '개발용 API 전환 패널 열기'
           }
         >
-          <span className="support-chat-fab-glow" />
+          <span className="dev-floating-fab-glow" />
           <ArrowRightLeft
             size={21}
             className={`relative z-10 transition-transform ${

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -74,43 +74,44 @@ function MyPage() {
 
         <main className="relative z-10 mx-auto flex min-h-[calc(100dvh-6rem)] w-full max-w-[1280px] flex-col px-4 pt-24 pb-10 sm:min-h-[calc(100dvh-7rem)] sm:px-6 sm:pt-28 sm:pb-12 lg:min-h-[calc(100dvh-8rem)] lg:px-10 lg:pt-32 xl:px-14">
           <MyPageProfileContainer
-            nickname={myPageProfile.profileNickname}
-            name={myPageProfile.profileName}
-            genderLabel={myPageProfile.profileGenderLabel}
-            socialAccount={socialAccount}
-            profileImageUrl={myPageProfile.profileImageUrl}
-            isProfileLoading={myPageProfile.isProfileLoading}
-            isProfileImageUploading={myPageProfile.isProfileImageUploading}
-            isProfileUpdating={myPageProfile.isProfileUpdating}
-            isLoggingOut={isLogoutPending}
-            onLogout={() => {
-              void logout();
+            profile={{
+              nickname: myPageProfile.profileNickname,
+              name: myPageProfile.profileName,
+              genderLabel: myPageProfile.profileGenderLabel,
+              socialAccount,
+              profileImageUrl: myPageProfile.profileImageUrl,
+              isLoading: myPageProfile.isProfileLoading,
+              isImageUploading: myPageProfile.isProfileImageUploading,
+              isUpdating: myPageProfile.isProfileUpdating,
+              isLoggingOut: isLogoutPending,
+              canShowPasswordChange,
+              isPasswordPanelOpen: myPagePasswordChange.isPasswordPanelOpen,
+              toast,
             }}
-            onNicknameSave={myPageProfile.handleNicknameSave}
-            onProfileImageSelect={myPageProfile.handleProfileImageSelect}
-            canShowPasswordChange={canShowPasswordChange}
-            isPasswordPanelOpen={myPagePasswordChange.isPasswordPanelOpen}
-            onPasswordToggle={myPagePasswordChange.togglePasswordPanel}
-            passwordValues={myPagePasswordChange.passwordValues}
-            passwordFieldRefs={myPagePasswordChange.passwordFieldRefs}
-            passwordErrors={myPagePasswordChange.resolvedPasswordErrors}
-            passwordPanelMessage={
-              myPagePasswordChange.passwordPanelMessage?.message
-            }
-            passwordPanelMessageTone={
-              myPagePasswordChange.passwordPanelMessage?.tone ?? 'error'
-            }
-            isPasswordChangePending={
-              myPagePasswordChange.isChangePasswordPending
-            }
-            toast={toast}
-            onToastClose={() => setToast(null)}
-            onPasswordValueChange={
-              myPagePasswordChange.handlePasswordValueChange
-            }
-            onPasswordBlur={myPagePasswordChange.handlePasswordBlur}
-            onPasswordCancel={myPagePasswordChange.closePasswordPanel}
-            onPasswordSubmit={myPagePasswordChange.handlePasswordSubmit}
+            profileActions={{
+              onLogout: () => {
+                void logout();
+              },
+              onNicknameSave: myPageProfile.handleNicknameSave,
+              onProfileImageSelect: myPageProfile.handleProfileImageSelect,
+              onPasswordToggle: myPagePasswordChange.togglePasswordPanel,
+              onToastClose: () => setToast(null),
+            }}
+            passwordChange={{
+              values: myPagePasswordChange.passwordValues,
+              fieldRefs: myPagePasswordChange.passwordFieldRefs,
+              errors: myPagePasswordChange.resolvedPasswordErrors,
+              message: myPagePasswordChange.passwordPanelMessage?.message,
+              messageTone:
+                myPagePasswordChange.passwordPanelMessage?.tone ?? 'error',
+              isPending: myPagePasswordChange.isChangePasswordPending,
+            }}
+            passwordChangeActions={{
+              onValueChange: myPagePasswordChange.handlePasswordValueChange,
+              onFieldBlur: myPagePasswordChange.handlePasswordBlur,
+              onCancel: myPagePasswordChange.closePasswordPanel,
+              onSubmit: myPagePasswordChange.handlePasswordSubmit,
+            }}
           />
 
           <MyPageLikedGamesSection

--- a/src/pages/mypage/components/MyPageProfileContainer.tsx
+++ b/src/pages/mypage/components/MyPageProfileContainer.tsx
@@ -8,71 +8,93 @@ import PasswordChangePanel, {
 import type { CurrentUserSocialResponse } from '../../../features/auth/types/auth';
 import type { MyPageToast } from '../types';
 
-type MyPageProfileContainerProps = {
+type MyPageProfileViewModel = {
   nickname: string;
   name: string;
   genderLabel: string;
   socialAccount?: CurrentUserSocialResponse | null;
   profileImageUrl?: string | null;
-  isProfileLoading: boolean;
-  isProfileImageUploading: boolean;
-  isProfileUpdating: boolean;
+  isLoading: boolean;
+  isImageUploading: boolean;
+  isUpdating: boolean;
   isLoggingOut: boolean;
+  canShowPasswordChange: boolean;
+  isPasswordPanelOpen: boolean;
+  toast: MyPageToast;
+};
+
+type MyPageProfileActions = {
   onLogout: () => void;
   onNicknameSave: (nickname: string) => Promise<boolean>;
   onProfileImageSelect: (file: File | null) => Promise<void>;
-  canShowPasswordChange: boolean;
-  isPasswordPanelOpen: boolean;
   onPasswordToggle: () => void;
-  passwordValues: PasswordChangeValues;
-  passwordFieldRefs: Record<
+  onToastClose: () => void;
+};
+
+type MyPagePasswordChangeViewModel = {
+  values: PasswordChangeValues;
+  fieldRefs: Record<
     PasswordChangeFieldName,
     RefObject<HTMLInputElement | null>
   >;
-  passwordErrors: Partial<Record<PasswordChangeFieldName, string>>;
-  passwordPanelMessage?: string;
-  passwordPanelMessageTone?: 'success' | 'error';
-  isPasswordChangePending: boolean;
-  toast: MyPageToast;
-  onToastClose: () => void;
-  onPasswordValueChange: (
-    fieldName: PasswordChangeFieldName,
-    value: string,
-  ) => void;
-  onPasswordBlur: (fieldName: PasswordChangeFieldName) => void;
-  onPasswordCancel: () => void;
-  onPasswordSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  errors: Partial<Record<PasswordChangeFieldName, string>>;
+  message?: string;
+  messageTone?: 'success' | 'error';
+  isPending: boolean;
+};
+
+type MyPagePasswordChangeActions = {
+  onValueChange: (fieldName: PasswordChangeFieldName, value: string) => void;
+  onFieldBlur: (fieldName: PasswordChangeFieldName) => void;
+  onCancel: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+};
+
+type MyPageProfileContainerProps = {
+  profile: MyPageProfileViewModel;
+  profileActions: MyPageProfileActions;
+  passwordChange: MyPagePasswordChangeViewModel;
+  passwordChangeActions: MyPagePasswordChangeActions;
 };
 
 function MyPageProfileContainer({
-  nickname,
-  name,
-  genderLabel,
-  socialAccount = null,
-  profileImageUrl,
-  isProfileLoading,
-  isProfileImageUploading,
-  isProfileUpdating,
-  isLoggingOut,
-  onLogout,
-  onNicknameSave,
-  onProfileImageSelect,
-  canShowPasswordChange,
-  isPasswordPanelOpen,
-  onPasswordToggle,
-  passwordValues,
-  passwordFieldRefs,
-  passwordErrors,
-  passwordPanelMessage,
-  passwordPanelMessageTone = 'error',
-  isPasswordChangePending,
-  toast,
-  onToastClose,
-  onPasswordValueChange,
-  onPasswordBlur,
-  onPasswordCancel,
-  onPasswordSubmit,
+  profile,
+  profileActions,
+  passwordChange,
+  passwordChangeActions,
 }: MyPageProfileContainerProps) {
+  const {
+    nickname,
+    name,
+    genderLabel,
+    socialAccount = null,
+    profileImageUrl,
+    isLoading,
+    isImageUploading,
+    isUpdating,
+    isLoggingOut,
+    canShowPasswordChange,
+    isPasswordPanelOpen,
+    toast,
+  } = profile;
+  const {
+    onLogout,
+    onNicknameSave,
+    onProfileImageSelect,
+    onPasswordToggle,
+    onToastClose,
+  } = profileActions;
+  const {
+    values,
+    fieldRefs,
+    errors,
+    message,
+    messageTone = 'error',
+    isPending,
+  } = passwordChange;
+  const { onValueChange, onFieldBlur, onCancel, onSubmit } =
+    passwordChangeActions;
+
   return (
     <MyPageProfileSection
       nickname={nickname}
@@ -80,9 +102,9 @@ function MyPageProfileContainer({
       genderLabel={genderLabel}
       socialAccount={socialAccount}
       profileImageUrl={profileImageUrl}
-      isProfileLoading={isProfileLoading}
-      isProfileImageUploading={isProfileImageUploading}
-      isProfileUpdating={isProfileUpdating}
+      isProfileLoading={isLoading}
+      isProfileImageUploading={isImageUploading}
+      isProfileUpdating={isUpdating}
       isLoggingOut={isLoggingOut}
       toast={toast}
       onToastClose={onToastClose}
@@ -97,16 +119,16 @@ function MyPageProfileContainer({
     >
       {canShowPasswordChange && isPasswordPanelOpen ? (
         <PasswordChangePanel
-          values={passwordValues}
-          fieldRefs={passwordFieldRefs}
-          errors={passwordErrors}
-          message={passwordPanelMessage}
-          messageTone={passwordPanelMessageTone}
-          isPending={isPasswordChangePending}
-          onValueChange={onPasswordValueChange}
-          onFieldBlur={onPasswordBlur}
-          onCancel={onPasswordCancel}
-          onSubmit={onPasswordSubmit}
+          values={values}
+          fieldRefs={fieldRefs}
+          errors={errors}
+          message={message}
+          messageTone={messageTone}
+          isPending={isPending}
+          onValueChange={onValueChange}
+          onFieldBlur={onFieldBlur}
+          onCancel={onCancel}
+          onSubmit={onSubmit}
         />
       ) : null}
     </MyPageProfileSection>


### PR DESCRIPTION
## 관련 이슈

- closes #418

## 변경 내용

- 회원가입 폼 검증/상수 로직을 별도 유틸로 분리했습니다.
- 마이페이지 프로필 컨테이너 props를 역할별 객체로 정리했습니다.
- Header 인증 표시 상태를 단일 상태 모델로 정리했습니다.
- 닫힌 개발용 로그인/API 패널이 DOM에 남지 않도록 조건부 렌더링으로 변경했습니다.
- 고객센터 챗봇 FAB 외부 클릭 로직의 CSS 클래스 의존성을 제거하고 ref 기반으로 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

- 첨부 없음

## 참고사항


