### PR TITLE
[Fix] 초기 추천 질문 문구 정리

### DIFF
--- a/src/features/support-chat/data/faqs.ts
+++ b/src/features/support-chat/data/faqs.ts
@@ -15,20 +15,19 @@ export const SUPPORT_CHAT_WELCOME_MESSAGE =
   '안녕하세요! 고객센터 챗봇입니다.\n궁금한 내용을 입력하시거나 아래 예시 질문을 눌러 바로 도움을 받아보세요.';
 
 export const SUPPORT_CHAT_QUICK_ACTIONS: SupportChatQuickAction[] = [
-  { id: 'account-help', label: '아이디 비밀번호 변경은 어떻게 하나요?' },
+  { id: 'password-change-help', label: '비밀번호 변경은 어떻게 하나요 ?' },
   { id: 'search-help', label: '게임을 검색했는데 안나와요.' },
   {
     id: 'delete-account-help',
-    label: '계정 삭제 하고 싶은데 어떻게 하나요?',
+    label: '계정 삭제 하고 싶은데 어떻게 하나요 ?',
   },
-  { id: 'find-id-help', label: '아이디를 찾고 싶어요' },
-  { id: 'google-login-help', label: '구글 로그인은 어떻게 하나요?' },
+  { id: 'google-login-help', label: '구글 로그인은 어떻게 하나요 ?' },
 ];
 
 const SUPPORT_FAQ_ENTRIES: SupportFaqEntry[] = [
   {
     id: 'account-change',
-    label: '아이디 비밀번호 변경은 어떻게 하나요?',
+    label: '비밀번호 변경 안내',
     keywords: ['아이디', '비밀번호', '변경', '수정', '로그인 정보'],
     answer:
       '아이디 확인이나 비밀번호 변경이 필요하시면 로그인 화면 또는 마이페이지를 이용해 주세요.\n비밀번호 변경은 마이페이지에서 진행할 수 있고, 아이디 찾기는 본인 확인 절차가 준비되면 안내에 따라 확인하실 수 있습니다.',
@@ -42,14 +41,14 @@ const SUPPORT_FAQ_ENTRIES: SupportFaqEntry[] = [
   },
   {
     id: 'delete-account',
-    label: '계정 삭제 하고 싶은데 어떻게 하나요?',
+    label: '계정 삭제 하고 싶은데 어떻게 하나요 ?',
     keywords: ['계정 삭제', '회원 탈퇴', '탈퇴', '계정 제거'],
     answer:
       '회원탈퇴는 마이페이지 하단의 회원탈퇴 버튼에서 진행하실 수 있습니다.\n탈퇴 전에는 계정 정보와 저장된 로그인 상태가 함께 정리되므로, 필요한 정보가 있다면 먼저 확인해 주세요.',
   },
   {
     id: 'find-id',
-    label: '아이디를 찾고 싶어요',
+    label: '아이디 찾기 안내',
     keywords: ['아이디', '찾고', '분실', '모르겠'],
     answer:
       '아이디 찾기는 본인 인증 기반 안내가 준비되는 대로 로그인 화면과 고객센터 안내를 통해 제공될 예정입니다.\n현재는 가입 시 사용한 이름과 닉네임 정보를 먼저 확인해 주세요.',
@@ -69,7 +68,7 @@ const SUPPORT_FAQ_ENTRIES: SupportFaqEntry[] = [
   },
   {
     id: 'google-login',
-    label: '구글 로그인은 어떻게 하나요?',
+    label: '구글 로그인은 어떻게 하나요 ?',
     keywords: ['구글 로그인', '구글', 'google', '소셜 로그인'],
     answer:
       '로그인 화면 상단의 구글 로그인 버튼을 누르면 구글 계정으로 바로 로그인할 수 있습니다.\n소셜 로그인 사용자는 별도 비밀번호 없이 구글 인증만으로 계정에 접속하실 수 있습니다.',


### PR DESCRIPTION
## 관련 이슈

- closes #439

## 변경 내용

- 챗봇 초기 추천 질문에서 `아이디 비밀번호 변경은 어떻게 하나요?` 항목을 제거했습니다.
- 챗봇 초기 추천 질문에서 `아이디를 찾고 싶어요` 항목을 제거했습니다.
- `비밀번호 변경은 어떻게 하나요 ?` 질문을 새로 추가했습니다.
- 계정 삭제/구글 로그인 질문의 물음표 앞 공백을 기존 문구 스타일과 맞췄습니다.
- FAQ 내부 라벨도 동일한 문구 기준으로 정리했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경이 없거나 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

<img width="618" height="914" alt="image" src="https://github.com/user-attachments/assets/b887a731-7668-4b0b-9bfd-93ceffdbd344" />

## 참고사항

