### PR TITLE
[Refactor] 설문/매칭/추천 페이지 분기 단순화

### DIFF
--- a/src/pages/matching/MatchingListPage.tsx
+++ b/src/pages/matching/MatchingListPage.tsx
@@ -41,42 +41,6 @@ function MatchingGenreCardSkeleton() {
   );
 }
 
-function MatchingListLoadingState() {
-  return (
-    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(160,25,25,0.18),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_34%)] opacity-90" />
-      <LazyHeader fixed />
-
-      <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-22 pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-25 md:pb-14">
-        <section className="mx-auto max-w-240">
-          <div className="mb-7 text-center sm:mb-8">
-            <div className="mx-auto h-4 w-24 animate-pulse rounded-full bg-[#792222]/35" />
-            <div className="relative mt-3">
-              <h1 className="text-3xl font-semibold tracking-[-0.03em] text-transparent sm:text-4xl md:text-[42px]">
-                장르별 게임 매칭
-              </h1>
-              <div className="absolute top-1/2 left-1/2 h-11 w-62 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-full bg-white/9" />
-            </div>
-            <div className="relative mt-3">
-              <p className="truncate text-sm leading-6 text-transparent sm:text-[15px]">
-                좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에
-                맞는 게임을 빠르게 추천해드려요.
-              </p>
-              <div className="absolute top-1/2 left-1/2 h-4 w-full max-w-124 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-full bg-white/7" />
-            </div>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            {MATCHING_GENRES.map((genre) => (
-              <MatchingGenreCardSkeleton key={genre.slug} />
-            ))}
-          </div>
-        </section>
-      </main>
-    </div>
-  );
-}
-
 function MatchingListPage() {
   const location = useLocation();
   const queryClient = useQueryClient();
@@ -134,9 +98,10 @@ function MatchingListPage() {
     );
   }
 
-  if (authGate.needsAuthCheck) {
-    return <MatchingListLoadingState />;
-  }
+  const shouldShowPageSkeleton = authGate.needsAuthCheck;
+  const shouldShowHeaderSkeleton = shouldShowPageSkeleton;
+  const shouldShowCardSkeleton =
+    shouldShowPageSkeleton || shouldShowGenreImageSkeleton;
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
@@ -144,7 +109,7 @@ function MatchingListPage() {
       <LazyHeader fixed />
 
       <main className="relative z-10 mx-auto min-h-screen w-full max-w-280 px-4 pt-22 pb-12 sm:px-6 sm:pt-24 md:px-8 md:pt-25 md:pb-14">
-        {!canAccessPage ? (
+        {!canAccessPage && !shouldShowPageSkeleton ? (
           <AuthGateStatusPanel
             title="로그인 후 매칭을 시작할 수 있어요."
             description="로그인하면 장르를 고르고 트레일러를 보며 별점을 남긴 뒤, 취향에 맞는 추천 결과까지 바로 이어서 확인할 수 있어요."
@@ -153,23 +118,42 @@ function MatchingListPage() {
           />
         ) : (
           <section className="mx-auto max-w-240">
-            <div className="mb-7 text-center sm:mb-8">
-              <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
-                Matching
-              </p>
-              <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[42px]">
-                장르별 게임 매칭
-              </h1>
-              <p
-                className="mt-3 truncate text-sm leading-6 text-white/58 sm:text-[15px]"
-                title="좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에 맞는 게임을 빠르게 추천해드려요."
-              >
-                좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에
-                맞는 게임을 빠르게 추천해드려요.
-              </p>
-            </div>
+            {shouldShowHeaderSkeleton ? (
+              <div className="mb-7 text-center sm:mb-8">
+                <div className="mx-auto h-4 w-24 animate-pulse rounded-full bg-[#792222]/35" />
+                <div className="relative mt-3">
+                  <h1 className="text-3xl font-semibold tracking-[-0.03em] text-transparent sm:text-4xl md:text-[42px]">
+                    장르별 게임 매칭
+                  </h1>
+                  <div className="absolute top-1/2 left-1/2 h-11 w-62 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-full bg-white/9" />
+                </div>
+                <div className="relative mt-3">
+                  <p className="truncate text-sm leading-6 text-transparent sm:text-[15px]">
+                    좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에
+                    맞는 게임을 빠르게 추천해드려요.
+                  </p>
+                  <div className="absolute top-1/2 left-1/2 h-4 w-full max-w-124 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-full bg-white/7" />
+                </div>
+              </div>
+            ) : (
+              <div className="mb-7 text-center sm:mb-8">
+                <p className="text-sm font-semibold tracking-[0.2em] text-[#d93737] uppercase">
+                  Matching
+                </p>
+                <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl md:text-[42px]">
+                  장르별 게임 매칭
+                </h1>
+                <p
+                  className="mt-3 truncate text-sm leading-6 text-white/58 sm:text-[15px]"
+                  title="좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에 맞는 게임을 빠르게 추천해드려요."
+                >
+                  좋아하는 장르를 고르고 트레일러를 보며 별점을 남기면, 취향에
+                  맞는 게임을 빠르게 추천해드려요.
+                </p>
+              </div>
+            )}
 
-            {shouldShowGenreImageSkeleton ? (
+            {shouldShowCardSkeleton ? (
               <div className="grid gap-4 md:grid-cols-2">
                 {MATCHING_GENRES.map((genre) => (
                   <MatchingGenreCardSkeleton key={genre.slug} />

--- a/src/pages/recommendation/RecommendationListPage.tsx
+++ b/src/pages/recommendation/RecommendationListPage.tsx
@@ -235,41 +235,6 @@ function RecommendationPromptCard({
   );
 }
 
-function RecommendationPageLoadingState() {
-  return (
-    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
-      <RecommendationBackdrop items={[]} />
-      <LazyHeader fixed />
-
-      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-300 flex-col px-3 pt-24 pb-8 sm:px-4 sm:pt-28 sm:pb-10 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
-        <section className="mx-auto flex min-h-0 w-full max-w-245 flex-1 flex-col">
-          <div className="mb-8">
-            <div className="grid gap-4 md:grid-cols-[1fr_auto_1fr] md:items-end">
-              <div className="hidden md:block" />
-
-              <div className="text-center">
-                <div className="relative">
-                  <h1 className="text-3xl font-semibold tracking-[-0.04em] text-transparent sm:text-4xl md:text-[52px]">
-                    게임 추천 리스트
-                  </h1>
-                  <div className="absolute top-1/2 left-1/2 h-12 w-72 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-full bg-white/10" />
-                </div>
-              </div>
-
-              <div className="flex justify-center gap-2.5 md:justify-end">
-                <div className="h-[50px] w-31 animate-pulse rounded-2xl border border-white/10 bg-white/4" />
-                <div className="h-[50px] w-31 animate-pulse rounded-2xl border border-white/10 bg-white/4" />
-              </div>
-            </div>
-          </div>
-
-          <RecommendationListSkeleton />
-        </section>
-      </main>
-    </div>
-  );
-}
-
 function RecommendationListPage() {
   const [selectedGame, setSelectedGame] = useState<GameListItem | null>(null);
   const authGate = useAuthGate({ allowMockBypass: true });
@@ -321,9 +286,27 @@ function RecommendationListPage() {
     setFeedbackMessage,
   });
 
-  if (authGate.needsAuthCheck) {
-    return <RecommendationPageLoadingState />;
-  }
+  const shouldShowPageSkeleton = authGate.needsAuthCheck;
+  const promptCardProps =
+    !canAccessPage || shouldShowPageSkeleton
+      ? null
+      : !isMatchSource && !isSurveySource
+        ? {
+            title: '먼저 설문을 완료해 주세요.',
+            description:
+              '설문이 끝나면 추천 결과를 이 페이지에서 바로 확인할 수 있어요.',
+            ctaLabel: '설문 페이지로 이동',
+            to: `/${ROUTES.SURVEY}`,
+          }
+        : shouldShowMatchEntryCta
+          ? {
+              title: '먼저 매칭 평가를 완료해 주세요.',
+              description:
+                '좋아하는 장르를 고르고 최대 5개 게임의 트레일러를 보며 별점을 남기면 추천 결과가 바로 준비돼요.',
+              ctaLabel: '매칭 페이지로 이동',
+              to: `/${ROUTES.MATCHING_LIST}`,
+            }
+          : null;
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
@@ -337,12 +320,26 @@ function RecommendationListPage() {
               <div className="hidden md:block" />
 
               <div className="text-center">
-                <h1 className="text-3xl font-semibold tracking-[-0.04em] text-white sm:text-4xl md:text-[52px]">
-                  게임 추천 리스트
-                </h1>
+                {shouldShowPageSkeleton ? (
+                  <div className="relative">
+                    <h1 className="text-3xl font-semibold tracking-[-0.04em] text-transparent sm:text-4xl md:text-[52px]">
+                      게임 추천 리스트
+                    </h1>
+                    <div className="absolute top-1/2 left-1/2 h-12 w-72 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-full bg-white/10" />
+                  </div>
+                ) : (
+                  <h1 className="text-3xl font-semibold tracking-[-0.04em] text-white sm:text-4xl md:text-[52px]">
+                    게임 추천 리스트
+                  </h1>
+                )}
               </div>
 
-              {shouldShowSurveyActions ? (
+              {shouldShowPageSkeleton ? (
+                <div className="flex justify-center gap-2.5 md:justify-end">
+                  <div className="h-[50px] w-31 animate-pulse rounded-2xl border border-white/10 bg-white/4" />
+                  <div className="h-[50px] w-31 animate-pulse rounded-2xl border border-white/10 bg-white/4" />
+                </div>
+              ) : shouldShowSurveyActions ? (
                 <div className="flex flex-wrap items-center justify-center gap-2.5 md:justify-end">
                   <button
                     type="button"
@@ -367,25 +364,15 @@ function RecommendationListPage() {
             </div>
           </div>
 
-          {!canAccessPage ? (
+          {shouldShowPageSkeleton ? (
+            <RecommendationListSkeleton />
+          ) : !canAccessPage ? (
             <AuthGateStatusPanel
               title="로그인 후 추천 결과를 볼 수 있어요."
               description="실제 API 모드에서는 인증 토큰이 필요합니다. 개발 중에는 MSW를 켜두면 추천 결과 흐름을 확인할 수 있습니다."
             />
-          ) : !isMatchSource && !isSurveySource ? (
-            <RecommendationPromptCard
-              title="먼저 설문을 완료해 주세요."
-              description="설문이 끝나면 추천 결과를 이 페이지에서 바로 확인할 수 있어요."
-              ctaLabel="설문 페이지로 이동"
-              to={`/${ROUTES.SURVEY}`}
-            />
-          ) : shouldShowMatchEntryCta ? (
-            <RecommendationPromptCard
-              title="먼저 매칭 평가를 완료해 주세요."
-              description="좋아하는 장르를 고르고 최대 5개 게임의 트레일러를 보며 별점을 남기면 추천 결과가 바로 준비돼요."
-              ctaLabel="매칭 페이지로 이동"
-              to={`/${ROUTES.MATCHING_LIST}`}
-            />
+          ) : promptCardProps ? (
+            <RecommendationPromptCard {...promptCardProps} />
           ) : (
             <section className="flex min-h-0 flex-col overflow-hidden rounded-4xl border border-white/8 bg-[linear-gradient(180deg,rgba(16,16,18,0.92),rgba(9,9,10,0.98))] shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-2xl">
               {feedbackMessage ? (

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -36,20 +36,6 @@ function SurveyBackdrop() {
   );
 }
 
-function SurveyPageLoadingState() {
-  return (
-    <div className="relative min-h-screen overflow-hidden bg-[#050505]">
-      <SurveyBackdrop />
-      <div className="app-aurora pointer-events-none absolute inset-0 opacity-90" />
-      <LazyHeader fixed />
-
-      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
-        <SurveyChatLoadingState />
-      </main>
-    </div>
-  );
-}
-
 function SurveyPage() {
   const location = useLocation();
   const [searchParams] = useSearchParams();
@@ -129,10 +115,6 @@ function SurveyPage() {
     );
   }
 
-  if (authGate.needsAuthCheck) {
-    return <SurveyPageLoadingState />;
-  }
-
   if (shouldRedirectCompletedEntry) {
     const recommendationQuery = surveySessionId
       ? `?source=survey&session_id=${encodeURIComponent(surveySessionId)}`
@@ -145,6 +127,19 @@ function SurveyPage() {
     );
   }
 
+  const pageContent = authGate.needsAuthCheck ? (
+    <SurveyChatLoadingState />
+  ) : canAccessSurvey ? (
+    <SurveyChatPanel isHistoryView={isHistoryMode} />
+  ) : (
+    <AuthGateStatusPanel
+      title="로그인 후 설문을 시작할 수 있어요."
+      description="로그인하면 취향을 바탕으로 질문을 이어가고, 설문이 끝난 뒤 바로 추천 결과까지 확인할 수 있어요."
+      align="center"
+      className="mx-auto max-w-190 sm:py-12"
+    />
+  );
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050505]">
       <SurveyBackdrop />
@@ -152,16 +147,7 @@ function SurveyPage() {
       <LazyHeader fixed />
 
       <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-3 pt-[4.85rem] pb-6 sm:px-4 sm:pt-[5.15rem] sm:pb-8 md:h-dvh md:max-h-dvh md:overflow-hidden md:px-8 md:pt-[5.45rem] md:pb-6">
-        {canAccessSurvey ? (
-          <SurveyChatPanel isHistoryView={isHistoryMode} />
-        ) : (
-          <AuthGateStatusPanel
-            title="로그인 후 설문을 시작할 수 있어요."
-            description="로그인하면 취향을 바탕으로 질문을 이어가고, 설문이 끝난 뒤 바로 추천 결과까지 확인할 수 있어요."
-            align="center"
-            className="mx-auto max-w-190 sm:py-12"
-          />
-        )}
+        {pageContent}
       </main>
     </div>
   );


### PR DESCRIPTION
## 관련 이슈

- closes #396 

## 변경 내용

- 공용 파일은 건드리지 않고, 설문/매칭/추천 페이지 파일 범위 안에서만 분기와 중복 레이아웃을 정리했습니다.
- 설문 페이지는 로딩 상태와 실제 화면 전환 흐름을 한 파일 안에서 더 직접적으로 읽히도록 정리했습니다.
- 매칭 페이지는 auth 확인, 스켈레톤, 실제 카드 렌더 분기를 단순화하고 로딩 전용 흐름을 줄였습니다.
- 추천 리스트 페이지는 auth 확인, 진입 안내, 결과 리스트 분기를 더 직선적으로 보이도록 정리했습니다.
- helper나 공용 구조를 더 늘리기보다, 페이지 안에서 반복되던 조건 분기와 로딩 처리 흐름을 덜어내는 방향에 집중했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 구조를 더 잘게 나누는 것보다, 페이지 안에서 과하게 반복되던 분기와 전용 로딩 흐름을 줄이는 데 초점을 맞췄습니다.
- 변경 범위는 아래 3개 페이지 파일로 제한했습니다.
  - `src/pages/survey/SurveyPage.tsx`
  - `src/pages/matching/MatchingListPage.tsx`
  - `src/pages/recommendation/RecommendationListPage.tsx`
