### PR TITLE
[Fix] 로그아웃 시 게임 찜 상태 캐시 초기화

### DIFF
--- a/src/features/auth/hooks/useLogoutAction.ts
+++ b/src/features/auth/hooks/useLogoutAction.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 
 import { ROUTES } from '../../../constants/routes';
+import { resetGameLikedStateInQueryCache } from '../../games/queryCache';
 import { authKeys } from '../api/queryKeys';
 import { useLogoutMutation } from '../api/useAuthApi';
 import { clearAuthSession } from '../utils/sessionManager';
@@ -21,6 +22,7 @@ function useLogoutAction() {
     clearAuthSession();
     await queryClient.cancelQueries({ queryKey: authKeys.all });
     queryClient.removeQueries({ queryKey: authKeys.all });
+    resetGameLikedStateInQueryCache(queryClient);
     navigate(ROUTES.HOME, { replace: true });
   };
 

--- a/src/features/games/gameLikeCacheSync.ts
+++ b/src/features/games/gameLikeCacheSync.ts
@@ -66,6 +66,27 @@ const updateRecommendationPages = <TPage extends LikeableResultPage>(
       }
     : currentData;
 
+const resetGameListItemLikedState = (item: GameListItem): GameListItem => ({
+  ...item,
+  isLiked: false,
+});
+
+const resetRecommendationPagesLikedState = <TPage extends LikeableResultPage>(
+  currentData: InfiniteData<TPage> | undefined,
+) =>
+  currentData && Array.isArray(currentData.pages)
+    ? {
+        ...currentData,
+        pages: currentData.pages.map((page) => ({
+          ...page,
+          results: page.results.map((result) => ({
+            ...result,
+            is_liked: false,
+          })),
+        })),
+      }
+    : currentData;
+
 export const syncGameLikeStateInQueryCache = (
   queryClient: QueryClient,
   update: GameLikeCacheUpdate,
@@ -130,6 +151,64 @@ export const syncGameLikeStateInQueryCache = (
                 ? { ...result, is_liked: update.isLiked }
                 : result,
             ),
+          }
+        : currentData,
+  );
+};
+
+export const resetGameLikedStateInQueryCache = (queryClient: QueryClient) => {
+  queryClient.setQueriesData<GameDetail>(
+    { queryKey: [gamesKeys.all[0], 'detail'] },
+    (currentDetail) =>
+      currentDetail
+        ? {
+            ...currentDetail,
+            isLiked: false,
+          }
+        : currentDetail,
+  );
+
+  queryClient.setQueriesData<GameListItem[]>(
+    { queryKey: gamesKeys.top100Root() },
+    (currentGames) =>
+      Array.isArray(currentGames)
+        ? currentGames.map(resetGameListItemLikedState)
+        : currentGames,
+  );
+
+  queryClient.setQueriesData<InfiniteData<SearchGamesResult>>(
+    { queryKey: gamesKeys.searchRoot() },
+    (currentData) =>
+      currentData && Array.isArray(currentData.pages)
+        ? {
+            ...currentData,
+            pages: currentData.pages.map((page) => ({
+              ...page,
+              results: page.results.map(resetGameListItemLikedState),
+            })),
+          }
+        : currentData,
+  );
+
+  queryClient.setQueriesData<InfiniteData<LikeableResultPage>>(
+    { queryKey: ['survey-results'] },
+    (currentData) => resetRecommendationPagesLikedState(currentData),
+  );
+  queryClient.setQueriesData<InfiniteData<LikeableResultPage>>(
+    { queryKey: ['match-results'] },
+    (currentData) => resetRecommendationPagesLikedState(currentData),
+  );
+
+  queryClient.setQueriesData<MatchingCandidatesResponse>(
+    { queryKey: ['match-candidates'] },
+    (currentData) =>
+      currentData && Array.isArray(currentData.results)
+        ? {
+            ...currentData,
+            results: currentData.results.map((result) => ({
+              ...result,
+              is_liked: false,
+            })),
           }
         : currentData,
   );

--- a/src/features/games/queryCache.ts
+++ b/src/features/games/queryCache.ts
@@ -1,12 +1,16 @@
 import type { QueryClient } from '@tanstack/react-query';
 
-import { syncGameLikeStateInQueryCache } from './gameLikeCacheSync';
+import {
+  resetGameLikedStateInQueryCache,
+  syncGameLikeStateInQueryCache,
+} from './gameLikeCacheSync';
 import { syncLikedGamesStateInQueryCache } from './likedGamesCacheSync';
 import { gamesKeys } from './queryKeys';
 import type { LikeMutationCacheUpdate } from './queryCache.types';
 
 export {
   gamesKeys,
+  resetGameLikedStateInQueryCache,
   syncGameLikeStateInQueryCache,
   syncLikedGamesStateInQueryCache,
 };


### PR DESCRIPTION
## 관련 이슈

- closes #441

## 변경 내용

- 로그아웃 시 auth cache 정리 이후 games 계열 liked cache도 함께 초기화하도록 수정했습니다.
- 게임 상세, 메인/TOP100, 검색 결과, 추천 결과, 매칭 결과, 매칭 후보에 남아 있던 `isLiked` / `is_liked` 상태를 로그아웃 시 `false`로 초기화합니다.
- `likeCount`는 개인 세션 데이터가 아니라 집계 데이터이므로 유지하도록 처리했습니다.
- 외부 API, 라우트, auth store 계약은 변경하지 않고 내부 캐시 정리 범위만 확장했습니다.

## 검증

- [x] `npm run lint`
- [x] `npm run build`
- [x] 브라우저에서 주요 화면을 확인했습니다.
- [x] UI 변경 스크린샷을 첨부했습니다.

## 요구사항 및 API 영향

- [x] 요구사항 정의서와 충돌하는 부분이 없습니다.
- [x] API 명세와 충돌하는 부분이 없습니다.
- [x] API/기획 미확정 사항이 있으면 아래 참고사항에 적었습니다.

## 스크린샷

UI 변경 없음

## 참고사항

- 기존에는 로그아웃 시 `authKeys` 캐시만 제거되어, games 계열 query cache에 남아 있던 liked 상태가 비로그인 화면에도 보일 수 있었습니다.
- 이번 변경은 전체 게임 캐시 제거가 아니라, 로그아웃 시점에 개인화된 liked 상태만 초기화하는 범위로 제한했습니다.
- 수동 확인 시 메인 목록, 추천 결과, 매칭 결과, 상세 모달에서 로그아웃 직후 찜 상태가 바로 해제되는지 확인하면 됩니다.
