### PR TITLE
[Fix] check-password 응답 계약 정리

### DIFF
--- a/docs/ai/api-contract/auth.md
+++ b/docs/ai/api-contract/auth.md
@@ -40,6 +40,7 @@
 - **주의**: API 명세서 표에 `refresh_token` body 예시가 있어도, 실서버 동작 기준은 HttpOnly 쿠키 인증이며 프론트는 `withCredentials` 요청으로 맞춥니다.
 - **로그아웃**: `POST /api/v1/accounts/logout` (액세스 토큰 무효화 및 서버측 쿠키 삭제 요청)
 - **비밀번호 변경**: `POST /api/v1/accounts/me/change-password`
+- **비밀번호 확인**: `POST /api/v1/accounts/me/check-password` (일반 로그인 회원 탈퇴 전 현재 비밀번호 검증)
 - **회원 탈퇴**: `DELETE /api/v1/accounts/me` (Authorization header만 사용, request body 없음, 성공 시 `204 No Content`)
 - **마이페이지 찜 목록 조회**: `GET /api/v1/accounts/me/game-like`
 - **마이페이지 찜 해제**: `DELETE /api/v1/games/{game_id}/like` (게임 공통 좋아요 취소 API 사용)
@@ -48,9 +49,18 @@
 ### 회원 탈퇴 Contract
 
 - 요구사항 정의서상 일반 로그인 회원은 회원탈퇴 UX에서 비밀번호 확인을 거치고, 소셜 로그인 회원은 탈퇴 동의 후 진행합니다.
+- 일반 로그인 회원은 `POST /api/v1/accounts/me/check-password`로 현재 비밀번호를 먼저 검증한 뒤, 성공하면 `DELETE /api/v1/accounts/me`를 호출합니다.
+- 소셜 로그인 회원은 비밀번호 입력 없이 탈퇴 동의 후 바로 `DELETE /api/v1/accounts/me`를 호출합니다.
 - 공식 API 명세서 기준 실제 탈퇴 요청은 `DELETE /api/v1/accounts/me`이며, request body 없이 `Authorization` header만 전송합니다.
 - 성공 응답은 `204 No Content`, 인증 실패 응답은 `401 Unauthorized`를 기준으로 처리합니다.
 - 프론트에서 비밀번호 확인 UI를 유지하더라도 API adapter 경계에서 탈퇴 요청 body에 `password`를 포함하지 않습니다.
+
+### 비밀번호 확인 Contract
+
+- `POST /api/v1/accounts/me/check-password`는 현재 비밀번호 검증 성공 여부만 판단하는 API입니다.
+- 성공 시 `200 OK`를 기준으로 처리하며, 프론트는 성공 response body를 사용하지 않습니다.
+- 프론트 호출부는 성공/실패 여부만 분기하고, 성공 payload shape를 가정하지 않습니다.
+- 실패 시에만 `error_detail` 또는 field error를 사용해 UI 메시지를 노출합니다.
 
 ### 비밀번호 변경 필드 계약
 

--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -403,13 +403,11 @@ export const changePassword = async (payload: ChangePasswordRequest) => {
 };
 
 export const checkPassword = async (payload: CheckPasswordRequest) => {
-  const response = await api.post<CheckPasswordResponse>(
+  await api.post<CheckPasswordResponse>(
     `${AUTH_BASE_PATH}/me/check-password`,
     payload,
     createCredentialedAuthRequestConfig(),
   );
-
-  return response.data;
 };
 
 export const deleteAccount = async () => {

--- a/src/features/auth/mocks/handlers.ts
+++ b/src/features/auth/mocks/handlers.ts
@@ -10,7 +10,6 @@ import type {
   AuthGender,
   CheckIdDuplicateRequest,
   CheckNicknameDuplicateRequest,
-  CheckPasswordResponse,
   ChangePasswordRequest,
   ChangePasswordResponse,
   ConfirmProfileImageRequest,
@@ -1046,9 +1045,7 @@ const accountHandlers = [
 
     await delay(160);
 
-    return HttpResponse.json({
-      detail: '비밀번호 확인에 성공했습니다.',
-    } satisfies CheckPasswordResponse);
+    return new HttpResponse(null, { status: 200 });
   }),
 
   http.delete(`${AUTH_BASE_PATH}/me`, async ({ request }) => {

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -29,9 +29,7 @@ export interface CheckPasswordRequest {
   password: string;
 }
 
-export interface CheckPasswordResponse {
-  detail: string;
-}
+export type CheckPasswordResponse = void;
 
 export interface ChangePasswordRequest {
   old_password: string;


### PR DESCRIPTION
## 관련 이슈

- closes #423

## 변경 내용

- `POST /api/v1/accounts/me/check-password` 성공 응답 타입을 body 미사용 기준으로 정리했습니다.
- auth transport에서 `checkPassword`가 `response.data`를 반환하지 않고 성공 여부만 확인하도록 수정했습니다.
- MSW mock handler도 `check-password` 성공 시 `200 OK` 빈 응답을 반환하도록 맞췄습니다.
- `docs/ai/api-contract/auth.md`에 `check-password` 계약과 회원 탈퇴 전 비밀번호 검증 플로우를 문서화했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- `check-password`는 성공 시 `200 OK`만 기준으로 처리하고, 프론트는 성공 response body를 소비하지 않도록 정리했습니다.
- 회원 탈퇴 플로우는 일반 로그인 회원의 경우 `check-password` 선검증 후 `DELETE /api/v1/accounts/me`를 호출하는 기준으로 문서화했습니다.
