### PR TITLE
[Fix] 불필요한 초기 추천 질문 제거

### DIFF
--- a/src/features/support-chat/data/faqs.ts
+++ b/src/features/support-chat/data/faqs.ts
@@ -22,7 +22,6 @@ export const SUPPORT_CHAT_QUICK_ACTIONS: SupportChatQuickAction[] = [
     label: '계정 삭제 하고 싶은데 어떻게 하나요?',
   },
   { id: 'find-id-help', label: '아이디를 찾고 싶어요' },
-  { id: 'forgot-password-help', label: '비밀번호가 기억이 안나요.' },
   { id: 'google-login-help', label: '구글 로그인은 어떻게 하나요?' },
 ];
 
@@ -57,7 +56,7 @@ const SUPPORT_FAQ_ENTRIES: SupportFaqEntry[] = [
   },
   {
     id: 'forgot-password',
-    label: '비밀번호가 기억이 안나요.',
+    label: '비밀번호 찾기 안내',
     keywords: [
       '비밀번호',
       '기억이 안나',


### PR DESCRIPTION
## 관련 이슈

- closes #420

## 변경 내용

- 고객센터 챗봇 초기 추천 질문에서 `비밀번호가 기억이 안나요.` 항목을 제거했습니다.
- 동일 문구가 데이터에 남지 않도록 FAQ 내부 label을 `비밀번호 찾기 안내`로 정리했습니다.
- API 통신 로직과 챗봇 세션 로직은 변경하지 않았습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="874" height="1396" alt="image" src="https://github.com/user-attachments/assets/955145e8-bba6-40eb-8ee5-3d356b3167c5" />

## 참고사항


