### PR TITLE
[Fix] 소셜 로그인 로그아웃 401 오류 수정

### DIFF
--- a/src/features/auth/api/auth.transport.ts
+++ b/src/features/auth/api/auth.transport.ts
@@ -51,17 +51,29 @@ type RefreshAccessTokenRequestOptions = {
   preferDirectBackendOriginInDev?: boolean;
 };
 
-const resolveRefreshRequestUrl = (
-  options: RefreshAccessTokenRequestOptions = {},
+type LogoutRequestOptions = {
+  preferDirectBackendOriginInDev?: boolean;
+};
+
+const resolveCredentialedRequestUrl = (
+  requestPath: string,
+  options: { preferDirectBackendOriginInDev?: boolean } = {},
 ) => {
   if (import.meta.env.DEV && !options.preferDirectBackendOriginInDev) {
-    return refreshRequestPath;
+    return requestPath;
   }
 
   const backendOrigin = configuredApiBaseUrl || FALLBACK_BACKEND_ORIGIN;
 
-  return `${backendOrigin}${refreshRequestPath}`;
+  return `${backendOrigin}${requestPath}`;
 };
+
+const resolveRefreshRequestUrl = (
+  options: RefreshAccessTokenRequestOptions = {},
+) => resolveCredentialedRequestUrl(refreshRequestPath, options);
+
+const resolveLogoutRequestUrl = (options: LogoutRequestOptions = {}) =>
+  resolveCredentialedRequestUrl(logoutRequestPath, options);
 
 const readRefreshThrottleTimestamp = () => {
   if (typeof window === 'undefined') {
@@ -205,17 +217,18 @@ export const requestLogin = async (payload: LoginRequest) => {
   return response.data;
 };
 
-export const requestLogout = async () => {
+export const requestLogout = async (options: LogoutRequestOptions = {}) => {
   const requestConfig = createCredentialedAuthRequestConfig();
+  const logoutRequestUrl = resolveLogoutRequestUrl(options);
 
   logCredentialedAuthRequestDiagnostics({
     label: 'logout',
-    requestUrl: logoutRequestPath,
+    requestUrl: logoutRequestUrl,
     withCredentials: true,
   });
 
   const response = await api.post<LogoutResponse>(
-    logoutRequestPath,
+    logoutRequestUrl,
     undefined,
     requestConfig,
   );

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,4 +1,5 @@
 import type { LoginRequest } from '../types/auth';
+import { useAuthStore } from '../../../store/useAuthStore';
 import {
   clearMockRefreshToken,
   createRefreshTokenFallbackRequestBody,
@@ -15,6 +16,7 @@ import {
   requestLogout,
   requestRefreshAccessToken,
 } from './auth.transport';
+import { isSocialLoginAccount } from '../utils/socialAccount';
 
 export {
   checkIdDuplicate,
@@ -60,8 +62,14 @@ export const login = async (payload: LoginRequest) => {
 };
 
 export const logout = async () => {
+  const shouldPreferDirectBackendLogoutInDev =
+    import.meta.env.DEV &&
+    isSocialLoginAccount(useAuthStore.getState().socialAccount);
+
   try {
-    return await requestLogout();
+    return await requestLogout({
+      preferDirectBackendOriginInDev: shouldPreferDirectBackendLogoutInDev,
+    });
   } finally {
     clearMockRefreshToken();
   }

--- a/src/features/auth/utils/socialAuth.ts
+++ b/src/features/auth/utils/socialAuth.ts
@@ -106,6 +106,11 @@ export const getSocialCallbackAuthorizationCode = (
   searchParams: URLSearchParams,
 ) => getNormalizedSocialCallbackParam(searchParams, 'code');
 
+export const getSocialCallbackAccessToken = (searchParams: URLSearchParams) =>
+  getNormalizedSocialCallbackParam(searchParams, 'access_token') ||
+  getNormalizedSocialCallbackParam(searchParams, 'accessToken') ||
+  getNormalizedSocialCallbackParam(searchParams, 'token');
+
 const getSocialCallbackErrorMessageFromCode = (errorCode: string | null) => {
   if (!errorCode) {
     return null;

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -6,6 +6,7 @@ import { ROUTE_PATHS } from '../constants/routes';
 import { extractAuthApiErrorMessage } from '../features/auth/api/auth';
 import {
   clearPendingSocialAuthProvider,
+  getSocialCallbackAccessToken,
   getSocialCallbackAuthorizationCode,
   getSocialCallbackErrorMessage,
   hasPendingSocialAuthProvider,
@@ -13,12 +14,27 @@ import {
 import {
   clearAuthSession,
   ensureAuthSessionRestored,
+  hydrateAuthSessionFromAccessToken,
 } from '../features/auth/utils/sessionManager';
 
 const DEFAULT_CALLBACK_ERROR_MESSAGE =
   '소셜 로그인 정보를 확인하지 못했습니다. 다시 시도해 주세요.';
 const DEFAULT_REFRESH_ERROR_MESSAGE =
   '세션을 확인하지 못했습니다. 다시 로그인해 주세요.';
+
+const createCallbackParams = (search: string, hash: string) => {
+  const callbackParams = new URLSearchParams(search);
+  const normalizedHash = hash.startsWith('#') ? hash.slice(1) : hash;
+  const hashParams = new URLSearchParams(normalizedHash);
+
+  hashParams.forEach((value, key) => {
+    if (!callbackParams.has(key)) {
+      callbackParams.set(key, value);
+    }
+  });
+
+  return callbackParams;
+};
 
 function AuthCallbackPage() {
   const navigate = useNavigate();
@@ -41,16 +57,19 @@ function AuthCallbackPage() {
     const handleAuthCallback = async () => {
       setIsLoading(true);
 
-      const searchParams = new URLSearchParams(location.search);
+      const searchParams = createCallbackParams(location.search, location.hash);
+      const accessToken = getSocialCallbackAccessToken(searchParams);
       const authorizationCode =
         getSocialCallbackAuthorizationCode(searchParams);
       const callbackErrorMessage = getSocialCallbackErrorMessage(searchParams);
       const hasPendingSocialProvider = hasPendingSocialAuthProvider();
       const shouldRestoreSession =
+        Boolean(accessToken) ||
         Boolean(authorizationCode) ||
         hasPendingSocialProvider ||
         searchParams.size === 0;
       const shouldPreferDirectBackendRefreshInDev =
+        !accessToken &&
         import.meta.env.DEV &&
         (Boolean(authorizationCode) || hasPendingSocialProvider);
 
@@ -65,9 +84,14 @@ function AuthCallbackPage() {
       }
 
       try {
-        await ensureAuthSessionRestored({
-          preferDirectBackendOriginInDev: shouldPreferDirectBackendRefreshInDev,
-        });
+        if (accessToken) {
+          await hydrateAuthSessionFromAccessToken(accessToken);
+        } else {
+          await ensureAuthSessionRestored({
+            preferDirectBackendOriginInDev:
+              shouldPreferDirectBackendRefreshInDev,
+          });
+        }
 
         if (!isMounted) {
           return;
@@ -91,7 +115,7 @@ function AuthCallbackPage() {
     return () => {
       isMounted = false;
     };
-  }, [location.search, navigate]);
+  }, [location.hash, location.search, navigate]);
 
   return isLoading ? <MainPageLoadingFallback /> : null;
 }


### PR DESCRIPTION
## 관련 이슈

- closes #422

## 변경 내용

- 소셜 로그인 콜백에서 `access_token`, `accessToken`, `token` 파라미터를 query/hash 모두에서 읽도록 보강했습니다.
- 소셜 로그인 성공 후 일반 로그인과 동일하게 Access Token을 `sessionStorage`와 Zustand 상태에 저장하도록 수정했습니다.
- 로컬 개발 환경에서 소셜 계정 로그아웃 시 백엔드 쿠키 도메인과 맞도록 로그아웃 요청 origin을 보정했습니다.
- 일반 계정 로그아웃 흐름과 배포 환경 동작은 유지했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- 로컬 개발 환경에서만 소셜 로그아웃 요청 origin을 보정하며, 배포 환경에는 영향이 없습니다.
