### PR TITLE
[Refactor] 훅 책임 분리 및 파일 단위 구조화

### DIFF
--- a/src/features/auth/api/accountHooks.ts
+++ b/src/features/auth/api/accountHooks.ts
@@ -1,0 +1,40 @@
+import { useMutation } from '@tanstack/react-query';
+
+import {
+  changePassword,
+  checkIdDuplicate,
+  checkNicknameDuplicate,
+  checkPassword,
+  deleteAccount,
+} from './auth';
+import { authKeys } from './queryKeys';
+
+export const useChangePasswordMutation = () =>
+  useMutation({
+    mutationKey: authKeys.changePassword(),
+    mutationFn: changePassword,
+  });
+
+export const useCheckPasswordMutation = () =>
+  useMutation({
+    mutationKey: authKeys.checkPassword(),
+    mutationFn: checkPassword,
+  });
+
+export const useDeleteAccountMutation = () =>
+  useMutation({
+    mutationKey: authKeys.deleteAccount(),
+    mutationFn: deleteAccount,
+  });
+
+export const useCheckIdDuplicateMutation = () =>
+  useMutation({
+    mutationKey: authKeys.checkIdDuplicate(),
+    mutationFn: checkIdDuplicate,
+  });
+
+export const useCheckNicknameDuplicateMutation = () =>
+  useMutation({
+    mutationKey: authKeys.checkNicknameDuplicate(),
+    mutationFn: checkNicknameDuplicate,
+  });

--- a/src/features/auth/api/likedGamesHooks.ts
+++ b/src/features/auth/api/likedGamesHooks.ts
@@ -1,0 +1,75 @@
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import { syncLikeMutationStateInQueryCache } from '../../games/queryCache';
+import { getLikedGames, unlikeLikedGame } from './auth';
+import { authKeys } from './queryKeys';
+import type { LikedGamesRequest } from '../types/auth';
+
+const LIKED_GAMES_PAGE_SIZE = 20;
+
+export const useLikedGamesQuery = (
+  enabled = true,
+  payload: LikedGamesRequest = {},
+) =>
+  useQuery({
+    queryKey: authKeys.likedGamesList(payload),
+    queryFn: () => getLikedGames(payload),
+    enabled,
+    staleTime: 60_000,
+  });
+
+export const useInfiniteLikedGamesQuery = (
+  enabled = true,
+  payload: LikedGamesRequest = {},
+) => {
+  const pageSize = payload.page_size ?? LIKED_GAMES_PAGE_SIZE;
+  const initialPage = payload.page ?? 1;
+
+  return useInfiniteQuery({
+    queryKey: authKeys.likedGamesInfiniteList({
+      page_size: pageSize,
+    }),
+    queryFn: ({ pageParam }) =>
+      getLikedGames({
+        ...payload,
+        page: pageParam,
+        page_size: pageSize,
+      }),
+    initialPageParam: initialPage,
+    getNextPageParam: (lastPage, allPages) => {
+      const loadedCount = allPages.reduce(
+        (totalCount, page) =>
+          totalCount + (Array.isArray(page.results) ? page.results.length : 0),
+        0,
+      );
+      const totalCount =
+        typeof lastPage.count === 'number' ? lastPage.count : loadedCount;
+
+      return loadedCount < totalCount
+        ? initialPage + allPages.length
+        : undefined;
+    },
+    enabled,
+    staleTime: 60_000,
+  });
+};
+
+export const useUnlikeLikedGameMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: authKeys.unlikeLikedGame(),
+    mutationFn: unlikeLikedGame,
+    onSuccess: (_, gameId) => {
+      syncLikeMutationStateInQueryCache(queryClient, {
+        gameId,
+        isLiked: false,
+      });
+    },
+  });
+};

--- a/src/features/auth/api/profileHooks.ts
+++ b/src/features/auth/api/profileHooks.ts
@@ -1,0 +1,84 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useAuthStore } from '../../../store/useAuthStore';
+import { syncAuthAccount } from '../utils/sessionManager';
+import {
+  confirmProfileImage,
+  getProfileImagePresignedUrl,
+  updateUserInfo,
+  uploadFileToS3,
+} from './auth';
+import { authKeys } from './queryKeys';
+import type {
+  ConfirmProfileImageRequest,
+  CurrentUserProfileResponse,
+  ProfileImagePresignedUrlRequest,
+  UpdateUserInfoResponse,
+  UpdateUserInfoRequest,
+  UploadFileToS3Request,
+} from '../types/auth';
+
+const mergeUpdatedUserInfo = (
+  currentProfile: CurrentUserProfileResponse,
+  response: UpdateUserInfoResponse,
+): Partial<CurrentUserProfileResponse> => {
+  const nextProfile: Partial<CurrentUserProfileResponse> = {};
+
+  if (typeof response.nickname === 'string') {
+    nextProfile.nickname = response.nickname;
+  }
+
+  if (response.profile_img_url !== undefined) {
+    nextProfile.profile_img_url =
+      response.profile_img_url ?? currentProfile.profile_img_url ?? null;
+  }
+
+  return nextProfile;
+};
+
+export const useProfileImagePresignedUrlMutation = () =>
+  useMutation({
+    mutationKey: authKeys.profileImagePresignedUrl(),
+    mutationFn: (payload: ProfileImagePresignedUrlRequest) =>
+      getProfileImagePresignedUrl(payload),
+  });
+
+export const useUploadFileToS3Mutation = () =>
+  useMutation({
+    mutationKey: authKeys.profileImageUpload(),
+    mutationFn: (payload: UploadFileToS3Request) => uploadFileToS3(payload),
+  });
+
+export const useConfirmProfileImageMutation = () =>
+  useMutation({
+    mutationKey: authKeys.profileImageConfirm(),
+    mutationFn: (payload: ConfirmProfileImageRequest) =>
+      confirmProfileImage(payload),
+  });
+
+export const useUpdateUserInfoMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: authKeys.updateUserInfo(),
+    mutationFn: (payload: UpdateUserInfoRequest) => updateUserInfo(payload),
+    onSuccess: (data) => {
+      const cachedProfile =
+        queryClient.getQueryData<CurrentUserProfileResponse>(authKeys.me()) ??
+        useAuthStore.getState().account;
+
+      if (!cachedProfile) {
+        void queryClient.invalidateQueries({ queryKey: authKeys.me() });
+        return;
+      }
+
+      const nextProfile: CurrentUserProfileResponse = {
+        ...cachedProfile,
+        ...mergeUpdatedUserInfo(cachedProfile, data),
+      };
+
+      queryClient.setQueryData(authKeys.me(), nextProfile);
+      syncAuthAccount(nextProfile);
+    },
+  });
+};

--- a/src/features/auth/api/sessionHooks.ts
+++ b/src/features/auth/api/sessionHooks.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+import { getCurrentUserProfile, login, logout, signup } from './auth';
+import { authKeys } from './queryKeys';
+
+export const useLoginMutation = () =>
+  useMutation({
+    mutationKey: authKeys.login(),
+    mutationFn: login,
+  });
+
+export const useSignupMutation = () =>
+  useMutation({
+    mutationKey: authKeys.signup(),
+    mutationFn: signup,
+  });
+
+export const useLogoutMutation = () =>
+  useMutation({
+    mutationKey: authKeys.logout(),
+    mutationFn: logout,
+  });
+
+export const useCurrentUserProfileQuery = (enabled = true) =>
+  useQuery({
+    queryKey: authKeys.me(),
+    queryFn: getCurrentUserProfile,
+    enabled,
+    staleTime: 60_000,
+  });

--- a/src/features/auth/api/useAuthApi.ts
+++ b/src/features/auth/api/useAuthApi.ts
@@ -1,222 +1,24 @@
-import {
-  useInfiniteQuery,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
-
-import {
-  checkIdDuplicate,
-  checkNicknameDuplicate,
-  checkPassword,
-  changePassword,
-  confirmProfileImage,
-  deleteAccount,
-  getProfileImagePresignedUrl,
-  getCurrentUserProfile,
-  getLikedGames,
-  login,
-  logout,
-  signup,
-  unlikeLikedGame,
-  updateUserInfo,
-  uploadFileToS3,
-} from './auth';
-import { authKeys } from './queryKeys';
-import type {
-  ConfirmProfileImageRequest,
-  CurrentUserProfileResponse,
-  LikedGamesRequest,
-  ProfileImagePresignedUrlRequest,
-  UpdateUserInfoResponse,
-  UpdateUserInfoRequest,
-  UploadFileToS3Request,
-} from '../types/auth';
-import { syncLikeMutationStateInQueryCache } from '../../games/queryCache';
-import { syncAuthAccount } from '../utils/sessionManager';
-import { useAuthStore } from '../../../store/useAuthStore';
-
-const LIKED_GAMES_PAGE_SIZE = 20;
-
-export const useLoginMutation = () =>
-  useMutation({
-    mutationKey: authKeys.login(),
-    mutationFn: login,
-  });
-
-export const useSignupMutation = () =>
-  useMutation({
-    mutationKey: authKeys.signup(),
-    mutationFn: signup,
-  });
-
-export const useLogoutMutation = () =>
-  useMutation({
-    mutationKey: authKeys.logout(),
-    mutationFn: logout,
-  });
-
-export const useCurrentUserProfileQuery = (enabled = true) =>
-  useQuery({
-    queryKey: authKeys.me(),
-    queryFn: getCurrentUserProfile,
-    enabled,
-    staleTime: 60_000,
-  });
-
-export const useLikedGamesQuery = (
-  enabled = true,
-  payload: LikedGamesRequest = {},
-) =>
-  useQuery({
-    queryKey: authKeys.likedGamesList(payload),
-    queryFn: () => getLikedGames(payload),
-    enabled,
-    staleTime: 60_000,
-  });
-
-export const useInfiniteLikedGamesQuery = (
-  enabled = true,
-  payload: LikedGamesRequest = {},
-) => {
-  const pageSize = payload.page_size ?? LIKED_GAMES_PAGE_SIZE;
-  const initialPage = payload.page ?? 1;
-
-  return useInfiniteQuery({
-    queryKey: authKeys.likedGamesInfiniteList({
-      page_size: pageSize,
-    }),
-    queryFn: ({ pageParam }) =>
-      getLikedGames({
-        ...payload,
-        page: pageParam,
-        page_size: pageSize,
-      }),
-    initialPageParam: initialPage,
-    getNextPageParam: (lastPage, allPages) => {
-      const loadedCount = allPages.reduce(
-        (totalCount, page) =>
-          totalCount + (Array.isArray(page.results) ? page.results.length : 0),
-        0,
-      );
-      const totalCount =
-        typeof lastPage.count === 'number' ? lastPage.count : loadedCount;
-
-      return loadedCount < totalCount
-        ? initialPage + allPages.length
-        : undefined;
-    },
-    enabled,
-    staleTime: 60_000,
-  });
-};
-
-export const useUnlikeLikedGameMutation = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationKey: authKeys.unlikeLikedGame(),
-    mutationFn: unlikeLikedGame,
-    onSuccess: (_, gameId) => {
-      syncLikeMutationStateInQueryCache(queryClient, {
-        gameId,
-        isLiked: false,
-      });
-    },
-  });
-};
-
-export const useProfileImagePresignedUrlMutation = () =>
-  useMutation({
-    mutationKey: authKeys.profileImagePresignedUrl(),
-    mutationFn: (payload: ProfileImagePresignedUrlRequest) =>
-      getProfileImagePresignedUrl(payload),
-  });
-
-export const useUploadFileToS3Mutation = () =>
-  useMutation({
-    mutationKey: authKeys.profileImageUpload(),
-    mutationFn: (payload: UploadFileToS3Request) => uploadFileToS3(payload),
-  });
-
-export const useConfirmProfileImageMutation = () =>
-  useMutation({
-    mutationKey: authKeys.profileImageConfirm(),
-    mutationFn: (payload: ConfirmProfileImageRequest) =>
-      confirmProfileImage(payload),
-  });
-
-export const useChangePasswordMutation = () =>
-  useMutation({
-    mutationKey: authKeys.changePassword(),
-    mutationFn: changePassword,
-  });
-
-export const useCheckPasswordMutation = () =>
-  useMutation({
-    mutationKey: authKeys.checkPassword(),
-    mutationFn: checkPassword,
-  });
-
-export const useDeleteAccountMutation = () =>
-  useMutation({
-    mutationKey: authKeys.deleteAccount(),
-    mutationFn: deleteAccount,
-  });
-
-export const useUpdateUserInfoMutation = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationKey: authKeys.updateUserInfo(),
-    mutationFn: (payload: UpdateUserInfoRequest) => updateUserInfo(payload),
-    onSuccess: (data) => {
-      const cachedProfile =
-        queryClient.getQueryData<CurrentUserProfileResponse>(authKeys.me()) ??
-        useAuthStore.getState().account;
-
-      if (!cachedProfile) {
-        void queryClient.invalidateQueries({ queryKey: authKeys.me() });
-        return;
-      }
-
-      const nextProfile: CurrentUserProfileResponse = {
-        ...cachedProfile,
-        ...mergeUpdatedUserInfo(cachedProfile, data),
-      };
-
-      queryClient.setQueryData(authKeys.me(), nextProfile);
-      syncAuthAccount(nextProfile);
-    },
-  });
-};
-
-const mergeUpdatedUserInfo = (
-  currentProfile: CurrentUserProfileResponse,
-  response: UpdateUserInfoResponse,
-): Partial<CurrentUserProfileResponse> => {
-  const nextProfile: Partial<CurrentUserProfileResponse> = {};
-
-  if (typeof response.nickname === 'string') {
-    nextProfile.nickname = response.nickname;
-  }
-
-  if (response.profile_img_url !== undefined) {
-    nextProfile.profile_img_url =
-      response.profile_img_url ?? currentProfile.profile_img_url ?? null;
-  }
-
-  return nextProfile;
-};
-
-export const useCheckIdDuplicateMutation = () =>
-  useMutation({
-    mutationKey: authKeys.checkIdDuplicate(),
-    mutationFn: checkIdDuplicate,
-  });
-
-export const useCheckNicknameDuplicateMutation = () =>
-  useMutation({
-    mutationKey: authKeys.checkNicknameDuplicate(),
-    mutationFn: checkNicknameDuplicate,
-  });
+export {
+  useCurrentUserProfileQuery,
+  useLoginMutation,
+  useLogoutMutation,
+  useSignupMutation,
+} from './sessionHooks';
+export {
+  useInfiniteLikedGamesQuery,
+  useLikedGamesQuery,
+  useUnlikeLikedGameMutation,
+} from './likedGamesHooks';
+export {
+  useConfirmProfileImageMutation,
+  useProfileImagePresignedUrlMutation,
+  useUpdateUserInfoMutation,
+  useUploadFileToS3Mutation,
+} from './profileHooks';
+export {
+  useChangePasswordMutation,
+  useCheckIdDuplicateMutation,
+  useCheckNicknameDuplicateMutation,
+  useCheckPasswordMutation,
+  useDeleteAccountMutation,
+} from './accountHooks';

--- a/src/features/games/hooks/useGameDetailData.ts
+++ b/src/features/games/hooks/useGameDetailData.ts
@@ -1,0 +1,66 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { shouldRetryApiQuery } from '../../../api/queryRetry';
+import {
+  GAME_DETAIL_GC_TIME,
+  GAME_DETAIL_STALE_TIME,
+  mergeGameDetail,
+} from '../detailUtils';
+import { getGameDetail } from '../gameApi';
+import { gamesKeys } from '../queryCache';
+import type { GameDetail, GameListItem } from '../types';
+
+export type DetailErrorKind = 'not-found' | 'error' | null;
+
+const getDetailErrorKind = (error: unknown): DetailErrorKind => {
+  if (!(error instanceof AxiosError)) {
+    return error ? 'error' : null;
+  }
+
+  if (error.response?.status === 404) {
+    return 'not-found';
+  }
+
+  return 'error';
+};
+
+export const useGameDetailData = (game: GameListItem) => {
+  const queryClient = useQueryClient();
+
+  const detailQuery = useQuery({
+    queryKey: gamesKeys.detail(game.gameId),
+    queryFn: async () => {
+      const incomingDetail = await getGameDetail(game.gameId);
+      const previousDetail =
+        queryClient.getQueryData<GameDetail>(gamesKeys.detail(game.gameId)) ??
+        null;
+
+      return mergeGameDetail(previousDetail, incomingDetail);
+    },
+    staleTime: GAME_DETAIL_STALE_TIME,
+    gcTime: GAME_DETAIL_GC_TIME,
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
+    retry: shouldRetryApiQuery,
+  });
+
+  const detail = detailQuery.data;
+  const detailErrorKind = getDetailErrorKind(detailQuery.error);
+
+  const hasFallbackSummary = Boolean(
+    game.name.trim() ||
+    game.thumbnailUrl ||
+    game.genres.length > 0 ||
+    typeof game.rating === 'number' ||
+    typeof game.isLiked === 'boolean',
+  );
+
+  return {
+    detailQuery,
+    detail,
+    detailErrorKind,
+    hasFallbackSummary,
+    hasResolvedDetail: Boolean(detail),
+  };
+};

--- a/src/features/games/hooks/useGameDetailLikeAction.ts
+++ b/src/features/games/hooks/useGameDetailLikeAction.ts
@@ -1,0 +1,134 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+
+import { useAuthStore } from '../../../store/useAuthStore';
+import useAuthSessionState from '../../auth/hooks/useAuthSessionState';
+import { getToggleLikeErrorMessage } from '../likeError';
+import { likeGame, unlikeGame } from '../gameApi';
+import { syncLikeMutationStateInQueryCache } from '../queryCache';
+import type { GameDetail, GameListItem } from '../types';
+
+const LOGIN_REQUIRED_MESSAGE = '로그인 후 찜하기를 사용할 수 있어요.';
+const AUTH_CHECK_PENDING_MESSAGE =
+  '로그인 상태를 확인하고 있어요. 잠시만 기다려 주세요.';
+const LIKE_ERROR_MESSAGE =
+  '찜하기 상태를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+const DETAIL_NOT_FOUND_MESSAGE = '해당 게임 상세 정보를 찾을 수 없습니다.';
+const TOAST_DURATION_MS = 3000;
+
+export type GameDetailModalToast = {
+  message: string;
+  tone: 'error';
+};
+
+const getLikeErrorMessage = (error: unknown) => {
+  return getToggleLikeErrorMessage(error, {
+    loginRequired: LOGIN_REQUIRED_MESSAGE,
+    defaultError: LIKE_ERROR_MESSAGE,
+    notFound: DETAIL_NOT_FOUND_MESSAGE,
+  });
+};
+
+export const useGameDetailLikeAction = ({
+  game,
+  detail,
+}: {
+  game: GameListItem;
+  detail: GameDetail | undefined;
+}) => {
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const { isAuthLoading } = useAuthSessionState();
+  const queryClient = useQueryClient();
+  const [likeState, setLikeState] = useState<{
+    gameId: number;
+    isLiked: boolean | null;
+    likeCount: number;
+  } | null>(null);
+  const [toast, setToast] = useState<GameDetailModalToast | null>(null);
+
+  const activeLikeState = likeState?.gameId === game.gameId ? likeState : null;
+  const currentLiked =
+    activeLikeState?.isLiked ??
+    detail?.isLiked ??
+    (typeof game.isLiked === 'boolean' ? game.isLiked : null);
+  const isLiked = currentLiked === true;
+
+  const likeMutation = useMutation({
+    mutationFn: (nextLiked: boolean) =>
+      nextLiked ? likeGame(game.gameId) : unlikeGame(game.gameId),
+    onMutate: () => {
+      setToast(null);
+    },
+    onSuccess: (response) => {
+      const nextLikeState = {
+        gameId: response.gameId,
+        isLiked: response.isLiked,
+        likeCount: response.likeCount,
+      };
+
+      setLikeState(nextLikeState);
+      syncLikeMutationStateInQueryCache(queryClient, {
+        ...nextLikeState,
+        likedGame: {
+          gameId: response.gameId,
+          title: detail?.title ?? game.name,
+          thumbnailUrl: detail?.coverImageUrl ?? game.thumbnailUrl,
+          genres: detail?.genres?.length ? detail.genres : game.genres,
+        },
+      });
+    },
+    onError: (error) => {
+      setToast({
+        message: getLikeErrorMessage(error),
+        tone: 'error',
+      });
+    },
+  });
+
+  const handleToggleLike = () => {
+    if (isAuthLoading) {
+      setToast({
+        message: AUTH_CHECK_PENDING_MESSAGE,
+        tone: 'error',
+      });
+      return;
+    }
+
+    if (!accessToken) {
+      setToast({
+        message: LOGIN_REQUIRED_MESSAGE,
+        tone: 'error',
+      });
+      return;
+    }
+
+    likeMutation.mutate(!isLiked);
+  };
+
+  useEffect(() => {
+    if (!toast) {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setToast(null);
+    }, TOAST_DURATION_MS);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [toast]);
+
+  return {
+    clearToast: () => setToast(null),
+    handleToggleLike,
+    isLikeInteractionDisabled: isAuthLoading || likeMutation.isPending,
+    isLiked,
+    likeCount: Math.max(
+      0,
+      activeLikeState?.likeCount ?? detail?.likeCount ?? 0,
+    ),
+    likeLabel: isLiked ? '찜하기 취소' : '찜하기',
+    toast,
+  };
+};

--- a/src/features/games/hooks/useGameDetailModal.ts
+++ b/src/features/games/hooks/useGameDetailModal.ts
@@ -1,186 +1,40 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
-import { useEffect, useState } from 'react';
-
-import { useAuthStore } from '../../../store/useAuthStore';
-import { shouldRetryApiQuery } from '../../../api/queryRetry';
-import useAuthSessionState from '../../auth/hooks/useAuthSessionState';
-import {
-  GAME_DETAIL_GC_TIME,
-  GAME_DETAIL_STALE_TIME,
-  mergeGameDetail,
-} from '../detailUtils';
-import { getGameDetail, likeGame, unlikeGame } from '../gameApi';
-import { gamesKeys, syncLikeMutationStateInQueryCache } from '../queryCache';
-import type { GameDetail, GameListItem } from '../types';
-
-const LOGIN_REQUIRED_MESSAGE = '로그인 후 찜하기를 사용할 수 있어요.';
-const AUTH_CHECK_PENDING_MESSAGE =
-  '로그인 상태를 확인하고 있어요. 잠시만 기다려 주세요.';
-const LIKE_ERROR_MESSAGE =
-  '찜하기 상태를 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.';
-const DETAIL_NOT_FOUND_MESSAGE = '해당 게임 상세 정보를 찾을 수 없습니다.';
-const TOAST_DURATION_MS = 3000;
-
-type GameDetailModalToast = {
-  message: string;
-  tone: 'error';
-};
-
-type DetailErrorKind = 'not-found' | 'error' | null;
-
-const getLikeErrorMessage = (error: unknown) => {
-  if (error instanceof AxiosError) {
-    if (error.response?.status === 401) {
-      return LOGIN_REQUIRED_MESSAGE;
-    }
-
-    if (error.response?.status === 404) {
-      return DETAIL_NOT_FOUND_MESSAGE;
-    }
-  }
-
-  return LIKE_ERROR_MESSAGE;
-};
-
-const getDetailErrorKind = (error: unknown): DetailErrorKind => {
-  if (!(error instanceof AxiosError)) {
-    return error ? 'error' : null;
-  }
-
-  if (error.response?.status === 404) {
-    return 'not-found';
-  }
-
-  return 'error';
-};
+import type { GameListItem } from '../types';
+import { useGameDetailData } from './useGameDetailData';
+import { useGameDetailLikeAction } from './useGameDetailLikeAction';
 
 export const useGameDetailModal = (game: GameListItem) => {
-  const accessToken = useAuthStore((state) => state.accessToken);
-  const { isAuthLoading } = useAuthSessionState();
-  const queryClient = useQueryClient();
-  const [likeState, setLikeState] = useState<{
-    gameId: number;
-    isLiked: boolean | null;
-    likeCount: number;
-  } | null>(null);
-  const [toast, setToast] = useState<GameDetailModalToast | null>(null);
-
-  const detailQuery = useQuery({
-    queryKey: gamesKeys.detail(game.gameId),
-    queryFn: async () => {
-      const incomingDetail = await getGameDetail(game.gameId);
-      const previousDetail =
-        queryClient.getQueryData<GameDetail>(gamesKeys.detail(game.gameId)) ??
-        null;
-
-      return mergeGameDetail(previousDetail, incomingDetail);
-    },
-    staleTime: GAME_DETAIL_STALE_TIME,
-    gcTime: GAME_DETAIL_GC_TIME,
-    refetchOnMount: true,
-    refetchOnWindowFocus: false,
-    retry: shouldRetryApiQuery,
+  const {
+    detailQuery,
+    detail,
+    detailErrorKind,
+    hasFallbackSummary,
+    hasResolvedDetail,
+  } = useGameDetailData(game);
+  const {
+    clearToast,
+    handleToggleLike,
+    isLikeInteractionDisabled,
+    isLiked,
+    likeCount,
+    likeLabel,
+    toast,
+  } = useGameDetailLikeAction({
+    game,
+    detail,
   });
-
-  const detail = detailQuery.data;
-  const detailErrorKind = getDetailErrorKind(detailQuery.error);
-  const hasFallbackSummary = Boolean(
-    game.name.trim() ||
-    game.thumbnailUrl ||
-    game.genres.length > 0 ||
-    typeof game.rating === 'number' ||
-    typeof game.isLiked === 'boolean',
-  );
-  const activeLikeState = likeState?.gameId === game.gameId ? likeState : null;
-  const currentLiked =
-    activeLikeState?.isLiked ??
-    detail?.isLiked ??
-    (typeof game.isLiked === 'boolean' ? game.isLiked : null);
-  const isLiked = currentLiked === true;
-
-  const likeMutation = useMutation({
-    mutationFn: (nextLiked: boolean) =>
-      nextLiked ? likeGame(game.gameId) : unlikeGame(game.gameId),
-    onMutate: () => {
-      setToast(null);
-    },
-    onSuccess: (response) => {
-      const nextLikeState = {
-        gameId: response.gameId,
-        isLiked: response.isLiked,
-        likeCount: response.likeCount,
-      };
-
-      setLikeState(nextLikeState);
-      syncLikeMutationStateInQueryCache(queryClient, {
-        ...nextLikeState,
-        likedGame: {
-          gameId: response.gameId,
-          title: detail?.title ?? game.name,
-          thumbnailUrl: detail?.coverImageUrl ?? game.thumbnailUrl,
-          genres: detail?.genres?.length ? detail.genres : game.genres,
-        },
-      });
-    },
-    onError: (error) => {
-      setToast({
-        message: getLikeErrorMessage(error),
-        tone: 'error',
-      });
-    },
-  });
-  const isLikeInteractionDisabled = isAuthLoading || likeMutation.isPending;
-
-  const handleToggleLike = () => {
-    if (isAuthLoading) {
-      setToast({
-        message: AUTH_CHECK_PENDING_MESSAGE,
-        tone: 'error',
-      });
-      return;
-    }
-
-    if (!accessToken) {
-      setToast({
-        message: LOGIN_REQUIRED_MESSAGE,
-        tone: 'error',
-      });
-      return;
-    }
-
-    likeMutation.mutate(!isLiked);
-  };
-
-  useEffect(() => {
-    if (!toast) {
-      return undefined;
-    }
-
-    const timeout = window.setTimeout(() => {
-      setToast(null);
-    }, TOAST_DURATION_MS);
-
-    return () => {
-      window.clearTimeout(timeout);
-    };
-  }, [toast]);
 
   return {
     canRenderFallbackSummary: hasFallbackSummary,
-    clearToast: () => setToast(null),
+    clearToast,
     detail,
     detailErrorKind,
     detailQuery,
     handleToggleLike,
-    hasResolvedDetail: Boolean(detail),
+    hasResolvedDetail,
     isLikeInteractionDisabled,
     isLiked,
-    likeCount: Math.max(
-      0,
-      activeLikeState?.likeCount ?? detail?.likeCount ?? 0,
-    ),
-    likeLabel: isLiked ? '찜하기 취소' : '찜하기',
+    likeCount,
+    likeLabel,
     toast,
   };
 };

--- a/src/pages/main/hooks/mainPageGames.utils.ts
+++ b/src/pages/main/hooks/mainPageGames.utils.ts
@@ -1,0 +1,31 @@
+import { AxiosError } from 'axios';
+
+export const SEARCH_DEBOUNCE_MS = 300;
+export const SEARCH_RESULT_PAGE_SIZE = 20;
+
+export const getMainGamesErrorMessage = (
+  error: unknown,
+  isSearchMode: boolean,
+) => {
+  const subject = isSearchMode ? '검색 결과' : '인기 게임 목록';
+
+  if (error instanceof AxiosError) {
+    if (!error.response) {
+      return `${subject} 서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.`;
+    }
+
+    const data = error.response.data as
+      | { detail?: string; error_detail?: string }
+      | undefined;
+
+    if (typeof data?.detail === 'string') {
+      return data.detail;
+    }
+
+    if (typeof data?.error_detail === 'string') {
+      return data.error_detail;
+    }
+  }
+
+  return `${subject}을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.`;
+};

--- a/src/pages/main/hooks/useMainPageGameQueries.ts
+++ b/src/pages/main/hooks/useMainPageGameQueries.ts
@@ -1,0 +1,69 @@
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+
+import { shouldRetryApiQuery } from '../../../api/queryRetry';
+import { getTopGames, searchGames } from '../../../features/games/gameApi';
+import type { GameGenreFilter } from '../../../features/games/genres';
+import { gamesKeys } from '../../../features/games/queryCache';
+import {
+  getPaginatedCount,
+  getPaginatedLoadedCount,
+} from '../../../utils/paginatedResults';
+import { SEARCH_RESULT_PAGE_SIZE } from './mainPageGames.utils';
+
+type UseMainPageGameQueriesParams = {
+  selectedGenre: GameGenreFilter;
+  debouncedSearchText: string;
+  isSearchMode: boolean;
+};
+
+export const useMainPageGameQueries = ({
+  selectedGenre,
+  debouncedSearchText,
+  isSearchMode,
+}: UseMainPageGameQueriesParams) => {
+  const topGamesQuery = useQuery({
+    queryKey: gamesKeys.top100(selectedGenre),
+    enabled: !isSearchMode,
+    queryFn: () => getTopGames({ genre: selectedGenre }),
+    staleTime: 60_000,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    retry: shouldRetryApiQuery,
+  });
+
+  const searchGamesQuery = useInfiniteQuery({
+    queryKey: gamesKeys.search(debouncedSearchText, selectedGenre),
+    enabled: isSearchMode,
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) =>
+      searchGames({
+        search: debouncedSearchText,
+        genre: selectedGenre,
+        page: pageParam,
+        pageSize: SEARCH_RESULT_PAGE_SIZE,
+      }),
+    getNextPageParam: (lastPage, allPages) => {
+      if (typeof lastPage.next === 'number') {
+        return lastPage.next;
+      }
+
+      const loadedCount = getPaginatedLoadedCount(allPages);
+      const totalCount = getPaginatedCount(lastPage, loadedCount);
+
+      if (loadedCount >= totalCount) {
+        return undefined;
+      }
+
+      return allPages.length + 1;
+    },
+    staleTime: 60_000,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    retry: shouldRetryApiQuery,
+  });
+
+  return {
+    topGamesQuery,
+    searchGamesQuery,
+  };
+};

--- a/src/pages/main/hooks/useMainPageGames.ts
+++ b/src/pages/main/hooks/useMainPageGames.ts
@@ -1,27 +1,17 @@
 import { useEffect, useMemo, useState } from 'react';
-import {
-  useInfiniteQuery,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
-import { AxiosError } from 'axios';
+import { useQueryClient } from '@tanstack/react-query';
 
-import { shouldRetryApiQuery } from '../../../api/queryRetry';
 import { primeGameDetailCacheFromList } from '../../../features/games/detailCachePriming';
-import { getTopGames, searchGames } from '../../../features/games/gameApi';
 import type { GameGenreFilter } from '../../../features/games/genres';
 import { useDebouncedValue } from '../../../features/games/hooks/useDebouncedValue';
-import { gamesKeys } from '../../../features/games/queryCache';
 import { normalizeSearchText } from '../../../features/games/search';
 import type { GameListItem } from '../../../features/games/types';
+import { getPaginatedResults } from '../../../utils/paginatedResults';
 import {
-  getPaginatedCount,
-  getPaginatedLoadedCount,
-  getPaginatedResults,
-} from '../../../utils/paginatedResults';
-
-const SEARCH_DEBOUNCE_MS = 300;
-const SEARCH_RESULT_PAGE_SIZE = 20;
+  getMainGamesErrorMessage,
+  SEARCH_DEBOUNCE_MS,
+} from './mainPageGames.utils';
+import { useMainPageGameQueries } from './useMainPageGameQueries';
 
 export type MainPageGamesState = {
   searchText: string;
@@ -42,30 +32,6 @@ export type MainPageGamesState = {
   retryGames: () => void;
 };
 
-const getMainGamesErrorMessage = (error: unknown, isSearchMode: boolean) => {
-  const subject = isSearchMode ? '검색 결과' : '인기 게임 목록';
-
-  if (error instanceof AxiosError) {
-    if (!error.response) {
-      return `${subject} 서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.`;
-    }
-
-    const data = error.response.data as
-      | { detail?: string; error_detail?: string }
-      | undefined;
-
-    if (typeof data?.detail === 'string') {
-      return data.detail;
-    }
-
-    if (typeof data?.error_detail === 'string') {
-      return data.error_detail;
-    }
-  }
-
-  return `${subject}을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.`;
-};
-
 export const useMainPageGames = (): MainPageGamesState => {
   const queryClient = useQueryClient();
   const [searchText, setSearchText] = useState('');
@@ -76,45 +42,10 @@ export const useMainPageGames = (): MainPageGamesState => {
   );
   const isSearchMode = debouncedSearchText.length > 0;
 
-  const topGamesQuery = useQuery({
-    queryKey: gamesKeys.top100(selectedGenre),
-    enabled: !isSearchMode,
-    queryFn: () => getTopGames({ genre: selectedGenre }),
-    staleTime: 60_000,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    retry: shouldRetryApiQuery,
-  });
-
-  const searchGamesQuery = useInfiniteQuery({
-    queryKey: gamesKeys.search(debouncedSearchText, selectedGenre),
-    enabled: isSearchMode,
-    initialPageParam: 1,
-    queryFn: ({ pageParam }) =>
-      searchGames({
-        search: debouncedSearchText,
-        genre: selectedGenre,
-        page: pageParam,
-        pageSize: SEARCH_RESULT_PAGE_SIZE,
-      }),
-    getNextPageParam: (lastPage, allPages) => {
-      if (typeof lastPage.next === 'number') {
-        return lastPage.next;
-      }
-
-      const loadedCount = getPaginatedLoadedCount(allPages);
-      const totalCount = getPaginatedCount(lastPage, loadedCount);
-
-      if (loadedCount >= totalCount) {
-        return undefined;
-      }
-
-      return allPages.length + 1;
-    },
-    staleTime: 60_000,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    retry: shouldRetryApiQuery,
+  const { topGamesQuery, searchGamesQuery } = useMainPageGameQueries({
+    selectedGenre,
+    debouncedSearchText,
+    isSearchMode,
   });
 
   const games = useMemo(


### PR DESCRIPTION
## 관련 이슈

- closes #429

## 변경 내용

- `useAuthApi.ts`를 세션·좋아요·프로필·계정 4개 파일로 분리하고 배럴 re-export로 교체
- `useGameDetailModal.ts`에서 데이터 조회(`useGameDetailData`)와 찜하기 액션(`useGameDetailLikeAction`)을 분리
- `useMainPageGames.ts`에서 쿼리 로직(`useMainPageGameQueries`)과 상수·유틸(`mainPageGames.utils`)을 별도 파일로 추출

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음.

## 참고사항

- 로직 변경 없는 순수 구조 분리 PR입니다.
- 기존 `useAuthApi.ts` import 경로는 배럴 파일로 유지되어 외부 호환성을 깨지 않습니다.