### PR TITLE
[Fix] 매칭 상세 줄거리/제목 보기 UX 개선

### DIFF
--- a/src/pages/matching/components/MatchingCandidatePanel.tsx
+++ b/src/pages/matching/components/MatchingCandidatePanel.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, Heart } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Heart, X } from 'lucide-react';
 
 import { formatMatchingCandidateRating } from '../utils/matchingDetail';
 import type {
@@ -75,6 +75,10 @@ function MatchingCandidatePanel({
   } = overlay;
   const shouldShowTitleToggle = isTitleOverflowing;
   const shouldShowSummaryToggle = isSummaryOverflowing;
+  const summaryCollapsedLineCount = Math.max(
+    1,
+    Math.round(summaryCollapsedHeightRem / 1.5),
+  );
 
   return (
     <article className="survey-panel relative flex flex-col px-5 py-5 sm:px-6 sm:py-6">
@@ -113,20 +117,24 @@ function MatchingCandidatePanel({
               </div>
             ) : null}
           </div>
-          <p
-            ref={summaryRef}
-            className="mt-3 text-sm leading-6 break-keep text-white/62"
-            style={
-              isSummaryOverlayOpen
-                ? undefined
-                : {
-                    maxHeight: `${summaryCollapsedHeightRem}rem`,
-                    overflow: 'hidden',
-                  }
-            }
-          >
-            {candidateSummary}
-          </p>
+          <div className="mt-3">
+            <p
+              ref={summaryRef}
+              className="text-sm leading-6 break-keep text-white/62"
+              style={
+                isSummaryOverlayOpen
+                  ? undefined
+                  : {
+                      display: '-webkit-box',
+                      WebkitBoxOrient: 'vertical',
+                      WebkitLineClamp: summaryCollapsedLineCount,
+                      overflow: 'hidden',
+                    }
+              }
+            >
+              {candidateSummary}
+            </p>
+          </div>
           {shouldShowSummaryToggle ? (
             <button
               type="button"
@@ -260,8 +268,8 @@ function MatchingCandidatePanel({
           <div className="flex h-full flex-col">
             <div className="flex items-start justify-between gap-4">
               <div className="min-w-0">
-                <p className="text-xs font-semibold tracking-[0.18em] text-[#ff8d8d] uppercase">
-                  Summary
+                <p className="text-xs font-semibold tracking-[0.18em] text-[#ff8d8d]">
+                  게임소개
                 </p>
                 <h3 className="mt-2 text-xl font-semibold break-keep text-white sm:text-2xl">
                   {candidate.title}
@@ -270,9 +278,10 @@ function MatchingCandidatePanel({
               <button
                 type="button"
                 onClick={closeSummaryOverlay}
-                className="inline-flex shrink-0 items-center gap-2 self-start rounded-full border border-white/10 bg-white/4 px-3 py-2 text-sm font-medium text-white/86 transition hover:border-white/20 hover:bg-white/7"
+                aria-label="게임소개 닫기"
+                className="inline-flex h-9 w-9 shrink-0 items-center justify-center self-start rounded-full border border-white/10 bg-white/4 text-white/86 transition hover:border-white/20 hover:bg-white/7"
               >
-                닫기
+                <X size={16} />
               </button>
             </div>
 


### PR DESCRIPTION
## 관련 이슈

- closes #435 

## 변경 내용

- 매칭 상세 카드에서 접힌 줄거리 끝부분에 `...` 느낌이 보이도록 처리해, 뒤에 내용이 더 있다는 점이 더 직관적으로 보이게 했습니다.
- 줄거리 전체 보기 오버레이의 헤더 문구를 `Summary`에서 `게임소개`로 변경했습니다.
- 줄거리 전체 보기 오버레이의 닫기 버튼은 텍스트 대신 `X` 아이콘 버튼으로 정리했습니다.
- 제목 전체 보기 hover/focus 프리뷰 흐름은 최신 구조 기준으로 유지하면서, 전체 줄거리 보기와의 시각적 톤을 맞췄습니다.

## 검증

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 브라우저에서 주요 화면을 확인했습니다.
- [ ] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [ ] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [ ] API 명세와 충돌하는 부분이 없습니다.
- [ ] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경이 있으면 첨부합니다.

## 참고사항

- 이번 PR은 구조 리팩토링이 아니라, 매칭 상세 화면의 텍스트 확인 경험과 시각적 완성도를 보완하는 작은 UX 수정입니다.
- 최신 `dev` 구조(상세 페이지 / 훅 / 패널 분리) 기준으로 수정 위치를 맞췄습니다.
